### PR TITLE
docs: add multilingual README support

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,47 @@
+# DownKyi Core Cross-Platform Edition
+
+<div align="center">
+
+[简体中文](README.md) | [繁體中文](README.zh-TW.md) | [English](README.en.md)
+
+[![GitHub Repo stars](https://img.shields.io/github/stars/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/network)
+[![GitHub issues](https://img.shields.io/github/issues/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/issues)
+[![LICENSE](https://img.shields.io/github/license/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/blob/main/LICENSE)
+
+</div>
+
+## Download
+
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub Release Date](https://img.shields.io/github/release-date/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub all releases](https://img.shields.io/github/downloads/crazysmile-PhD/downkyicore/total)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+
+[Changelog](CHANGELOG.md)
+
+## Introduction
+
+- This project is a cross-platform edition based on [DownKyi for Windows](https://github.com/leiurayer/downkyi) and [Avalonia UI](https://github.com/AvaloniaUI/Avalonia). It supports Windows, Linux, and macOS.
+- This version was created because the maintainer uses macOS in daily work. When trying to download videos from Bilibili creators, the maintainer found [DownKyi for Windows](https://github.com/leiurayer/downkyi), which is useful but does not support macOS. This project was therefore rebuilt with Avalonia UI as a cross-platform edition.
+
+## Usage
+
+- The application includes the .NET 6, ffmpeg, and aria2 runtime environments. No separate installation is required.
+- Default download paths:
+  - Windows: the `Media` folder under the application directory
+  - macOS: `~/Library/Application Support/DownKyi/Media`
+  - Linux: `~/.config/DownKyi/Media`
+
+## Sponsorship
+
+If this project is helpful to you and you would like to support its development and maintenance, feel free to donate by scanning the QR codes below. Thank you for your support!
+
+![Alipay.png](https://s3.bzdrs.cn/downkyi/img/AliPay.png)![WeChat.png](https://s3.bzdrs.cn/downkyi/img/WechatPay.jpg)
+
+## Disclaimer
+
+1. This software only provides video parsing. It does not upload resources or store them on any server.
+2. This software only parses content from Bilibili. It does not re-encode the parsed audio or video. Some videos may undergo limited format conversion or merging.
+3. All parsed content comes from videos uploaded and shared by Bilibili creators. Copyright belongs to the original authors. Content providers and uploaders are fully responsible for the content they provide and upload.
+4. **All content provided by this software is for learning and communication purposes only. Any other use without authorization from the original author is prohibited. Please delete downloaded content within 24 hours. To respect copyright, please watch the content on the original publishing platform and support the creators.**
+5. The software author is not responsible for any copyright issues caused by the use of this software.

--- a/README.md
+++ b/README.md
@@ -1,44 +1,47 @@
-# 哔哩下载姬(跨平台版)
+# 哔哩下载姬（跨平台版）
 
 <div align="center">
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/network)
-[![GitHub issues](https://img.shields.io/github/issues/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/issues)
-[![LICENSE](https://img.shields.io/github/license/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/blob/main/LICENSE)
+[简体中文](README.md) | [繁體中文](README.zh-TW.md) | [English](README.en.md)
+
+[![GitHub Repo stars](https://img.shields.io/github/stars/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/network)
+[![GitHub issues](https://img.shields.io/github/issues/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/issues)
+[![LICENSE](https://img.shields.io/github/license/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/blob/main/LICENSE)
 
 </div>
 
 ## 下载
 
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/releases/latest)
-[![GitHub Release Date](https://img.shields.io/github/release-date/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/releases/latest)
-[![GitHub all releases](https://img.shields.io/github/downloads/yaobiao131/downkyicore/total)](https://github.com/yaobiao131/downkyicore/releases/latest)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub Release Date](https://img.shields.io/github/release-date/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub all releases](https://img.shields.io/github/downloads/crazysmile-PhD/downkyicore/total)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
 
 [更新日志](CHANGELOG.md)
 
 ## 介绍
 
-- 基于[哔哩下载姬Windows版](https://github.com/leiurayer/downkyi)和[AvaloniaUI](https://github.com/AvaloniaUI/Avalonia)制作的跨平台版本(支持Windows、linux、macOS)。
-- 开发这个版本目的是由于本人日常使用macOS，当我想下载up视频是偶然间发现了[哔哩下载姬Windows版](https://github.com/leiurayer/downkyi)，发现很好用，就是不能支持macOS使用，就基于AvaloniaUI重新开发了一个跨平台版本。
+- 基于[哔哩下载姬 Windows 版](https://github.com/leiurayer/downkyi)和[Avalonia UI](https://github.com/AvaloniaUI/Avalonia)制作的跨平台版本，支持 Windows、Linux、macOS。
+- 开发这个版本的原因是本人日常使用 macOS。当我想下载 UP 主视频时，偶然发现了[哔哩下载姬 Windows 版](https://github.com/leiurayer/downkyi)，它很好用，但不支持 macOS，因此基于 Avalonia UI 重新开发了这个跨平台版本。
 
 ## 使用说明
-- 软件自带.NET6、ffmpeg、aria2运行环境、无需自行安装
-- 默认下载路径:
-  - Windows: 软件运行目录下的Media文件夹
-  - macOS: ~/Library/Application Support/DownKyi/Media
-  - linux: ~/.config/DownKyi/Media
+
+- 软件自带 .NET 6、ffmpeg、aria2 运行环境，无需自行安装。
+- 默认下载路径：
+  - Windows：软件运行目录下的 `Media` 文件夹
+  - macOS：`~/Library/Application Support/DownKyi/Media`
+  - Linux：`~/.config/DownKyi/Media`
 
 ## 赞助
 
-如果这个项目对您有很大帮助，并且您希望支持该项目的开发和维护，请随时扫描一下二维码进行捐赠。非常感谢您的捐款，谢谢！
+如果这个项目对您有帮助，并且您希望支持项目的开发和维护，欢迎扫描下方二维码进行捐赠。非常感谢您的支持！
 
 ![Alipay.png](https://s3.bzdrs.cn/downkyi/img/AliPay.png)![WeChat.png](https://s3.bzdrs.cn/downkyi/img/WechatPay.jpg)
 
-## 免责申明
-1. 本软件只提供视频解析，不提供任何资源上传、存储到服务器的功能。
-2. 本软件仅解析来自B站的内容，不会对解析到的音视频进行二次编码，部分视频会进行有限的格式转换、拼接等操作。
-3. 本软件解析得到的所有内容均来自B站UP主上传、分享，其版权均归原作者所有。内容提供者、上传者(UP主)应对其提供、上传的内容承担全部责任。
-4. **本软件提供的所有内容，仅可用作学习交流使用，未经原作者授权，禁止用于其他用途。请在下载24小时内删除。为尊重作者版权，请前往资源的原始发布网站观看，支持原创，谢谢。**
-5. 因使用本软件产生的版权问题，软件作者概不负责。
+## 免责声明
 
+1. 本软件只提供视频解析，不提供任何资源上传、存储到服务器的功能。
+2. 本软件仅解析来自 B 站的内容，不会对解析到的音视频进行二次编码，部分视频会进行有限的格式转换、拼接等操作。
+3. 本软件解析得到的所有内容均来自 B 站 UP 主上传、分享，其版权均归原作者所有。内容提供者、上传者（UP 主）应对其提供、上传的内容承担全部责任。
+4. **本软件提供的所有内容，仅可用作学习交流使用，未经原作者授权，禁止用于其他用途。请在下载 24 小时内删除。为尊重作者版权，请前往资源的原始发布网站观看，支持原创，谢谢。**
+5. 因使用本软件产生的版权问题，软件作者概不负责。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,0 +1,47 @@
+# 嗶哩下載姬（跨平台版）
+
+<div align="center">
+
+[简体中文](README.md) | [繁體中文](README.zh-TW.md) | [English](README.en.md)
+
+[![GitHub Repo stars](https://img.shields.io/github/stars/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/network)
+[![GitHub issues](https://img.shields.io/github/issues/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/issues)
+[![LICENSE](https://img.shields.io/github/license/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/blob/main/LICENSE)
+
+</div>
+
+## 下載
+
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub Release Date](https://img.shields.io/github/release-date/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub all releases](https://img.shields.io/github/downloads/crazysmile-PhD/downkyicore/total)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+
+[更新日誌](CHANGELOG.md)
+
+## 介紹
+
+- 本專案是基於[嗶哩下載姬 Windows 版](https://github.com/leiurayer/downkyi)與 [Avalonia UI](https://github.com/AvaloniaUI/Avalonia) 製作的跨平台版本，支援 Windows、Linux、macOS。
+- 開發這個版本的原因是本人日常使用 macOS。當我想下載 UP 主影片時，偶然發現了[嗶哩下載姬 Windows 版](https://github.com/leiurayer/downkyi)，它很好用，但不支援 macOS，因此基於 Avalonia UI 重新開發了這個跨平台版本。
+
+## 使用說明
+
+- 軟體內建 .NET 6、ffmpeg、aria2 執行環境，無需自行安裝。
+- 預設下載路徑：
+  - Windows：軟體執行目錄下的 `Media` 資料夾
+  - macOS：`~/Library/Application Support/DownKyi/Media`
+  - Linux：`~/.config/DownKyi/Media`
+
+## 贊助
+
+如果這個專案對您有幫助，並且您希望支持專案的開發與維護，歡迎掃描下方 QR Code 進行捐贈。非常感謝您的支持！
+
+![Alipay.png](https://s3.bzdrs.cn/downkyi/img/AliPay.png)![WeChat.png](https://s3.bzdrs.cn/downkyi/img/WechatPay.jpg)
+
+## 免責聲明
+
+1. 本軟體只提供影片解析，不提供任何資源上傳或儲存到伺服器的功能。
+2. 本軟體僅解析來自 B 站的內容，不會對解析到的音訊、影片進行二次編碼，部分影片會進行有限的格式轉換、合併等操作。
+3. 本軟體解析得到的所有內容均來自 B 站 UP 主上傳、分享，其版權均歸原作者所有。內容提供者、上傳者（UP 主）應對其提供、上傳的內容承擔全部責任。
+4. **本軟體提供的所有內容，僅可用作學習交流使用，未經原作者授權，禁止用於其他用途。請在下載 24 小時內刪除。為尊重作者版權，請前往資源的原始發布網站觀看，支持原創，謝謝。**
+5. 因使用本軟體產生的版權問題，軟體作者概不負責。


### PR DESCRIPTION
## Summary

- Add language switch links to the main `README.md`.
- Add Traditional Chinese README: `README.zh-TW.md`.
- Add English README: `README.en.md`.
- Update README badges and release links to point to `crazysmile-PhD/downkyicore` instead of the upstream repository.

## Notes

This PR keeps Simplified Chinese as the default README language while adding Traditional Chinese and English documentation entries.