### PR TITLE
fix: preserve recoverable files after ffmpeg mux failure

### DIFF
--- a/DownKyi.Core.Tests/FFMpeg/FFMpegTests.cs
+++ b/DownKyi.Core.Tests/FFMpeg/FFMpegTests.cs
@@ -1,3 +1,4 @@
+using Xunit;
 using FFMpegHelper = DownKyi.Core.FFMpeg.FFMpeg;
 
 namespace DownKyi.Core.Tests.FFMpeg;

--- a/DownKyi.Core.Tests/FFMpeg/FFMpegTests.cs
+++ b/DownKyi.Core.Tests/FFMpeg/FFMpegTests.cs
@@ -1,0 +1,53 @@
+using FFMpegHelper = DownKyi.Core.FFMpeg.FFMpeg;
+
+namespace DownKyi.Core.Tests.FFMpeg;
+
+public class FFMpegTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(Path.GetTempPath(), $"downkyi-ffmpeg-tests-{Guid.NewGuid():N}");
+
+    public FFMpegTests()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, true);
+        }
+    }
+
+    [Fact]
+    public void IsValidOutputFile_ReturnsFalse_WhenOutputIsMissing()
+    {
+        var output = Path.Combine(_tempDirectory, "missing.mp4");
+
+        var result = FFMpegHelper.IsValidOutputFile(output);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidOutputFile_ReturnsFalse_WhenOutputIsEmpty()
+    {
+        var output = Path.Combine(_tempDirectory, "empty.mp4");
+        File.WriteAllBytes(output, Array.Empty<byte>());
+
+        var result = FFMpegHelper.IsValidOutputFile(output);
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void IsValidOutputFile_ReturnsTrue_WhenOutputIsNonEmpty()
+    {
+        var output = Path.Combine(_tempDirectory, "valid.mp4");
+        File.WriteAllBytes(output, new byte[] { 1 });
+
+        var result = FFMpegHelper.IsValidOutputFile(output);
+
+        Assert.True(result);
+    }
+}

--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -226,7 +226,6 @@ public class FFMpeg
                 .ForceFormat("image2")
                 .WithVideoCodec("mjpeg")
             )
-            .NotifyOnError(x => Console.WriteLine(x))
             .ProcessAsynchronously(false);
         ms.Position = 0;
         return ms;

--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -1,5 +1,6 @@
-﻿using DownKyi.Core.Logging;
+using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
+using Console = DownKyi.Core.Utils.Debugging.Console;
 using FFMpegCore;
 using FFMpegCore.Enums;
 using FFMpegCore.Helpers;
