### PR TITLE
DSA-07: Harden built-in downloader cancellation cleanup behavior

### DIFF
--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -344,12 +344,14 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
             var downloader = downloading.DownloadService;
             var isFinished = false;
             var isComplete = false;
+            var isCancelled = false;
             if (downloading.DownloadService == null)
             {
                 downloader = new Downloader.DownloadService(downloadOpt);
                 downloader.DownloadFileCompleted += (_, args) =>
                 {
                     isComplete = !args.Cancelled && args.Error == null && File.Exists(Path.Combine(path, localFileName));
+                    isCancelled = args.Cancelled;
                     isFinished = true;
                     downloading.DownloadService = null;
                 };
@@ -378,23 +380,45 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 downloader?.Resume();
             }
 
-            // 阻塞当前任务，监听暂停事件
-            while (!isFinished)
+            try
             {
-                CancellationToken?.ThrowIfCancellationRequested();
-                switch (downloading.Downloading.DownloadStatus)
+                // 阻塞当前任务，监听暂停事件
+                while (!isFinished)
                 {
-                    case DownloadStatus.Pause:
-                        // 暂停下载
-                        downloader?.Pause();
-                        // 通知UI，并阻塞当前线程
-                        Pause(downloading);
-                        break;
-                    case DownloadStatus.Downloading:
-                        break;
+                    CancellationToken?.ThrowIfCancellationRequested();
+                    switch (downloading.Downloading.DownloadStatus)
+                    {
+                        case DownloadStatus.Pause:
+                            // 暂停下载
+                            downloader?.Pause();
+                            // 通知UI，并阻塞当前线程
+                            Pause(downloading);
+                            break;
+                        case DownloadStatus.Downloading:
+                            break;
+                    }
+
+                    Thread.Sleep(100);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                try
+                {
+                    downloader?.Pause();
+                }
+                catch (Exception)
+                {
+                    // 已忽略
                 }
 
-                Thread.Sleep(100);
+                downloading.DownloadService = null;
+                throw;
+            }
+
+            if (isCancelled)
+            {
+                throw new OperationCanceledException("Stop builtin downloader by user action");
             }
 
             if (isComplete)


### PR DESCRIPTION
### Motivation

- Distinguish user-driven cancellation (pause/cancel/delete) from ordinary URL failure so intentional stops are not misclassified as download failures. 
- Ensure built-in downloader exits immediately on user cancellation and does not continue trying backup URLs or trigger outer retry logic. 
- Avoid leaving stale in-memory `downloading.DownloadService` state after a user stop action.

### Description

- Track callback cancellation from the downloader by introducing an `isCancelled` flag set from `args.Cancelled` in the `DownloadFileCompleted` handler. 
- Wrap the wait loop in a `try/catch` and on `OperationCanceledException` attempt to pause the in-flight downloader, clear `downloading.DownloadService`, and rethrow to propagate cancellation upstream. 
- If `isCancelled` is observed after the download completes, throw an `OperationCanceledException` so user cancellations stop the builtin flow immediately and do not fall through to backup-URL failover. 
- Preserve existing URL-failure semantics so ordinary failures still iterate backup URLs and only return overall failure when all URLs are exhausted.

### Testing

- The repository contains no automated unit tests for downloader logic per `AGENTS.md`, so no test suite was run. 
- Attempted to run `dotnet build DownKyi/DownKyi.csproj -c Debug` but the environment lacks `dotnet` and the build could not be executed (`/bin/bash: dotnet: command not found`). 
- Changes were statically reviewed and committed locally with message `Fix builtin downloader cancellation flow handling`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0beee13c808330bb7454f73de97b7c)