### PR TITLE
Harden Bilibili buvid header compatibility

### DIFF
--- a/DownKyi.Core.Tests/BiliApi/WebClientTests.cs
+++ b/DownKyi.Core.Tests/BiliApi/WebClientTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using DownKyi.Core.BiliApi.Login;
+using DownKyi.Core.Storage;
 using Xunit;
 using BiliWebClient = DownKyi.Core.BiliApi.WebClient;
 
@@ -6,6 +8,119 @@ namespace DownKyi.Core.Tests.BiliApi;
 
 public class WebClientTests
 {
+    [Fact]
+    public void RequestWeb_SpiBuvidRequestIncludesUserAgentAndAcceptLanguage()
+    {
+        BiliWebClient.ResetBuvidForTests();
+        var handler = new CapturingHandler(_ => JsonResponse("{\"code\":0,\"data\":{\"b_3\":\"test-buvid3\",\"b_4\":\"test-buvid4\"}}"));
+        using var httpClient = new HttpClient(handler);
+
+        BiliWebClient.RequestWeb(httpClient, "https://api.bilibili.com/x/frontend/finger/spi");
+
+        var request = Assert.Single(handler.Requests);
+        Assert.True(request.Headers.UserAgent.Any());
+        Assert.Contains(request.Headers.GetValues("accept-language"), value => value.Contains("zh-CN"));
+    }
+
+    [Fact]
+    public void RequestWeb_NormalApiRequestIncludesBuvidCookiesAfterSpiResponse()
+    {
+        BiliWebClient.ResetBuvidForTests();
+        LoginHelper.SetLoginInfoCookiesForTests(null);
+        var handler = new CapturingHandler(request =>
+            request.RequestUri?.AbsoluteUri == "https://api.bilibili.com/x/frontend/finger/spi"
+                ? JsonResponse("{\"code\":0,\"data\":{\"b_3\":\"test-buvid3\",\"b_4\":\"test-buvid4\"}}")
+                : JsonResponse("{}"));
+        using var httpClient = new HttpClient(handler);
+
+        BiliWebClient.RequestWeb(httpClient, "https://api.bilibili.com/x/web-interface/nav");
+        Assert.Equal(2, handler.Requests.Count);
+        var cookie = Assert.Single(handler.Requests[1].Headers.GetValues("cookie"));
+        Assert.Contains("buvid3=test-buvid3", cookie);
+        Assert.Contains("buvid4=test-buvid4", cookie);
+        Assert.Equal("https://www.bilibili.com", Assert.Single(handler.Requests[1].Headers.GetValues("origin")));
+    }
+
+    [Fact]
+    public void RequestWeb_NormalApiRequestKeepsLoginCookiesWithBuvidCookies()
+    {
+        BiliWebClient.ResetBuvidForTests();
+        LoginHelper.SetLoginInfoCookiesForTests(null);
+
+        try
+        {
+            LoginHelper.SetLoginInfoCookiesForTests(new List<DownKyiCookie>
+            {
+                new("SESSDATA", "fake-session", ".bilibili.com"),
+                new("bili_jct", "fake-jct", ".bilibili.com")
+            });
+
+            var handler = new CapturingHandler(request =>
+                request.RequestUri?.AbsoluteUri == "https://api.bilibili.com/x/frontend/finger/spi"
+                    ? JsonResponse("{\"code\":0,\"data\":{\"b_3\":\"test-buvid3\",\"b_4\":\"test-buvid4\"}}")
+                    : JsonResponse("{}"));
+            using var httpClient = new HttpClient(handler);
+
+            BiliWebClient.RequestWeb(httpClient, "https://api.bilibili.com/x/web-interface/nav");
+            var cookie = Assert.Single(handler.Requests[1].Headers.GetValues("cookie"));
+            Assert.Contains("SESSDATA=fake-session", cookie);
+            Assert.Contains("bili_jct=fake-jct", cookie);
+            Assert.Contains("buvid3=test-buvid3", cookie);
+            Assert.Contains("buvid4=test-buvid4", cookie);
+        }
+        finally
+        {
+            LoginHelper.SetLoginInfoCookiesForTests(null);
+        }
+    }
+
+    [Fact]
+    public void RequestWeb_GetLoginUrlDoesNotReceiveCookieOrOriginInjection()
+    {
+        BiliWebClient.ResetBuvidForTests();
+        LoginHelper.SetLoginInfoCookiesForTests(null);
+
+        try
+        {
+            LoginHelper.SetLoginInfoCookiesForTests(new List<DownKyiCookie>
+            {
+                new("SESSDATA", "fake-session", ".bilibili.com")
+            });
+
+            var handler = new CapturingHandler(_ => JsonResponse("{}"));
+            using var httpClient = new HttpClient(handler);
+
+            BiliWebClient.RequestWeb(httpClient, "https://example.test/getLogin");
+
+            var request = Assert.Single(handler.Requests);
+            Assert.False(request.Headers.Contains("cookie"));
+            Assert.False(request.Headers.Contains("origin"));
+        }
+        finally
+        {
+            LoginHelper.SetLoginInfoCookiesForTests(null);
+        }
+    }
+
+    [Fact]
+    public void RequestWeb_SpiFailureDoesNotPreventNormalRequestFallback()
+    {
+        BiliWebClient.ResetBuvidForTests();
+        LoginHelper.SetLoginInfoCookiesForTests(null);
+        var handler = new CapturingHandler(request =>
+            request.RequestUri?.AbsoluteUri == "https://api.bilibili.com/x/frontend/finger/spi"
+                ? new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("failure") }
+                : JsonResponse("normal-response"));
+        using var httpClient = new HttpClient(handler);
+
+        var response = BiliWebClient.RequestWeb(httpClient, "https://api.bilibili.com/x/web-interface/nav");
+        Assert.Equal("normal-response", response);
+        Assert.Equal(3, handler.Requests.Count);
+        Assert.Equal("https://api.bilibili.com/x/web-interface/nav", handler.Requests[2].RequestUri?.AbsoluteUri);
+        Assert.False(handler.Requests[2].Headers.Contains("cookie"));
+        Assert.Equal("https://www.bilibili.com", Assert.Single(handler.Requests[2].Headers.GetValues("origin")));
+    }
+
     [Fact]
     public void RequestStream_ReturnsReadableStreamThatRemainsValidAfterReturn()
     {
@@ -137,6 +252,51 @@ public class WebClientTests
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             return Task.FromResult(_response);
+        }
+    }
+
+
+    private static HttpResponseMessage JsonResponse(string content)
+    {
+        return new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(content)
+        };
+    }
+
+    private sealed class CapturingHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseFactory;
+
+        public CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage> responseFactory)
+        {
+            _responseFactory = responseFactory;
+        }
+
+        public List<HttpRequestMessage> Requests { get; } = new();
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(CloneRequest(request));
+            return _responseFactory(request);
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(CloneRequest(request));
+            return Task.FromResult(_responseFactory(request));
+        }
+
+        private static HttpRequestMessage CloneRequest(HttpRequestMessage request)
+        {
+            var clone = new HttpRequestMessage(request.Method, request.RequestUri);
+
+            foreach (var header in request.Headers)
+            {
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return clone;
         }
     }
 

