### PR TITLE
Avoid blocking downloader callbacks on UI-thread progress updates

### DIFF
--- a/DownKyi/App.axaml.cs
+++ b/DownKyi/App.axaml.cs
@@ -197,6 +197,11 @@ public partial class App : PrismApplication
         Dispatcher.UIThread.Invoke(callback);
     }
 
+    public static void PropertyChangePost(Action callback)
+    {
+        Dispatcher.UIThread.Post(callback);
+    }
+
     /// <summary>
     /// 下载完成列表排序
     /// </summary>

--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -567,7 +567,7 @@ public class AriaDownloadService : DownloadService, IDownloadService
             percent = (float)completedLength / totalLength * 100;
         }
 
-        App.PropertyChangeAsync(() =>
+        App.PropertyChangePost(() =>
         {
             // 根据进度判断本次是否需要更新UI
             if (Math.Abs(percent - video.Progress) < 0.01)

--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -357,7 +357,7 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 };
                 downloader.DownloadProgressChanged += (_, args) =>
                 {
-                    App.PropertyChangeAsync(() =>
+                    App.PropertyChangePost(() =>
                     {
                         // 下载进度百分比
                         downloading.Progress = (float)args.ProgressPercentage;


### PR DESCRIPTION
### Motivation
- High-frequency downloader progress callbacks were synchronously marshaled via `App.PropertyChangeAsync(...)` which uses `Dispatcher.UIThread.Invoke(...)`, risking worker-side blocking when the UI thread is busy.
- The intent is to make progress/status UI updates non-blocking while preserving existing semantics for code paths that depend on synchronous UI dispatch.

### Description
- Add a non-blocking UI dispatch helper `App.PropertyChangePost(Action)` implemented with `Dispatcher.UIThread.Post(...)` and keep `App.PropertyChangeAsync(Action)` unchanged to avoid altering synchronous semantics elsewhere (`DownKyi/App.axaml.cs`).
- Replace high-frequency progress dispatches to use the non-blocking helper in the built-in downloader progress callback (`Downloader.DownloadProgressChanged`) in `DownKyi/Services/Download/BuiltinDownloadService.cs`.
- Replace Aria2 status progress updates (`AriaTellStatus`) to use the non-blocking helper in `DownKyi/Services/Download/AriaDownloadService.cs` while preserving the existing threshold check and field updates (`Progress`, `DownloadingFileSize`, `SpeedDisplay`, `Downloading.MaxSpeed`).

### Testing
- Attempted an automated build with `dotnet build`, but the environment lacks the .NET SDK and the command failed with `/bin/bash: line 1: dotnet: command not found`.
- The repository contains no automated unit tests per project documentation, so no CI/unit tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf3749f4c833082d666639074362e)