### PR TITLE
DSA-06: prevent FFmpeg merge from overwriting existing outputs

### DIFF
--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -47,7 +47,7 @@ public class FFMpeg
             arguments = FFMpegArguments
                 .FromFileInput(audio!)
                 .AddFileInput(video!)
-                .OutputToFile(destVideo, true, options => options
+                .OutputToFile(destVideo, false, options => options
                     .WithCustomArgument("-strict -2")
                     .WithAudioCodec("copy")
                     .WithVideoCodec("copy")
@@ -58,7 +58,7 @@ public class FFMpeg
         {
             arguments = FFMpegArguments.FromFileInput(video!).OutputToFile(
                 destVideo,
-                true,
+                false,
                 options => options.WithCustomArgument("-strict -2").WithVideoCodec("copy").WithAudioCodec("copy").ForceFormat("mp4")
             );
         }
@@ -66,7 +66,7 @@ public class FFMpeg
         {
             arguments = FFMpegArguments.FromFileInput(audio!).OutputToFile(
                 destVideo,
-                true,
+                false,
                 options => options.WithCustomArgument("-strict -2").DisableChannel(Channel.Video).ForceFormat("mp3")
             );
         }
@@ -74,7 +74,7 @@ public class FFMpeg
         {
             arguments = FFMpegArguments.FromFileInput(audio!).OutputToFile(
                 destVideo,
-                true,
+                false,
                 options => options.WithCustomArgument("-strict -2").DisableChannel(Channel.Video).WithAudioCodec("copy")
             );
         }

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -344,23 +344,49 @@ public abstract class DownloadService
                     : $"{downloading.DownloadBase.FilePath}.aac";
         }
 
+        var mergeOutputFile = GetSafeMergeOutputPath(finalFile);
+
         // 合并音视频
-        var isMergeSuccess = FFMpeg.Instance.MergeVideo(audioUid, videoUid, finalFile);
+        var isMergeSuccess = FFMpeg.Instance.MergeVideo(audioUid, videoUid, mergeOutputFile);
 
         // 获取文件大小
-        if (isMergeSuccess && File.Exists(finalFile))
+        if (isMergeSuccess && File.Exists(mergeOutputFile))
         {
-            var info = new FileInfo(finalFile);
+            var info = new FileInfo(mergeOutputFile);
             if (info.Length > 0)
             {
                 downloading.FileSize = Format.FormatFileSize(info.Length);
-                return finalFile;
+                return mergeOutputFile;
             }
         }
 
         downloading.FileSize = Format.FormatFileSize(0);
-        LogManager.Error(Tag, $"BaseMixedFlow混流失败或输出文件无效，audioUid: {audioUid}, videoUid: {videoUid}, finalFile: {finalFile}");
+        LogManager.Error(Tag, $"BaseMixedFlow混流失败或输出文件无效，audioUid: {audioUid}, videoUid: {videoUid}, finalFile: {mergeOutputFile}");
         return string.Empty;
+    }
+
+
+    private static string GetSafeMergeOutputPath(string finalFile)
+    {
+        if (!File.Exists(finalFile))
+        {
+            return finalFile;
+        }
+
+        var directory = Path.GetDirectoryName(finalFile);
+        var filenameWithoutExtension = Path.GetFileNameWithoutExtension(finalFile);
+        var extension = Path.GetExtension(finalFile);
+
+        for (var i = 1; i < int.MaxValue; i++)
+        {
+            var safeFile = Path.Combine(directory ?? string.Empty, $"{filenameWithoutExtension}_{i}{extension}");
+            if (!File.Exists(safeFile))
+            {
+                return safeFile;
+            }
+        }
+
+        return finalFile;
     }
 
 


### PR DESCRIPTION
### Motivation

- The FFmpeg merge path could call `OutputToFile(..., true, ...)`, which allows silent overwrite of an existing user file at the final output path and was flagged by the stability audit. 

### Description

- Changed all `OutputToFile(..., true, ...)` usages in `DownKyi.Core/FFMpeg/FFMpeg.cs` to `OutputToFile(..., false, ...)` so FFmpeg will not overwrite an existing destination file. 
- Added `GetSafeMergeOutputPath(string finalFile)` in `DownKyi/Services/Download/DownloadService.cs` to generate a non-conflicting filename by appending `_1`, `_2`, etc., when the target exists. 
- Updated `BaseMixedFlow()` to use the resolved `mergeOutputFile` for the mux operation and to validate/return the actual produced path on success while preserving input temp files unless the merge completes successfully. 
- Preserved existing mux options, retry behavior, and output validation semantics (`processSuccess && IsValidOutputFile(...)`) so zero-byte or missing outputs remain failures. 

### Testing

- There are no repository automated unit tests to run for this change (the project has no test projects). 
- Attempted `dotnet build` in this environment but it failed because the `dotnet` SDK is not available here, so a build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0beb42fd988330a25ffa14b7818bbc)