### PR TITLE
Fix Node action deprecation and nullable annotations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       release_body: ${{ steps.git-cliff.outputs.content }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Generate a changelog
@@ -39,9 +39,9 @@ jobs:
         trimmed: [ true, false ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
       - name: Read Version Text
@@ -128,9 +128,9 @@ jobs:
             cpu: arm64
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
       - name: Read Version Text
@@ -178,7 +178,7 @@ jobs:
         cpu: [ x64, arm64 ]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Import certificate
         uses: apple-actions/import-codesign-certs@v2
         with:
@@ -190,7 +190,7 @@ jobs:
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=true
           brew install create-dmg tree
       - name: Install .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
       - name: Read Version Text

--- a/DownKyi.Core/Aria2cNet/AriaManager.cs
+++ b/DownKyi.Core/Aria2cNet/AriaManager.cs
@@ -10,7 +10,7 @@ public class AriaManager
     // gid对应项目的状态
     public delegate void TellStatusHandler(long totalLength, long completedLength, long speed, string gid);
 
-    public event TellStatusHandler TellStatus;
+    public event TellStatusHandler? TellStatus;
 
     protected virtual void OnTellStatus(long totalLength, long completedLength, long speed, string gid)
     {
@@ -18,11 +18,11 @@ public class AriaManager
     }
 
     // 下载结果回调
-    public delegate void DownloadFinishHandler(bool isSuccess, string downloadPath, string gid, string msg = null);
+    public delegate void DownloadFinishHandler(bool isSuccess, string? downloadPath, string gid, string? msg = null);
 
-    public event DownloadFinishHandler DownloadFinish;
+    public event DownloadFinishHandler? DownloadFinish;
 
-    protected virtual void OnDownloadFinish(bool isSuccess, string downloadPath, string gid, string msg = null)
+    protected virtual void OnDownloadFinish(bool isSuccess, string? downloadPath, string gid, string? msg = null)
     {
         DownloadFinish?.Invoke(isSuccess, downloadPath, gid, msg);
     }
@@ -30,7 +30,7 @@ public class AriaManager
     // 全局下载状态
     public delegate void GetGlobalStatusHandler(long speed);
 
-    public event GetGlobalStatusHandler GlobalStatus;
+    public event GetGlobalStatusHandler? GlobalStatus;
 
     protected virtual void OnGlobalStatus(long speed)
     {
@@ -46,7 +46,7 @@ public class AriaManager
     /// <param name="gid"></param>
     /// <param name="action"></param>
     /// <returns></returns>
-    public DownloadResult GetDownloadStatus(string gid, Action action = null)
+    public DownloadResult GetDownloadStatus(string gid, Action? action = null)
     {
         string filePath = "";
         while (true)

--- a/DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticallMathod.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticallMathod.cs
@@ -1,11 +1,13 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace DownKyi.Core.Aria2cNet.Client.Entity;
 
 [JsonObject]
 public class SystemMulticallMathod
 {
-    [JsonProperty("method")] public string Method { get; set; }
+    [JsonProperty("method")]
+    public string Method { get; set; } = string.Empty;
 
-    [JsonProperty("params")] public List<object> Params { get; set; }
+    [JsonProperty("params")]
+    public List<object> Params { get; set; } = new();
 }

--- a/DownKyi.Core/BiliApi/Bangumi/Models/BangumiArea.cs
+++ b/DownKyi.Core/BiliApi/Bangumi/Models/BangumiArea.cs
@@ -1,10 +1,13 @@
-﻿using DownKyi.Core.BiliApi.Models;
+using DownKyi.Core.BiliApi.Models;
 using Newtonsoft.Json;
 
 namespace DownKyi.Core.BiliApi.Bangumi.Models;
 
 public class BangumiArea : BaseModel
 {
-    [JsonProperty("id")] public int Id { get; set; }
-    [JsonProperty("name")] public string Name { get; set; }
+    [JsonProperty("id")]
+    public int Id { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; } = string.Empty;
 }

--- a/DownKyi.Core/BiliApi/Bangumi/Models/BangumiUpInfo.cs
+++ b/DownKyi.Core/BiliApi/Bangumi/Models/BangumiUpInfo.cs
@@ -1,19 +1,23 @@
-﻿using DownKyi.Core.BiliApi.Models;
+using DownKyi.Core.BiliApi.Models;
 using Newtonsoft.Json;
 
 namespace DownKyi.Core.BiliApi.Bangumi.Models;
 
 public class BangumiUpInfo : BaseModel
 {
-    [JsonProperty("avatar")] public string Avatar { get; set; }
+    [JsonProperty("avatar")]
+    public string Avatar { get; set; } = string.Empty;
 
     // follower
     // is_follow
-    [JsonProperty("mid")] public long Mid { get; set; }
+    [JsonProperty("mid")]
+    public long Mid { get; set; }
 
     // pendant
     // theme_type
-    [JsonProperty("uname")] public string Name { get; set; }
+    [JsonProperty("uname")]
+    public string Name { get; set; } = string.Empty;
+
     // verify_type
     // vip_status
     // vip_type

--- a/DownKyi.Core/BiliApi/History/Models/ToViewList.cs
+++ b/DownKyi.Core/BiliApi/History/Models/ToViewList.cs
@@ -1,4 +1,4 @@
-﻿using DownKyi.Core.BiliApi.Models;
+using DownKyi.Core.BiliApi.Models;
 using Newtonsoft.Json;
 
 namespace DownKyi.Core.BiliApi.History.Models
@@ -7,14 +7,17 @@ namespace DownKyi.Core.BiliApi.History.Models
     {
         [JsonProperty("aid")]
         public long Aid { get; set; }
+
         // videos
         // tid
         // tname
         // copyright
         [JsonProperty("pic")]
-        public string Pic { get; set; }
+        public string Pic { get; set; } = string.Empty;
+
         [JsonProperty("title")]
-        public string Title { get; set; }
+        public string Title { get; set; } = string.Empty;
+
         // pubdate
         // ctime
         // desc
@@ -22,7 +25,8 @@ namespace DownKyi.Core.BiliApi.History.Models
         // duration
         // rights
         [JsonProperty("owner")]
-        public VideoOwner Owner { get; set; }
+        public VideoOwner Owner { get; set; } = new();
+
         // stat
         // dynamic
         // dimension
@@ -32,11 +36,14 @@ namespace DownKyi.Core.BiliApi.History.Models
         // count
         [JsonProperty("cid")]
         public long Cid { get; set; }
+
         // progress
         [JsonProperty("add_at")]
         public long AddAt { get; set; }
+
         [JsonProperty("bvid")]
-        public string Bvid { get; set; }
+        public string Bvid { get; set; } = string.Empty;
+
         // uri
         // viewed
     }


### PR DESCRIPTION
### Motivation
- Remove the GitHub Actions Node.js 20 deprecation source and keep CI actions up-to-date by upgrading checkout and setup-dotnet actions.
- Reduce C# nullable reference warnings (CS8618 / CS8625) in a small set of DTOs and Aria manager signatures without touching business logic.

### Description
- Updated `.github/workflows/build.yml` to replace `actions/checkout@v4` with `actions/checkout@v6` and `actions/setup-dotnet@v4` with `actions/setup-dotnet@v5` while leaving other actions unchanged.
- Replaced `DownKyi.Core/BiliApi/History/Models/ToViewList.cs` with the provided DTO and added `= string.Empty` / `= new()` initializers for non-nullable properties.
- Replaced `DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticallMathod.cs` with the provided DTO, kept the class name `SystemMulticallMathod`, and added default initializers for `Method` and `Params`.
- Replaced `DownKyi.Core/BiliApi/Bangumi/Models/BangumiArea.cs` and `DownKyi.Core/BiliApi/Bangumi/Models/BangumiUpInfo.cs` with the provided DTOs and initialized string properties with `= string.Empty`.
- Applied only the requested nullability/type adjustments in `DownKyi.Core/Aria2cNet/AriaManager.cs` by making event fields nullable, converting `string` delegate parameters and `Action` parameters to nullable (`string?`, `Action?`), and updating related method signatures without changing control flow.
- Diffs were produced and inspected for each modified file (`.github/workflows/build.yml`, `DownKyi.Core/BiliApi/History/Models/ToViewList.cs`, `DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticallMathod.cs`, `DownKyi.Core/BiliApi/Bangumi/Models/BangumiArea.cs`, `DownKyi.Core/BiliApi/Bangumi/Models/BangumiUpInfo.cs`, `DownKyi.Core/Aria2cNet/AriaManager.cs`).

### Testing
- Ran `dotnet restore` which completed successfully.
- Ran `dotnet build -c Release` which completed successfully with 0 errors and the solution built; many pre-existing nullable warnings remain outside the files that were allowed to be changed.
- Verified that the repository-level changes produced `git diff` outputs for each targeted file and a combined `git diff --stat` showing the six modified files and the summary `47 insertions(+), 31 deletions(-)`.
- Remaining warnings: CS8618 and CS8625 still appear in other files that were intentionally out of scope for this change, and the workflow updates applied should address the Node.js 20 deprecation source in the actions referenced (runtime confirmation requires an actual GitHub Actions run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d50142d7c8330bb3b86fc2b187838)