### PR TITLE
docs: mark DSA-11/DSA-12 completed and add DSA-03 ffmpeg mux cancellation plan

### DIFF
--- a/docs/maintenance/download-service-stability-audit.md
+++ b/docs/maintenance/download-service-stability-audit.md
@@ -185,42 +185,16 @@ Findings:
 | Aria2 cleanup blocking | P2 | Cleanup responsiveness | `DownKyi/Services/Download/AriaDownloadService.cs` / cleanup path | Aria2 cleanup path avoids synchronous waits and uses async best-effort cleanup. | Follow-up runtime fix completed in PR #28. | ✅ Completed in PR #28 |
 | DSA-09 | P2 | Path safety | `DownKyi/Services/Download/DownloadService.cs`, `DownKyi/Services/Download/BuiltinDownloadService.cs`, `DownKyi/Services/Download/AriaDownloadService.cs` / path derivation | Path parsing/derivation is centralized and guarded. | Follow-up runtime fix completed in PR #24. | ✅ Completed in PR #24 |
 | DSA-10 | P2 | Temp cleanup | `DownKyi.Core/FFMpeg/FFMpeg.cs` / `ConcatVideos()` | Successful concat temp-segment cleanup policy is clarified and guarded. | Follow-up runtime fix completed in PR #26. | ✅ Completed in PR #26 |
-| DSA-11 | P2 | Persistence | `DownKyi/Services/Download/DownloadService.cs` / `DownloadFailed()` | Failed status may not be persisted immediately. | `DownloadFailed()` updates in-memory fields but does not call `DownloadStorageService.UpdateDownloading()`. | `fix: persist failed download state immediately` |
-| DSA-12 | P2 | Concurrency | `DownKyi/Services/Download/DownloadService.cs` / `SingleDownload()` and storage calls | Per-item dictionaries/lists can be read for persistence while download task mutates them. | `DownloadFiles` and `DownloadedFiles` are mutable collections persisted as JSON. | `fix: snapshot download file maps before persistence` |
+| DSA-11 | P2 | Persistence | `DownKyi/Services/Download/DownloadService.cs` / `DownloadFailed()` | Failed status persistence is now immediate. | Follow-up runtime fix completed in PR #30. | ✅ Completed in PR #30 |
+| DSA-12 | P2 | Concurrency | `DownKyi/Services/Download/DownloadService.cs` / `SingleDownload()` and storage calls | Persistence now snapshots mutable per-item collections before serialization. | Follow-up runtime fix completed in PR #31. | ✅ Completed in PR #31 |
 | DSA-13 | P2 | FFmpeg robustness | `DownKyi.Core/FFMpeg/FFMpeg.cs` / `ConcatVideos()` | FFmpeg concat list temp filenames are collision-resistant. | Follow-up runtime fix completed in PR #22. | ✅ Completed in PR #22 |
 | DSA-14 | P2 | Diagnostics | `DownKyi/Services/Download/DownloadService.cs` / `DownloadFailed()` | Failure logging includes video id, path, mode, phase, and exception context. | Follow-up runtime fix completed in PR #19. | ✅ Completed in PR #19 |
 | DSA-15 | P3 | Logging | `DownKyi/Services/Download/DownloadService.cs` / `GenerateNfoFile()` | NFO generation failure path logs errors with context instead of silently swallowing. | Follow-up runtime fix completed in PR #20. | ✅ Completed in PR #20 |
 | DSA-16 | P3 | Maintainability | `DownKyi/Services/Download/AriaDownloadService.cs` / `AriaDownloadFinish()` | Completion diagnostics were missing and reduced operability in incident triage. | Handler subscription existed; follow-up now emits completion context logs (`success/gid/path/message`). | ✅ Completed in diagnostics-only follow-up PR (no runtime behavior change) |
 | DSA-17 | P3 | Memory | `DownKyi/Services/Download/BuiltinDownloadService.cs` / `DownloadByBuiltin()` | Aggregate memory use scales with concurrent built-in downloads. | Per-download `MaximumMemoryBufferBytes` is 50 MiB. | ✅ Completed as inline guardrail comments documenting memory budget formula (diagnostics-only) |
 
