### PR TITLE
Add build-warning root-cause analysis doc and parsing script

### DIFF
--- a/docs/maintenance/build-warning-root-cause-analysis.md
+++ b/docs/maintenance/build-warning-root-cause-analysis.md
@@ -1,0 +1,309 @@
+# Build Warning Root-Cause Analysis
+
+## Source
+
+- Build command: `dotnet build DownKyi.sln --configuration Release -p:ContinuousIntegrationBuild=true -v minimal`
+- Log file: `artifacts/build-warning-inventory.log`
+- Derived CSV (all warnings): `artifacts/build-warning-inventory.csv`
+- Derived CSV (deduplicated): `artifacts/build-warning-inventory.unique.csv`
+- Parser script: `scripts/analyze-build-warnings.py`
+- Note: `artifacts/*` files are generated locally for analysis and are not committed.
+- Commit: `4a3b7157ca1b80a33f6b2d745b71c18903f0cab4`
+- Date checked: 2026-05-20
+- Raw warning line count: 2308
+- Unique warning count: 1152
+- Unique warning code count: 15
+
+## Executive summary
+
+Warnings are dominated by nullable contract mismatches (`CS8618`) in DTO/model-heavy modules. The largest root-cause modules are `DownKyi.Core/Aria2cNet` and `DownKyi.Core/BiliApi*` where response/request models declare non-nullable properties without constructor initialization. `DownKyi/ViewModels` has a mixed pattern: some fields/commands are intentionally lazy-initialized but typed non-nullable (root), while some dereference/assignment warnings are downstream of nullable service/model results. `DownKyi/Services/Download` warnings are mostly downstream from nullable `PlayUrl` and API return contracts.
+
+## Warning count by code
+
+| Warning | Count | Meaning | Main affected modules |
+|---|---:|---|---|
+| CS8618 | 997 | Non-nullable member not initialized | DownKyi.Core/Aria2cNet, DownKyi.Core/BiliApi/Video, DownKyi.Core/BiliApi/Users, DownKyi.Core/BiliApi |
+| CS8602 | 42 | Possible null dereference | DownKyi.Core/Aria2cNet, DownKyi.Core/BiliApi/Video, DownKyi.Core/Utils, Other |
+| CS8601 | 37 | Possible null assignment | DownKyi.Core/Utils, DownKyi.Core/Logging, Other, DownKyi/Services |
+| CS8603 | 25 | Possible null return | DownKyi.Core/Aria2cNet, DownKyi.Core/BiliApi/Video, DownKyi.Core/BiliApi, DownKyi.Core/Logging |
+| CS8625 | 19 | Null literal to non-nullable | DownKyi.Core/Aria2cNet, DownKyi/Services, DownKyi/ViewModels |
+| CS8600 | 9 | Possible null conversion | DownKyi.Core/Aria2cNet, DownKyi.Core/Utils, DownKyi.Core/Logging, DownKyi/ViewModels |
+| CS8604 | 7 | Possible null arg | DownKyi.Core/BiliApi/Users, DownKyi.Core/Utils, DownKyi/Services, DownKyi/ViewModels |
+| CS8619 | 4 | Nullability mismatch assign | DownKyi.Core/BiliApi/Users, DownKyi/Services, DownKyi/Utils |
+| CS8622 | 4 | Delegate nullability mismatch | Other |
+| CS0168 | 3 | Unused variable | DownKyi/Services, DownKyi/ViewModels |
+| CS0472 | 1 | Always false ref compare | DownKyi.Core/Settings |
+| CS8605 | 1 | Unboxing possibly null | Other |
+| CS8620 | 1 | Generic nullability mismatch | DownKyi/ViewModels |
+| CS0169 | 1 | Unused field | DownKyi/ViewModels |
+| CS0649 | 1 | Never assigned field | DownKyi/ViewModels |
+
+## Warning count by module
+
+| Module | Count | Main warning codes | Root/source or downstream? |
+|---|---:|---|---|
+| DownKyi/ViewModels | 346 | CS8618,CS8601,CS8625 | Mixed |
+| DownKyi.Core/Aria2cNet | 250 | CS8618,CS8625,CS8603 | Root cause |
+| DownKyi.Core/BiliApi/Users | 160 | CS8618,CS8619,CS8604 | Root cause |
+| DownKyi.Core/BiliApi | 140 | CS8618,CS8603 | Root cause |
+| DownKyi.Core/BiliApi/Video | 114 | CS8618,CS8603,CS8602 | Root cause |
+| DownKyi/Services/Download | 39 | CS8602,CS8603,CS8601 | Downstream symptom |
+| DownKyi/Models | 29 | CS8618 | Downstream symptom |
+| Other | 28 | CS8618,CS8602,CS8622 | Downstream symptom |
+| DownKyi.Core/Logging | 17 | CS8601,CS8618,CS8600 | Downstream symptom |
+| DownKyi/Services | 15 | CS8602,CS8601,CS8604 | Downstream symptom |
+| DownKyi.Core/Utils | 6 | CS8602,CS8604,CS8600 | Downstream symptom |
+| DownKyi.Core/Settings | 5 | CS8618,CS8603,CS0472 | Downstream symptom |
+| DownKyi/Utils | 3 | CS8600,CS8603,CS8619 | Downstream symptom |
+
+## Top noisy files
+
+| File | Count | Main warning codes | Likely reason |
+|---|---:|---|---|
+| DownKyi.Core/Aria2cNet/Client/Entity/AriaOption.cs | 77 | CS8618 | Non-nullable contract / lazy init mismatch |
+| DownKyi/ViewModels/ViewMySpaceViewModel.cs | 33 | CS8618, CS8625 | Non-nullable contract / lazy init mismatch |
+| DownKyi.Core/Aria2cNet/Client/Entity/AriaTellStatus.cs | 29 | CS8618 | Non-nullable contract / lazy init mismatch |
+| DownKyi/ViewModels/Settings/ViewVideoViewModel.cs | 23 | CS8618, CS8601 | Non-nullable contract / lazy init mismatch |
+| DownKyi.Core/BiliApi/Users/Models/SpacePublicationListType.cs | 21 | CS8618 | Non-nullable contract / lazy init mismatch |
+| DownKyi/ViewModels/ViewUserSpaceViewModel.cs | 21 | CS8618, CS8625 | Non-nullable contract / lazy init mismatch |
+| DownKyi/Services/Download/DownloadService.cs | 19 | CS8602, CS8603 | Non-nullable contract / lazy init mismatch |
+| DownKyi.Core/BiliApi/Bangumi/Models/BangumiSeason.cs | 16 | CS8618 | Non-nullable contract / lazy init mismatch |
+| DownKyi.Core/BiliApi/Video/Models/VideoView.cs | 14 | CS8618 | Non-nullable contract / lazy init mismatch |
+| DownKyi/Models/NfoModels.cs | 14 | CS8618 | Non-nullable contract / lazy init mismatch |
+| DownKyi/ViewModels/PageViewModels/HistoryMedia.cs | 14 | CS8618 | Non-nullable contract / lazy init mismatch |
+| DownKyi/ViewModels/PageViewModels/Favorites.cs | 14 | CS8618 | Non-nullable contract / lazy init mismatch |
+
+## Root-cause groups
+
+### Group 1 — Aria2 JSON-RPC DTO non-nullable initialization
+
+**Classification:** Root cause
+
+**Affected modules:**
+- DownKyi.Core/Aria2cNet
+
+**Warning codes:**
+- CS8618
+
+**Representative warnings:**
+- `DownKyi.Core/Aria2cNet/Client/Entity/AriaOption.cs(9,23): warning CS8618: Non-nullable property ...`
+- `DownKyi.Core/Aria2cNet/Client/Entity/AriaTellStatus.cs(10,23): warning CS8618: Non-nullable property ...`
+
+**Source inspection:** DTO classes are plain JSON containers with many non-nullable `string`/collection properties and no constructor/default initializers.
+
+**Upstream trace:** Deserialized via Aria RPC client model binding.
+
+**Likely root cause:** Nullable contract is stricter than real incoming JSON payload guarantees.
+
+**Downstream symptoms:** Nullability warnings when consuming deserialized fields across download/services.
+
+**Recommended first fix location:** `DownKyi.Core/Aria2cNet/Client/Entity/*`.
+
+**Why not fix downstream first:** Use-site guards hide schema contract issues and duplicate defensive code.
+
+**Suggested repair PR:**
+- PR title: `Align Aria2 DTO nullability with JSON-RPC contract`
+- Target files: `DownKyi.Core/Aria2cNet/Client/Entity/*`
+- Forbidden files: `DownKyi/Services/*`, `DownKyi/ViewModels/*`
+- Expected warning reduction: High (~200+)
+- Risk level: Low
+
+
+### Group 2 — BiliApi external JSON model contract mismatch
+
+**Classification:** Root cause
+
+**Affected modules:**
+- DownKyi.Core/BiliApi
+- DownKyi.Core/BiliApi/Users
+- DownKyi.Core/BiliApi/Video
+
+**Warning codes:**
+- CS8618
+
+**Representative warnings:**
+- `DownKyi.Core/BiliApi/Users/Models/SpacePublicationListType.cs(8,58): warning CS8618 ...`
+
+**Source inspection:** API model properties are non-nullable but only assigned by JSON deserializer; no defaults/required-nullable modeling.
+
+**Upstream trace:** Parsed in API methods returning model graphs used by services/viewmodels.
+
+**Likely root cause:** Model definitions do not represent optional/absent fields in upstream Bilibili payloads.
+
+**Downstream symptoms:** Service and VM null checks/assignments warn when traversing possibly-null members.
+
+**Recommended first fix location:** `DownKyi.Core/BiliApi/**/Models/*.cs`.
+
+**Why not fix downstream first:** Fixing consumers first causes repeated noisy checks and can mask actual missing data semantics.
+
+**Suggested repair PR:**
+- PR title: `Normalize BiliApi model nullability to payload reality`
+- Target files: `DownKyi.Core/BiliApi/**/Models/*.cs`
+- Forbidden files: `DownKyi/Services/Download/*`
+- Expected warning reduction: High (~350+)
+- Risk level: Medium
+
+
+### Group 3 — DownloadService PlayUrl nullable chain
+
+**Classification:** Downstream symptom
+
+**Affected modules:**
+- DownKyi/Services/Download
+- DownKyi/Services
+
+**Warning codes:**
+- CS8602
+- CS8601
+- CS8603
+- CS8625
+
+**Representative warnings:**
+- `DownKyi/Services/Download/DownloadService.cs(...): warning CS8602 ...`
+
+**Source inspection:** `PlayUrl` is assigned from nullable API methods (`GetVideoPlayUrl`, `GetBangumiPlayUrl`) and then dereferenced across multi-branch logic.
+
+**Upstream trace:** `DownKyi.Core/BiliApi/VideoStream/VideoStream.cs` methods return `PlayUrl?`.
+
+**Likely root cause:** Upstream API return contract and model optionality not normalized at service boundary.
+
+**Downstream symptoms:** Repeated nullability warnings in download service and dependent workflows.
+
+**Recommended first fix location:** Boundary methods in `DownKyi/Services/VideoInfoService.cs` and download entrypoints (after model fixes).
+
+**Why not fix downstream first:** scattered guards/`!` create fragile behavior and obscure invalid states.
+
+**Suggested repair PR:**
+- PR title: `Establish non-null PlayUrl boundary contract in download pipeline`
+- Target files: `DownKyi/Services/Download/*.cs`, `DownKyi/Services/VideoInfoService.cs`
+- Forbidden files: `DownKyi.Core/BiliApi/**/Models/*`
+- Expected warning reduction: Medium (~40-70)
+- Risk level: Medium
+
+
+### Group 4 — ViewModel field and command initialization
+
+**Classification:** Mixed
+
+**Affected modules:**
+- DownKyi/ViewModels
+
+**Warning codes:**
+- CS8618, CS8601, CS8602, CS8625
+
+**Representative warnings:**
+- `DownKyi/ViewModels/ViewMySpaceViewModel.cs(25,...): warning CS8618 ...`
+
+**Source inspection:** Many backing fields/commands are declared non-nullable but initialized later by navigation/loading/lazy command factories.
+
+**Upstream trace:** also consumes nullable API/service results.
+
+**Likely root cause:** Mixed of local initialization contract issues and downstream nullable flows.
+
+**Downstream symptoms:** assignment and dereference warnings in event handlers and async loaders.
+
+**Recommended first fix location:** per-VM high-noise files, starting `ViewMySpaceViewModel.cs`.
+
+**Why not fix downstream first:** mechanical guards without contract cleanup keep warnings and cognitive overhead high.
+
+**Suggested repair PR:**
+- PR title: `Correct ViewModel initialization/nullability contracts for high-noise pages`
+- Target files: `DownKyi/ViewModels/ViewMySpaceViewModel.cs`, nearby page viewmodels
+- Forbidden files: `DownKyi/Services/Download/*`
+- Expected warning reduction: Medium (~80-120)
+- Risk level: Medium
+
+
+## Cascading nullable chains
+
+### Cascading chain — DownloadService PlayUrl nullable chain
+**Upstream source:** `DownKyi.Core/BiliApi/VideoStream/VideoStream.cs` (`GetVideoPlayUrl*`, `GetBangumiPlayUrl`)
+**Downstream affected files:** `DownKyi/Services/Download/DownloadService.cs`, `DownKyi/Services/VideoInfoService.cs`
+**Representative warnings:** CS8602/CS8601 around `downloading.PlayUrl` use
+**Why this is probably one chain:** nullable return is propagated then dereferenced in multiple branches
+**Best first fix location:** service boundary where PlayUrl enters UI/download pipeline
+**Do not fix by:** adding broad `!`, suppressions, empty-string coercions, random null guards
+
+### Cascading chain — Aria2 JSON-RPC DTO initialization chain
+**Upstream source:** `DownKyi.Core/Aria2cNet/Client/Entity/*.cs` DTO properties
+**Downstream affected files:** Aria download service/client calls
+**Representative warnings:** CS8618 across Aria DTO files
+**Why this is probably one chain:** same pattern repeated over many RPC response/request models
+**Best first fix location:** DTO contract layer
+**Do not fix by:** broad `!` or consumer-side patching
+
+### Cascading chain — BiliApi external JSON model contract chain
+**Upstream source:** `DownKyi.Core/BiliApi/**/Models/*.cs`
+**Downstream affected files:** `DownKyi/Services/*`, `DownKyi/ViewModels/*`
+**Representative warnings:** CS8618 in models + CS8601/CS8602 in consumers
+**Why this is probably one chain:** deserialization contract mismatch propagates uncertain nullability
+**Best first fix location:** API model definitions
+**Do not fix by:** forcing defaults blindly
+
+### Cascading chain — ViewModel initialization chain
+**Upstream source:** VM constructors + lazy command fields
+**Downstream affected files:** high-noise page VMs
+**Representative warnings:** CS8618, CS8625
+**Why this is probably one chain:** similar deferred init style across VMs
+**Best first fix location:** highest-count VM files
+
+### Cascading chain — SettingsManager nullable access chain
+**Upstream source:** settings backing fields and `_appSettings` graph
+**Downstream affected files:** services reading settings
+**Representative warnings:** limited in current build; mostly not dominant
+**Why this is probably one chain:** persistent settings object may expose nullable members
+**Best first fix location:** settings model declarations
+
+### Cascading chain — Logging nullable message chain
+**Upstream source:** `DownKyi.Core/Logging/LogManager.cs` overloads and event payloads
+**Downstream affected files:** callers passing nullable exception/message text
+**Representative warnings:** minor count in logging module
+**Why this is probably one chain:** signature strictness vs callsite reality
+**Best first fix location:** logging API surface
+
+
+## Recommended repair schedule
+
+| Rank | Batch name | Root cause | Modules | Warning codes | Estimated warning reduction | Risk | Recommended timing |
+|---:|---|---|---|---|---:|---|---|
+| 1 | Aria2 DTO contract alignment | Yes | DownKyi.Core/Aria2cNet | CS8618 | 200-260 | Low | First |
+| 2 | BiliApi model nullability normalization | Yes | DownKyi.Core/BiliApi* | CS8618 | 300-420 | Medium | Second |
+| 3 | ViewModel init contract cleanup (high-noise files) | Mixed | DownKyi/ViewModels | CS8618/CS8601/CS8602 | 80-120 | Medium | Third |
+| 4 | DownloadService PlayUrl boundary hardening | Mostly downstream | DownKyi/Services/Download | CS8601/CS8602/CS8603 | 40-70 | Medium | Fourth |
+
+
+## First 3 recommended repair PRs
+
+1. **Align Aria2 DTO nullability with JSON-RPC contract**
+- target module: `DownKyi.Core/Aria2cNet`
+- warning codes: `CS8618`
+- expected reduction: `~200+`
+- risk: Low
+- why first: biggest low-risk root-cause cluster
+- what not to change: download workflow logic
+
+2. **Normalize BiliApi model nullability to external payloads**
+- target module: `DownKyi.Core/BiliApi/**/Models`
+- warning codes: `CS8618`
+- expected reduction: `~300+`
+- risk: Medium
+- why first: removes root ambiguity feeding services/viewmodels
+- what not to change: DownloadService behavior
+
+3. **Fix ViewModel initialization contracts in top noisy pages**
+- target module: `DownKyi/ViewModels`
+- warning codes: `CS8618`, `CS8601`, `CS8602`, `CS8625`
+- expected reduction: `~100`
+- risk: Medium
+- why first: improves runtime safety for UI initialization paths
+- what not to change: API model contracts and service boundary semantics in same PR
+
+
+## Defer list
+- Minor compiler hygiene warnings (`CS0168`, `CS0169`, `CS0649`, `CS0472`) until nullable contract batches complete.
+- Low-count Logging/Settings warnings pending confirmation of intended nullability semantics.
+
+## Unknowns
+- Exact external Bilibili field optionality for some endpoints requires payload sampling.
+- Whether certain ViewModel fields are intentionally set via XAML binding lifecycle needs maintainer confirmation.
+- Aria RPC always-present fields versus optional fields requires protocol-level confirmation for safest contract tightening.