--- a/DownKyi.Core/BiliApi/Login/LoginHelper.cs
+++ b/DownKyi.Core/BiliApi/Login/LoginHelper.cs
@@ -35,6 +35,22 @@ public static class LoginHelper
         }
     }
 
+    internal static void SetLoginInfoCookiesForTests(List<DownKyiCookie>? cookies)
+    {
+        CacheLock.EnterWriteLock();
+        try
+        {
+            _cachedCookies = cookies?.Select(cookie => new DownKyiCookie(cookie.Name, HttpUtility.UrlEncode(cookie.Value), cookie.Domain)).ToList();
+            _cachedCookieString = _cachedCookies is { Count: > 0 }
+                ? string.Join("; ", _cachedCookies.Select(item => $"{item.Name}={item.Value}"))
+                : "";
+        }
+        finally
+        {
+            CacheLock.ExitWriteLock();
+        }
+    }
+
     /// <summary>
     /// 保存登录的cookies到文件
     /// </summary>

--- a/DownKyi.Core/BiliApi/WebClient.cs
+++ b/DownKyi.Core/BiliApi/WebClient.cs
@@ -15,6 +15,11 @@ namespace DownKyi.Core.BiliApi;
 
 public static class WebClient
 {
+    private const string Tag = "WebClient";
+    private const string SpiUrl = "https://api.bilibili.com/x/frontend/finger/spi";
+    private const string BilibiliOrigin = "https://www.bilibili.com";
+    private const string AcceptLanguage = "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7";
+
     private static readonly HttpClient HttpClient;
     private static string? _bvuid3 = string.Empty;
     private static string? _bvuid4 = string.Empty;
@@ -57,8 +62,7 @@ public static class WebClient
         }
 
         HttpClient = new HttpClient(socketsHandler);
