### PR TITLE
Reduce synchronous waits in Aria2 cleanup path

### DIFF
--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -316,7 +316,7 @@ public class AriaDownloadService : DownloadService, IDownloadService
         }
         else
         {
-            _ = CleanupAriaTaskAsync(downloading, true, true);
+            StartRemoveAriaTaskCleanup(downloading, true);
 
             return Task.FromResult(false);
         }
@@ -479,7 +479,7 @@ public class AriaDownloadService : DownloadService, IDownloadService
                 switch (downloading.Downloading.DownloadStatus)
                 {
                     case DownloadStatus.Pause:
-                        _ = CleanupAriaTaskAsync(downloading, false, false);
+                        _ = CleanupAriaTaskAsync(downloading.Downloading.Gid, false, false);
                         // 通知UI，并阻塞当前线程
                         Pause(downloading);
                         break;
@@ -492,14 +492,14 @@ public class AriaDownloadService : DownloadService, IDownloadService
         {
             LogManager.Info(Tag, $"DownloadByAria cancelled, gid={downloading.Downloading.Gid}");
             Core.Utils.Debugging.Console.PrintLine("DownloadByAria取消下载: {0}", e.Message);
-            _ = CleanupAriaTaskAsync(downloading, false, false);
+            _ = CleanupAriaTaskAsync(downloading.Downloading.Gid, false, false);
             return DownloadResult.ABORT;
         }
         catch (Exception e)
         {
             LogManager.Error(Tag, e);
             Core.Utils.Debugging.Console.PrintLine("DownloadByAria发生异常: {0}", e);
-            _ = CleanupAriaTaskAsync(downloading, true, true);
+            StartRemoveAriaTaskCleanup(downloading, true);
             return DownloadResult.FAILED;
         }
     }
@@ -510,9 +510,15 @@ public class AriaDownloadService : DownloadService, IDownloadService
     /// <param name="downloading"></param>
     /// <param name="removeTask">是否删除任务</param>
     /// <param name="removeResult">是否删除任务结果</param>
-    private async Task CleanupAriaTaskAsync(DownloadingItem downloading, bool removeTask, bool removeResult)
+    private void StartRemoveAriaTaskCleanup(DownloadingItem downloading, bool removeResult)
     {
         var gid = downloading.Downloading.Gid;
+        downloading.Downloading.Gid = null;
+        _ = CleanupAriaTaskAsync(gid, true, removeResult);
+    }
+
+    private async Task CleanupAriaTaskAsync(string? gid, bool removeTask, bool removeResult)
+    {
         if (string.IsNullOrEmpty(gid))
         {
             return;
@@ -527,7 +533,6 @@ public class AriaDownloadService : DownloadService, IDownloadService
                 if (removeResult || ariaRemove == null || ariaRemove.Result == gid)
                 {
                     _ = await AriaClient.RemoveDownloadResultAsync(gid);
-                    downloading.Downloading.Gid = null;
                 }
             }
             else

--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -316,7 +316,7 @@ public class AriaDownloadService : DownloadService, IDownloadService
         }
         else
         {
-            CleanupAriaTask(downloading, true, true);
+            _ = CleanupAriaTaskAsync(downloading, true, true);
 
             return Task.FromResult(false);
         }
@@ -479,7 +479,7 @@ public class AriaDownloadService : DownloadService, IDownloadService
                 switch (downloading.Downloading.DownloadStatus)
                 {
                     case DownloadStatus.Pause:
-                        CleanupAriaTask(downloading, false, false);
+                        _ = CleanupAriaTaskAsync(downloading, false, false);
                         // 通知UI，并阻塞当前线程
                         Pause(downloading);
                         break;
@@ -492,14 +492,14 @@ public class AriaDownloadService : DownloadService, IDownloadService
         {
             LogManager.Info(Tag, $"DownloadByAria cancelled, gid={downloading.Downloading.Gid}");
             Core.Utils.Debugging.Console.PrintLine("DownloadByAria取消下载: {0}", e.Message);
-            CleanupAriaTask(downloading, false, false);
+            _ = CleanupAriaTaskAsync(downloading, false, false);
             return DownloadResult.ABORT;
         }
         catch (Exception e)
         {
             LogManager.Error(Tag, e);
             Core.Utils.Debugging.Console.PrintLine("DownloadByAria发生异常: {0}", e);
-            CleanupAriaTask(downloading, true, true);
+            _ = CleanupAriaTaskAsync(downloading, true, true);
             return DownloadResult.FAILED;
         }
     }