--- a/scripts/analyze-build-warnings.py
+++ b/scripts/analyze-build-warnings.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import csv
+import hashlib
+import re
+from pathlib import Path
+
+LOG = Path('artifacts/build-warning-inventory.log')
+CSV_ALL = Path('artifacts/build-warning-inventory.csv')
+CSV_UNIQ = Path('artifacts/build-warning-inventory.unique.csv')
+
+PAT = re.compile(r'^(?P<File>/.+?)\((?P<Line>\d+),(?P<Column>\d+)\): warning (?P<WarningCode>[A-Z]{2}\d+): (?P<Message>.+?) \[(?P<Project>.+?)\]$')
+FIELDS = ['Project','WarningCode','File','Line','Column','Message','RawWarningLine']
+
+if not LOG.exists():
+    raise SystemExit(f'missing log: {LOG}')
+
+rows = []
+with LOG.open('r', encoding='utf-8', errors='ignore') as f:
+    for line in f:
+        raw = line.rstrip('\n')
+        m = PAT.match(raw)
+        if not m:
+            continue
+        d = m.groupdict()
+        d['RawWarningLine'] = raw
+        rows.append(d)
+
+CSV_ALL.parent.mkdir(parents=True, exist_ok=True)
+with CSV_ALL.open('w', encoding='utf-8', newline='') as f:
+    w = csv.DictWriter(f, fieldnames=FIELDS)
+    w.writeheader()
+    for r in rows:
+        w.writerow({k: r[k] for k in FIELDS})
+
+seen = set()
+uniq = []
+for r in rows:
+    key = (r['File'], r['Line'], r['Column'], r['WarningCode'], r['Message'])
+    if key in seen:
+        continue
+    seen.add(key)
+    uniq.append(r)
+
+with CSV_UNIQ.open('w', encoding='utf-8', newline='') as f:
+    w = csv.DictWriter(f, fieldnames=FIELDS)
+    w.writeheader()
+    for r in uniq:
+        w.writerow({k: r[k] for k in FIELDS})
+
+sha = hashlib.sha256(LOG.read_bytes()).hexdigest()
+print(f'log={LOG}')
+print(f'log_sha256={sha}')
+print(f'raw_warning_count={len(rows)}')
+print(f'unique_warning_count={len(uniq)}')
+print(f'unique_warning_codes={len({r["WarningCode"] for r in uniq})}')
+print(f'wrote={CSV_ALL}')
+print(f'wrote={CSV_UNIQ}')


