### PR TITLE
Snapshot mutable download file collections before persistence

### DIFF
--- a/DownKyi/Services/Download/DownloadStorageService.cs
+++ b/DownKyi/Services/Download/DownloadStorageService.cs
@@ -648,10 +648,13 @@ WHERE id = @id";
 
     private static void BindDownloading(SqliteCommand cmd, Downloading dl)
     {
+        var downloadFilesSnapshot = SnapshotDictionary(dl.DownloadFiles);
+        var downloadedFilesSnapshot = SnapshotList(dl.DownloadedFiles);
+
         cmd.Parameters.AddWithValue("@id", dl.Id);
         cmd.Parameters.AddWithValue("@gid", dl.Gid ?? (object)DBNull.Value);
-        cmd.Parameters.AddWithValue("@download_files", ToJson(dl.DownloadFiles));
-        cmd.Parameters.AddWithValue("@downloaded_files", ToJson(dl.DownloadedFiles));
+        cmd.Parameters.AddWithValue("@download_files", ToJson(downloadFilesSnapshot));
+        cmd.Parameters.AddWithValue("@downloaded_files", ToJson(downloadedFilesSnapshot));
         cmd.Parameters.AddWithValue("@play_stream_type", (int)dl.PlayStreamType);
         cmd.Parameters.AddWithValue("@download_status", (int)dl.DownloadStatus);
         cmd.Parameters.AddWithValue("@download_content", dl.DownloadContent ?? (object)DBNull.Value);
@@ -660,6 +663,46 @@ WHERE id = @id";
         cmd.Parameters.AddWithValue("@downloading_file_size", dl.DownloadingFileSize ?? (object)DBNull.Value);
         cmd.Parameters.AddWithValue("@max_speed", dl.MaxSpeed);
         cmd.Parameters.AddWithValue("@speed_display", dl.SpeedDisplay ?? (object)DBNull.Value);
+    }
+
+    private static Dictionary<string, string> SnapshotDictionary(Dictionary<string, string>? source)
+    {
+        if (source == null)
+        {
+            return new Dictionary<string, string>();
+        }
+
+        while (true)
+        {
+            try
+            {
+                return new Dictionary<string, string>(source);
+            }
+            catch (InvalidOperationException)
+            {
+                Thread.Yield();
+            }
+        }
+    }
+
+    private static List<string> SnapshotList(List<string>? source)
+    {
+        if (source == null)
+        {
+            return new List<string>();
+        }
+
+        while (true)
+        {
+            try
+            {
+                return new List<string>(source);
+            }
+            catch (InvalidOperationException)
+            {
+                Thread.Yield();
+            }
+        }
     }
 
     private static void BindDownloaded(SqliteCommand cmd, Downloaded d)

--- a/DownKyi/Services/Download/DownloadStorageService.cs
+++ b/DownKyi/Services/Download/DownloadStorageService.cs
@@ -20,6 +20,7 @@ namespace DownKyi.Services.Download;
 public class DownloadStorageService : IDisposable
 {
     private const string Tag = "DownloadStorageService";
+    private const int SnapshotRetryCount = 3;
     private readonly SqliteConnection _connection;
     private readonly object _lock = new();
     private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
@@ -672,17 +673,19 @@ WHERE id = @id";
             return new Dictionary<string, string>();
         }
 
-        while (true)
+        for (var attempt = 0; attempt < SnapshotRetryCount; attempt++)
         {
             try
             {
                 return new Dictionary<string, string>(source);
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException) when (attempt < SnapshotRetryCount - 1)
             {
                 Thread.Yield();
             }
         }
+
+        return new Dictionary<string, string>(source);
     }
 
     private static List<string> SnapshotList(List<string>? source)
@@ -692,17 +695,19 @@ WHERE id = @id";
             return new List<string>();
         }
 
-        while (true)
+        for (var attempt = 0; attempt < SnapshotRetryCount; attempt++)
         {
             try
             {
                 return new List<string>(source);
             }
-            catch (InvalidOperationException)
+            catch (InvalidOperationException) when (attempt < SnapshotRetryCount - 1)
             {
                 Thread.Yield();
             }
         }
+
+        return new List<string>(source);
     }
 
     private static void BindDownloaded(SqliteCommand cmd, Downloaded d)


### PR DESCRIPTION
### Motivation

- The download-service audit flagged that mutable collections (`DownloadFiles`, `DownloadedFiles`) may be serialized while being mutated, producing inconsistent persisted JSON or enumeration exceptions, so snapshots are needed before persistence while preserving existing behavior and schema.

### Description

- `DownloadStorageService.BindDownloading` now serializes `download_files` and `downloaded_files` from local snapshots instead of the live collections by calling `SnapshotDictionary` and `SnapshotList`.
- Added narrow helpers `SnapshotDictionary(Dictionary<string,string>?)` and `SnapshotList(List<string>?)` that retry on transient `InvalidOperationException` and use `Thread.Yield()` between attempts, avoiding broad locking or concurrency redesign.
- No database schema, JSON field names/shape, retry/cancellation logic, download flow, or UI behavior were changed.

### Testing
Local dotnet was unavailable in the Codex environment. GitHub Actions PR Build passed and is the authoritative validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1391ae408330a87fc9cafeae505b)