-## 12. Follow-up PR plan
+## 12. Remaining unresolved risk
 
-Recommended narrow PR order:
+- DSA-03: FFmpeg mux-phase cancellation support.
 
-1. `fix: marshal download progress updates to UI thread`
-   - Scope: `BuiltinDownloadService.DownloadByBuiltin()`, `AriaDownloadService.AriaTellStatus()`, and minimal shared helper if needed.
-   - Why first: reduces crash risk from worker-thread property notifications.
-
-2. `fix: harden download cancellation cleanup`
-   - Scope: make built-in and aria2 active transfers respond consistently to service cancellation, pause, and delete; no refactor beyond cancellation handling.
-   - Why second: cancellation brokenness is a common user-visible stability problem.
-
-3. `fix: preserve recoverable files after ffmpeg mux failure`
-   - Scope: `FFMpeg.MergeVideo()` success detection and input deletion timing; `BaseMixedFlow()` consumes result.
-   - Why third: prevents expensive redownloads and data loss during mux failures.
-
-4. `fix: try built-in downloader backup URLs before failing`
-   - Scope: `BuiltinDownloadService.DownloadByBuiltin()` URL loop only.
-   - Why fourth: improves common recovery without changing the overall pipeline.
-
-5. `fix: enforce explicit final output overwrite policy`
-   - Scope: pre-mux final file conflict checks for media and sidecars; no schema changes.
-   - Why fifth: prevents accidental overwrite/data loss.
-
-6. `fix: make aria2 and built-in downloader failure states consistent`
-   - Scope: map built-in, aria2, parse, and mux failures into a common logged failure reason and immediate persisted status.
-   - Why seventh: improves recoverability and user trust.
-
-7. `docs: document download failure recovery behavior`
-   - Scope: user/developer docs explaining which partial files are preserved, when retry resumes, and when delete removes temp data.
-   - Why ninth: should follow implementation of explicit policies.
+See `docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md` for the focused implementation plan for the future runtime PR.

--- a/docs/maintenance/download-stability-fixes-summary.md
+++ b/docs/maintenance/download-stability-fixes-summary.md
@@ -99,11 +99,11 @@ To keep the above fixes narrow and low-risk, the completed PRs intentionally did
 
 ## 4) Remaining risks and follow-up recommendations
 
-The following audit items were not part of the completed runtime-fix set through PR #28 and should remain on the follow-up list:
+The following audit items were not part of the completed runtime-fix set through PR #31 and should remain on the follow-up list:
 
 - DSA-03: FFmpeg mux-phase cancellation support.
 
 ## 5) Maintainer notes
 
-- Treat PR #11–#28 as the completed stability batches to date, covering fallback, cancellation cleanup, overwrite protection, thread-safe progress signaling, path safety, concat temp handling, resume-state handling, and aria2 cleanup responsiveness.
+- Treat PR #11–#31 as the completed stability batches to date, covering fallback, cancellation cleanup, overwrite protection, thread-safe progress signaling, path safety, concat temp handling, resume-state handling, aria2 cleanup responsiveness, and the DSA-11/DSA-12 persistence hardening updates.
 - For future stability work, prefer narrow PRs mapped 1:1 to remaining DSA items to keep rollback and verification simple.

--- a/docs/maintenance/download-stability-fixes-summary.md
+++ b/docs/maintenance/download-stability-fixes-summary.md
@@ -2,7 +2,7 @@
 
 This document summarizes the download-stability audit findings that have already been addressed and merged.
 
-Scope: documentation-only summary of completed work from PR #11 through PR #28.
+Scope: documentation-only summary of completed work from PR #11 through PR #31.
 
 ## 1) Completed findings map
 
