### PR TITLE
DSA-09: Harden download output/temp path derivation guards

### DIFF
--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -261,7 +261,15 @@ public class FFMpeg
             LogManager.Debug(Tag, $"开始合并 {inputFlvs.Count} 个视频到 {outputVideo}");
 
 
-            var listFile = Path.Combine(Path.GetTempPath(), $"flvlist_{DateTime.Now:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}.txt");
+            var tempDirectory = Path.GetTempPath();
+            if (string.IsNullOrWhiteSpace(tempDirectory))
+            {
+                action?.Invoke("系统临时目录不可用");
+                LogManager.Error(Tag, "ConcatVideos失败，Path.GetTempPath()返回空");
+                return false;
+            }
+
+            var listFile = Path.Combine(tempDirectory, $"flvlist_{DateTime.Now:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}.txt");
             File.WriteAllLines(listFile, inputFlvs.Select(f => $"file '{f.Replace("'", "'\\''")}'"));
 
             FFMpegArguments

--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -97,10 +97,11 @@ public class AriaDownloadService : DownloadService, IDownloadService
         }
 
         // 路径
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath.Replace("\\", "/");
-        var temp = downloading.DownloadBase.FilePath.Split('/');
-        //string path = downloading.DownloadBase.FilePath.Replace(temp[temp.Length - 1], "");
-        var path = downloading.DownloadBase.FilePath.TrimEnd(temp[temp.Length - 1].ToCharArray());
+        if (!TryGetDownloadDirectory(downloading, out var path))
+        {
+            LogManager.Error(Tag, $"DownloadVideo解析下载目录失败，filePath: {downloading?.DownloadBase?.FilePath ?? NullMark}");
+            return NullMark;
+        }
 
         // 下载文件名
         var fileName = Guid.NewGuid().ToString("N");

--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -97,10 +97,12 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
         }
 
         // 路径
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath.Replace("\\", "/");
-        var temp = downloading.DownloadBase.FilePath.Split('/');
-        //string path = downloading.DownloadBase.FilePath.Replace(temp[temp.Length - 1], "");
-        var path = downloading.DownloadBase.FilePath.TrimEnd(temp[^1].ToCharArray());
+        if (!TryGetDownloadDirectory(downloading, out var path))
+        {
+            Console.PrintLine($"{Tag}.DownloadVideo()解析下载目录失败");
+            LogManager.Error(Tag, $"DownloadVideo解析下载目录失败，filePath: {downloading?.DownloadBase?.FilePath ?? NullMark}");
+            return NullMark;
+        }
 
         // 下载文件名
         var fileName = Guid.NewGuid().ToString("N");

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -409,7 +409,7 @@ public abstract class DownloadService
         var directory = Path.GetDirectoryName(finalFile);
         if (string.IsNullOrWhiteSpace(directory))
         {
-            LogManager.Error(Tag, $"GetSafeMergeOutputPath目录为空，保持原输出路径: {finalFile}");
+            LogManager.Error(nameof(DownloadService), $"GetSafeMergeOutputPath目录为空，保持原输出路径: {finalFile}");
             return finalFile;
         }
         var filenameWithoutExtension = Path.GetFileNameWithoutExtension(finalFile);

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -46,6 +46,38 @@ public abstract class DownloadService
 
     protected readonly DownloadStorageService DownloadStorageService = (DownloadStorageService)App.Current.Container.Resolve(typeof(DownloadStorageService));
 
+    protected bool TryGetDownloadDirectory(DownloadingItem downloading, out string directoryPath)
+    {
+        directoryPath = string.Empty;
+        var basePath = downloading?.DownloadBase?.FilePath;
+        if (string.IsNullOrWhiteSpace(basePath))
+        {
+            LogManager.Error(Tag, "TryGetDownloadDirectory失败，DownloadBase.FilePath为空");
+            return false;
+        }
+
+        var normalizedFilePath = basePath.Replace("\\", "/");
+        downloading.DownloadBase.FilePath = normalizedFilePath;
+
+        directoryPath = Path.GetDirectoryName(normalizedFilePath) ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            return true;
+        }
+
+        if (normalizedFilePath.EndsWith("/", StringComparison.Ordinal))
+        {
+            directoryPath = normalizedFilePath.TrimEnd('/');
+            if (!string.IsNullOrWhiteSpace(directoryPath))
+            {
+                return true;
+            }
+        }
+
+        LogManager.Error(Tag, $"TryGetDownloadDirectory失败，无法从FilePath解析目录: {normalizedFilePath}");
+        return false;
+    }
+
     /// <summary>
     /// 初始化
     /// </summary>