@@ -10,7 +11,7 @@ namespace DownKyi.Core.FFMpeg;
 public class FFMpeg
 {
     private const string Tag = "FFmpegHelper";
-    private static readonly FFMpeg instance = new();
+    private static readonly Lazy<FFMpeg> InstanceValue = new(() => new FFMpeg());
 
     static FFMpeg()
     {
@@ -22,7 +23,7 @@ public class FFMpeg
         FFMpegHelper.VerifyFFMpegExists(GlobalFFOptions.Current);
     }
 
-    public static FFMpeg Instance => instance;
+    public static FFMpeg Instance => InstanceValue.Value;
 
     /// <summary>
     /// 合并音频和视频
@@ -32,50 +33,102 @@ public class FFMpeg
     /// <param name="destVideo"></param>
     public bool MergeVideo(string? audio, string? video, string destVideo)
     {
-        if (!File.Exists(audio) && !File.Exists(video)) return false;
-
-        var arguments = FFMpegArguments
-            .FromFileInput(audio)
-            .AddFileInput(video)
-            .OutputToFile(destVideo, true, options => options
-                .WithCustomArgument("-strict -2")
-                .WithAudioCodec("copy")
-                .WithVideoCodec("copy")
-                .ForceFormat("mp4")
-            );
-        if (audio == null || !File.Exists(audio))
+        var hasAudio = File.Exists(audio);
+        var hasVideo = File.Exists(video);
+        if (!hasAudio && !hasVideo)
         {
-            arguments = FFMpegArguments.FromFileInput(video).OutputToFile(
+            LogManager.Error(Tag, $"MergeVideo输入文件不存在，audio: {audio}, video: {video}, destVideo: {destVideo}");
+            return false;
+        }
+
+        FFMpegArgumentProcessor arguments;
+        if (hasAudio && hasVideo)
+        {
+            arguments = FFMpegArguments
+                .FromFileInput(audio!)
+                .AddFileInput(video!)
+                .OutputToFile(destVideo, true, options => options
+                    .WithCustomArgument("-strict -2")
+                    .WithAudioCodec("copy")
+                    .WithVideoCodec("copy")
+                    .ForceFormat("mp4")
+                );
+        }
+        else if (hasVideo)
+        {
+            arguments = FFMpegArguments.FromFileInput(video!).OutputToFile(
                 destVideo,
                 true,
                 options => options.WithCustomArgument("-strict -2").WithVideoCodec("copy").WithAudioCodec("copy").ForceFormat("mp4")
             );
         }
-        if (video == null || !File.Exists(video))
+        else if (SettingsManager.GetInstance().GetIsTranscodingAacToMp3() == AllowStatus.Yes)
         {
-            if (SettingsManager.GetInstance().GetIsTranscodingAacToMp3() == AllowStatus.Yes)
-            {
-                arguments = FFMpegArguments.FromFileInput(audio).OutputToFile(
-                    destVideo,
-                    true,
-                    options => options.WithCustomArgument("-strict -2").DisableChannel(Channel.Video).ForceFormat("mp3")
-                );
-            }
-            else
-            {
-                arguments = FFMpegArguments.FromFileInput(audio).OutputToFile(
-                    destVideo,
-                    true,
-                    options => options.WithCustomArgument("-strict -2").DisableChannel(Channel.Video).WithAudioCodec("copy")
-                );
-            }
+            arguments = FFMpegArguments.FromFileInput(audio!).OutputToFile(
+                destVideo,
+                true,
+                options => options.WithCustomArgument("-strict -2").DisableChannel(Channel.Video).ForceFormat("mp3")
+            );
+        }
+        else
+        {
+            arguments = FFMpegArguments.FromFileInput(audio!).OutputToFile(
+                destVideo,
+                true,
+                options => options.WithCustomArgument("-strict -2").DisableChannel(Channel.Video).WithAudioCodec("copy")
+            );
         }
 
         LogManager.Debug(Tag, arguments.Arguments);
 
-        arguments
-            .NotifyOnError(s => LogManager.Debug(Tag, s))
-            .ProcessSynchronously(false);
+        var processSuccess = false;
+        var success = false;
+        try
+        {
+            processSuccess = arguments
+                .NotifyOnError(s => LogManager.Debug(Tag, s))
+                .ProcessSynchronously(false);
+            success = processSuccess && IsValidOutputFile(destVideo);
+
+            if (!success)
+            {
+                LogManager.Error(Tag, $"MergeVideo混流失败，processSuccess: {processSuccess}, outputExists: {File.Exists(destVideo)}, outputLength: {GetFileLength(destVideo)}, audio: {audio}, video: {video}, destVideo: {destVideo}");
+            }
+        }
+        catch (Exception e)
+        {
+            Console.PrintLine("MergeVideo()发生异常: {0}", e);
+            LogManager.Error(Tag, e);
+            success = false;
+        }
+
+        if (!success)
+        {
+            LogManager.Debug(Tag, $"MergeVideo保留输入文件以便恢复，audio: {audio}, video: {video}, destVideo: {destVideo}");
+            return false;
+        }
+
+        DeleteMergeInputs(audio, video);
+        return true;
+    }
+
+    internal static bool IsValidOutputFile(string output)
+    {
+        if (!File.Exists(output))
+        {
+            return false;
+        }
+
+        return new FileInfo(output).Length > 0;
+    }
+
+    internal static long GetFileLength(string output)
+    {
+        return File.Exists(output) ? new FileInfo(output).Length : 0;
+    }
+
+    private static void DeleteMergeInputs(string? audio, string? video)
+    {
         try
         {
             if (audio != null)
@@ -90,11 +143,9 @@ public class FFMpeg
         }
         catch (IOException e)
         {
-            Console.WriteLine("MergeVideo()发生IO异常: {0}", e);
+            Console.PrintLine("MergeVideo()删除输入文件发生IO异常: {0}", e);
             LogManager.Error(Tag, e);
         }
-
-        return true;
     }
 
     /// <summary>

--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -226,6 +226,7 @@ public class FFMpeg
                 .ForceFormat("image2")
                 .WithVideoCodec("mjpeg")
             )
+            .NotifyOnError(x => LogManager.Debug(Tag, x))
             .ProcessAsynchronously(false);
         ms.Position = 0;
         return ms;

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
@@ -345,20 +345,22 @@ public abstract class DownloadService
         }
 
         // 合并音视频