@@ -20,6 +20,8 @@ Scope: documentation-only summary of completed work from PR #11 through PR #28.
 | DSA-15 | NFO failure-path logging hardening | ✅ Completed | #20 | NFO generation failure path no longer silently swallows errors. |
 | DSA-09 | Download path parsing hardening | ✅ Completed | #24 | Download path parsing is centralized and guarded. |
 | DSA-10 | Concat temp-segment cleanup policy hardening | ✅ Completed | #26 | Successful concat temp-segment cleanup policy is clarified and guarded. |
+| DSA-11 | Failed state persistence | ✅ Completed | #30 | `DownloadFailed(...)` now persists failed state immediately. |
+| DSA-12 | Persistence collection snapshots | ✅ Completed | #31 | `DownloadFiles` and `DownloadedFiles` are snapshotted before persistence serialization. |
 | Built-in resume branch | Resume-state handling for built-in downloader | ✅ Completed | #27 | Built-in downloader resume branch observes completion state. |
 | Aria2 cleanup blocking | Cleanup path async behavior | ✅ Completed | #28 | Aria2 cleanup no longer uses synchronous waits in the cleanup path. |
 | DSA-16 | aria2 completion handler diagnosability cleanup | ✅ Completed | this PR | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
@@ -28,6 +30,14 @@ Scope: documentation-only summary of completed work from PR #11 through PR #28.
 Related follow-up hardening (not a separate DSA row in the original table):
 
 - PR #17 prevents blocking downloader callbacks while still performing UI-thread marshaling for progress updates.
+
+
+## 1.1) Newly completed fixes since the last summary refresh
+
+| Audit ID | Area | PR | Status | Notes |
+|---|---|---|---|---|
+| DSA-11 | Failed state persistence | #30 | Completed | `DownloadFailed(...)` now persists failed state immediately. |
+| DSA-12 | Persistence collection snapshots | #31 | Completed | `DownloadFiles` and `DownloadedFiles` are snapshotted before persistence serialization. |
 
 ## 2) What changed (behavioral summary)
 
@@ -73,6 +83,8 @@ Related follow-up hardening (not a separate DSA row in the original table):
 - PR #26 completed DSA-10 by adding guarded cleanup for clearly owned concat temp segments after successful concat.
 - PR #27 hardened the built-in downloader resume branch so resumed downloads update local completion/cancellation state.
 - PR #28 reduced Aria2 cleanup blocking by replacing synchronous RPC waits with async best-effort cleanup while clearing stale gids for remove-task cleanup paths.
+- PR #30 completed DSA-11 by persisting failed download state immediately in `DownloadFailed(...)`.
+- PR #31 completed DSA-12 by snapshotting mutable per-item persistence collections before serialization.
 
 ## 3) What was intentionally **not** changed
 
@@ -90,8 +102,6 @@ To keep the above fixes narrow and low-risk, the completed PRs intentionally did
 The following audit items were not part of the completed runtime-fix set through PR #28 and should remain on the follow-up list:
 
 - DSA-03: FFmpeg mux-phase cancellation support.
-- DSA-11: immediate persistence of failed status.
-- DSA-12: snapshot/guard mutable per-item collections during persistence.
 
 ## 5) Maintainer notes
 

