### PR TITLE
docs: add path/string helper nullability candidate inventory

### DIFF
--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -103,4 +103,5 @@ Do not:
 - PR #XX: removed unused usings and obviously unused locals without behavior changes.
 - PR #XX: added pure helper nullability cleanup audit; no nullable code changes yet.
 
-- PR #XX: annotated formatting helper nullability in `DownKyi.Core/Utils/Format.cs` without behavior changes.
+- PR #42: annotated formatting helper nullability in `DownKyi.Core/Utils/Format.cs` without behavior changes.
+- PR #XX: added `docs/maintenance/path-string-helper-nullability-candidates.md` as discovery inventory for the next narrow helper nullability batch (docs-only).

--- a/docs/maintenance/helper-nullability-cleanup-audit.md
+++ b/docs/maintenance/helper-nullability-cleanup-audit.md
@@ -78,3 +78,7 @@ Future PR rules:
 - no downloader behavior changes
 - no FFmpeg process behavior changes
 - GitHub Actions PR Build passes
+
+## 7. Related discovery docs
+
+- `docs/maintenance/path-string-helper-nullability-candidates.md` — concrete file-level candidates for the next path/string helper nullable cleanup PR.

--- a/docs/maintenance/path-string-helper-nullability-candidates.md
+++ b/docs/maintenance/path-string-helper-nullability-candidates.md
@@ -1,0 +1,54 @@
+# Path/String Helper Nullability Candidates
+
+## 1. Purpose
+
+This document is a discovery-only inventory for the **next narrow nullable cleanup PR** focused on path/string/helper code.
+
+- This document does **not** change production behavior.
+- This document does **not** claim warning counts.
+- Candidate status should be re-checked against current build warnings when implementation starts.
+
+## 2. Selection constraints for the next PR
+
+The next implementation PR should:
+
+- stay in one small helper area;
+- avoid downloader/network/UI/DB behavior changes;
+- preserve existing return-value contracts (`null`, empty string, fallback values);
+- avoid broad refactors or signature changes unless required by warnings.
+
+## 3. Candidate inventory (existing files)
+
+| Candidate file | Current helper role | Nullable cleanup opportunity | Risk level | Notes for future implementation PR |
+|---|---|---|---|---|
+| `DownKyi.Core/Storage/StorageManager.cs` | Centralized path/directory resolver wrappers (`GetAriaDir`, `GetLogsDir`, etc.) | Validate directory argument flows and helper return assumptions around path creation wrappers. | Medium | Touch with care: this file is used broadly; keep behavior identical (same created paths and return strings). |
+| `DownKyi.Core/Utils/ObjectHelper.cs` | String/URL/cookie parsing and file-serialization helper methods | Tighten nullable annotations for URL/query/cookie parsing boundaries and stream/file read return paths. | Medium | Keep existing error/fallback behavior (`null` or `false` on failure) unchanged. |
+| `DownKyi.Core/Utils/StringLogicalComparer.cs` | String comparison helper with numeric segment ordering | Improve generic/string null-flow handling and remove nullable ambiguity in compare inputs. | Low-Medium | Should remain algorithm-preserving; comparator ordering behavior must not change. |
+| `DownKyi.Core/Utils/Encryptor/Encryptor.String.cs` | Pure string encryption/decryption helper surface | Clarify nullability assumptions for input/key parameters and fallback returns on exceptions. | Low-Medium | Preserve current fallback semantics (return original input when crypto fails). |
+
+## 4. Deferred / out-of-scope for the first path-string batch
+
+These are related but should be deferred from the first narrow batch:
+
+- `DownKyi.Core/Utils/Encryptor/Encryptor.File.cs` (file IO + crypto state; higher behavior risk).
+- `DownKyi.Core/Storage/Database/SqliteDatabase.cs` (database-facing behavior).
+- Any files under `DownKyi/` UI ViewModels/Views (binding and navigation risk).
+- Downloader/network execution paths (non-helper side effects).
+
+## 5. Suggested PR slicing
+
+Recommended order for upcoming implementation PRs:
+
+1. `fix: annotate path-string helper nullability (string comparer + object helper)`
+2. `fix: annotate storage path helper nullability (storage manager only)`
+3. Optional follow-up: evaluate encryptor string helper separately if warning pressure remains.
+
+Each PR should remain behavior-neutral and independently reviewable.
+
+## 6. Verification checklist for the future implementation PR
+
+- Build succeeds after nullable changes.
+- No runtime path output changes.
+- No URL/cookie parsing behavior drift.
+- No comparator ordering behavior drift.
+- No schema/network/downloader/UI behavior touched.


### PR DESCRIPTION
### Motivation

- Prepare a narrow, actionable discovery inventory for the next nullable-cleanup PR that focuses on path/string/helper code while avoiding production changes. 
- Keep future nullable fixes incremental and low-risk by identifying safe, pure helper files and explicitly deferring higher-risk areas. 

### Description

- Add a new discovery-only document `docs/maintenance/path-string-helper-nullability-candidates.md` listing concrete file-level candidates, risk notes, and suggested PR slicing. 
- Update `docs/maintenance/build-warning-cleanup-audit.md` to record the prior `PR #42` formatting-helper annotation and add a progress entry referencing the new inventory doc. 
- Add a short cross-link in `docs/maintenance/helper-nullability-cleanup-audit.md` to point readers at the new candidate inventory. 
- This PR is documentation-only and does not modify any production code, packages, CI, or runtime behavior. 

### Testing

- Verified the new file exists and contains the expected candidate inventory and guidance by inspecting the file contents with local file previews (commands such as `nl`/`sed`). 
- Verified both updated audit documents include the new entries and cross-link by previewing the modified sections. 
- Local dotnet was unavailable in the Codex environment. GitHub Actions PR Build passed and is the authoritative validation.
- All local verification steps completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d200716208330990f2c6736fc0e7d)