### PR TITLE
docs(download): add aria2 completion logging and built-in downloader memory-budget comments

### DIFF
--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -594,6 +594,8 @@ public class AriaDownloadService : DownloadService, IDownloadService
 
     private void AriaDownloadFinish(bool isSuccess, string downloadPath, string gid, string msg)
     {
-        //throw new NotImplementedException();
+        // DSA-16: 保持运行时行为不变，仅补充完成事件诊断信息，便于排查aria2任务结束原因。
+        LogManager.Info(Tag, $"Aria download finish. success={isSuccess}, gid={gid}, path={downloadPath}, message={msg}");
+        Core.Utils.Debugging.Console.PrintLine("AriaDownloadFinish: success={0}, gid={1}, path={2}, message={3}", isSuccess, gid, downloadPath, msg);
     }
 }

--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -337,6 +337,9 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
             RequestConfiguration = requestConfiguration,
             ParallelDownload = true,
             ParallelCount = 2,
+            // DSA-17: 内建下载器每个活跃任务最多使用约50MiB内存缓冲。
+            // 总内存预算近似为: MaxCurrentDownloads * 50MiB + 其它进程开销。
+            // 该参数为既有运行时行为，当前仅补充容量规划注释，不调整数值。
             MaximumMemoryBufferBytes = 1024 * 1024 * 50
         };
         foreach (var url in urls)

--- a/docs/maintenance/download-service-stability-audit.md
+++ b/docs/maintenance/download-service-stability-audit.md
@@ -165,8 +165,8 @@ Findings:
 - `DownloadService.GenerateNfoFile()` swallows all exceptions with an empty `catch (Exception e) { /**/ }`, losing context. Severity: **P3**. Recommended fix: log NFO generation failures with video/path context. Safe as a small PR: **yes**.
 - `BaseDownloadAudio()` catches all exceptions for Dolby/Flac fallback and swallows them without comment-specific logging. Severity: **P3**. Recommended fix: add a comment explaining intentionally ignored missing optional audio variants or log at debug level. Safe as a small PR: **yes**.
 - `DownloadFailed()` updates UI state but does not log the video id/BVID, target path, download mode, phase, or exception. Severity: **P2**. Recommended fix: accept/record failure reason and log `{bvid,cid,path,mode,phase,exception}`. Safe as a small PR: **yes**.
-- `BuiltinDownloadService.DownloadByBuiltin()` progress/error context lacks the current URL index and local file path in logs. Severity: **P3**. Recommended fix: log selected URL host/index and temp path on failures. Safe as a small PR: **yes**.
-- `AriaDownloadService.DownloadByAria()` and `AriaManager.GetDownloadStatus()` log some aria2 errors, but `AriaDownloadFinish()` is empty and does not record success/failure details. Severity: **P3**. Recommended fix: either remove unused event subscription or log completion details including GID/path. Safe as a small PR: **yes**.
+- `BuiltinDownloadService.DownloadByBuiltin()` progress/error context lacks the current URL index and local file path in logs. Severity: **P3**. Recommended fix remains: log selected URL host/index and temp path on failures. Safe as a small PR: **yes**.
+- `AriaDownloadService.DownloadByAria()` and `AriaManager.GetDownloadStatus()` log some aria2 errors; completion-path diagnostics are now covered by `AriaDownloadFinish()` logging of success/failure context (GID/path/message). Severity after follow-up: **closed (diagnostics added)**.
 - FFmpeg logs stderr and arguments, but `BaseMixedFlow()` does not add video id/path/mode context around mux start/failure. Severity: **P2**. Recommended fix: log mux phase with input paths, output path, BVID/CID, and mode. Safe as a small PR: **yes**.
 
 ## 11. Risk table
@@ -188,8 +188,8 @@ Findings:
 | DSA-13 | P2 | FFmpeg robustness | `DownKyi.Core/FFMpeg/FFMpeg.cs` / `ConcatVideos()` | Temp concat list file can collide under concurrent concat operations in the same second. | List file name uses `flvlist_{DateTime.Now:yyyyMMddHHmmss}.txt`. | `fix: use unique concat list temp file names` |
 | DSA-14 | P2 | Diagnostics | `DownKyi/Services/Download/DownloadService.cs` / `DownloadFailed()` | Failure logs lack video id, path, mode, phase, and exception details. | `DownloadFailed()` does not log; callers often call it without a reason. | `fix: add contextual download failure logging` |
 | DSA-15 | P3 | Logging | `DownKyi/Services/Download/DownloadService.cs` / `GenerateNfoFile()` | NFO generation failures are silently swallowed. | Empty catch block contains only `/**/`. | `fix: log nfo generation failures` |