--- a/docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md
+++ b/docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md
@@ -1,0 +1,68 @@
+# DSA-03 FFmpeg mux-phase cancellation plan
+
+## Problem
+
+The download flow can enter FFmpeg mux/merge/concat phases after media download is complete. If the user cancels during mux, the current process may not propagate cancellation into the FFmpeg process lifecycle.
+
+## Risk
+
+- FFmpeg may continue running after user cancellation.
+- Temp files may be deleted or preserved inconsistently.
+- Final output may be partially written.
+- Failed/cancelled status classification may become ambiguous.
+- Killing FFmpeg incorrectly may corrupt recoverable temp inputs.
+
+## Required future behavior
+
+A future runtime PR should ensure:
+
+1. User cancellation during mux attempts to stop the active FFmpeg process.
+2. Cancelled mux should not be reported as successful completion.
+3. Recoverable audio/video temp inputs should be preserved on cancellation.
+4. Partial final output should not be treated as valid final output.
+5. Cancellation should remain distinct from ordinary failure.
+6. Existing mux success behavior should remain unchanged.
+7. Existing retry behavior should remain unchanged unless explicitly justified.
+
+## Implementation constraints for future PR
+
+The future runtime PR must not combine DSA-03 with:
+
+- package updates
+- path rewrite
+- retry redesign
+- Aria2 changes
+- built-in downloader changes
+- WebClient changes
+- UI redesign
+- database schema changes
+- nullable warning cleanup
+
+## Suggested future implementation strategy
+
+Recommend a narrow follow-up PR:
+
+```text
+fix: support cancellation during ffmpeg mux phase
+```
+
+Suggested strategy for that runtime-only PR:
+
+1. Introduce a small cancellation-aware mux execution wrapper in the FFmpeg integration boundary (not in downloader implementations).
+2. Thread the existing download cancellation token from `DownloadService.BaseMixedFlow()` / `ConcatVideos()` call sites into mux execution only.
+3. On cancellation request during mux, attempt graceful process termination first, then forceful kill if required by timeout policy.
+4. Return an explicit mux result classification (`Success`, `Cancelled`, `Failed`) so callers can map states without ambiguity.
+5. Treat `Cancelled` as a non-success terminal path and avoid success-side cleanup/status transitions.
+6. Preserve recoverable temp audio/video inputs on `Cancelled` and on non-success mux outcomes where retry is meaningful.
+7. Mark any partial final output as invalid (delete or quarantine consistently) before exiting cancellation flow.
+8. Add focused logging for mux start/stop/result classification and cancellation path decisions (without broad logging refactors).
+9. Verify no behavioral drift in existing successful mux and existing retry loops.
+
+## Validation checklist for future runtime PR
+
+- Cancel during long mux causes FFmpeg process to stop promptly.
+- UI/state ends as cancelled, not completed.
+- Temp inputs remain available for manual/automatic retry paths.
+- Partial final output is not treated as finished output.
+- Success path for non-cancelled mux remains unchanged.
+- No unrelated subsystem changes are included in the PR scope.


### PR DESCRIPTION
### Motivation

- Record that diagnostics fixes for DSA-11 and DSA-12 have been completed and remove them from the outstanding-risk list. 
- Keep the maintenance audit up-to-date so follow-up effort focuses on the remaining P1 mux cancellation risk (DSA-03). 
- Provide a focused, constrained implementation plan for DSA-03 to guide a future runtime-only PR without changing production code now.

### Description

- Update `docs/maintenance/download-stability-fixes-summary.md` to extend the coverage through PR `#31`, add completed rows for `DSA-11` (PR `#30`) and `DSA-12` (PR `#31`), and include a short "newly completed fixes" section. 
- Update `docs/maintenance/download-service-stability-audit.md` to mark `DSA-11` and `DSA-12` as completed in the risk table and remove them from the remaining follow-up plan, leaving only `DSA-03` as unresolved with a pointer to the new plan. 
- Add a new focused planning document `docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md` which states the problem and risks, enumerates required future behavior, prescribes implementation constraints, suggests a narrow implementation strategy (`fix: support cancellation during ffmpeg mux phase`), and provides a validation checklist for the future runtime PR. 
- This is a documentation-only change and intentionally avoids any runtime or production-code modifications.

### Testing

- No automated unit/integration tests exist for these documentation files; this change is docs-only. 
- Performed repository validations to confirm the three files were updated/added and that the diffs reflect the intended status and plan changes. 
- Created PR metadata describing the change so maintainers can review the docs-only update and proceed with a separate runtime PR for `DSA-03` when ready.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c179e333483309f3994391a013fb8)