### PR TITLE
DSA-01/DSA-02: marshal download progress updates to UI thread

### DIFF
--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -567,26 +567,29 @@ public class AriaDownloadService : DownloadService, IDownloadService
             percent = (float)completedLength / totalLength * 100;
         }
 
-        // 根据进度判断本次是否需要更新UI
-        if (Math.Abs(percent - video.Progress) < 0.01)
+        App.PropertyChangeAsync(() =>
         {
-            return;
-        }
+            // 根据进度判断本次是否需要更新UI
+            if (Math.Abs(percent - video.Progress) < 0.01)
+            {
+                return;
+            }
 
-        // 下载进度
-        video.Progress = percent;
+            // 下载进度
+            video.Progress = percent;
 
-        // 下载大小
-        video.DownloadingFileSize = Format.FormatFileSize(completedLength) + "/" + Format.FormatFileSize(totalLength);
+            // 下载大小
+            video.DownloadingFileSize = Format.FormatFileSize(completedLength) + "/" + Format.FormatFileSize(totalLength);
 
-        // 下载速度
-        video.SpeedDisplay = Format.FormatSpeed(speed);
+            // 下载速度
+            video.SpeedDisplay = Format.FormatSpeed(speed);
 
-        // 最大下载速度
-        if (video.Downloading.MaxSpeed < speed)
-        {
-            video.Downloading.MaxSpeed = speed;
-        }
+            // 最大下载速度
+            if (video.Downloading.MaxSpeed < speed)
+            {
+                video.Downloading.MaxSpeed = speed;
+            }
+        });
     }
 
     private void AriaDownloadFinish(bool isSuccess, string downloadPath, string gid, string msg)

--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -357,20 +357,23 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 };
                 downloader.DownloadProgressChanged += (_, args) =>
                 {
-                    // 下载进度百分比
-                    downloading.Progress = (float)args.ProgressPercentage;
-
-                    // 下载大小
-                    downloading.DownloadingFileSize = Format.FormatFileSize(args.ReceivedBytesSize) + "/" + Format.FormatFileSize(args.TotalBytesToReceive);
-
-                    // 下载速度
-                    var speed = (long)args.BytesPerSecondSpeed;
-                    downloading.SpeedDisplay = Format.FormatSpeed(speed);
-                    // 最大下载速度
-                    if (downloading.Downloading.MaxSpeed < speed)
+                    App.PropertyChangeAsync(() =>
                     {
-                        downloading.Downloading.MaxSpeed = speed;
-                    }
+                        // 下载进度百分比
+                        downloading.Progress = (float)args.ProgressPercentage;
+
+                        // 下载大小
+                        downloading.DownloadingFileSize = Format.FormatFileSize(args.ReceivedBytesSize) + "/" + Format.FormatFileSize(args.TotalBytesToReceive);
+
+                        // 下载速度
+                        var speed = (long)args.BytesPerSecondSpeed;
+                        downloading.SpeedDisplay = Format.FormatSpeed(speed);
+                        // 最大下载速度
+                        if (downloading.Downloading.MaxSpeed < speed)
+                        {
+                            downloading.Downloading.MaxSpeed = speed;
+                        }
+                    });
                 };
                 downloading.DownloadService = downloader;
                 downloader.DownloadFileTaskAsync(url, Path.Combine(path, localFileName)).ConfigureAwait(false);


### PR DESCRIPTION
### Motivation
- Download progress and status callbacks were updating UI-bound `DownloadingItem` properties from background threads, which can cause Avalonia UI-thread violations and intermittent crashes.
- The change limits scope to UI-thread marshaling only and preserves existing download, retry, and cancellation semantics.

### Description
- Wrapped built-in downloader progress callback mutations in `App.PropertyChangeAsync(...)` inside `DownloadProgressChanged` to marshal updates for `Progress`, `DownloadingFileSize`, `SpeedDisplay`, and `Downloading.MaxSpeed` to the UI thread in `BuiltinDownloadService`.
- Wrapped Aria2 status-driven mutations in `App.PropertyChangeAsync(...)` inside `AriaTellStatus` to marshal updates for `Progress`, `DownloadingFileSize`, `SpeedDisplay`, and `Downloading.MaxSpeed` to the UI thread in `AriaDownloadService` while keeping the percent-threshold check semantics intact.
- No changes were made to progress calculation, retry behavior, cancellation behavior, temporary file handling, downloader selection, or UI layout.

### Testing
- Attempted to run `dotnet build DownKyi.sln -c Debug`, but the `dotnet` SDK is not available in this environment (`dotnet: command not found`).
- No repository unit tests exist per `AGENTS.md`, so no automated test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf1fa651083308b571d73ca52d06a)