-| DSA-16 | P3 | Maintainability | `DownKyi/Services/Download/AriaDownloadService.cs` / `AriaDownloadFinish()` | Empty completion handler obscures intended aria2 diagnostics. | Handler is subscribed but body is empty. | `fix: log or remove unused aria2 finish handler` |
-| DSA-17 | P3 | Memory | `DownKyi/Services/Download/BuiltinDownloadService.cs` / `DownloadByBuiltin()` | Aggregate memory use scales with concurrent built-in downloads. | Per-download `MaximumMemoryBufferBytes` is 50 MiB. | `docs: document built-in downloader memory budget` |
+| DSA-16 | P3 | Maintainability | `DownKyi/Services/Download/AriaDownloadService.cs` / `AriaDownloadFinish()` | Completion diagnostics were missing and reduced operability in incident triage. | Handler subscription existed; follow-up now emits completion context logs (`success/gid/path/message`). | ✅ Completed in diagnostics-only follow-up PR (no runtime behavior change) |
+| DSA-17 | P3 | Memory | `DownKyi/Services/Download/BuiltinDownloadService.cs` / `DownloadByBuiltin()` | Aggregate memory use scales with concurrent built-in downloads. | Per-download `MaximumMemoryBufferBytes` is 50 MiB. | ✅ Completed as inline guardrail comments documenting memory budget formula (diagnostics-only) |
 
 ## 12. Follow-up PR plan
 

--- a/docs/maintenance/download-stability-fixes-summary.md
+++ b/docs/maintenance/download-stability-fixes-summary.md
@@ -15,6 +15,8 @@ Scope: documentation-only summary of completed work from PR #11 through PR #17.
 | DSA-06 | FFmpeg output overwrite safety | ✅ Completed | #13 | Final output overwrite behavior was hardened to avoid unsafe overwrite scenarios. |
 | DSA-07 | Built-in downloader cancellation cleanup | ✅ Completed | #14 | Cancellation path cleanup was hardened for built-in downloads. |
 | DSA-08 | aria2 cancellation cleanup | ✅ Completed | #15 | Cancellation path cleanup was hardened for aria2 downloads. |
+| DSA-16 | aria2 completion handler diagnosability cleanup | ✅ Completed | this PR | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
+| DSA-17 | built-in downloader memory-budget guardrail docs | ✅ Completed | this PR | Added inline comments documenting per-task memory budget and capacity planning formula. |
 
 Related follow-up hardening (not a separate DSA row in the original table):
 
@@ -80,8 +82,6 @@ The following audit items were not part of PR #11–#17 and should remain on the
 - DSA-13: unique concat-list temp naming for high concurrency.
 - DSA-14: richer failure-context logging in `DownloadFailed` paths.
 - DSA-15: remove silent swallow in NFO failure path (log with context).
-- DSA-16: aria2 completion handler diagnosability cleanup.
-- DSA-17: explicit documentation/guardrails for built-in downloader memory budget.
 
 ## 5) Maintainer notes
 


### PR DESCRIPTION
### Motivation

- Close two low-risk diagnosability items from the download stability audit by adding lightweight diagnostics and developer guardrail documentation without changing runtime behavior. 
- Specifically address DSA-16 (aria2 completion handler diagnosability) and DSA-17 (built-in downloader memory-budget documentation) to make incident triage and capacity planning clearer.

### Description

- Implemented completion-context logging in `AriaDownloadService.AriaDownloadFinish(...)` that records `success`, `gid`, `path`, and `message` via `LogManager.Info` and debug console printing, while keeping the handler behavior otherwise unchanged; file updated: `DownKyi/Services/Download/AriaDownloadService.cs`.
- Added inline guardrail comments next to `MaximumMemoryBufferBytes` in `BuiltinDownloadService.DownloadByBuiltin()` documenting the per-task ~50MiB buffer and an approximate total-memory planning formula, without changing the numeric value; file updated: `DownKyi/Services/Download/BuiltinDownloadService.cs`.
- Updated audit and summary docs to mark DSA-16 and DSA-17 as completed diagnostics-only follow-ups and to reflect the added notes; files updated: `docs/maintenance/download-service-stability-audit.md` and `docs/maintenance/download-stability-fixes-summary.md`.

### Testing

- No unit tests exist in this repository to run, and no automated test suite was executed for this diagnostics-only change. 
- An attempt to run `dotnet build -c Release` in the environment failed due to the `.NET SDK` being unavailable (`dotnet: command not found`).
- Verified the textual changes via repository search/inspection to confirm the new logging/comment lines and updated documentation files were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bf96afa2c8330ab0fb6c196995036)