### PR TITLE
docs: close DSA-03 and finalize download-stability audit through PR #33

### DIFF
--- a/docs/maintenance/download-service-stability-audit.md
+++ b/docs/maintenance/download-service-stability-audit.md
@@ -175,7 +175,7 @@ Findings:
 |---|---|---|---|---|---|---|
 | DSA-01 | P1 | UI thread safety | `DownKyi/Services/Download/BuiltinDownloadService.cs` / `DownloadByBuiltin()` | Progress updates can raise UI-bound property changes from downloader callback threads. | `DownloadProgressChanged` directly sets `downloading.Progress`, `DownloadingFileSize`, and `SpeedDisplay`. | `fix: marshal built-in download progress updates to UI thread` |
 | DSA-02 | P1 | UI thread safety | `DownKyi/Services/Download/AriaDownloadService.cs` / `AriaTellStatus()` | aria2 polling updates UI-bound properties from the download worker task. | `AriaManager.GetDownloadStatus()` invokes `TellStatus`; handler directly sets `video.Progress`, `DownloadingFileSize`, and `SpeedDisplay`. | `fix: marshal aria2 progress updates to UI thread` |
-| DSA-03 | P1 | Cancellation | `DownKyi.Core/FFMpeg/FFMpeg.cs` / `MergeVideo()` and `DownKyi/Services/Download/DownloadService.cs` / `BaseMixedFlow()` | FFmpeg mux cannot be canceled once started. | No cancellation token is accepted or checked by mux methods. | `fix: support cancellation around ffmpeg mux phase` |
+| DSA-03 | P1 | FFmpeg cancellation | `DownKyi.Core/FFMpeg/FFMpeg.cs`, `DownKyi/Services/Download/DownloadService.cs` / mux and concat phases | FFmpeg mux/concat cancellation is now observed and classified distinctly from failure/success. | Runtime fix completed in PR #33. | ✅ Completed in PR #33 |
 | DSA-04 | P1 | Failure recovery | `DownKyi.Core/FFMpeg/FFMpeg.cs` / `MergeVideo()` | Temp audio/video files can be deleted after FFmpeg failure, forcing large redownloads. | Inputs are deleted after `ProcessSynchronously(false)` without checking final output or process success. | `fix: preserve recoverable files after ffmpeg mux failure` |
 | DSA-05 | P1 | Retry | `DownKyi/Services/Download/BuiltinDownloadService.cs` / `DownloadByBuiltin()` | Backup URLs may not be attempted in built-in mode. | Method loops over `urls` but returns `isComplete` after the first iteration. | `fix: try built-in downloader backup URLs before failing` |
 | DSA-06 | P1 | Overwrite safety | `DownKyi.Core/FFMpeg/FFMpeg.cs` / `MergeVideo()` and `ConcatVideos()` | Final output can overwrite existing files. | `OutputToFile(..., true, ...)` enables overwrite; final pre-mux conflict check is absent. | `fix: enforce explicit final output overwrite policy` |
@@ -195,6 +195,6 @@ Findings:
 
 ## 12. Remaining unresolved risk
 
-- DSA-03: FFmpeg mux-phase cancellation support.
+None from the original DSA runtime-risk table.
 
