### PR TITLE
fix: support cancellation during FFmpeg mux/concat phase

### DIFF
--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -106,7 +106,7 @@ public class FFMpeg
         }
         catch (OperationCanceledException)
         {
-            LogManager.Warning(Tag, $"MergeVideo已取消，audio: {audio}, video: {video}, destVideo: {destVideo}");
+            LogManager.Info(Tag, $"MergeVideo已取消，audio: {audio}, video: {video}, destVideo: {destVideo}");
             DeleteInvalidOutput(destVideo);
             return MuxResult.Cancelled;
         }
@@ -302,29 +302,35 @@ public class FFMpeg
             }
 
             var listFile = Path.Combine(tempDirectory, $"flvlist_{DateTime.Now:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}.txt");
-            File.WriteAllLines(listFile, inputFlvs.Select(f => $"file '{f.Replace("'", "'\\''")}'"));
+            try
+            {
+                File.WriteAllLines(listFile, inputFlvs.Select(f => $"file '{f.Replace("'", "'\\''")}'"));
 
-            FFMpegArguments
-             .FromFileInput(listFile, false, options => options
-                 .WithCustomArgument("-f concat -safe 0"))
-             .OutputToFile(outputVideo, true, options => options
-                 .WithVideoCodec("libx264")  
-                 .WithAudioCodec("aac")   
-                 .WithCustomArgument("-movflags +faststart")
-                 .WithCustomArgument("-avoid_negative_ts make_zero")
-             )
-             .NotifyOnOutput(action.Invoke)
-             .NotifyOnError(action.Invoke)
-             .CancellableThrough(cancellationToken)
-             .ProcessSynchronously(false);
+                FFMpegArguments
+                 .FromFileInput(listFile, false, options => options
+                     .WithCustomArgument("-f concat -safe 0"))
+                 .OutputToFile(outputVideo, true, options => options
+                     .WithVideoCodec("libx264")  
+                     .WithAudioCodec("aac")   
+                     .WithCustomArgument("-movflags +faststart")
+                     .WithCustomArgument("-avoid_negative_ts make_zero")
+                 )
+                 .NotifyOnOutput(action.Invoke)
+                 .NotifyOnError(action.Invoke)
+                 .CancellableThrough(cancellationToken)
+                 .ProcessSynchronously(false);
+            }
+            finally
+            {
+                try { File.Delete(listFile); } catch { /* 已忽略 */ }
+            }
 
-            try { File.Delete(listFile); } catch {  }
             LogManager.Debug(Tag, "视频合并完成");
             return MuxResult.Success;
         }
         catch (OperationCanceledException)
         {
-            LogManager.Warning(Tag, $"ConcatVideos已取消，outputVideo: {outputVideo}");
+            LogManager.Info(Tag, $"ConcatVideos已取消，outputVideo: {outputVideo}");
             DeleteInvalidOutput(outputVideo);
             return MuxResult.Cancelled;
         }

