### PR TITLE
Upgrade project to .NET 10, bump dependencies, and update CI/packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '10.0.x'
       - name: Read Version Text
         id: version
         uses: juliangruber/read-file-action@v1
@@ -51,7 +51,7 @@ jobs:
           path: version.txt
       - name: Install Pupnet
         run: |
-          dotnet tool install -g KuiperZone.PupNet --version 1.8.0
+          dotnet tool install -g KuiperZone.PupNet --version 1.10.0
       - name: Get Deps
         run: |
           .\ffmpeg.ps1 ${{ matrix.cpu }}
@@ -132,7 +132,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '10.0.x'
       - name: Read Version Text
         id: version
         uses: juliangruber/read-file-action@v1
@@ -140,7 +140,7 @@ jobs:
           path: version.txt
       - name: Install Pupnet
         run: |
-          dotnet tool install -g KuiperZone.PupNet --version 1.8.0
+          dotnet tool install -g KuiperZone.PupNet --version 1.10.0
           sudo apt-get update
           sudo apt-get install libfuse2
       - name: Get Deps
@@ -192,7 +192,7 @@ jobs:
       - name: Install .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '10.0.x'
       - name: Read Version Text
         id: version
         uses: juliangruber/read-file-action@v1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,8 +36,8 @@
 
 | 项目 | 类型 | 目标框架 |
 |---|---|---|
-| `DownKyi` | WinExe（Avalonia UI） | `net6.0` |
-| `DownKyi.Core` | 类库 | `net6.0` |
+| `DownKyi` | WinExe（Avalonia UI） | `net10.0` |
+| `DownKyi.Core` | 类库 | `net10.0` |
 
 目标运行时：`win-x64`、`win-x86`、`linux-x64`、`linux-arm64`、`osx-x64`、`osx-arm64`。
 
@@ -90,7 +90,7 @@ DownKyi/
 
 ### 前置条件
 
-- .NET 6 SDK
+- .NET 10 SDK
 - 系统 PATH 中存在 FFmpeg 二进制文件（开发时混流操作所需）
 - `PupNet` 工具（仅打包时需要，开发构建无需）
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,20 +1,20 @@
 <Project ToolsVersion="15.0">
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="11.3.13" />
+    <PackageVersion Include="Avalonia" Version="11.3.15" />
     <PackageVersion Include="Avalonia.Controls.DataGrid" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Desktop" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.13" />
-    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.3.13" />
-    <PackageVersion Include="System.Formats.Nrbf" Version="9.0.5" />
+    <PackageVersion Include="Avalonia.Desktop" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Diagnostics" Version="11.3.15" />
+    <PackageVersion Include="Avalonia.Themes.Simple" Version="11.3.15" />
+    <PackageVersion Include="System.Formats.Nrbf" Version="10.0.7" />
     <PackageVersion Include="Xaml.Behaviors" Version="11.3.9.5" />
-    <PackageVersion Include="Downloader" Version="3.3.4" />
+    <PackageVersion Include="Downloader" Version="5.5.0" />
     <PackageVersion Include="Prism.Avalonia" Version="8.1.97.11073" />
     <PackageVersion Include="Prism.DryIoc.Avalonia" Version="8.1.97.11073" />
-    <PackageVersion Include="FFMpegCore" Version="5.1.0" />
-    <PackageVersion Include="Google.Protobuf" Version="3.25.1" />
-    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="9.0.5" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="QRCoder" Version="1.6.0" />
+    <PackageVersion Include="FFMpegCore" Version="5.4.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.34.1" />
+    <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.7" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="QRCoder" Version="1.8.0" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlcipher" Version="2.1.11" />
   </ItemGroup>
 </Project>

--- a/DownKyi.Core/DownKyi.Core.csproj
+++ b/DownKyi.Core/DownKyi.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == '' And '$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' And '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X64'">win-x64</RuntimeIdentifier>

--- a/DownKyi/DownKyi.csproj
+++ b/DownKyi/DownKyi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
         <ApplicationManifest>app.manifest</ApplicationManifest>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
+  }
+}

--- a/script/macos/package.sh
+++ b/script/macos/package.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 arch=$1
 APP_NAME="./哔哩下载姬.app"
-PUBLISH_OUTPUT_DIRECTORY="../../DownKyi/bin/Release/net6.0/osx-$arch/publish/."
+PUBLISH_OUTPUT_DIRECTORY="../../DownKyi/bin/Release/net10.0/osx-$arch/publish/."
 
 INFO_PLIST="./Info.plist"
 ICON_FILE="./logo.icns"


### PR DESCRIPTION
### Motivation
- Move the solution and libraries from `net6.0` to `net10.0` to use the newer SDK and runtime features.
- Align package versions and native tooling with the newer runtime to avoid compatibility issues.
- Update CI and packaging scripts to install and target the .NET 10 SDK and newer packaging tools.

### Description
- Updated `DownKyi/DownKyi.csproj` and `DownKyi.Core/DownKyi.Core.csproj` to target `net10.0` instead of `net6.0`.
- Added `global.json` to pin the SDK to `10.0.100` with `rollForward: latestFeature`.
- Bumped package versions in `Directory.Packages.props` (including `Avalonia`, `Downloader`, `FFMpegCore`, `Google.Protobuf`, `Microsoft.Data.Sqlite.Core`, `System.Formats.Nrbf`, `Newtonsoft.Json`, and `QRCoder`).
- Updated `AGENTS.md` documentation to reflect `net10.0` and the `.NET 10 SDK` prerequisite.
- Updated CI workflow `.github/workflows/build.yml` to use `actions/setup-dotnet@v4` with `dotnet-version: '10.0.x'` and upgraded `KuiperZone.PupNet` install version to `1.10.0`.
- Adjusted macOS packaging script `script/macos/package.sh` to point at the `net10.0` publish output path.

### Testing
- No automated tests were executed as part of this PR; CI is updated to use .NET 10 and will run on the normal workflow triggers.
- Local build verification is recommended after merging to confirm runtime-specific native assets and packaging behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01420150548330b5f9790c980f32ac)