-        HttpClient.DefaultRequestHeaders.Add("User-Agent", SettingsManager.GetInstance().GetUserAgent());
-        HttpClient.DefaultRequestHeaders.Add("accept-language", "zh-CN,zh;q=0.9,en-US;q=0.8,en;q=0.7");
+        EnsureDefaultHeaders(HttpClient);
     }
 
     internal class SpiOrigin
@@ -74,16 +78,35 @@ public static class WebClient
         [JsonPropertyName("b_4")] public string? Bvuid4 { get; set; }
     }
 
-    private static void GetBuvid()
+    private static void GetBuvid(HttpClient httpClient)
     {
-        const string url = "https://api.bilibili.com/x/frontend/finger/spi";
-        var response = RequestWeb(url);
-        var spi = JsonSerializer.Deserialize<SpiOrigin>(response);
-        _bvuid3 = spi?.Data?.Bvuid3;
-        _bvuid4 = spi?.Data?.Bvuid4;
+        try
+        {
+            var response = RequestWeb(httpClient, SpiUrl);
+            if (string.IsNullOrWhiteSpace(response))
+            {
+                Console.PrintLine("GetBuvid()返回空响应");
+                LogManager.Error(Tag, "GetBuvid() returned an empty response.");
+                return;
+            }
+
+            var spi = JsonSerializer.Deserialize<SpiOrigin>(response);
+            _bvuid3 = spi?.Data?.Bvuid3;
+            _bvuid4 = spi?.Data?.Bvuid4;
+        }
+        catch (Exception e)
+        {
+            Console.PrintLine("GetBuvid()发生异常: {0}", e);
+            LogManager.Error(Tag, e);
+        }
     }
 
     public static string RequestWeb(string url, string? referer = null, string method = "GET", Dictionary<string, object?>? parameters = null, int retry = 2, bool json = false)
