### PR TITLE
Add robust path parsing for downloads and improve temp/merge path handling

### DIFF
--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -261,7 +261,15 @@ public class FFMpeg
             LogManager.Debug(Tag, $"开始合并 {inputFlvs.Count} 个视频到 {outputVideo}");
 
 
-            var listFile = Path.Combine(Path.GetTempPath(), $"flvlist_{DateTime.Now:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}.txt");
+            var tempDirectory = Path.GetTempPath();
+            if (string.IsNullOrWhiteSpace(tempDirectory))
+            {
+                action?.Invoke("系统临时目录不可用");
+                LogManager.Error(Tag, "ConcatVideos失败，Path.GetTempPath()返回空");
+                return false;
+            }
+
+            var listFile = Path.Combine(tempDirectory, $"flvlist_{DateTime.Now:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}.txt");
             File.WriteAllLines(listFile, inputFlvs.Select(f => $"file '{f.Replace("'", "'\\''")}'"));
 
             FFMpegArguments

--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -97,10 +97,11 @@ public class AriaDownloadService : DownloadService, IDownloadService
         }
 
         // 路径
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath.Replace("\\", "/");
-        var temp = downloading.DownloadBase.FilePath.Split('/');
-        //string path = downloading.DownloadBase.FilePath.Replace(temp[temp.Length - 1], "");
-        var path = downloading.DownloadBase.FilePath.TrimEnd(temp[temp.Length - 1].ToCharArray());
+        if (!TryGetDownloadDirectory(downloading, out var path))
+        {
+            LogManager.Error(Tag, $"DownloadVideo解析下载目录失败，filePath: {downloading?.DownloadBase?.FilePath ?? NullMark}");
+            return NullMark;
+        }
 
         // 下载文件名
         var fileName = Guid.NewGuid().ToString("N");

--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -97,10 +97,12 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
         }
 
         // 路径
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath.Replace("\\", "/");
-        var temp = downloading.DownloadBase.FilePath.Split('/');
-        //string path = downloading.DownloadBase.FilePath.Replace(temp[temp.Length - 1], "");
-        var path = downloading.DownloadBase.FilePath.TrimEnd(temp[^1].ToCharArray());
+        if (!TryGetDownloadDirectory(downloading, out var path))
+        {
+            Console.PrintLine($"{Tag}.DownloadVideo()解析下载目录失败");
+            LogManager.Error(Tag, $"DownloadVideo解析下载目录失败，filePath: {downloading?.DownloadBase?.FilePath ?? NullMark}");
+            return NullMark;
+        }
 
         // 下载文件名
         var fileName = Guid.NewGuid().ToString("N");

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -46,6 +46,38 @@ public abstract class DownloadService
 
     protected readonly DownloadStorageService DownloadStorageService = (DownloadStorageService)App.Current.Container.Resolve(typeof(DownloadStorageService));
 
+    protected bool TryGetDownloadDirectory(DownloadingItem downloading, out string directoryPath)
+    {
+        directoryPath = string.Empty;
+        var basePath = downloading?.DownloadBase?.FilePath;
+        if (string.IsNullOrWhiteSpace(basePath))
+        {
+            LogManager.Error(Tag, "TryGetDownloadDirectory失败，DownloadBase.FilePath为空");
+            return false;
+        }
+
+        var normalizedFilePath = basePath.Replace("\\", "/");
+        downloading.DownloadBase.FilePath = normalizedFilePath;
+
+        directoryPath = Path.GetDirectoryName(normalizedFilePath) ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(directoryPath))
+        {
+            return true;
+        }
+
+        if (normalizedFilePath.EndsWith("/", StringComparison.Ordinal))
+        {
+            directoryPath = normalizedFilePath.TrimEnd('/');
+            if (!string.IsNullOrWhiteSpace(directoryPath))
+            {
+                return true;
+            }
+        }
+
+        LogManager.Error(Tag, $"TryGetDownloadDirectory失败，无法从FilePath解析目录: {normalizedFilePath}");
+        return false;
+    }
+
     /// <summary>
     /// 初始化
     /// </summary>
@@ -375,12 +407,17 @@ public abstract class DownloadService
         }
 
         var directory = Path.GetDirectoryName(finalFile);
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            LogManager.Error(nameof(DownloadService), $"GetSafeMergeOutputPath目录为空，保持原输出路径: {finalFile}");
+            return finalFile;
+        }
         var filenameWithoutExtension = Path.GetFileNameWithoutExtension(finalFile);
         var extension = Path.GetExtension(finalFile);
 
         for (var i = 1; i < int.MaxValue; i++)
         {
-            var safeFile = Path.Combine(directory ?? string.Empty, $"{filenameWithoutExtension}_{i}{extension}");
+            var safeFile = Path.Combine(directory, $"{filenameWithoutExtension}_{i}{extension}");
             if (!File.Exists(safeFile))
             {
                 return safeFile;
@@ -537,10 +574,15 @@ public abstract class DownloadService
     private async Task SingleDownload(DownloadingItem downloading)
     {
         // 路径
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath.Replace("\\", "/");
-        var temp = downloading.DownloadBase.FilePath.Split('/');
-        //string path = downloading.DownloadBase.FilePath.Replace(temp[temp.Length - 1], "");
-        var path = downloading.DownloadBase.FilePath.TrimEnd(temp[temp.Length - 1].ToCharArray());
+        if (!TryGetDownloadDirectory(downloading, out var path))
+        {
+            var filePathDisplay = downloading?.DownloadBase?.FilePath ?? NullMark;
+            Console.PrintLine($"{Tag}.SingleDownload()解析下载目录失败，filePath: {filePathDisplay}");
+            LogManager.Error(Tag, $"SingleDownload解析下载目录失败，filePath: {filePathDisplay}");
+            var alertService = new AlertService(DialogService);
+            await alertService.ShowError(DictionaryResource.GetString("DirectoryError"));
+            return;
+        }
 
         // 路径不存在则创建
         if (!Directory.Exists(path))


### PR DESCRIPTION
### Motivation

- Make download file path parsing reliable across different path formats and add centralized logic to avoid repeated brittle string manipulation. 
- Harden temporary file handling in `FFMpeg.ConcatVideos` and avoid unsafe behavior when system temp or output directories are not available. 

### Description

- Introduced `TryGetDownloadDirectory` in `DownloadService` to normalize `DownloadBase.FilePath` and return a directory path using `Path.GetDirectoryName` with fallbacks, and added logging on failure. 
- Replaced ad-hoc `FilePath` string manipulation with calls to `TryGetDownloadDirectory` in `AriaDownloadService`, `BuiltinDownloadService`, and `SingleDownload` to centralize parsing and error handling. 
- Updated `FFMpeg.ConcatVideos` to validate `Path.GetTempPath()` and log/return on failure, and to build the list file path using the validated temp directory. 
- Guarded `GetSafeMergeOutputPath` against empty directory names and simplified the safe file name generation to avoid `null` directory usage. 
- Added error logging, `Console` output, and a user alert (via `AlertService`) when download directory parsing fails. 

### Testing

- Built the solution with `dotnet build` and the build completed successfully. 
- Ran the existing automated test suite with `dotnet test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0bfc1f9ff08330928370f86243425b)