--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -10,6 +10,13 @@ namespace DownKyi.Core.FFMpeg;
 
 public class FFMpeg
 {
+    public enum MuxResult
+    {
+        Success,
+        Cancelled,
+        Failed
+    }
+
     private const string Tag = "FFmpegHelper";
     private static readonly Lazy<FFMpeg> InstanceValue = new(() => new FFMpeg());
 
@@ -31,14 +38,14 @@ public class FFMpeg
     /// <param name="audio">音频</param>
     /// <param name="video">视频</param>
     /// <param name="destVideo"></param>
-    public bool MergeVideo(string? audio, string? video, string destVideo)
+    public MuxResult MergeVideo(string? audio, string? video, string destVideo, CancellationToken cancellationToken = default)
     {
         var hasAudio = File.Exists(audio);
         var hasVideo = File.Exists(video);
         if (!hasAudio && !hasVideo)
         {
             LogManager.Error(Tag, $"MergeVideo输入文件不存在，audio: {audio}, video: {video}, destVideo: {destVideo}");
-            return false;
+            return MuxResult.Failed;
         }
 
         FFMpegArgumentProcessor arguments;
@@ -85,8 +92,10 @@ public class FFMpeg
         var success = false;
         try
         {
+            LogManager.Debug(Tag, $"MergeVideo开始，audio: {audio}, video: {video}, destVideo: {destVideo}");
             processSuccess = arguments
                 .NotifyOnError(s => LogManager.Debug(Tag, s))
+                .CancellableThrough(cancellationToken)
                 .ProcessSynchronously(false);
             success = processSuccess && IsValidOutputFile(destVideo);
 
@@ -94,6 +103,12 @@ public class FFMpeg
             {
                 LogManager.Error(Tag, $"MergeVideo混流失败，processSuccess: {processSuccess}, outputExists: {File.Exists(destVideo)}, outputLength: {GetFileLength(destVideo)}, audio: {audio}, video: {video}, destVideo: {destVideo}");
             }
+        }
+        catch (OperationCanceledException)
+        {
+            LogManager.Warning(Tag, $"MergeVideo已取消，audio: {audio}, video: {video}, destVideo: {destVideo}");
+            DeleteInvalidOutput(destVideo);
+            return MuxResult.Cancelled;
         }
         catch (Exception e)
         {
@@ -104,12 +119,13 @@ public class FFMpeg
 
         if (!success)
         {
+            DeleteInvalidOutput(destVideo);
             LogManager.Debug(Tag, $"MergeVideo保留输入文件以便恢复，audio: {audio}, video: {video}, destVideo: {destVideo}");
-            return false;
+            return MuxResult.Failed;
         }
 
         DeleteMergeInputs(audio, video);
-        return true;
+        return MuxResult.Success;
     }
 
     internal static bool IsValidOutputFile(string output)
@@ -125,6 +141,22 @@ public class FFMpeg
     internal static long GetFileLength(string output)
     {
         return File.Exists(output) ? new FileInfo(output).Length : 0;
+    }
+
+    private static void DeleteInvalidOutput(string output)
+    {
+        try
+        {
+            if (File.Exists(output))
+            {
+                File.Delete(output);
+            }
+        }
+        catch (IOException e)
+        {
+            Console.PrintLine("DeleteInvalidOutput()删除输出文件发生IO异常: {0}", e);
+            LogManager.Error(Tag, e);
+        }
     }
 
     private static void DeleteMergeInputs(string? audio, string? video)
@@ -239,13 +271,13 @@ public class FFMpeg
     /// <param name="outputVideo">输出视频路径</param>
     /// <param name="action">进度回调</param>
     /// <returns>是否成功</returns>
-    public bool ConcatVideos(List<string> inputFlvs, string outputVideo, Action<string> action)
+    public MuxResult ConcatVideos(List<string> inputFlvs, string outputVideo, Action<string> action, CancellationToken cancellationToken = default)
     {
         try
         {
             if (inputFlvs == null || inputFlvs.Count == 0)
             {
-                return false;
+                return MuxResult.Failed;
             }
 
             // 验证所有输入文件都存在
@@ -254,7 +286,7 @@ public class FFMpeg
                 if (!File.Exists(video))
                 {
                     action?.Invoke($"文件不存在: {video}");
-                    return false;
+                    return MuxResult.Failed;
                 }
             }
 
@@ -266,7 +298,7 @@ public class FFMpeg
             {
                 action?.Invoke("系统临时目录不可用");
                 LogManager.Error(Tag, "ConcatVideos失败，Path.GetTempPath()返回空");
-                return false;
+                return MuxResult.Failed;
             }
 
             var listFile = Path.Combine(tempDirectory, $"flvlist_{DateTime.Now:yyyyMMddHHmmssfff}_{Guid.NewGuid():N}.txt");
@@ -283,16 +315,24 @@ public class FFMpeg
              )
              .NotifyOnOutput(action.Invoke)
              .NotifyOnError(action.Invoke)
+             .CancellableThrough(cancellationToken)
              .ProcessSynchronously(false);
 
             try { File.Delete(listFile); } catch {  }
             LogManager.Debug(Tag, "视频合并完成");
-            return true;
+            return MuxResult.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            LogManager.Warning(Tag, $"ConcatVideos已取消，outputVideo: {outputVideo}");
+            DeleteInvalidOutput(outputVideo);
+            return MuxResult.Cancelled;
         }
         catch (Exception ex)
         {
+            DeleteInvalidOutput(outputVideo);
             LogManager.Error(Tag, ex);
-            return false;
+            return MuxResult.Failed;
         }
     }
 }

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -380,10 +380,16 @@ public abstract class DownloadService
         var mergeOutputFile = GetSafeMergeOutputPath(finalFile);
 
         // 合并音视频
-        var isMergeSuccess = FFMpeg.Instance.MergeVideo(audioUid, videoUid, mergeOutputFile);
+        var mergeResult = FFMpeg.Instance.MergeVideo(audioUid, videoUid, mergeOutputFile, CancellationToken ?? default);
+        if (mergeResult == FFMpeg.MuxResult.Cancelled)
+        {
+            downloading.FileSize = Format.FormatFileSize(0);
+            LogManager.Warning(Tag, $"BaseMixedFlow混流已取消，audioUid: {audioUid}, videoUid: {videoUid}, finalFile: {mergeOutputFile}");
+            return string.Empty;
+        }
 
         // 获取文件大小