### PR DESCRIPTION
### Motivation

- Capture and summarize compiler warning output to prioritize nullable/contract fixes across the repository. 
- Provide a reproducible parser to derive CSV inventories and a deduplicated warning set for triage. 
- Surface high-noise files/modules and recommend targeted repair PRs to reduce CS8618/CS860* warnings. 

### Description

- Add a human-readable analysis document at `docs/maintenance/build-warning-root-cause-analysis.md` containing counts, top files/modules, root-cause groups, cascading chains, and suggested repair PRs. 
- Add an executable parsing utility `scripts/analyze-build-warnings.py` that parses `artifacts/build-warning-inventory.log` into `artifacts/build-warning-inventory.csv` and `artifacts/build-warning-inventory.unique.csv`, computes a SHA256 of the log, and prints summary metrics. 
- The parser matches MSBuild-style warning lines and deduplicates warnings by file/line/column/code/message. 
- The docs record the analyzed commit/date and recommended remediation schedule focusing on `DownKyi.Core/Aria2cNet`, `DownKyi.Core/BiliApi`, and `DownKyi/ViewModels` as high-impact targets. 

### Testing

- Ran the new analyzer with `scripts/analyze-build-warnings.py` against `artifacts/build-warning-inventory.log`, which completed successfully and wrote `artifacts/build-warning-inventory.csv` and `artifacts/build-warning-inventory.unique.csv` and printed the `raw_warning_count`/`unique_warning_count`/`unique_warning_codes` summary. 
- No other automated tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d41f5e1748330910e4f6052e035c3)