+    {
+        return RequestWeb(HttpClient, url, referer, method, parameters, retry, json);
+    }
+
+    internal static string RequestWeb(HttpClient httpClient, string url, string? referer = null, string method = "GET", Dictionary<string, object?>? parameters = null, int retry = 2, bool json = false)
     {
         if (retry <= 0)
         {
@@ -92,9 +115,11 @@ public static class WebClient
 
         try
         {
-            if (string.IsNullOrEmpty(_bvuid3) && url != "https://api.bilibili.com/x/frontend/finger/spi")
+            EnsureDefaultHeaders(httpClient);
+
+            if (string.IsNullOrEmpty(_bvuid3) && !IsSpiUrl(url) && !IsGetLoginUrl(url))
             {
-                GetBuvid();
+                GetBuvid(httpClient);
             }
 
             var request = new HttpRequestMessage(new HttpMethod(method), url);
@@ -104,11 +129,13 @@ public static class WebClient
                 request.Headers.Referrer = new Uri(referer);
             }
 
-            if (!url.Contains("getLogin"))
+            if (!IsGetLoginUrl(url))
             {
-                request.Headers.Add("origin", "https://www.bilibili.com");
+                request.Headers.Add("origin", BilibiliOrigin);
 
-                var cookies = LoginHelper.GetLoginInfoCookies();
+                var cookies = LoginHelper.GetLoginInfoCookies()
+                    .Select(item => new DownKyiCookie(item.Name, item.Value, item.Domain))
+                    .ToList();
 
                 if (!string.IsNullOrEmpty(_bvuid3))
                 {
@@ -144,7 +171,7 @@ public static class WebClient
                 request.RequestUri = new Uri(url);
             }
 
-            var response = HttpClient.Send(request);
+            var response = httpClient.Send(request);
             response.EnsureSuccessStatusCode();
 
             using var reader = new StreamReader(response.Content.ReadAsStream());
@@ -154,14 +181,43 @@ public static class WebClient
         {
             Console.PrintLine("RequestWeb()发生HTTP请求异常: {0}", e);
             LogManager.Error(e);
-            return RequestWeb(url, referer, method, parameters, retry - 1);
+            return RequestWeb(httpClient, url, referer, method, parameters, retry - 1, json);
         }
         catch (Exception e)
         {
             Console.PrintLine("RequestWeb()发生其他异常: {0}", e);
             LogManager.Error(e);
-            return RequestWeb(url, referer, method, parameters, retry - 1);
+            return RequestWeb(httpClient, url, referer, method, parameters, retry - 1, json);
         }
+    }
+
+    private static bool IsSpiUrl(string url)
+    {
+        return string.Equals(url, SpiUrl, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsGetLoginUrl(string url)
+    {
+        return url.Contains("getLogin", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static void EnsureDefaultHeaders(HttpClient httpClient)
+    {
+        if (!httpClient.DefaultRequestHeaders.UserAgent.Any())
+        {
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", SettingsManager.GetInstance().GetUserAgent());
+        }
+
+        if (!httpClient.DefaultRequestHeaders.AcceptLanguage.Any())
+        {
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("accept-language", AcceptLanguage);
+        }
+    }
+
+    internal static void ResetBuvidForTests()
+    {
+        _bvuid3 = string.Empty;
+        _bvuid4 = string.Empty;
     }
 
     public static void DownloadFile(string url, string destFile, string? referer = null)


### PR DESCRIPTION
### Motivation
- Preserve and harden compatibility for Bilibili-related requests around buvid acquisition, cookie injection, and request headers without rewiring the existing WebClient facade. 
- Ensure `getLogin` URLs are not contaminated by login/buvid cookies or origin injection and that SPI (buvid) failures are logged and do not break normal request flows. 

### Description
- Added a small internal seam to `WebClient` allowing an `HttpClient` to be passed to `RequestWeb` for testability and to scope default header application; introduced `EnsureDefaultHeaders` to consistently apply `User-Agent` and `accept-language`. (edited: `DownKyi.Core/BiliApi/WebClient.cs`) 
- Made buvid acquisition use the injected `HttpClient` with `GetBuvid(HttpClient)` and added logging on empty/failing SPI responses to preserve fallback behavior. (edited: `DownKyi.Core/BiliApi/WebClient.cs`) 
- Preserved previous cookie semantics by copying login cookies, appending `buvid3`/`buvid4` (URL-encoded) into the request cookie header without mutating the cached login cookie list, and ensured `origin` uses the expected Bilibili host; special-cased `getLogin` URLs to skip origin/cookie injection. (edited: `DownKyi.Core/BiliApi/WebClient.cs`) 
- Added minimal test seams: `WebClient.ResetBuvidForTests()` and `LoginHelper.SetLoginInfoCookiesForTests(...)` so unit tests can inject fake buvid/login state without touching real disk or credentials. (edited: `DownKyi.Core/BiliApi/WebClient.cs`, `DownKyi.Core/BiliApi/Login/LoginHelper.cs`) 
- Added focused unit tests that use a fake `HttpMessageHandler` to validate header and cookie behavior for SPI requests, normal API requests, `getLogin` exceptions, and SPI failure fallback. (added: `DownKyi.Core.Tests/BiliApi/WebClientTests.cs`) 

### Testing
- Added unit tests in `DownKyi.Core.Tests/BiliApi/WebClientTests.cs` covering: `RequestWeb_SpiBuvidRequestIncludesUserAgentAndAcceptLanguage`, `RequestWeb_NormalApiRequestIncludesBuvidCookiesAfterSpiResponse`, `RequestWeb_NormalApiRequestKeepsLoginCookiesWithBuvidCookies`, `RequestWeb_GetLoginUrlDoesNotReceiveCookieOrOriginInjection`, and `RequestWeb_SpiFailureDoesNotPreventNormalRequestFallback` (tests use fake `HttpMessageHandler`). 
- Test files were created and committed, however `dotnet` was not available in the execution environment so `dotnet restore`, `dotnet build`, and `dotnet test` could not be executed here (tests should be run in CI or a dev machine). 
- No existing behavior that is out of scope (retry counts, proxy behavior, login flow, UI, package versions) was changed and tests are designed to avoid calling real Bilibili endpoints or using real credentials.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0acf95c1d08330b43fa1e71a94fcf9)