-        if (isMergeSuccess && File.Exists(mergeOutputFile))
+        if (mergeResult == FFMpeg.MuxResult.Success && File.Exists(mergeOutputFile))
         {
             var info = new FileInfo(mergeOutputFile);
             if (info.Length > 0)
@@ -436,8 +442,8 @@ public abstract class DownloadService
         downloading.SpeedDisplay = string.Empty;
 
         var finalFile = $"{downloading.DownloadBase.FilePath}.mp4";
-        FFMpeg.Instance.ConcatVideos(videoUids, finalFile, (x) => { });
-        if (File.Exists(finalFile))
+        var concatResult = FFMpeg.Instance.ConcatVideos(videoUids, finalFile, (x) => { }, CancellationToken ?? default);
+        if (concatResult == FFMpeg.MuxResult.Success && File.Exists(finalFile))
         {
             var info = new FileInfo(finalFile);
             downloading.FileSize = Format.FormatFileSize(info.Length);
@@ -446,6 +452,10 @@ public abstract class DownloadService
         else
         {
             downloading.FileSize = Format.FormatFileSize(0);
+            if (concatResult == FFMpeg.MuxResult.Cancelled)
+            {
+                LogManager.Warning(Tag, $"ConcatVideos已取消，finalFile: {finalFile}");
+            }
         }
 
         return finalFile;

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -384,8 +384,8 @@ public abstract class DownloadService
         if (mergeResult == FFMpeg.MuxResult.Cancelled)
         {
             downloading.FileSize = Format.FormatFileSize(0);
-            LogManager.Warning(Tag, $"BaseMixedFlow混流已取消，audioUid: {audioUid}, videoUid: {videoUid}, finalFile: {mergeOutputFile}");
-            return string.Empty;
+            LogManager.Info(Tag, $"BaseMixedFlow混流已取消，audioUid: {audioUid}, videoUid: {videoUid}, finalFile: {mergeOutputFile}");
+            throw new OperationCanceledException("FFmpeg mux cancelled");
         }
 
         // 获取文件大小
@@ -443,6 +443,13 @@ public abstract class DownloadService
 
         var finalFile = $"{downloading.DownloadBase.FilePath}.mp4";
         var concatResult = FFMpeg.Instance.ConcatVideos(videoUids, finalFile, (x) => { }, CancellationToken ?? default);
+        if (concatResult == FFMpeg.MuxResult.Cancelled)
+        {
+            downloading.FileSize = Format.FormatFileSize(0);
+            LogManager.Info(Tag, $"ConcatVideos已取消，finalFile: {finalFile}");
+            throw new OperationCanceledException("FFmpeg concat cancelled");
+        }
+
         if (concatResult == FFMpeg.MuxResult.Success && File.Exists(finalFile))
         {
             var info = new FileInfo(finalFile);
@@ -452,10 +459,6 @@ public abstract class DownloadService
         else
         {
             downloading.FileSize = Format.FormatFileSize(0);
-            if (concatResult == FFMpeg.MuxResult.Cancelled)
-            {
-                LogManager.Warning(Tag, $"ConcatVideos已取消，finalFile: {finalFile}");
-            }
         }
 
         return finalFile;


### PR DESCRIPTION
### Motivation

- Prevent FFmpeg from continuing or leaving partial outputs when the user cancels during mux/merge/concat, and avoid ambiguous success classification.
- Preserve recoverable inputs on cancel/failure and ensure cancellation is distinct from ordinary failure.

### Description

- Add `MuxResult` enum (`Success`, `Cancelled`, `Failed`) and return it from `FFMpeg.MergeVideo(...)` and `FFMpeg.ConcatVideos(...)` instead of plain `bool` to make outcome explicit.
- Thread a `CancellationToken` into `MergeVideo` and `ConcatVideos` and call `.CancellableThrough(cancellationToken)` so FFmpeg execution observes cancellation, and map `OperationCanceledException` to `MuxResult.Cancelled`.
- Remove or quarantine partial final outputs on cancel/failure via a new `DeleteInvalidOutput(...)` helper, while preserving input files for retry/recovery on non-success outcomes.
- Update `DownloadService.BaseMixedFlow(...)` and `ConcatVideos(...)` caller sites to pass the service `CancellationToken`, treat `MuxResult.Cancelled` as a non-success terminal path, and log explicit cancellation without performing success-only cleanup.

### Testing

- Attempted automated build with `dotnet build`, but it could not run in this environment because the `dotnet` SDK is not available (`dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1b9de86c8330ba246ba4c39fd8a9)