@@ -375,12 +407,17 @@ public abstract class DownloadService
         }
 
         var directory = Path.GetDirectoryName(finalFile);
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            LogManager.Error(Tag, $"GetSafeMergeOutputPath目录为空，保持原输出路径: {finalFile}");
+            return finalFile;
+        }
         var filenameWithoutExtension = Path.GetFileNameWithoutExtension(finalFile);
         var extension = Path.GetExtension(finalFile);
 
         for (var i = 1; i < int.MaxValue; i++)
         {
-            var safeFile = Path.Combine(directory ?? string.Empty, $"{filenameWithoutExtension}_{i}{extension}");
+            var safeFile = Path.Combine(directory, $"{filenameWithoutExtension}_{i}{extension}");
             if (!File.Exists(safeFile))
             {
                 return safeFile;
@@ -537,10 +574,15 @@ public abstract class DownloadService
     private async Task SingleDownload(DownloadingItem downloading)
     {
         // 路径
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath.Replace("\\", "/");
-        var temp = downloading.DownloadBase.FilePath.Split('/');
-        //string path = downloading.DownloadBase.FilePath.Replace(temp[temp.Length - 1], "");
-        var path = downloading.DownloadBase.FilePath.TrimEnd(temp[temp.Length - 1].ToCharArray());
+        if (!TryGetDownloadDirectory(downloading, out var path))
+        {
+            var filePathDisplay = downloading?.DownloadBase?.FilePath ?? NullMark;
+            Console.PrintLine($"{Tag}.SingleDownload()解析下载目录失败，filePath: {filePathDisplay}");
+            LogManager.Error(Tag, $"SingleDownload解析下载目录失败，filePath: {filePathDisplay}");
+            var alertService = new AlertService(DialogService);
+            await alertService.ShowError(DictionaryResource.GetString("DirectoryError"));
+            return;
+        }
 
         // 路径不存在则创建
         if (!Directory.Exists(path))


### PR DESCRIPTION
### Motivation
- Address DSA-09 audit finding that path helpers like `Path.GetDirectoryName(...)` and ad-hoc string trimming can return null/empty and lead to unsafe path derivation. 
- Add narrow, defensive guards so invalid or missing `DownloadBase.FilePath` values fail safely instead of producing unexpected file operations or throwing. 
- Preserve existing output naming, retry, cancellation, and cleanup semantics while preventing user output from being redirected to unexpected locations.

### Description
- Added `TryGetDownloadDirectory(DownloadingItem, out string)` to `DownKyi/Services/Download/DownloadService.cs` to normalize `FilePath`, derive a parent directory safely, and log/fail when derivation is not possible. 
- Replaced ad-hoc `Replace/TrimEnd/Split` directory derivation in `BuiltinDownloadService` and `AriaDownloadService` with calls to `TryGetDownloadDirectory(...)` and return the existing failure marker (`NullMark`) when derivation fails. 
- Updated `SingleDownload(...)` in `DownloadService` to use `TryGetDownloadDirectory(...)` and show a user-facing directory error dialog plus logging when the download directory cannot be resolved. 
- Hardened merge/duplicate-name logic in `GetSafeMergeOutputPath(...)` to avoid composing paths with an empty directory and log+keep original path if the parent directory cannot be determined. 
- Added a temp-path availability guard in `DownKyi.Core/FFMpeg/FFMpeg.cs::ConcatVideos` that logs and fails safely if `Path.GetTempPath()` returns empty, otherwise creating the concat list file in the temp directory as before. 
- Changes are intentionally minimal and defensive; normal valid `FilePath` behavior, naming, retry, cancellation, and cleanup remain unchanged and unchanged code paths are preserved.

### Testing
- Repository contains no automated unit tests per project documentation, so no `dotnet test` was run. 
- Attempted to run a release build with `dotnet build -c Release`, but the environment does not have the .NET SDK installed so the build could not be executed (`dotnet: command not found`). 
- Verified modified call sites and behavior locally in the patch by static inspection and small runtime guards; changes are limited and log on failure to aid diagnosis during runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfc1f9ff08330928370f86243425b)