### PR TITLE
fix: require exact encryptor IV and salt reads

### DIFF
--- a/DownKyi.Core/Utils/Encryptor/Encryptor.File.cs
+++ b/DownKyi.Core/Utils/Encryptor/Encryptor.File.cs
@@ -82,9 +82,9 @@ public static partial class Encryptor
         var outValue = 0;
 
         var iv = new byte[16];
-        fin.Read(iv, 0, 16);
+        fin.ReadExactly(iv, 0, iv.Length);
         var salt = new byte[16];
-        fin.Read(salt, 0, 16);
+        fin.ReadExactly(salt, 0, salt.Length);
 
         var sma = CreateRijndael(password, salt);
         sma.IV = iv;

--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -106,3 +106,4 @@ Do not:
 - PR #42: annotated formatting helper nullability in `DownKyi.Core/Utils/Format.cs` without behavior changes.
 - PR #XX: added `docs/maintenance/path-string-helper-nullability-candidates.md` as discovery inventory for the next narrow helper nullability batch (docs-only).
 - PR #XX: annotated `StringLogicalComparer<T>` nullability without changing comparator ordering behavior.
+- PR #XX: fixed CA2022 in `Encryptor.File` by requiring exact IV/salt reads during decrypt setup.


### PR DESCRIPTION
### Motivation
- Fix a concrete CA2022 in `DownKyi.Core/Utils/Encryptor/Encryptor.File.cs` by ensuring the fixed-size IV and salt reads performed during decrypt setup are exact. 
- Make truncated or malformed encrypted input fail deterministically at decrypt setup instead of continuing with partially-filled IV/salt buffers.

### Description
- Replaced the unchecked calls to `fin.Read(iv, 0, 16)` and `fin.Read(salt, 0, 16)` with `fin.ReadExactly(iv, 0, iv.Length)` and `fin.ReadExactly(salt, 0, salt.Length)` inside `DecryptFile` in `DownKyi.Core/Utils/Encryptor/Encryptor.File.cs`.
- Preserved encryption format and behavior, including IV size (16 bytes), salt size (16 bytes), `FcTag`, hash verification, and all public method signatures. 
- Added the requested progress note to `docs/maintenance/build-warning-cleanup-audit.md`: `- PR #XX: fixed CA2022 in `Encryptor.File` by requiring exact IV/salt reads during decrypt setup.`

### Testing
- Ran `git diff --check` which reported no whitespace/patch issues. 
- Built the core project with `dotnet build DownKyi.Core/DownKyi.Core.csproj -v minimal` which completed successfully. 
- Built the full solution with `dotnet build DownKyi.sln --configuration Release -p:ContinuousIntegrationBuild=true` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d3dfc9a388330903529e4f8372d72)