### PR TITLE
Upgrade project to .NET 8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - name: Read Version Text
         id: version
         uses: juliangruber/read-file-action@v1
@@ -132,7 +132,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - name: Read Version Text
         id: version
         uses: juliangruber/read-file-action@v1
@@ -192,7 +192,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
       - name: Read Version Text
         id: version
         uses: juliangruber/read-file-action@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@
 
 | 项目 | 类型 | 目标框架 |
 |---|---|---|
-| `DownKyi` | WinExe（Avalonia UI） | `net6.0` |
-| `DownKyi.Core` | 类库 | `net6.0` |
+| `DownKyi` | WinExe（Avalonia UI） | `net8.0` |
+| `DownKyi.Core` | 类库 | `net8.0` |
 
 目标运行时：`win-x64`、`win-x86`、`linux-x64`、`linux-arm64`、`osx-x64`、`osx-arm64`。
 
@@ -90,7 +90,7 @@ DownKyi/
 
 ### 前置条件
 
-- .NET 6 SDK
+- .NET 8 SDK
 - 系统 PATH 中存在 FFmpeg 二进制文件（开发时混流操作所需）
 - `PupNet` 工具（仅打包时需要，开发构建无需）
 

--- a/DownKyi.Core/DownKyi.Core.csproj
+++ b/DownKyi.Core/DownKyi.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X64'">win-x64</RuntimeIdentifier>

--- a/DownKyi/DownKyi.csproj
+++ b/DownKyi/DownKyi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/script/macos/package.sh
+++ b/script/macos/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 arch=$1
 APP_NAME="./哔哩下载姬.app"
-PUBLISH_OUTPUT_DIRECTORY="../../DownKyi/bin/Release/net6.0/osx-$arch/publish/."
+PUBLISH_OUTPUT_DIRECTORY="../../DownKyi/bin/Release/net8.0/osx-$arch/publish/."
 
 INFO_PLIST="./Info.plist"
 ICON_FILE="./logo.icns"


### PR DESCRIPTION
### Motivation
- Incrementally move the solution off .NET 6 as the first phase toward the final .NET 10 LTS upgrade to reduce risk and verify CI/workspace compatibility with .NET 8.
- Ensure local and CI SDKs are pinned to a known .NET 8 SDK to provide reproducible restores/builds.

### Description
- Retarget `DownKyi/DownKyi.csproj` and `DownKyi.Core/DownKyi.Core.csproj` from `net6.0` to `net8.0`.
- Update GitHub Actions `setup-dotnet` steps from `dotnet-version: '6.0.x'` to `dotnet-version: '8.0.x'` in `.github/workflows/build.yml`.
- Add `global.json` to lock the repository SDK to `8.0.100` with `rollForward: "latestFeature"`, and update documentation and macOS packaging output path (`script/macos/package.sh`) to reference `net8.0`.
- No NuGet package versions were changed and runtime identifier settings were not altered.

### Testing
- Ran `dotnet restore` using a downloaded .NET 8 SDK, and restore completed successfully.
- Ran `dotnet build -c Release`, which completed successfully (0 errors) but produced existing nullable/nullability and related warnings (no build blockers).
- Ran `dotnet publish DownKyi/DownKyi.csproj -c Release -r win-x64 --self-contained`, which completed successfully and published to `DownKyi/bin/Release/net8.0/win-x64/publish/`.
- No automated test projects exist in the repo; no package compatibility errors were encountered that blocked the above steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01420150548330b5f9790c980f32ac)