### PR TITLE
fix: align aria2 system wrapper nullability

### DIFF
--- a/DownKyi.Core/Aria2cNet/Client/Entity/SystemListMethods.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/SystemListMethods.cs
@@ -5,13 +5,13 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity;
 [JsonObject]
 public class SystemListMethods
 {
-    [JsonProperty("id")] public string Id { get; set; }
+    [JsonProperty("id")] public string? Id { get; set; }
 
-    [JsonProperty("jsonrpc")] public string Jsonrpc { get; set; }
+    [JsonProperty("jsonrpc")] public string? Jsonrpc { get; set; }
 
-    [JsonProperty("result")] public List<string> Result { get; set; }
+    [JsonProperty("result")] public List<string>? Result { get; set; }
 
-    [JsonProperty("error")] public AriaError Error { get; set; }
+    [JsonProperty("error")] public AriaError? Error { get; set; }
 
     public override string ToString()
     {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/SystemListNotifications.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/SystemListNotifications.cs
@@ -5,13 +5,13 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity;
 [JsonObject]
 public class SystemListNotifications
 {
-    [JsonProperty("id")] public string Id { get; set; }
+    [JsonProperty("id")] public string? Id { get; set; }
 
-    [JsonProperty("jsonrpc")] public string Jsonrpc { get; set; }
+    [JsonProperty("jsonrpc")] public string? Jsonrpc { get; set; }
 
-    [JsonProperty("result")] public List<string> Result { get; set; }
+    [JsonProperty("result")] public List<string>? Result { get; set; }
 
-    [JsonProperty("error")] public AriaError Error { get; set; }
+    [JsonProperty("error")] public AriaError? Error { get; set; }
 
     public override string ToString()
     {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticall.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticall.cs
@@ -5,13 +5,13 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity;
 [JsonObject]
 public class SystemMulticall
 {
-    [JsonProperty("id")] public string Id { get; set; }
+    [JsonProperty("id")] public string? Id { get; set; }
 
-    [JsonProperty("jsonrpc")] public string Jsonrpc { get; set; }
+    [JsonProperty("jsonrpc")] public string? Jsonrpc { get; set; }
 
-    [JsonProperty("result")] public string Result { get; set; }
+    [JsonProperty("result")] public string? Result { get; set; }
 
-    [JsonProperty("error")] public AriaError Error { get; set; }
+    [JsonProperty("error")] public AriaError? Error { get; set; }
 
     public override string ToString()
     {

--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -109,3 +109,5 @@ Do not:
 - PR #XX: fixed CA2022 in `Encryptor.File` by requiring exact IV/salt reads during decrypt setup.
 - PR #XX: aligned the first small Aria2 JSON-RPC response DTO nullability batch with nullable result/error response semantics.
 - PR #XX: aligned the second small Aria2 JSON-RPC response/result DTO nullability batch with nullable deserialization semantics.
+
+- PR #XX: aligned the third small Aria2 JSON-RPC wrapper DTO nullability batch with nullable result/error response semantics.


### PR DESCRIPTION
### Motivation
- Resolve CS8618 nullable-reference warnings in a small, low-risk subset of Aria2 JSON-RPC wrapper DTOs by matching property nullability to JSON-RPC response semantics (fields may be absent or null during deserialization).

### Description
- Annotated `Id`, `Jsonrpc`, `Result`, and `Error` as nullable (`string?`, `List<string>?`, `string?`, `AriaError?` as applicable) in `SystemListMethods`, `SystemListNotifications`, and `SystemMulticall`, and added a single progress entry to `docs/maintenance/build-warning-cleanup-audit.md`.

### Testing
- Executed `git diff --check`, `dotnet build DownKyi.Core/DownKyi.Core.csproj -v minimal`, and `dotnet build DownKyi.sln --configuration Release -p:ContinuousIntegrationBuild=true`, and confirmed the targeted CS8618 warnings for the three modified files are no longer reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d4da4819083309e9791efee3527ba)