### PR TITLE
fix: try built-in downloader backup urls

### DIFF
--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -342,14 +342,15 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
         foreach (var url in urls)
         {
             var downloader = downloading.DownloadService;
+            var isFinished = false;
             var isComplete = false;
             if (downloading.DownloadService == null)
             {
                 downloader = new Downloader.DownloadService(downloadOpt);
-                downloader.DownloadFileCompleted += (_, _) =>
+                downloader.DownloadFileCompleted += (_, args) =>
                 {
-                    if (!File.Exists(Path.Combine(path, localFileName))) return;
-                    isComplete = true;
+                    isComplete = !args.Cancelled && args.Error == null && File.Exists(Path.Combine(path, localFileName));
+                    isFinished = true;
                     downloading.DownloadService = null;
                 };
                 downloader.DownloadProgressChanged += (_, args) =>
@@ -378,7 +379,7 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
             }
 
             // 阻塞当前任务，监听暂停事件
-            while (!isComplete)
+            while (!isFinished)
             {
                 CancellationToken?.ThrowIfCancellationRequested();
                 switch (downloading.Downloading.DownloadStatus)
@@ -396,7 +397,10 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 Thread.Sleep(100);
             }
 
-            return isComplete;
+            if (isComplete)
+            {
+                return true;
+            }
         }
 
         return false;


### PR DESCRIPTION
### Motivation
- Fix DSA-05 where `DownloadByBuiltin()` returned after the first URL attempt which prevented backup URLs from being tried when the primary URL failed.

### Description
- Update `DownloadByBuiltin()` in `DownKyi/Services/Download/BuiltinDownloadService.cs` to track a finished attempt (`isFinished`) separately from a successful attempt (`isComplete`) and only return success when an attempted URL completes successfully.
- Make the completion callback evaluate `args.Cancelled` and `args.Error` and verify the downloaded file exists before treating the attempt as successful, and continue to the next URL when an attempt finishes but did not succeed.
- Preserve existing progress updates, pause/delete polling, temp file path and overall retry semantics driven by `SingleDownload()`; no public API or retry-count changes.

### Testing
- Ran `git diff --check` and repository checks with no issues reported and committed the change (`fix: try built-in downloader backup urls`).
- Attempted `dotnet restore` but `dotnet` is not available in the environment so full build/test could not be executed here.
- Note: this repository has no automated test project per `AGENTS.md`, so manual or CI build verification is recommended after this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b104a59ac833089dacda639db46f4)