### PR TITLE
Fix built-in downloader resume branch completion state handling

### DIFF
--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -350,16 +350,13 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
             var isFinished = false;
             var isComplete = false;
             var isCancelled = false;
-            if (downloading.DownloadService == null)
+            EventHandler<DownloadFileCompletedArgs>? downloadFileCompletedHandler = null;
+            var isNewDownloader = false;
+
+            if (downloader == null)
             {
+                isNewDownloader = true;
                 downloader = new Downloader.DownloadService(downloadOpt);
-                downloader.DownloadFileCompleted += (_, args) =>
-                {
-                    isComplete = !args.Cancelled && args.Error == null && File.Exists(Path.Combine(path, localFileName));
-                    isCancelled = args.Cancelled;
-                    isFinished = true;
-                    downloading.DownloadService = null;
-                };
                 downloader.DownloadProgressChanged += (_, args) =>
                 {
                     App.PropertyChangePost(() =>
@@ -381,6 +378,19 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                     });
                 };
                 downloading.DownloadService = downloader;
+            }
+
+            downloadFileCompletedHandler = (_, args) =>
+            {
+                isComplete = !args.Cancelled && args.Error == null && File.Exists(Path.Combine(path, localFileName));
+                isCancelled = args.Cancelled;
+                isFinished = true;
+                downloading.DownloadService = null;
+            };
+            downloader.DownloadFileCompleted += downloadFileCompletedHandler;
+
+            if (isNewDownloader)
+            {
                 downloader.DownloadFileTaskAsync(url, Path.Combine(path, localFileName)).ConfigureAwait(false);
             }
             else
@@ -426,13 +436,17 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
 
             if (isCancelled)
             {
+                downloader.DownloadFileCompleted -= downloadFileCompletedHandler;
                 throw new OperationCanceledException("Stop builtin downloader by user action");
             }
 
             if (isComplete)
             {
+                downloader.DownloadFileCompleted -= downloadFileCompletedHandler;
                 return true;
             }
+
+            downloader.DownloadFileCompleted -= downloadFileCompletedHandler;
         }
 
         return false;

--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.IO;
 using System.Net;
 using System.Threading;
@@ -350,7 +351,6 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
             var isFinished = false;
             var isComplete = false;
             var isCancelled = false;
-            EventHandler<DownloadFileCompletedArgs>? downloadFileCompletedHandler = null;
             var isNewDownloader = false;
 
             if (downloader == null)
@@ -380,26 +380,27 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 downloading.DownloadService = downloader;
             }
 
-            downloadFileCompletedHandler = (_, args) =>
+            void DownloadFileCompletedHandler(object? _, AsyncCompletedEventArgs args)
             {
                 isComplete = !args.Cancelled && args.Error == null && File.Exists(Path.Combine(path, localFileName));
                 isCancelled = args.Cancelled;
                 isFinished = true;
                 downloading.DownloadService = null;
-            };
-            downloader.DownloadFileCompleted += downloadFileCompletedHandler;
-
-            if (isNewDownloader)
-            {
-                downloader.DownloadFileTaskAsync(url, Path.Combine(path, localFileName)).ConfigureAwait(false);
-            }
-            else
-            {
-                downloader?.Resume();
             }
 
             try
             {
+                downloader.DownloadFileCompleted += DownloadFileCompletedHandler;
+
+                if (isNewDownloader)
+                {
+                    downloader.DownloadFileTaskAsync(url, Path.Combine(path, localFileName)).ConfigureAwait(false);
+                }
+                else
+                {
+                    downloader.Resume();
+                }
+
                 // 阻塞当前任务，监听暂停事件
                 while (!isFinished)
                 {
@@ -418,6 +419,16 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
 
                     Thread.Sleep(100);
                 }
+
+                if (isCancelled)
+                {
+                    throw new OperationCanceledException("Stop builtin downloader by user action");
+                }
+
+                if (isComplete)
+                {
+                    return true;
+                }
             }
             catch (OperationCanceledException)
             {
@@ -433,20 +444,10 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 downloading.DownloadService = null;
                 throw;
             }
-
-            if (isCancelled)
+            finally
             {
-                downloader.DownloadFileCompleted -= downloadFileCompletedHandler;
-                throw new OperationCanceledException("Stop builtin downloader by user action");
+                downloader.DownloadFileCompleted -= DownloadFileCompletedHandler;
             }
-
-            if (isComplete)
-            {
-                downloader.DownloadFileCompleted -= downloadFileCompletedHandler;
-                return true;
-            }
-
-            downloader.DownloadFileCompleted -= downloadFileCompletedHandler;
         }
 
         return false;


### PR DESCRIPTION
### Motivation
- The resume branch in `DownloadByBuiltin(...)` could call `Resume()` on an existing `Downloader.DownloadService` without wiring a local completion handler, which risked the local wait loop never observing `isFinished` and hanging or misclassifying completion/cancellation. 
- The fix must be narrow and preserve all existing behaviors (fresh downloads, backup URL fallback, cancellation, progress, temp files, retry counts). 

### Description
- Attach a scoped `DownloadFileCompleted` handler before using `Resume()` so the current invocation updates its local flags `isFinished`, `isComplete`, and `isCancelled`. 
- Introduce an `isNewDownloader` flag to distinguish newly created downloaders from resumed ones and keep the original `DownloadFileTaskAsync(...)`/progress wiring for fresh downloads. 
- Ensure the scoped completion handler is unsubscribed after each URL attempt including success and cancellation paths to avoid stale subscriptions. 

### Testing
- Attempted an automated build with `dotnet build`, which failed due to the environment lacking the `dotnet` SDK (`/bin/bash: dotnet: command not found`).
- No other automated tests exist in the repository and no further automated checks were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c07d723288330a8a65afea8a6c2ab)