### PR TITLE
fix: align more aria2 json-rpc dto nullability

### DIFF
--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaGetSessionInfo.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaGetSessionInfo.cs
@@ -6,16 +6,16 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     public class AriaGetSessionInfo
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonProperty("jsonrpc")]
-        public string Jsonrpc { get; set; }
+        public string? Jsonrpc { get; set; }
 
         [JsonProperty("result")]
-        public AriaGetSessionInfoResult Result { get; set; }
+        public AriaGetSessionInfoResult? Result { get; set; }
 
         [JsonProperty("error")]
-        public AriaError Error { get; set; }
+        public AriaError? Error { get; set; }
 
         public override string ToString()
         {
@@ -27,7 +27,7 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     public class AriaGetSessionInfoResult
     {
         [JsonProperty("sessionId")]
-        public string SessionId { get; set; }
+        public string? SessionId { get; set; }
 
         public override string ToString()
         {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaGetUris.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaGetUris.cs
@@ -7,16 +7,16 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     public class AriaGetUris
     {
         [JsonProperty("id")]
-        public string Id { get; set; }
+        public string? Id { get; set; }
 
         [JsonProperty("jsonrpc")]
-        public string Jsonrpc { get; set; }
+        public string? Jsonrpc { get; set; }
 
         [JsonProperty("result")]
-        public List<AriaUri> Result { get; set; }
+        public List<AriaUri>? Result { get; set; }
 
         [JsonProperty("error")]
-        public AriaError Error { get; set; }
+        public AriaError? Error { get; set; }
 
         public override string ToString()
         {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaVersion.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaVersion.cs
@@ -5,13 +5,13 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity;
 [JsonObject]
 public class AriaVersion
 {
-    [JsonProperty("id")] public string Id { get; set; }
+    [JsonProperty("id")] public string? Id { get; set; }
 
-    [JsonProperty("jsonrpc")] public string Jsonrpc { get; set; }
+    [JsonProperty("jsonrpc")] public string? Jsonrpc { get; set; }
 
-    [JsonProperty("result")] public AriaVersionResult Result { get; set; }
+    [JsonProperty("result")] public AriaVersionResult? Result { get; set; }
 
-    [JsonProperty("error")] public AriaError Error { get; set; }
+    [JsonProperty("error")] public AriaError? Error { get; set; }
 
     public override string ToString()
     {
@@ -22,9 +22,9 @@ public class AriaVersion
 [JsonObject]
 public class AriaVersionResult
 {
-    [JsonProperty("enabledFeatures")] public List<string> EnabledFeatures { get; set; }
+    [JsonProperty("enabledFeatures")] public List<string>? EnabledFeatures { get; set; }
 
-    [JsonProperty("version")] public string Version { get; set; }
+    [JsonProperty("version")] public string? Version { get; set; }
 
     public override string ToString()
     {

--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -108,3 +108,4 @@ Do not:
 - PR #XX: annotated `StringLogicalComparer<T>` nullability without changing comparator ordering behavior.
 - PR #XX: fixed CA2022 in `Encryptor.File` by requiring exact IV/salt reads during decrypt setup.
 - PR #XX: aligned the first small Aria2 JSON-RPC response DTO nullability batch with nullable result/error response semantics.
+- PR #XX: aligned the second small Aria2 JSON-RPC response/result DTO nullability batch with nullable deserialization semantics.


### PR DESCRIPTION
### Motivation

- Silence CS8618 warnings in a small, low-risk batch of Aria2 JSON-RPC DTOs by aligning nullability with JSON deserialization semantics. 
- Limit the change surface to wrapper/result DTOs that are populated via JSON deserialization and avoid behavioral or API changes.

### Description

- Marked JSON-RPC wrapper properties nullable (`Id`, `Jsonrpc`, `Result`, `Error`) in `AriaVersion`, `AriaGetUris` and `AriaGetSessionInfo` to reflect that fields may be absent or null at runtime. 
- Marked nested result properties nullable where they are populated solely by deserialization (`EnabledFeatures`, `Version`, `List<AriaUri> Result`, `SessionId`) without adding fake defaults or null-forgiving operators. 
- Preserved JSON property names, class names, namespaces and `ToString()` implementations. 
- Appended a single progress entry to `docs/maintenance/build-warning-cleanup-audit.md` noting this second small Aria2 DTO nullability batch (using `PR #XX` placeholder). 

### Testing

- Ran `git diff --check` which reported no whitespace/merge issues. 
- Built the core project with `dotnet build DownKyi.Core/DownKyi.Core.csproj -v minimal` which succeeded and produced no warnings for the targeted files. 
- Built the solution with `dotnet build DownKyi.sln --configuration Release -p:ContinuousIntegrationBuild=true` which succeeded (overall repository still contains unrelated warnings outside the scoped DTO changes). 
- Verified targeted warnings were removed by building and checking the output log for `AriaVersion.cs`, `AriaGetUris.cs` and `AriaGetSessionInfo.cs`, which produced no matches (targeted CS8618 instances gone).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4a15124483309502fc9580012b75)