### PR TITLE
Fix WebClient stream lifetime and add tests

### DIFF
--- a/DownKyi.Core.Tests/BiliApi/WebClientTests.cs
+++ b/DownKyi.Core.Tests/BiliApi/WebClientTests.cs
@@ -1,0 +1,200 @@
+using System.Net;
+using Xunit;
+using BiliWebClient = DownKyi.Core.BiliApi.WebClient;
+
+namespace DownKyi.Core.Tests.BiliApi;
+
+public class WebClientTests
+{
+    [Fact]
+    public void RequestStream_ReturnsReadableStreamThatRemainsValidAfterReturn()
+    {
+        var contentStream = new TrackingStream(CreatePayload(1024 * 1024));
+        var response = new TrackingResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(contentStream)
+        };
+        using var httpClient = new HttpClient(new StaticResponseHandler(response));
+
+        using var stream = BiliWebClient.RequestStream(httpClient, "https://example.test/getLogin");
+
+        Assert.True(stream.CanRead);
+        Assert.Equal(0, contentStream.TotalBytesRead);
+
+        var buffer = new byte[8192];
+        var read = stream.Read(buffer, 0, buffer.Length);
+
+        Assert.Equal(buffer.Length, read);
+        Assert.Equal(buffer.Length, contentStream.TotalBytesRead);
+        Assert.Equal(CreatePayload(buffer.Length), buffer);
+    }
+
+    [Fact]
+    public void RequestStream_DisposeDisposesOwnedHttpResponse()
+    {
+        var contentStream = new TrackingStream(CreatePayload(128));
+        var response = new TrackingResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(contentStream)
+        };
+        using var httpClient = new HttpClient(new StaticResponseHandler(response));
+
+        var stream = BiliWebClient.RequestStream(httpClient, "https://example.test/getLogin");
+        stream.Dispose();
+
+        Assert.True(contentStream.IsDisposed);
+        Assert.True(response.IsDisposed);
+    }
+
+    [Fact]
+    public void DownloadFile_WritesResponseContentToDisk()
+    {
+        var payload = CreatePayload(64 * 1024);
+        var response = new TrackingResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(new TrackingStream(payload))
+        };
+        using var httpClient = new HttpClient(new StaticResponseHandler(response));
+        var destFile = Path.Combine(Path.GetTempPath(), $"downkyi-webclient-{Guid.NewGuid():N}.bin");
+
+        try
+        {
+            BiliWebClient.DownloadFile(httpClient, "https://example.test/getLogin", destFile);
+
+            Assert.Equal(payload, File.ReadAllBytes(destFile));
+            Assert.True(response.IsDisposed);
+        }
+        finally
+        {
+            if (File.Exists(destFile))
+            {
+                File.Delete(destFile);
+            }
+        }
+    }
+
+    [Fact]
+    public void RequestStream_DisposesResponseWhenStatusIsUnsuccessful()
+    {
+        var response = new TrackingResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StreamContent(new TrackingStream(CreatePayload(128)))
+        };
+        using var httpClient = new HttpClient(new StaticResponseHandler(response));
+
+        Assert.Throws<HttpRequestException>(() => BiliWebClient.RequestStream(httpClient, "https://example.test/getLogin"));
+        Assert.True(response.IsDisposed);
+    }
+
+    private static byte[] CreatePayload(int length)
+    {
+        var payload = new byte[length];
+        for (var i = 0; i < payload.Length; i++)
+        {
+            payload[i] = (byte)(i % 251);
+        }
+
+        return payload;
+    }
+
+    private sealed class StaticResponseHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+
+        public StaticResponseHandler(HttpResponseMessage response)
+        {
+            _response = response;
+        }
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return _response;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(_response);
+        }
+    }
+
+    private sealed class TrackingResponseMessage : HttpResponseMessage
+    {
+        public TrackingResponseMessage(HttpStatusCode statusCode) : base(statusCode)
+        {
+        }
+
+        public bool IsDisposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            base.Dispose(disposing);
+        }
+    }
+
+    private sealed class TrackingStream : Stream
+    {
+        private readonly MemoryStream _inner;
+
+        public TrackingStream(byte[] payload)
+        {
+            _inner = new MemoryStream(payload, writable: false);
+        }
+
+        public long TotalBytesRead { get; private set; }
+
+        public bool IsDisposed { get; private set; }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => _inner.CanSeek;
+
+        public override bool CanWrite => false;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush()
+        {
+            _inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            var read = _inner.Read(buffer, offset, count);
+            TotalBytesRead += read;
+            return read;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _inner.Write(buffer, offset, count);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            IsDisposed = true;
+            if (disposing)
+            {
+                _inner.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/DownKyi.Core.Tests/BiliApi/WebClientTests.cs
+++ b/DownKyi.Core.Tests/BiliApi/WebClientTests.cs
@@ -47,6 +47,29 @@ public class WebClientTests
     }
 
     [Fact]
+    public async Task RequestStream_CopyToAsyncCopiesContentAndDisposeAsyncDisposesOwnedHttpResponse()
+    {
+        var payload = CreatePayload(32 * 1024);
+        var contentStream = new TrackingStream(payload);
+        var response = new TrackingResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(contentStream)
+        };
+        using var httpClient = new HttpClient(new StaticResponseHandler(response));
+
+        var stream = BiliWebClient.RequestStream(httpClient, "https://example.test/getLogin");
+        await using var destination = new MemoryStream();
+
+        await stream.CopyToAsync(destination);
+        await stream.DisposeAsync();
+
+        Assert.Equal(payload, destination.ToArray());
+        Assert.Equal(payload.Length, contentStream.TotalBytesRead);
+        Assert.True(contentStream.IsDisposed);
+        Assert.True(response.IsDisposed);
+    }
+
+    [Fact]
     public void DownloadFile_WritesResponseContentToDisk()
     {
         var payload = CreatePayload(64 * 1024);
@@ -171,6 +194,27 @@ public class WebClientTests
             return read;
         }
 
+        public override int Read(Span<byte> buffer)
+        {
+            var read = _inner.Read(buffer);
+            TotalBytesRead += read;
+            return read;
+        }
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            var read = await _inner.ReadAsync(buffer, offset, count, cancellationToken);
+            TotalBytesRead += read;
+            return read;
+        }
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            var read = await _inner.ReadAsync(buffer, cancellationToken);
+            TotalBytesRead += read;
+            return read;
+        }
+
         public override long Seek(long offset, SeekOrigin origin)
         {
             return _inner.Seek(offset, origin);
@@ -184,6 +228,13 @@ public class WebClientTests
         public override void Write(byte[] buffer, int offset, int count)
         {
             _inner.Write(buffer, offset, count);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            IsDisposed = true;
+            await _inner.DisposeAsync();
+            await base.DisposeAsync();
         }
 
         protected override void Dispose(bool disposing)

--- a/DownKyi.Core/BiliApi/WebClient.cs
+++ b/DownKyi.Core/BiliApi/WebClient.cs
@@ -242,9 +242,34 @@ public static class WebClient
             _inner.Flush();
         }
 
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            return _inner.FlushAsync(cancellationToken);
+        }
+
         public override int Read(byte[] buffer, int offset, int count)
         {
             return _inner.Read(buffer, offset, count);
+        }
+
+        public override int Read(Span<byte> buffer)
+        {
+            return _inner.Read(buffer);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            return _inner.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            return _inner.ReadAsync(buffer, cancellationToken);
+        }
+
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            return _inner.CopyToAsync(destination, bufferSize, cancellationToken);
         }
 
         public override long Seek(long offset, SeekOrigin origin)
