### PR TITLE
Add failure-context logging for DownloadFailed transitions

### DIFF
--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -859,6 +859,29 @@ public abstract class DownloadService
     /// <param name="downloading"></param>
     protected void DownloadFailed(DownloadingItem downloading)
     {
+        try
+        {
+            var downloadBase = downloading.DownloadBase;
+            var needDownloadContent = downloadBase?.NeedDownloadContent;
+
+            var videoRequested = needDownloadContent != null && needDownloadContent.TryGetValue("downloadVideo", out var downloadVideo) && downloadVideo;
+            var audioRequested = needDownloadContent != null && needDownloadContent.TryGetValue("downloadAudio", out var downloadAudio) && downloadAudio;
+            var danmakuRequested = needDownloadContent != null && needDownloadContent.TryGetValue("downloadDanmaku", out var downloadDanmaku) && downloadDanmaku;
+            var subtitleRequested = needDownloadContent != null && needDownloadContent.TryGetValue("downloadSubtitle", out var downloadSubtitle) && downloadSubtitle;
+            var coverRequested = needDownloadContent != null && needDownloadContent.TryGetValue("downloadCover", out var downloadCover) && downloadCover;
+
+            LogManager.Warning(Tag,
+                $"DownloadFailed context: title={downloadBase?.Name ?? NullMark}, bvid={downloadBase?.Bvid ?? NullMark}, avid={downloadBase?.Avid}, cid={downloadBase?.Cid}, " +
+                $"filePath={downloadBase?.FilePath ?? NullMark}, downloaderMode={GetType().Name}, status={downloading.Downloading.DownloadStatus}, " +
+                $"videoCodec={downloadBase?.VideoCodecName ?? NullMark}, videoResolution={downloadBase?.Resolution?.Name ?? NullMark}, audioCodec={downloadBase?.AudioCodec?.Name ?? NullMark}, " +
+                $"needVideo={videoRequested}, needAudio={audioRequested}, needDanmaku={danmakuRequested}, needSubtitle={subtitleRequested}, needCover={coverRequested}");
+        }
+        catch (Exception e)
+        {
+            Console.PrintLine("DownloadFailed记录失败上下文发生异常: {0}", e);
+            LogManager.Error(Tag, e);
+        }
+
         downloading.DownloadStatusTitle = DictionaryResource.GetString("DownloadFailed");
         downloading.DownloadContent = string.Empty;
         downloading.DownloadingFileSize = string.Empty;

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -870,7 +870,7 @@ public abstract class DownloadService
             var subtitleRequested = needDownloadContent != null && needDownloadContent.TryGetValue("downloadSubtitle", out var downloadSubtitle) && downloadSubtitle;
             var coverRequested = needDownloadContent != null && needDownloadContent.TryGetValue("downloadCover", out var downloadCover) && downloadCover;
 
-            LogManager.Warning(Tag,
+            LogManager.Error(Tag,
                 $"DownloadFailed context: title={downloadBase?.Name ?? NullMark}, bvid={downloadBase?.Bvid ?? NullMark}, avid={downloadBase?.Avid}, cid={downloadBase?.Cid}, " +
                 $"filePath={downloadBase?.FilePath ?? NullMark}, downloaderMode={GetType().Name}, status={downloading.Downloading.DownloadStatus}, " +
                 $"videoCodec={downloadBase?.VideoCodecName ?? NullMark}, videoResolution={downloadBase?.Resolution?.Name ?? NullMark}, audioCodec={downloadBase?.AudioCodec?.Name ?? NullMark}, " +


### PR DESCRIPTION
### Motivation
- Improve diagnosability of download failures by recording contextual, non-sensitive metadata when a download enters the failed state, addressing DSA-14 from the stability audit.

### Description
- Add a defensive logging block inside `DownloadFailed(DownloadingItem)` that emits a `LogManager.Warning` with safe fields (title, `Bvid`, `Avid`, `Cid`, target `FilePath`, downloader mode via `GetType().Name`, current status, selected codecs/resolution, and requested content flags for audio/video/danmaku/subtitle/cover) and wrap the block in a `try/catch` so logging errors do not alter runtime download behavior, while keeping all existing failure handling, retry, cancellation, UI, and storage behavior unchanged.

### Testing
- Attempted `dotnet build DownKyi/DownKyi.csproj -c Debug` but the environment does not have `dotnet` installed so no build or automated tests ran; the change was committed locally and PR metadata was created.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf58a12748330b75284be9decee54)