### PR TITLE
fix: annotate string logical comparer nullability

### DIFF
--- a/DownKyi.Core/Utils/StringLogicalComparer.cs
+++ b/DownKyi.Core/Utils/StringLogicalComparer.cs
@@ -15,16 +15,33 @@ public class StringLogicalComparer<T> : IComparer<T>
             throw new ArgumentException("Parameters can't be null");
         }
 
-        var fileA = x as string;
-        var fileB = y as string;
-        var arr1 = fileA?.ToCharArray();
-        var arr2 = fileB?.ToCharArray();
-        int i = 0, j = 0;
-        while (i < arr1?.Length && j < arr2?.Length)
+        // StringLogicalComparer<T> is intended for string-compatible values.
+        // Keep existing behavior for non-string T inputs.
+        string? fileA = x as string;
+        string? fileB = y as string;
+        char[]? arr1 = fileA?.ToCharArray();
+        char[]? arr2 = fileB?.ToCharArray();
+
+        if (arr1 == null || arr2 == null)
+        {
+            int? arr1Length = arr1?.Length;
+            int? arr2Length = arr2?.Length;
+            if (arr1Length == arr2Length)
+            {
+                return 0;
+            }
+
+            return arr1Length > arr2Length ? 1 : -1;
+        }
+
+        int i = 0;
+        int j = 0;
+        while (i < arr1.Length && j < arr2.Length)
         {
             if (char.IsDigit(arr1[i]) && char.IsDigit(arr2[j]))
             {
-                string s1 = "", s2 = "";
+                string s1 = "";
+                string s2 = "";
                 while (i < arr1.Length && char.IsDigit(arr1[i]))
                 {
                     s1 += arr1[i];
@@ -64,11 +81,11 @@ public class StringLogicalComparer<T> : IComparer<T>
             }
         }
 
-        if (arr1?.Length == arr2?.Length)
+        if (arr1.Length == arr2.Length)
         {
             return 0;
         }
 
-        return arr1?.Length > arr2?.Length ? 1 : -1;
+        return arr1.Length > arr2.Length ? 1 : -1;
     }
 }

--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -105,3 +105,4 @@ Do not:
 
 - PR #42: annotated formatting helper nullability in `DownKyi.Core/Utils/Format.cs` without behavior changes.
 - PR #XX: added `docs/maintenance/path-string-helper-nullability-candidates.md` as discovery inventory for the next narrow helper nullability batch (docs-only).
+- PR #XX: annotated `StringLogicalComparer<T>` nullability without changing comparator ordering behavior.


### PR DESCRIPTION
### Motivation

- Reduce nullable-reference warnings in the string comparer helper by making the nullable flow explicit around the `as string` casts while preserving existing runtime behavior.
- Keep the comparator algorithm, numeric-segment ordering, and the existing null-input exception unchanged.

### Description

- Clarified local nullability flow in `DownKyi.Core/Utils/StringLogicalComparer.cs` by introducing explicit nullable `string?` locals and nullable `char[]?` locals and handling the `null` array case without changing ordering logic.
- Preserved the original null-input behavior (`ArgumentException("Parameters can't be null")`), the numeric-segment ordering, and character comparison ordering; return values remain 0, 1, or -1 as before.
- Added a single-line progress entry to `docs/maintenance/build-warning-cleanup-audit.md` noting the nullable annotation change for `StringLogicalComparer<T>`.

### Testing

- Ran `git diff --check` which completed successfully in this environment.
- Local dotnet was unavailable in the Codex environment. GitHub Actions PR Build is required as the authoritative validation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d21c0acd88330a30779cd1f3ec4cd)