@@ -260,6 +285,20 @@ public static class WebClient
         public override void Write(byte[] buffer, int offset, int count)
         {
             _inner.Write(buffer, offset, count);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            try
+            {
+                await _inner.DisposeAsync().ConfigureAwait(false);
+            }
+            finally
+            {
+                _response.Dispose();
+            }
+
+            await base.DisposeAsync().ConfigureAwait(false);
         }
 
         protected override void Dispose(bool disposing)

--- a/DownKyi.Core/BiliApi/WebClient.cs
+++ b/DownKyi.Core/BiliApi/WebClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Web;
@@ -6,6 +7,8 @@ using DownKyi.Core.BiliApi.Login;
 using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
 using DownKyi.Core.Storage;
+
+[assembly: InternalsVisibleTo("DownKyi.Core.Tests")]
 
 namespace DownKyi.Core.BiliApi;
 
@@ -161,14 +164,24 @@ public static class WebClient
 
     public static void DownloadFile(string url, string destFile, string? referer = null)
     {
+        DownloadFile(HttpClient, url, destFile, referer);
+    }
+
+    internal static void DownloadFile(HttpClient httpClient, string url, string destFile, string? referer = null)
+    {
         using var fs = File.Create(destFile);
-        using var stream = RequestStream(url, referer);
+        using var stream = RequestStream(httpClient, url, referer);
         stream.CopyTo(fs);
     }
 
     public static Stream RequestStream(string url, string? referer = null, string method = "GET")
     {
-        var request = new HttpRequestMessage(new HttpMethod(method), url);
+        return RequestStream(HttpClient, url, referer, method);
+    }
+
+    internal static Stream RequestStream(HttpClient httpClient, string url, string? referer = null, string method = "GET")
+    {
+        using var request = new HttpRequestMessage(new HttpMethod(method), url);
 
         if (referer != null)
         {
@@ -185,8 +198,79 @@ public static class WebClient
             }
         }
 
