### PR TITLE
Refactor ObjectHelper.ParseCookie nullable-check (behavior-neutral)

### DIFF
--- a/DownKyi.Core/Utils/ObjectHelper.cs
+++ b/DownKyi.Core/Utils/ObjectHelper.cs
@@ -17,17 +17,18 @@ public static class ObjectHelper
     /// <returns></returns>
     public static List<DownKyiCookie> ParseCookie(string? url)
     {
-        var cookies = new List<DownKyiCookie>();
-        if (url is null or "") return cookies;
+        if (string.IsNullOrEmpty(url))
+        {
+            return new List<DownKyiCookie>();
+        }
 
         var uri = new Uri(url);
         var queryString = uri.Query;
         var query = HttpUtility.ParseQueryString(queryString);
-        cookies = (from item in query.AllKeys.OfType<string>()
+        return (from item in query.AllKeys.OfType<string>()
             let value = query[item]
             where item is not ("Expires" or "gourl")
             select new DownKyiCookie(item, value, ".bilibili.com")).ToList();
-        return cookies;
         // if (url is null or "")
         // {
         //     return cookieContainer;


### PR DESCRIPTION
### Motivation
- Make the nullable-check in `ParseCookie(string? url)` clearer without changing runtime behavior after a previous attempt introduced unintended fallbacks.

### Description
- In `DownKyi.Core/Utils/ObjectHelper.cs` replaced `url is null or ""` with `string.IsNullOrEmpty(url)` and returned the LINQ projection directly instead of assigning to a temporary list, preserving the existing `Expires`/`gourl` filtering and cookie construction.

### Testing
- Built the core project with `dotnet build DownKyi.Core/DownKyi.Core.csproj -v minimal` which completed successfully with pre-existing repository warnings and no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3339be108330934114e61d4186f4)