### PR TITLE
DSA-10: restrict concat temp-segment cleanup to owned internal files

### DIFF
--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -441,6 +441,7 @@ public abstract class DownloadService
         {
             var info = new FileInfo(finalFile);
             downloading.FileSize = Format.FormatFileSize(info.Length);
+            CleanupOwnedConcatSegments(downloading, videoUids, finalFile);
         }
         else
         {
@@ -448,6 +449,76 @@ public abstract class DownloadService
         }
 
         return finalFile;
+    }
+
+    /// <summary>
+    /// 仅在concat成功且输出文件可用时，删除当前下载流程明确拥有的临时分段文件。
+    /// 任何归属不明确的输入文件一律保留，避免误删用户文件。
+    /// </summary>
+    private void CleanupOwnedConcatSegments(DownloadingItem downloading, List<string> inputSegments, string finalFile)
+    {
+        if (inputSegments == null || inputSegments.Count == 0)
+        {
+            return;
+        }
+
+        if (downloading?.Downloading?.DownloadFiles == null || downloading.DownloadBase?.FilePath == null)
+        {
+            LogManager.Debug(Tag, "CleanupOwnedConcatSegments跳过清理：上下文信息不足，无法确认文件归属");
+            return;
+        }
+
+        if (!TryGetDownloadDirectory(downloading, out var downloadDirectory))
+        {
+            LogManager.Debug(Tag, "CleanupOwnedConcatSegments跳过清理：下载目录解析失败");
+            return;
+        }
+
+        var ownedFileNames = new HashSet<string>(
+            downloading.Downloading.DownloadFiles.Values
+                .Where(x => !string.IsNullOrWhiteSpace(x)),
+            StringComparer.Ordinal);
+        var finalFileFullPath = Path.GetFullPath(finalFile);
+        var downloadDirectoryFullPath = Path.GetFullPath(downloadDirectory);
+
+        foreach (var segment in inputSegments.Where(x => !string.IsNullOrWhiteSpace(x)))
+        {
+            try
+            {
+                var segmentFullPath = Path.GetFullPath(segment);
+                if (string.Equals(segmentFullPath, finalFileFullPath, StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var fileName = Path.GetFileName(segmentFullPath);
+                var fileDirectory = Path.GetDirectoryName(segmentFullPath) ?? string.Empty;
+                var isUnderDownloadDirectory = string.Equals(
+                    Path.GetFullPath(fileDirectory),
+                    downloadDirectoryFullPath,
+                    StringComparison.Ordinal);
+
+                // 归属判定：
+                // 1) 文件名出现在本次任务的DownloadFiles记录中；
+                // 2) 文件位于当前任务下载目录下。
+                // 仅在同时满足时才删除，避免误删用户手动指定的源文件。
+                if (!ownedFileNames.Contains(fileName) || !isUnderDownloadDirectory)
+                {
+                    LogManager.Debug(Tag, $"CleanupOwnedConcatSegments保留未明确归属文件: {segmentFullPath}");
+                    continue;
+                }
+
+                if (File.Exists(segmentFullPath))
+                {
+                    File.Delete(segmentFullPath);
+                }
+            }
+            catch (Exception e)
+            {
+                LogManager.Error(Tag, e);
+                Console.PrintLine("CleanupOwnedConcatSegments发生异常: {0}", e);
+            }
+        }
     }
 
 


### PR DESCRIPTION
### Motivation
- Audit DSA-10 found concat temporary-segment cleanup behavior was unclear and risked deleting user files; the change documents and hardens deletion policy. 
- The goal is to only delete segments that are clearly owned by the current download flow and to preserve any file whose ownership is unclear or if concat failed.

### Description
- Call `CleanupOwnedConcatSegments(...)` from `DownloadService.ConcatVideos(...)` only after the concat output file exists. 
- Add `CleanupOwnedConcatSegments(DownloadingItem, List<string>, string)` which deletes inputs only when the segment filename appears in `downloading.Downloading.DownloadFiles` and the file is located under the resolved download directory. 
- The cleanup routine never targets the final output file, logs and preserves files when ownership or context is insufficient, and catches exceptions to avoid disrupting the flow. 
- No other behaviors were changed: FFmpeg concat arguments, retry/cancellation/output naming, downloader engines, and public APIs remain unchanged.

### Testing
- Attempted `dotnet build -c Release`, but the build could not be executed in this environment because `dotnet` is not installed (`dotnet: command not found`).
- The repository contains no automated unit tests (per project guidance), so no `dotnet test` was run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c04f1d178833098a8e60e6ea91720)