### PR TITLE
DSA-15: Log NFO generation failures instead of swallowing exceptions

### DIFF
--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -314,7 +314,8 @@ public abstract class DownloadService
         }
         catch (Exception e)
         {
-            /**/
+            Console.PrintLine($"{Tag}.GenerateNfoFile()发生异常: {0}", e);
+            LogManager.Error($"{Tag}.GenerateNfoFile()", e);
         }
     }
 


### PR DESCRIPTION
### Motivation
- Improve observability for NFO serialization/writing failures by removing the silent catch in `GenerateNfoFile` so failures are logged for diagnostics while remaining non-fatal (addresses DSA-15 in `docs/maintenance/download-service-stability-audit.md`).

### Description
- In `DownKyi/Services/Download/DownloadService.cs` replaced the empty `catch` in `GenerateNfoFile(DownloadingItem downloading)` with `Console.PrintLine(...)` and `LogManager.Error(...)` to surface exceptions without changing functional behavior. 

### Testing
- Attempted to run a build check with `dotnet build DownKyi.sln -c Debug`, but it failed in the environment due to `dotnet: command not found` (no further automated tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf81e67d08330be86be54a51f6fee)