### PR TITLE
fix: annotate formatting helper nullability

### DIFF
--- a/DownKyi.Core/Utils/Format.cs
+++ b/DownKyi.Core/Utils/Format.cs
@@ -1,5 +1,7 @@
 ﻿namespace DownKyi.Core.Utils;
 
+using System.Diagnostics.CodeAnalysis;
+
 public static class Format
 {
     /// <summary>
@@ -118,7 +120,7 @@ public static class Format
     /// </summary>
     /// <param name="originName"></param>
     /// <returns></returns>
-    public static string FormatFileName(string originName)
+    public static string FormatFileName([DisallowNull] string originName)
     {
         var destName = originName;
         destName = Path.GetInvalidFileNameChars().Aggregate(destName, (current, c) => current.Replace(c.ToString(), string.Empty));

--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -102,3 +102,5 @@ Do not:
 
 - PR #XX: removed unused usings and obviously unused locals without behavior changes.
 - PR #XX: added pure helper nullability cleanup audit; no nullable code changes yet.
+
+- PR #XX: annotated formatting helper nullability in `DownKyi.Core/Utils/Format.cs` without behavior changes.


### PR DESCRIPTION
### Motivation

- Reduce nullable-reference warning noise in a pure helper module while keeping runtime behavior identical.

### Description

- Added `using System.Diagnostics.CodeAnalysis;` and annotated `FormatFileName` with `[DisallowNull]` to make the non-null input contract explicit without changing logic or return values in `DownKyi.Core/Utils/Format.cs`.
- No formatting, algorithmic, or output changes were made to any `Format.*` helper methods and public APIs remain unchanged.
- Appended a single progress log entry to `docs/maintenance/build-warning-cleanup-audit.md` noting the helper nullability annotation (uses `PR #XX` placeholder).

### Testing

- Ran `git diff --check` to validate patch formatting and there were no check issues.
- Local dotnet was unavailable in the Codex environment. GitHub Actions PR Build is required as the authoritative validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d1e1713e8833091f0cabc28d10439)