### PR TITLE
Persist failed download state immediately on failure

### DIFF
--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -1005,6 +1005,16 @@ public abstract class DownloadService
         downloading.Downloading.DownloadStatus = DownloadStatus.DownloadFailed;
         downloading.StartOrPause = ButtonIcon.Instance().Retry;
         downloading.StartOrPause.Fill = DictionaryResource.GetColor("ColorPrimary");
+
+        try
+        {
+            DownloadStorageService.UpdateDownloading(downloading);
+        }
+        catch (Exception e)
+        {
+            Console.PrintLine("DownloadFailed持久化失败状态发生异常: {0}", e);
+            LogManager.Error(Tag, e);
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
### Motivation
- The download-service stability audit (DSA-11) found that when a download transitions to failed the in-memory status may be updated without immediately persisting to storage, risking lost or stale failed state after a crash or restart.

### Description
- Add an immediate persistence call `DownloadStorageService.UpdateDownloading(downloading)` in `DownloadService.DownloadFailed(...)` after existing in-memory failure/UI fields are set, and wrap it in a `try/catch` so storage errors are logged and do not crash the download worker.

### Testing
Local dotnet was unavailable in the Codex environment. GitHub Actions PR Build passed and is the authoritative validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c12139cd8833083cb8e6acd1601b4)