### PR TITLE
fix: align aria2 leaf dto nullability

### DIFF
--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaUri.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaUri.cs
@@ -5,9 +5,9 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity;
 [JsonObject]
 public class AriaUri
 {
-    [JsonProperty("status")] public string Status { get; set; }
+    [JsonProperty("status")] public string? Status { get; set; }
 
-    [JsonProperty("uri")] public string Uri { get; set; }
+    [JsonProperty("uri")] public string? Uri { get; set; }
 
     public override string ToString()
     {

--- a/DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticallMathod.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticallMathod.cs
@@ -5,7 +5,7 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity;
 [JsonObject]
 public class SystemMulticallMathod
 {
-    [JsonProperty("method")] public string Method { get; set; }
+    [JsonProperty("method")] public string? Method { get; set; }
 
-    [JsonProperty("params")] public List<object> Params { get; set; }
+    [JsonProperty("params")] public List<object>? Params { get; set; }
 }

--- a/docs/maintenance/build-warning-cleanup-audit.md
+++ b/docs/maintenance/build-warning-cleanup-audit.md
@@ -113,3 +113,4 @@ Do not:
 - PR #XX: aligned the third small Aria2 JSON-RPC wrapper DTO nullability batch with nullable result/error response semantics.
 
 - PR #XX: refreshed build warning inventory after the first three Aria2 DTO nullability batches; no production code changes.
+- PR #XX: aligned small Aria2 leaf DTO nullability for `AriaUri` and `SystemMulticallMathod` with nullable deserialization semantics.


### PR DESCRIPTION
### Motivation

- Silence CS8618 warnings reported in the recent warning inventory for two small Aria2 leaf DTOs that are JSON-populated and lack ctor/default initializers. 
- Keep the change very narrow and low-risk by aligning nullability with deserialization semantics only. 

### Description

- Marked `AriaUri` JSON-populated properties nullable: changed `Status` and `Uri` from `string` to `string?` in `DownKyi.Core/Aria2cNet/Client/Entity/AriaUri.cs`.
- Marked `SystemMulticallMathod` JSON-populated properties nullable: changed `Method` from `string` to `string?` and `Params` from `List<object>` to `List<object>?` in `DownKyi.Core/Aria2cNet/Client/Entity/SystemMulticallMathod.cs`.
- Added a single progress entry to `docs/maintenance/build-warning-cleanup-audit.md` recording the small Aria2 leaf DTO nullability alignment (uses `PR #XX` placeholder).
- No JSON property names, class names, namespaces, ToString() behavior, Aria2 client logic, or other runtime behavior was changed. 

### Testing

- Ran `git diff --check` and fixed trailing newline issues; no check failures remain.
- Built the core project with `dotnet build DownKyi.Core/DownKyi.Core.csproj -v minimal` and the targeted CS8618 warnings for `AriaUri` and `SystemMulticallMathod` were resolved (build succeeded).
- Built the solution with `dotnet build DownKyi.sln --configuration Release -p:ContinuousIntegrationBuild=true` and the solution build completed successfully; overall warnings unrelated to these two files remain but the targeted warnings are gone.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d5131af0c8330b805f773efcaeca0)