@@ -510,7 +510,7 @@ public class AriaDownloadService : DownloadService, IDownloadService
     /// <param name="downloading"></param>
     /// <param name="removeTask">是否删除任务</param>
     /// <param name="removeResult">是否删除任务结果</param>
-    private void CleanupAriaTask(DownloadingItem downloading, bool removeTask, bool removeResult)
+    private async Task CleanupAriaTaskAsync(DownloadingItem downloading, bool removeTask, bool removeResult)
     {
         var gid = downloading.Downloading.Gid;
         if (string.IsNullOrEmpty(gid))
@@ -522,17 +522,17 @@ public class AriaDownloadService : DownloadService, IDownloadService
         {
             if (removeTask)
             {
-                _ = AriaClient.UnpauseAsync(gid).GetAwaiter().GetResult();
-                var ariaRemove = AriaClient.RemoveAsync(gid).GetAwaiter().GetResult();
+                _ = await AriaClient.UnpauseAsync(gid);
+                var ariaRemove = await AriaClient.RemoveAsync(gid);
                 if (removeResult || ariaRemove == null || ariaRemove.Result == gid)
                 {
-                    _ = AriaClient.RemoveDownloadResultAsync(gid).GetAwaiter().GetResult();
+                    _ = await AriaClient.RemoveDownloadResultAsync(gid);
                     downloading.Downloading.Gid = null;
                 }
             }
             else
             {
-                _ = AriaClient.PauseAsync(gid).GetAwaiter().GetResult();
+                _ = await AriaClient.PauseAsync(gid);
             }
         }
         catch (Exception e)


### PR DESCRIPTION
### Motivation
- The Aria2 cleanup path used synchronous waits on async RPC calls which can block the download worker and complicate cancellation/cleanup semantics. 
- The change aims to remove blocking waits in the cleanup path while keeping the existing best-effort cleanup behavior and minimal scope of changes.

### Description
- Converted the synchronous `CleanupAriaTask` into an asynchronous `CleanupAriaTaskAsync` method and updated its signature to return `Task` and use `await` for Aria RPC calls such as `UnpauseAsync`, `RemoveAsync`, `RemoveDownloadResultAsync`, and `PauseAsync`.
- Replaced blocking `.GetAwaiter().GetResult()` usages with `await` inside the new async method and replaced direct calls at call sites with fire-and-forget invocations using `_ = CleanupAriaTaskAsync(...)` so cleanup runs best-effort without synchronously blocking the caller.
- Kept existing logging and exception swallowing behavior in the cleanup path so failures remain non-fatal to the download worker and behavior remains unchanged from a user perspective.
- Changes are narrowly scoped to `DownKyi/Services/Download/AriaDownloadService.cs` and the existing Aria2 RPC usage and retry semantics were not modified.

### Testing
- Performed static checks with `rg` to confirm removal of `GetAwaiter().GetResult()`-style synchronous waits in the Aria2 cleanup path and that call sites now call `CleanupAriaTaskAsync` in a non-blocking way, and these checks succeeded. 
- Attempted to run `dotnet build` but it could not be executed in this environment because the .NET SDK is not available (`dotnet: command not found`).
Local dotnet was unavailable in the Codex environment. GitHub Actions PR Build passed and is the authoritative validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c0c2a9bf88330abf9bdcfc1f65f31)