### PR TITLE
fix: align aria2 json-rpc response nullability

### DIFF
--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaPause.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaPause.cs
@@ -6,16 +6,16 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     public class AriaPause
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonProperty("jsonrpc")]
-        public string Jsonrpc { get; set; }
+        public string? Jsonrpc { get; set; }
 
         [JsonProperty("result")]
-        public string Result { get; set; }
+        public string? Result { get; set; }
 
         [JsonProperty("error")]
-        public AriaError Error { get; set; }
+        public AriaError? Error { get; set; }
 
         public override string ToString()
         {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaRemove.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaRemove.cs
@@ -6,16 +6,16 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     public class AriaRemove
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonProperty("jsonrpc")]
-        public string Jsonrpc { get; set; }
+        public string? Jsonrpc { get; set; }
 
         [JsonProperty("result")]
-        public string Result { get; set; }
+        public string? Result { get; set; }
 
         [JsonProperty("error")]
-        public AriaError Error { get; set; }
+        public AriaError? Error { get; set; }
 
         public override string ToString()
         {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaSaveSession.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaSaveSession.cs
@@ -6,16 +6,16 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     public class AriaSaveSession
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonProperty("jsonrpc")]
-        public string Jsonrpc { get; set; }
+        public string? Jsonrpc { get; set; }
 
         [JsonProperty("result")]
-        public string Result { get; set; }
+        public string? Result { get; set; }
 
         [JsonProperty("error")]
-        public AriaError Error { get; set; }
+        public AriaError? Error { get; set; }
 
         public override string ToString()
         {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaShutdown.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaShutdown.cs
@@ -6,16 +6,16 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     public class AriaShutdown
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonProperty("jsonrpc")]
-        public string Jsonrpc { get; set; }
+        public string? Jsonrpc { get; set; }
 
         [JsonProperty("result")]
-        public string Result { get; set; }
+        public string? Result { get; set; }
 
         [JsonProperty("error")]
-        public AriaError Error { get; set; }
+        public AriaError? Error { get; set; }
 
         public override string ToString()
         {

--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -107,3 +107,4 @@ Do not:
 - PR #XX: added `docs/maintenance/path-string-helper-nullability-candidates.md` as discovery inventory for the next narrow helper nullability batch (docs-only).
 - PR #XX: annotated `StringLogicalComparer<T>` nullability without changing comparator ordering behavior.
 - PR #XX: fixed CA2022 in `Encryptor.File` by requiring exact IV/salt reads during decrypt setup.
+- PR #XX: aligned the first small Aria2 JSON-RPC response DTO nullability batch with nullable result/error response semantics.


### PR DESCRIPTION
### Motivation

- Silence CS8618 in a small, low-risk batch of Aria2 JSON-RPC response DTOs by modeling deserialized fields as nullable to match JSON-RPC semantics where `id`, `result`, and `error` can be absent or null.

### Description

- Marked `Id`, `Jsonrpc`, and `Result` as `string?` and `Error` as `AriaError?` in the four response wrapper classes `AriaShutdown`, `AriaRemove`, `AriaPause`, and `AriaSaveSession` to reflect optional JSON fields.
- Kept JSON property names, class names, namespaces, and `ToString()` behavior unchanged.
- Updated `docs/maintenance/build-warning-cleanup-audit.md` with a single progress entry noting this PR using the `PR #XX` placeholder.

### Testing

- Ran `git diff --check` and it passed with no index issues.
- Built the core project with `dotnet build DownKyi.Core/DownKyi.Core.csproj -v minimal` and the build succeeded, and the targeted CS8618 warnings for the four modified files were eliminated.
- Built the full solution with `dotnet build DownKyi.sln --configuration Release -p:ContinuousIntegrationBuild=true` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d48241d548330b9ea7632ac432b67)