-See `docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md` for the focused implementation plan for the future runtime PR.
+Closure note: the original DSA findings are now either completed in merged runtime PRs (including DSA-03 in PR #33) or explicitly tracked as non-runtime documentation/maintenance follow-ups where applicable.

--- a/docs/maintenance/download-stability-fixes-summary.md
+++ b/docs/maintenance/download-stability-fixes-summary.md
@@ -2,7 +2,7 @@
 
 This document summarizes the download-stability audit findings that have already been addressed and merged.
 
-Scope: documentation-only summary of completed work from PR #11 through PR #31.
+Scope: documentation-only summary of completed work from PR #11 through PR #33.
 
 ## 1) Completed findings map
 
@@ -24,8 +24,9 @@ Scope: documentation-only summary of completed work from PR #11 through PR #31.
 | DSA-12 | Persistence collection snapshots | ✅ Completed | #31 | `DownloadFiles` and `DownloadedFiles` are snapshotted before persistence serialization. |
 | Built-in resume branch | Resume-state handling for built-in downloader | ✅ Completed | #27 | Built-in downloader resume branch observes completion state. |
 | Aria2 cleanup blocking | Cleanup path async behavior | ✅ Completed | #28 | Aria2 cleanup no longer uses synchronous waits in the cleanup path. |
-| DSA-16 | aria2 completion handler diagnosability cleanup | ✅ Completed | this PR | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
-| DSA-17 | built-in downloader memory-budget guardrail docs | ✅ Completed | this PR | Added inline comments documenting per-task memory budget and capacity planning formula. |
+| DSA-16 | aria2 completion handler diagnosability cleanup | ✅ Completed | #32 | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
+| DSA-03 | FFmpeg mux-phase cancellation support | ✅ Completed | #33 | FFmpeg mux/concat phases now honor cancellation and classify cancelled outcomes distinctly from success/failure. |
+| DSA-17 | built-in downloader memory-budget guardrail docs | ✅ Completed | #32 | Added inline comments documenting per-task memory budget and capacity planning formula. |
 
 Related follow-up hardening (not a separate DSA row in the original table):
 
@@ -36,8 +37,9 @@ Related follow-up hardening (not a separate DSA row in the original table):
 
 | Audit ID | Area | PR | Status | Notes |
 |---|---|---|---|---|
-| DSA-11 | Failed state persistence | #30 | Completed | `DownloadFailed(...)` now persists failed state immediately. |
-| DSA-12 | Persistence collection snapshots | #31 | Completed | `DownloadFiles` and `DownloadedFiles` are snapshotted before persistence serialization. |
+| DSA-16 | aria2 completion handler diagnosability cleanup | #32 | Completed | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
+| DSA-17 | built-in downloader memory-budget guardrail docs | #32 | Completed | Added inline memory-budget guardrail comments for capacity planning. |
+| DSA-03 | FFmpeg mux-phase cancellation support | #33 | Completed | FFmpeg mux/concat phases now support cancellation classification distinct from failure/success. |
 
 ## 2) What changed (behavioral summary)
 
@@ -85,6 +87,7 @@ Related follow-up hardening (not a separate DSA row in the original table):
 - PR #28 reduced Aria2 cleanup blocking by replacing synchronous RPC waits with async best-effort cleanup while clearing stale gids for remove-task cleanup paths.
 - PR #30 completed DSA-11 by persisting failed download state immediately in `DownloadFailed(...)`.
 - PR #31 completed DSA-12 by snapshotting mutable per-item persistence collections before serialization.
+- PR #33 completed DSA-03 by adding cancellation-aware FFmpeg mux/concat handling and distinct cancelled outcome classification.
 
 ## 3) What was intentionally **not** changed
 
@@ -99,11 +102,16 @@ To keep the above fixes narrow and low-risk, the completed PRs intentionally did
 
 ## 4) Remaining risks and follow-up recommendations
 
-The following audit items were not part of the completed runtime-fix set through PR #31 and should remain on the follow-up list:
+No remaining unresolved runtime-risk items from the original DSA table remain after PR #33.
 
-- DSA-03: FFmpeg mux-phase cancellation support.
+Any future download-stability work should be treated as new findings or incremental hardening outside the original DSA closure scope.
 
 ## 5) Maintainer notes
 
-- Treat PR #11–#31 as the completed stability batches to date, covering fallback, cancellation cleanup, overwrite protection, thread-safe progress signaling, path safety, concat temp handling, resume-state handling, aria2 cleanup responsiveness, and the DSA-11/DSA-12 persistence hardening updates.
+- Treat PR #11–#33 as the completed stability batches to date, covering fallback, cancellation cleanup, overwrite protection, thread-safe progress signaling, path safety, concat temp handling, resume-state handling, aria2 cleanup responsiveness, persistence hardening updates, and FFmpeg mux/concat cancellation completion (DSA-03).
 - For future stability work, prefer narrow PRs mapped 1:1 to remaining DSA items to keep rollback and verification simple.
+
+
+## 6) Closure note
+
+The original download-service stability audit findings are now closed: each runtime-risk DSA item is either completed in a merged PR (including DSA-03 in PR #33) or explicitly tracked as documentation/maintenance context rather than unresolved runtime risk.

--- a/docs/maintenance/download-stability-fixes-summary.md
+++ b/docs/maintenance/download-stability-fixes-summary.md
@@ -24,9 +24,9 @@ Scope: documentation-only summary of completed work from PR #11 through PR #33.
 | DSA-12 | Persistence collection snapshots | ✅ Completed | #31 | `DownloadFiles` and `DownloadedFiles` are snapshotted before persistence serialization. |
 | Built-in resume branch | Resume-state handling for built-in downloader | ✅ Completed | #27 | Built-in downloader resume branch observes completion state. |
 | Aria2 cleanup blocking | Cleanup path async behavior | ✅ Completed | #28 | Aria2 cleanup no longer uses synchronous waits in the cleanup path. |
-| DSA-16 | aria2 completion handler diagnosability cleanup | ✅ Completed | #32 | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
+| DSA-16 | aria2 completion handler diagnosability cleanup | ✅ Completed | #21 | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
 | DSA-03 | FFmpeg mux-phase cancellation support | ✅ Completed | #33 | FFmpeg mux/concat phases now honor cancellation and classify cancelled outcomes distinctly from success/failure. |
-| DSA-17 | built-in downloader memory-budget guardrail docs | ✅ Completed | #32 | Added inline comments documenting per-task memory budget and capacity planning formula. |
+| DSA-17 | built-in downloader memory-budget guardrail docs | ✅ Completed | #21 | Added inline comments documenting per-task memory budget and capacity planning formula. |
 
 Related follow-up hardening (not a separate DSA row in the original table):
 
@@ -37,8 +37,6 @@ Related follow-up hardening (not a separate DSA row in the original table):
 
 | Audit ID | Area | PR | Status | Notes |
 |---|---|---|---|---|
-| DSA-16 | aria2 completion handler diagnosability cleanup | #32 | Completed | Added completion-context logs in `AriaDownloadFinish()` without runtime behavior changes. |
-| DSA-17 | built-in downloader memory-budget guardrail docs | #32 | Completed | Added inline memory-budget guardrail comments for capacity planning. |
 | DSA-03 | FFmpeg mux-phase cancellation support | #33 | Completed | FFmpeg mux/concat phases now support cancellation classification distinct from failure/success. |
 
 ## 2) What changed (behavioral summary)

--- a/docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md
+++ b/docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md
@@ -1,4 +1,12 @@
-# DSA-03 FFmpeg mux-phase cancellation plan
+# DSA-03 FFmpeg mux-phase cancellation plan (closed)
+
+## Status
+
+✅ Completed in PR #33.
+
+This document is retained for historical traceability of the original implementation plan. The planned runtime work has been implemented and merged; DSA-03 should now be treated as closed in active audit tracking.
+
+## Historical plan (archived)
 
 ## Problem
 


### PR DESCRIPTION
### Motivation

- Close out the remaining download-stability documentation tracking by marking DSA-03 as implemented and removing it from the unresolved runtime-risk list. 
- Expand the documented closure scope to include runtime fixes merged through PR #33 so the summary reflects current completed work. 

### Description

- Updated the audit risk table in `docs/maintenance/download-service-stability-audit.md` to mark **DSA-03** as completed, attribute the runtime fix to **PR #33**, and replace the unresolved-risk entry with an explicit closure note. 
- Updated `docs/maintenance/download-stability-fixes-summary.md` to change the summarized scope from `PR #11 through PR #31` to `PR #11 through PR #33`, added DSA-03 to the completed mappings and newly-completed section, and added a final closure note. 
- Converted `docs/maintenance/dsa-03-ffmpeg-mux-cancellation-plan.md` into a closed historical record by adding a status header (`✅ Completed in PR #33`) while preserving the original archived plan content for traceability. 

### Testing

Local dotnet was unavailable in the Codex environment. GitHub Actions PR Build passed and is the authoritative validation.
------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c2017f05c83308290add844155564)