-        var response = HttpClient.Send(request);
-        response.EnsureSuccessStatusCode();
-        return response.Content.ReadAsStream();
+        var response = httpClient.Send(request, HttpCompletionOption.ResponseHeadersRead);
+
+        try
+        {
+            response.EnsureSuccessStatusCode();
+            return new HttpResponseStream(response.Content.ReadAsStream(), response);
+        }
+        catch
+        {
+            response.Dispose();
+            throw;
+        }
+    }
+
+    private sealed class HttpResponseStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly HttpResponseMessage _response;
+
+        public HttpResponseStream(Stream inner, HttpResponseMessage response)
+        {
+            _inner = inner;
+            _response = response;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+
+        public override bool CanSeek => _inner.CanSeek;
+
+        public override bool CanWrite => _inner.CanWrite;
+
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush()
+        {
+            _inner.Flush();
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _inner.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _inner.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _inner.SetLength(value);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _inner.Write(buffer, offset, count);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                _response.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent premature disposal of `HttpResponseMessage` when returning a content stream so callers can stream large responses without buffering into memory. 
- Ensure `DownloadFile` writes remain streaming-based and keep the HTTP response alive while copying to disk. 
- Add unit tests that exercise the streaming behavior and ensure the response is disposed only when the caller disposes the returned stream. 

### Description
- Updated `DownKyi.Core/BiliApi/WebClient.cs` to send requests with `HttpCompletionOption.ResponseHeadersRead` and return a response-owned stream wrapper so the `HttpResponseMessage` is kept alive until the caller disposes the stream. 
- Introduced an internal `HttpResponseStream` wrapper that delegates all `Stream` operations to the content stream and disposes both the inner stream and the owning `HttpResponseMessage` when disposed. 
- Routed `DownloadFile` through an `internal` overload that accepts an `HttpClient` and uses the streaming `RequestStream` so file downloads are written directly from the response stream. 
- Added `InternalsVisibleTo` for the test project to allow testing the `internal` helpers and added `DownKyi.Core.Tests/BiliApi/WebClientTests.cs` with tests that simulate responses without calling real Bilibili APIs. 

### Testing
- Ran automated tests with `PATH=/tmp/dotnet:$PATH dotnet test DownKyi.Core.Tests/DownKyi.Core.Tests.csproj` and the test run passed with `Passed: 38, Failed: 0`. 
- Also verified `dotnet test --no-restore --no-build` succeeded in the CI-style invocation. 
- Tests cover: readable streaming after `RequestStream` returns, that no eager buffering occurred before the caller reads, that disposing the returned stream disposes the underlying `HttpResponseMessage`, that unsuccessful status cases dispose the response, and that `DownloadFile` writes the response content to disk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ac996268c8330a0eaee8d863cc5fc)