-        FFMpeg.Instance.MergeVideo(audioUid, videoUid, finalFile);
+        var isMergeSuccess = FFMpeg.Instance.MergeVideo(audioUid, videoUid, finalFile);
 
         // 获取文件大小
-        if (File.Exists(finalFile))
+        if (isMergeSuccess && File.Exists(finalFile))
         {
             var info = new FileInfo(finalFile);
-            downloading.FileSize = Format.FormatFileSize(info.Length);
-        }
-        else
-        {
-            downloading.FileSize = Format.FormatFileSize(0);
+            if (info.Length > 0)
+            {
+                downloading.FileSize = Format.FormatFileSize(info.Length);
+                return finalFile;
+            }
         }
 
-        return finalFile;
+        downloading.FileSize = Format.FormatFileSize(0);
+        LogManager.Error(Tag, $"BaseMixedFlow混流失败或输出文件无效，audioUid: {audioUid}, videoUid: {videoUid}, finalFile: {finalFile}");
+        return string.Empty;
     }
 
 


### PR DESCRIPTION
### Motivation

- Address DSA-04 from the maintenance audit by preventing `FFMpeg.MergeVideo()` from deleting recovered temp audio/video files when mux fails or the final output is missing or empty.
- Ensure mux success is confirmed (process result + verified non-empty output) before removing inputs so users are not forced to redownload large media.
- Make `DownloadService.BaseMixedFlow()` treat failed or invalid muxes as failures so download state and size reporting remain correct.

### Description

- Changed `DownKyi.Core/FFMpeg/FFMpeg.cs` so `MergeVideo()` runs the FFmpeg arguments and only deletes input files after verifying success, where success requires the FFmpeg process result and `IsValidOutputFile(destVideo)` (file exists and length > 0). 
- Added helper methods `IsValidOutputFile(string)`, `GetFileLength(string)`, and `DeleteMergeInputs(string?, string?)`, improved error logging, and preserved input files on failure; also added a `Console` alias and switched the singleton to a `Lazy<FFMpeg>` initializer. 
- Updated `DownKyi/Services/Download/DownloadService.cs` `BaseMixedFlow()` to consume the boolean result from `MergeVideo()`, require a non-empty verified output before returning `finalFile`, set file size to zero and log on failure, and return `string.Empty` when mux fails. 
- Added focused unit tests `DownKyi.Core.Tests/FFMpeg/FFMpegTests.cs` that validate `IsValidOutputFile()` for missing, zero-byte, and non-empty files without invoking the real FFmpeg binary.

### Testing

- Added unit tests: `DownKyi.Core.Tests/FFMpeg/FFMpegTests.cs` that assert `IsValidOutputFile()` behavior for missing/empty/non-empty outputs and do not call FFmpeg.
- Commands attempted locally: `dotnet restore DownKyi.sln`, `dotnet build DownKyi.sln --configuration Release -p:ContinuousIntegrationBuild=true`, and `dotnet test DownKyi.Core.Tests/DownKyi.Core.Tests.csproj --configuration Release --collect:"XPlat Code Coverage"`, but they were not executed here because `dotnet` is not available in this container (`/bin/bash: line 1: dotnet: command not found`).
- Performed `git diff --check` which passed, created branch `fix/ffmpeg-preserve-inputs-on-mux-failure`, committed changes, and staged the new tests; CI (GitHub Actions) must be authoritative to run the full restore/build/test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b126aca508330a462c94e4068e929)