### PR TITLE
Improve download reliability and ffmpeg packaging

### DIFF
--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaSendData.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaSendData.cs
@@ -54,6 +54,15 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
         [JsonProperty("user-agent")]
         public string UserAgent { get; set; } = string.Empty;
 
+        [JsonProperty("split")]
+        public string Split { get; set; } = string.Empty;
+
+        [JsonProperty("max-connection-per-server")]
+        public string MaxConnectionPerServer { get; set; } = string.Empty;
+
+        [JsonProperty("min-split-size")]
+        public string MinSplitSize { get; set; } = string.Empty;
+
         public override string ToString()
         {
             return JsonConvert.SerializeObject(this);

--- a/DownKyi.Core/BiliApi/Models/Json/Subtitle.cs
+++ b/DownKyi.Core/BiliApi/Models/Json/Subtitle.cs
@@ -4,8 +4,8 @@ namespace DownKyi.Core.BiliApi.Models.Json;
 
 public class Subtitle : BaseModel
 {
-    [JsonProperty("from")] public float From { get; set; }
-    [JsonProperty("to")] public float To { get; set; }
+    [JsonProperty("from")] public decimal From { get; set; }
+    [JsonProperty("to")] public decimal To { get; set; }
     [JsonProperty("location")] public int Location { get; set; }
     [JsonProperty("content")] public string Content { get; set; } = string.Empty;
 }

--- a/DownKyi.Core/BiliApi/Models/Json/SubtitleJson.cs
+++ b/DownKyi.Core/BiliApi/Models/Json/SubtitleJson.cs
@@ -1,4 +1,5 @@
 using Newtonsoft.Json;
+using System.Text;
 
 namespace DownKyi.Core.BiliApi.Models.Json;
 
@@ -17,16 +18,16 @@ public class SubtitleJson : BaseModel
     /// <returns></returns>
     public string ToSubRip()
     {
-        string subRip = string.Empty;
+        var subRip = new StringBuilder();
         for (int i = 0; i < Body.Count; i++)
         {
-            subRip += $"{i + 1}\n";
-            subRip += $"{Second2hms(Body[i].From)} --> {Second2hms(Body[i].To)}\n";
-            subRip += $"{Body[i].Content}\n";
-            subRip += "\n";
+            subRip.AppendLine((i + 1).ToString());
+            subRip.AppendLine($"{SecondsToSrtTime(Body[i].From)} --> {SecondsToSrtTime(Body[i].To)}");
+            subRip.AppendLine(Body[i].Content);
+            subRip.AppendLine();
         }
 
-        return subRip;
+        return subRip.ToString();
     }
 
     /// <summary>
@@ -34,11 +35,12 @@ public class SubtitleJson : BaseModel
     /// </summary>
     /// <param name="seconds"></param>
     /// <returns></returns>
-    private static string Second2hms(float seconds)
+    private static string SecondsToSrtTime(decimal seconds)
     {
         if (seconds < 0) return "00:00:00,000";
 
-        var span = TimeSpan.FromSeconds(seconds);
+        var totalMilliseconds = decimal.ToInt64(decimal.Round(seconds * 1000m, 0, MidpointRounding.AwayFromZero));
+        var span = TimeSpan.FromMilliseconds(totalMilliseconds);
         return $"{(int)span.TotalHours:D2}:{span.Minutes:D2}:{span.Seconds:D2},{span.Milliseconds:D3}";
     }
 }

--- a/DownKyi.Core/BiliApi/VideoStream/Models/PlayUrlDashVideo.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/Models/PlayUrlDashVideo.cs
@@ -20,6 +20,8 @@ public class PlayUrlDashVideo : BaseModel
 
     [JsonProperty("frameRate")] public string FrameRate { get; set; } = string.Empty;
 
+    public long ExpectedSize { get; set; }
+
     // frame_rate
     // sar
     // startWithSap

--- a/DownKyi.Core/BiliApi/VideoStream/VideoStream.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/VideoStream.cs
@@ -86,12 +86,31 @@ public static class VideoStream
         {
             cancellationToken.ThrowIfCancellationRequested();
             const string referer = "https://www.bilibili.com";
-            var response = WebClient.RequestWeb($"https:{subtitle.SubtitleUrl}", referer, cancellationToken: cancellationToken);
+            var subtitleUrl = NormalizeSubtitleUrl(subtitle.SubtitleUrl);
+            if (subtitleUrl == null)
+            {
+                LogManager.Debug(nameof(GetSubtitle), $"Skip empty subtitle url. lan={subtitle.Lan}, lan_doc={subtitle.LanDoc}");
+                continue;
+            }
+
+            var response = WebClient.RequestWeb(subtitleUrl, referer, cancellationToken: cancellationToken);
+            if (string.IsNullOrWhiteSpace(response))
+            {
+                LogManager.Debug(nameof(GetSubtitle), $"Skip empty subtitle response. lan={subtitle.Lan}, lan_doc={subtitle.LanDoc}, type={subtitle.Type}");
+                continue;
+            }
 
             try
             {
                 var subtitleJson = JsonConvert.DeserializeObject<SubtitleJson>(response);
-                if (subtitleJson == null)
+                if (subtitleJson?.Body == null || subtitleJson.Body.Count == 0)
+                {
+                    LogManager.Debug(nameof(GetSubtitle), $"Skip subtitle with empty body. lan={subtitle.Lan}, lan_doc={subtitle.LanDoc}, type={subtitle.Type}");
+                    continue;
+                }
+
+                var srt = subtitleJson.ToSubRip();
+                if (string.IsNullOrWhiteSpace(srt))
                 {
                     continue;
                 }
@@ -100,7 +119,7 @@ public static class VideoStream
                 {
                     Lan = subtitle.Lan,
                     LanDoc = subtitle.LanDoc,
-                    SrtString = subtitleJson.ToSubRip()
+                    SrtString = srt
                 });
             }
             catch (OperationCanceledException)
@@ -115,6 +134,23 @@ public static class VideoStream
         }
 
         return subRipTexts;
+    }
+
+    private static string? NormalizeSubtitleUrl(string? subtitleUrl)
+    {
+        if (string.IsNullOrWhiteSpace(subtitleUrl))
+        {
+            return null;
+        }
+
+        if (Uri.TryCreate(subtitleUrl, UriKind.Absolute, out var absoluteUri))
+        {
+            return absoluteUri.ToString();
+        }
+
+        return subtitleUrl.StartsWith("//", StringComparison.Ordinal)
+            ? $"https:{subtitleUrl}"
+            : $"https://{subtitleUrl.TrimStart('/')}";
     }
 
     /// <summary>

--- a/DownKyi.Core/BiliApi/WebClient.cs
+++ b/DownKyi.Core/BiliApi/WebClient.cs
@@ -22,7 +22,7 @@ public static class WebClient
             PooledConnectionLifetime = TimeSpan.FromMinutes(10),
             PooledConnectionIdleTimeout = TimeSpan.FromMinutes(5),
             AutomaticDecompression = DecompressionMethods.All,
-            ConnectTimeout = TimeSpan.FromSeconds(3)
+            ConnectTimeout = TimeSpan.FromSeconds(8)
         };
         switch (SettingsManager.GetInstance().GetNetworkProxy())
         {
@@ -100,7 +100,8 @@ public static class WebClient
                 GetBuvid(cancellationToken);
             }
 
-            var request = new HttpRequestMessage(new HttpMethod(method), url);
+            var requestUrl = BuildRequestUrl(url, method, parameters);
+            using var request = new HttpRequestMessage(new HttpMethod(method), requestUrl);
 
             if (referer != null)
             {
@@ -141,17 +142,12 @@ public static class WebClient
                     request.Content = new FormUrlEncodedContent(parameters.Select(item => new KeyValuePair<string, string>(item.Key, item.Value?.ToString() ?? "")));
                 }
             }
-            else if (parameters != null)
-            {
-                var query = string.Join("&", parameters.Select(kvp => $"{kvp.Key}={kvp.Value}"));
-                url = $"{url}?{query}";
-                request.RequestUri = new Uri(url);
-            }
 
-            var response = HttpClient.Send(request, cancellationToken);
+            using var response = HttpClient.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            using var reader = new StreamReader(response.Content.ReadAsStream());
+            using var stream = response.Content.ReadAsStream(cancellationToken);
+            using var reader = new StreamReader(stream);
             return reader.ReadToEnd();
         }
         catch (OperationCanceledException)
@@ -162,14 +158,44 @@ public static class WebClient
         {
             Console.WriteLine("RequestWeb()发生HTTP请求异常: {0}", e);
             LogManager.Error(e);
+            WaitBeforeRetry(retry, cancellationToken);
             return RequestWeb(url, referer, method, parameters, retry - 1, json, cancellationToken);
         }
         catch (Exception e)
         {
             Console.WriteLine("RequestWeb()发生其他异常: {0}", e);
             LogManager.Error(e);
+            WaitBeforeRetry(retry, cancellationToken);
             return RequestWeb(url, referer, method, parameters, retry - 1, json, cancellationToken);
         }
+    }
+
+    private static string BuildRequestUrl(string url, string method, Dictionary<string, object?>? parameters)
+    {
+        if (method == "POST" || parameters == null || parameters.Count == 0)
+        {
+            return url;
+        }
+
+        var query = string.Join("&", parameters.Select(kvp =>
+            $"{HttpUtility.UrlEncode(kvp.Key)}={HttpUtility.UrlEncode(kvp.Value?.ToString() ?? string.Empty)}"));
+
+        return url.Contains("?", StringComparison.Ordinal)
+            ? $"{url}&{query}"
+            : $"{url}?{query}";
+    }
+
+    private static void WaitBeforeRetry(int retry, CancellationToken cancellationToken)
+    {
+        if (retry <= 1)
+        {
+            return;
+        }
+
+        var delayMilliseconds = Math.Clamp((3 - retry + 1) * 250, 250, 2000);
+        var delay = TimeSpan.FromMilliseconds(delayMilliseconds);
+        cancellationToken.WaitHandle.WaitOne(delay);
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
     public static void DownloadFile(string url, string destFile, string? referer = null, CancellationToken cancellationToken = default)
@@ -199,8 +225,68 @@ public static class WebClient
             }
         }
 
-        var response = HttpClient.Send(request, cancellationToken);
-        response.EnsureSuccessStatusCode();
-        return response.Content.ReadAsStream(cancellationToken);
+        var response = HttpClient.Send(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+        try
+        {
+            response.EnsureSuccessStatusCode();
+            return new ResponseStream(response.Content.ReadAsStream(cancellationToken), response, request);
+        }
+        catch
+        {
+            response.Dispose();
+            request.Dispose();
+            throw;
+        }
+    }
+
+    private sealed class ResponseStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly HttpResponseMessage _response;
+        private readonly HttpRequestMessage _request;
+
+        public ResponseStream(Stream inner, HttpResponseMessage response, HttpRequestMessage request)
+        {
+            _inner = inner;
+            _response = response;
+            _request = request;
+        }
+
+        public override bool CanRead => _inner.CanRead;
+        public override bool CanSeek => _inner.CanSeek;
+        public override bool CanWrite => _inner.CanWrite;
+        public override long Length => _inner.Length;
+
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        public override void Flush() => _inner.Flush();
+        public override int Read(byte[] buffer, int offset, int count) => _inner.Read(buffer, offset, count);
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+        public override void SetLength(long value) => _inner.SetLength(value);
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _inner.Dispose();
+                _response.Dispose();
+                _request.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override async ValueTask DisposeAsync()
+        {
+            await _inner.DisposeAsync().ConfigureAwait(false);
+            _response.Dispose();
+            _request.Dispose();
+            await base.DisposeAsync().ConfigureAwait(false);
+        }
     }
 }

--- a/DownKyi.Core/FFMpeg/FFMpeg.cs
+++ b/DownKyi.Core/FFMpeg/FFMpeg.cs
@@ -11,6 +11,8 @@ public class FFMpeg
 {
     private const string Tag = "FFmpegHelper";
     private static readonly FFMpeg instance = new();
+    private static readonly object FfmpegJobLock = new();
+    private static int _runningFfmpegJobs;
 
     static FFMpeg()
     {
@@ -77,11 +79,11 @@ public class FFMpeg
             }
         }
 
-        LogManager.Debug(Tag, arguments.Arguments);
+        if (!RunFfmpeg(arguments, "merge media"))
+        {
+            return false;
+        }
 
-        arguments
-            .NotifyOnError(s => LogManager.Debug(Tag, s))
-            .ProcessSynchronously(false);
         try
         {
             if (audio != null)
@@ -115,16 +117,15 @@ public class FFMpeg
     /// <param name="action"></param>
     public void Delogo(string video, string destVideo, int x, int y, int width, int height, Action<string> action)
     {
-        FFMpegArguments
+        var arguments = FFMpegArguments
             .FromFileInput(video)
             .OutputToFile(
                 destVideo,
                 true,
                 option => option
-                    .WithCustomArgument($"-vf delogo=x={x}:y={y}:w={width}:h={height}:show=0 -hide_banner"))
-            .NotifyOnOutput(action.Invoke)
-            .NotifyOnError(action.Invoke)
-            .ProcessSynchronously(false);
+                    .WithCustomArgument($"-vf delogo=x={x}:y={y}:w={width}:h={height}:show=0 -hide_banner"));
+
+        RunFfmpeg(arguments, "delogo", action);
     }
 
     /// <summary>
@@ -135,7 +136,7 @@ public class FFMpeg
     /// <param name="action">输出信息</param>
     public void ExtractAudio(string video, string audio, Action<string> action)
     {
-        FFMpegArguments
+        var arguments = FFMpegArguments
             .FromFileInput(video)
             .OutputToFile(audio,
                 true,
@@ -143,10 +144,9 @@ public class FFMpeg
                     .WithCustomArgument("-hide_banner")
                     .WithAudioCodec("copy")
                     .DisableChannel(Channel.Video)
-            )
-            .NotifyOnOutput(action.Invoke)
-            .NotifyOnError(action.Invoke)
-            .ProcessSynchronously(false);
+            );
+
+        RunFfmpeg(arguments, "extract audio", action);
     }
 
     /// <summary>
@@ -157,17 +157,16 @@ public class FFMpeg
     /// <param name="action">输出信息</param>
     public void ExtractVideo(string video, string destVideo, Action<string> action)
     {
-         FFMpegArguments.FromFileInput(video)
+        var arguments = FFMpegArguments.FromFileInput(video)
             .OutputToFile(
                 destVideo,
                 true,
                 options => options
                     .WithCustomArgument("-hide_banner")
                     .WithVideoCodec("copy")
-                    .DisableChannel(Channel.Audio))
-            .NotifyOnOutput(action.Invoke)
-            .NotifyOnError(action.Invoke)
-            .ProcessSynchronously(false);
+                    .DisableChannel(Channel.Audio));
+
+        RunFfmpeg(arguments, "extract video", action);
     }
 
     
@@ -196,6 +195,7 @@ public class FFMpeg
     /// <returns>是否成功</returns>
     public bool ConcatVideos(List<string> inputFlvs, string outputVideo, Action<string> action)
     {
+        var listFile = string.Empty;
         try
         {
             if (inputFlvs == null || inputFlvs.Count == 0)
@@ -213,33 +213,192 @@ public class FFMpeg
                 }
             }
 
-            LogManager.Debug(Tag, $"开始合并 {inputFlvs.Count} 个视频到 {outputVideo}");
+            LogManager.Info(Tag,
+                $"Concat video started. segments={inputFlvs.Count}; hw={SettingsManager.GetInstance().GetFfmpegHardwareAcceleration()}; maxParallel={SettingsManager.GetInstance().GetFfmpegMaxParallelJobs()}");
 
+            listFile = Path.Combine(Path.GetTempPath(), $"flvlist_{Guid.NewGuid():N}.txt");
+            File.WriteAllLines(listFile, inputFlvs.Select(ToConcatFileLine));
 
-            var listFile = Path.Combine(Path.GetTempPath(), $"flvlist_{DateTime.Now:yyyyMMddHHmmss}.txt");
-            File.WriteAllLines(listFile, inputFlvs.Select(f => $"file '{f.Replace("'", "'\\''")}'"));
+            if (TryConcatWithStreamCopy(listFile, outputVideo, action))
+            {
+                LogManager.Info(Tag, "Concat video completed by stream copy.");
+                return true;
+            }
 
-            FFMpegArguments
-             .FromFileInput(listFile, false, options => options
-                 .WithCustomArgument("-f concat -safe 0"))
-             .OutputToFile(outputVideo, true, options => options
-                 .WithVideoCodec("libx264")  
-                 .WithAudioCodec("aac")   
-                 .WithCustomArgument("-movflags +faststart")
-                 .WithCustomArgument("-avoid_negative_ts make_zero")
-             )
-             .NotifyOnOutput(action.Invoke)
-             .NotifyOnError(action.Invoke)
-             .ProcessSynchronously(false);
+            DeleteOutput(outputVideo);
 
-            try { File.Delete(listFile); } catch {  }
-            LogManager.Debug(Tag, "视频合并完成");
-            return true;
+            var encoder = FfmpegHardwareEncoderDetector.Select(SettingsManager.GetInstance().GetFfmpegHardwareAcceleration());
+            if (encoder != null && TryConcatWithHardwareEncoder(listFile, outputVideo, encoder, action))
+            {
+                LogManager.Info(Tag, $"Concat video completed by {encoder.DisplayName}.");
+                return true;
+            }
+
+            DeleteOutput(outputVideo);
+            var cpuResult = TryConcatWithCpuEncoder(listFile, outputVideo, action);
+            LogManager.Info(Tag, $"Concat video completed by CPU encoder. success={cpuResult}");
+            return cpuResult;
         }
         catch (Exception ex)
         {
             LogManager.Error(Tag, ex);
             return false;
+        }
+        finally
+        {
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(listFile) && File.Exists(listFile))
+                {
+                    File.Delete(listFile);
+                }
+            }
+            catch (Exception e)
+            {
+                LogManager.Error(Tag, e);
+            }
+        }
+    }
+
+    private bool TryConcatWithStreamCopy(string listFile, string outputVideo, Action<string> action)
+    {
+        var arguments = BuildConcatInput(listFile)
+            .OutputToFile(outputVideo, true, options => options
+                .WithVideoCodec("copy")
+                .WithAudioCodec("copy")
+                .WithCustomArgument("-movflags +faststart")
+                .WithCustomArgument("-avoid_negative_ts make_zero"));
+
+        return RunFfmpeg(arguments, "concat stream copy", action) && IsValidOutput(outputVideo);
+    }
+
+    private bool TryConcatWithHardwareEncoder(
+        string listFile,
+        string outputVideo,
+        FfmpegHardwareEncoderProfile encoder,
+        Action<string> action)
+    {
+        var arguments = BuildConcatInput(listFile)
+            .OutputToFile(outputVideo, true, options => options
+                .WithAudioCodec("aac")
+                .WithCustomArgument(encoder.OutputArguments)
+                .WithCustomArgument("-movflags +faststart")
+                .WithCustomArgument("-avoid_negative_ts make_zero"));
+
+        var success = RunFfmpeg(arguments, $"concat hardware transcode ({encoder.DisplayName})", action) &&
+                      IsValidOutput(outputVideo);
+        if (!success)
+        {
+            LogManager.Info(Tag, $"Hardware encoder failed, falling back to CPU. encoder={encoder.DisplayName}");
+        }
+
+        return success;
+    }
+
+    private bool TryConcatWithCpuEncoder(string listFile, string outputVideo, Action<string> action)
+    {
+        var arguments = BuildConcatInput(listFile)
+            .OutputToFile(outputVideo, true, options => options
+                .WithVideoCodec("libx264")
+                .WithAudioCodec("aac")
+                .WithCustomArgument("-preset veryfast")
+                .WithCustomArgument("-crf 23")
+                .WithCustomArgument("-threads 2")
+                .WithCustomArgument("-movflags +faststart")
+                .WithCustomArgument("-avoid_negative_ts make_zero"));
+
+        return RunFfmpeg(arguments, "concat CPU transcode", action) && IsValidOutput(outputVideo);
+    }
+
+    private static FFMpegArguments BuildConcatInput(string listFile)
+    {
+        return FFMpegArguments.FromFileInput(listFile, false, options => options
+            .WithCustomArgument("-f concat -safe 0"));
+    }
+
+    private static string ToConcatFileLine(string file)
+    {
+        var normalizedPath = Path.GetFullPath(file).Replace('\\', '/');
+        return $"file '{normalizedPath.Replace("'", "'\\''")}'";
+    }
+
+    private static bool IsValidOutput(string outputVideo)
+    {
+        return File.Exists(outputVideo) && new FileInfo(outputVideo).Length > 0;
+    }
+
+    private static void DeleteOutput(string outputVideo)
+    {
+        try
+        {
+            if (File.Exists(outputVideo))
+            {
+                File.Delete(outputVideo);
+            }
+        }
+        catch (Exception e)
+        {
+            LogManager.Error(Tag, e);
+        }
+    }
+
+    private static bool RunFfmpeg(FFMpegArgumentProcessor arguments, string operation, Action<string>? action = null)
+    {
+        using var _ = EnterFfmpegSlot(operation);
+        try
+        {
+            LogManager.Debug(Tag, arguments.Arguments);
+            var result = arguments
+                .NotifyOnOutput(s =>
+                {
+                    action?.Invoke(s);
+                    LogManager.Debug(Tag, s);
+                })
+                .NotifyOnError(s =>
+                {
+                    action?.Invoke(s);
+                    LogManager.Debug(Tag, s);
+                })
+                .ProcessSynchronously(false);
+
+            LogManager.Info(Tag, $"FFmpeg operation finished. operation={operation}; success={result}");
+            return result;
+        }
+        catch (Exception e)
+        {
+            LogManager.Error(Tag, e);
+            return false;
+        }
+    }
+
+    private static IDisposable EnterFfmpegSlot(string operation)
+    {
+        var maxParallel = SettingsManager.GetInstance().GetFfmpegMaxParallelJobs();
+        lock (FfmpegJobLock)
+        {
+            while (_runningFfmpegJobs >= maxParallel)
+            {
+                Monitor.Wait(FfmpegJobLock);
+                maxParallel = SettingsManager.GetInstance().GetFfmpegMaxParallelJobs();
+            }
+
+            _runningFfmpegJobs++;
+            LogManager.Info(Tag,
+                $"FFmpeg operation started. operation={operation}; running={_runningFfmpegJobs}; maxParallel={maxParallel}");
+        }
+
+        return new FfmpegSlot();
+    }
+
+    private sealed class FfmpegSlot : IDisposable
+    {
+        public void Dispose()
+        {
+            lock (FfmpegJobLock)
+            {
+                _runningFfmpegJobs = Math.Max(0, _runningFfmpegJobs - 1);
+                Monitor.PulseAll(FfmpegJobLock);
+            }
         }
     }
 }

--- a/DownKyi.Core/FFMpeg/FfmpegHardwareEncoderDetector.cs
+++ b/DownKyi.Core/FFMpeg/FfmpegHardwareEncoderDetector.cs
@@ -1,0 +1,195 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using DownKyi.Core.Logging;
+using DownKyi.Core.Settings;
+
+namespace DownKyi.Core.FFMpeg;
+
+internal sealed record FfmpegHardwareEncoderProfile(
+    FfmpegHardwareAcceleration Mode,
+    string DisplayName,
+    string EncoderName,
+    string OutputArguments);
+
+internal static class FfmpegHardwareEncoderDetector
+{
+    private const string Tag = "FfmpegHardwareEncoderDetector";
+    private static readonly Lazy<HashSet<string>> AvailableEncoders = new(LoadAvailableEncoders);
+
+    public static FfmpegHardwareEncoderProfile? Select(FfmpegHardwareAcceleration mode)
+    {
+        if (mode == FfmpegHardwareAcceleration.Disabled)
+        {
+            return null;
+        }
+
+        var candidates = mode == FfmpegHardwareAcceleration.Auto
+            ? GetAutoCandidates()
+            : GetManualCandidates(mode);
+
+        foreach (var candidate in candidates)
+        {
+            if (AvailableEncoders.Value.Contains(candidate.EncoderName))
+            {
+                LogManager.Info(Tag, $"Selected FFmpeg hardware encoder: {candidate.DisplayName}");
+                return candidate;
+            }
+        }
+
+        if (mode != FfmpegHardwareAcceleration.Auto && mode != FfmpegHardwareAcceleration.NotSet)
+        {
+            LogManager.Info(Tag, $"Requested FFmpeg hardware encoder is unavailable: {mode}");
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<FfmpegHardwareEncoderProfile> GetAutoCandidates()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            yield return VideoToolbox();
+            yield break;
+        }
+
+        yield return Nvidia();
+        yield return IntelQsv();
+        yield return AmdAmf();
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists(GetVaapiDevice()))
+        {
+            yield return Vaapi();
+        }
+    }
+
+    private static IEnumerable<FfmpegHardwareEncoderProfile> GetManualCandidates(FfmpegHardwareAcceleration mode)
+    {
+        return mode switch
+        {
+            FfmpegHardwareAcceleration.NvidiaNvenc => new[] { Nvidia() },
+            FfmpegHardwareAcceleration.IntelQsv => new[] { IntelQsv() },
+            FfmpegHardwareAcceleration.AmdAmf => new[] { AmdAmf() },
+            FfmpegHardwareAcceleration.Vaapi => new[] { Vaapi() },
+            FfmpegHardwareAcceleration.VideoToolbox => new[] { VideoToolbox() },
+            _ => GetAutoCandidates().ToArray()
+        };
+    }
+
+    private static FfmpegHardwareEncoderProfile Nvidia()
+    {
+        return new FfmpegHardwareEncoderProfile(
+            FfmpegHardwareAcceleration.NvidiaNvenc,
+            "NVIDIA NVENC",
+            "h264_nvenc",
+            "-c:v h264_nvenc -preset p4 -cq 23 -pix_fmt yuv420p");
+    }
+
+    private static FfmpegHardwareEncoderProfile IntelQsv()
+    {
+        return new FfmpegHardwareEncoderProfile(
+            FfmpegHardwareAcceleration.IntelQsv,
+            "Intel QSV",
+            "h264_qsv",
+            "-c:v h264_qsv -global_quality 23");
+    }
+
+    private static FfmpegHardwareEncoderProfile AmdAmf()
+    {
+        return new FfmpegHardwareEncoderProfile(
+            FfmpegHardwareAcceleration.AmdAmf,
+            "AMD AMF",
+            "h264_amf",
+            "-c:v h264_amf -quality balanced");
+    }
+
+    private static FfmpegHardwareEncoderProfile Vaapi()
+    {
+        return new FfmpegHardwareEncoderProfile(
+            FfmpegHardwareAcceleration.Vaapi,
+            "Linux VAAPI",
+            "h264_vaapi",
+            $"-vaapi_device {GetVaapiDevice()} -vf format=nv12,hwupload -c:v h264_vaapi -qp 23");
+    }
+
+    private static FfmpegHardwareEncoderProfile VideoToolbox()
+    {
+        return new FfmpegHardwareEncoderProfile(
+            FfmpegHardwareAcceleration.VideoToolbox,
+            "macOS VideoToolbox",
+            "h264_videotoolbox",
+            "-c:v h264_videotoolbox -b:v 6M");
+    }
+
+    private static HashSet<string> LoadAvailableEncoders()
+    {
+        var output = RunFfmpeg("-hide_banner -encoders");
+        var encoders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var line in output.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length >= 2)
+            {
+                encoders.Add(parts[1]);
+            }
+        }
+
+        LogManager.Info(Tag, $"Detected FFmpeg hardware encoders: {string.Join(",", encoders.Where(IsKnownHardwareEncoder))}");
+        return encoders;
+    }
+
+    private static bool IsKnownHardwareEncoder(string encoder)
+    {
+        return encoder is "h264_nvenc" or "h264_qsv" or "h264_amf" or "h264_vaapi" or "h264_videotoolbox";
+    }
+
+    private static string RunFfmpeg(string arguments)
+    {
+        try
+        {
+            using var process = new Process();
+            process.StartInfo = new ProcessStartInfo
+            {
+                FileName = GetFfmpegExecutable(),
+                Arguments = arguments,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            if (!process.WaitForExit(5000))
+            {
+                try
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+                catch
+                {
+                }
+            }
+
+            return output + Environment.NewLine + error;
+        }
+        catch (Exception e)
+        {
+            LogManager.Error(Tag, e);
+            return string.Empty;
+        }
+    }
+
+    private static string GetFfmpegExecutable()
+    {
+        var fileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "ffmpeg.exe" : "ffmpeg";
+        var bundledPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ffmpeg", fileName);
+        return File.Exists(bundledPath) ? bundledPath : "ffmpeg";
+    }
+
+    private static string GetVaapiDevice()
+    {
+        return "/dev/dri/renderD128";
+    }
+}

--- a/DownKyi.Core/Logging/LogManager.cs
+++ b/DownKyi.Core/Logging/LogManager.cs
@@ -22,8 +22,8 @@ public class LogManager
     private static readonly Regex CookieRegex = new("(?i)(cookie|set-cookie|SESSDATA|bili_jct|DedeUserID|DedeUserID__ckMd5|sid|access_key|csrf|token|secret|password)\\s*[:=]\\s*[^\\s;,&\"']+", RegexOptions.Compiled);
     private static readonly Regex QuerySecretRegex = new("(?i)([?&](?:SESSDATA|bili_jct|DedeUserID|DedeUserID__ckMd5|sid|access_key|csrf|token|secret|password)=)[^&#\\s\"']+", RegexOptions.Compiled);
     private static readonly Regex EmailRegex = new("(?i)[a-z0-9._%+\\-]+@[a-z0-9.\\-]+\\.[a-z]{2,}", RegexOptions.Compiled);
-    private static readonly Regex QuotedWindowsPathRegex = new("(?i)(?<=['\"])(?:[a-z]:\\\\|\\\\\\\\)[^\\r\\n\"']+(?=['\"])", RegexOptions.Compiled);
-    private static readonly Regex WindowsPathRegex = new("(?i)(?<![\\w])(?:[a-z]:\\\\|\\\\\\\\)[^\\r\\n\\s\"'<>|]+", RegexOptions.Compiled);
+    private static readonly Regex QuotedWindowsPathRegex = new("(?i)(?<=['\"])(?:[a-z]:[\\\\/]|\\\\\\\\)[^\\r\\n\"']+(?=['\"])", RegexOptions.Compiled);
+    private static readonly Regex WindowsPathRegex = new("(?i)(?<![\\w])(?:[a-z]:[\\\\/]|\\\\\\\\)[^\\r\\n\\s\"'<>|]+", RegexOptions.Compiled);
     private static readonly Regex UnixUserPathRegex = new("(?<!:)\\b(?:/Users/|/home/|/var/folders/|/tmp/)[^\\r\\n\\s\"'<>|]+", RegexOptions.Compiled);
     private static string? CachedLogDate;
     private static string? CachedLogPath;

--- a/DownKyi.Core/Settings/FfmpegHardwareAcceleration.cs
+++ b/DownKyi.Core/Settings/FfmpegHardwareAcceleration.cs
@@ -1,0 +1,13 @@
+namespace DownKyi.Core.Settings;
+
+public enum FfmpegHardwareAcceleration
+{
+    NotSet = 0,
+    Auto,
+    Disabled,
+    NvidiaNvenc,
+    IntelQsv,
+    AmdAmf,
+    Vaapi,
+    VideoToolbox
+}

--- a/DownKyi.Core/Settings/Models/NetworkSettings.cs
+++ b/DownKyi.Core/Settings/Models/NetworkSettings.cs
@@ -13,6 +13,7 @@ public class NetworkSettings
     public string UserAgent { get; set; } = string.Empty;
 
     public Downloader Downloader { get; set; } = Downloader.NotSet;
+    public AllowStatus HighSpeedDownloadMode { get; set; } = AllowStatus.None;
 
     public NetworkProxy NetworkProxy { get; set; } = NetworkProxy.None;
     
@@ -37,6 +38,8 @@ public class NetworkSettings
 
     public AriaConfigLogLevel AriaLogLevel { get; set; } = AriaConfigLogLevel.NOT_SET;
     public int AriaSplit { get; set; } = -1;
+    public int AriaMaxConnectionPerServer { get; set; } = -1;
+    public int AriaMinSplitSize { get; set; } = -1;
     public int AriaMaxOverallDownloadLimit { get; set; } = -1;
     public int AriaMaxDownloadLimit { get; set; } = -1;
     public AriaConfigFileAllocation AriaFileAllocation { get; set; } = AriaConfigFileAllocation.NOT_SET;

--- a/DownKyi.Core/Settings/Models/VideoSettings.cs
+++ b/DownKyi.Core/Settings/Models/VideoSettings.cs
@@ -13,6 +13,8 @@ public class VideoSettings
     public int VideoParseType { get; set; } // 视频解析类型
     public AllowStatus IsTranscodingFlvToMp4 { get; set; } = AllowStatus.None; // 是否将flv转为mp4
     public AllowStatus IsTranscodingAacToMp3 { get; set; } = AllowStatus.None; // 是否将aac转为mp3
+    public FfmpegHardwareAcceleration FfmpegHardwareAcceleration { get; set; } = FfmpegHardwareAcceleration.NotSet;
+    public int FfmpegMaxParallelJobs { get; set; } = -1;
     public string? SaveVideoRootPath { get; set; } // 视频保存路径
     public List<string>? HistoryVideoRootPaths { get; set; } // 历史视频保存路径
     public AllowStatus IsUseSaveVideoRootPath { get; set; } = AllowStatus.None; // 是否使用默认视频保存路径

--- a/DownKyi.Core/Settings/SettingsManager.Network.Speed.cs
+++ b/DownKyi.Core/Settings/SettingsManager.Network.Speed.cs
@@ -1,0 +1,72 @@
+namespace DownKyi.Core.Settings;
+
+public partial class SettingsManager
+{
+    public const int HighSpeedBuiltInSplit = 16;
+    public const int HighSpeedAriaSplit = 16;
+    public const int HighSpeedAriaMaxConnectionPerServer = 16;
+    public const int HighSpeedAriaMinSplitSize = 1;
+
+    private const AllowStatus HighSpeedDownloadMode = AllowStatus.No;
+    private const int AriaMaxConnectionPerServer = 8;
+    private const int AriaMinSplitSize = 10;
+
+    public AllowStatus GetHighSpeedDownloadMode()
+    {
+        if (_appSettings.Network.HighSpeedDownloadMode != AllowStatus.None)
+        {
+            return _appSettings.Network.HighSpeedDownloadMode;
+        }
+
+        SetHighSpeedDownloadMode(HighSpeedDownloadMode);
+        return HighSpeedDownloadMode;
+    }
+
+    public bool SetHighSpeedDownloadMode(AllowStatus highSpeedDownloadMode)
+    {
+        return SetProperty(
+            _appSettings.Network.HighSpeedDownloadMode,
+            highSpeedDownloadMode,
+            v => _appSettings.Network.HighSpeedDownloadMode = v);
+    }
+
+    public int GetAriaMaxConnectionPerServer()
+    {
+        if (_appSettings.Network.AriaMaxConnectionPerServer != -1)
+        {
+            return _appSettings.Network.AriaMaxConnectionPerServer;
+        }
+
+        SetAriaMaxConnectionPerServer(AriaMaxConnectionPerServer);
+        return AriaMaxConnectionPerServer;
+    }
+
+    public bool SetAriaMaxConnectionPerServer(int ariaMaxConnectionPerServer)
+    {
+        var value = Math.Clamp(ariaMaxConnectionPerServer, 1, 16);
+        return SetProperty(
+            _appSettings.Network.AriaMaxConnectionPerServer,
+            value,
+            v => _appSettings.Network.AriaMaxConnectionPerServer = v);
+    }
+
+    public int GetAriaMinSplitSize()
+    {
+        if (_appSettings.Network.AriaMinSplitSize != -1)
+        {
+            return _appSettings.Network.AriaMinSplitSize;
+        }
+
+        SetAriaMinSplitSize(AriaMinSplitSize);
+        return AriaMinSplitSize;
+    }
+
+    public bool SetAriaMinSplitSize(int ariaMinSplitSize)
+    {
+        var value = Math.Clamp(ariaMinSplitSize, 1, 1024);
+        return SetProperty(
+            _appSettings.Network.AriaMinSplitSize,
+            value,
+            v => _appSettings.Network.AriaMinSplitSize = v);
+    }
+}

--- a/DownKyi.Core/Settings/SettingsManager.Video.Ffmpeg.cs
+++ b/DownKyi.Core/Settings/SettingsManager.Video.Ffmpeg.cs
@@ -1,0 +1,47 @@
+namespace DownKyi.Core.Settings;
+
+public partial class SettingsManager
+{
+    private const FfmpegHardwareAcceleration DefaultFfmpegHardwareAcceleration =
+        Settings.FfmpegHardwareAcceleration.Auto;
+    private const int FfmpegMaxParallelJobs = 1;
+
+    public FfmpegHardwareAcceleration GetFfmpegHardwareAcceleration()
+    {
+        if (_appSettings.Video.FfmpegHardwareAcceleration != FfmpegHardwareAcceleration.NotSet)
+        {
+            return _appSettings.Video.FfmpegHardwareAcceleration;
+        }
+
+        SetFfmpegHardwareAcceleration(DefaultFfmpegHardwareAcceleration);
+        return DefaultFfmpegHardwareAcceleration;
+    }
+
+    public bool SetFfmpegHardwareAcceleration(FfmpegHardwareAcceleration acceleration)
+    {
+        return SetProperty(
+            _appSettings.Video.FfmpegHardwareAcceleration,
+            acceleration,
+            v => _appSettings.Video.FfmpegHardwareAcceleration = v);
+    }
+
+    public int GetFfmpegMaxParallelJobs()
+    {
+        if (_appSettings.Video.FfmpegMaxParallelJobs != -1)
+        {
+            return Math.Clamp(_appSettings.Video.FfmpegMaxParallelJobs, 1, 4);
+        }
+
+        SetFfmpegMaxParallelJobs(FfmpegMaxParallelJobs);
+        return FfmpegMaxParallelJobs;
+    }
+
+    public bool SetFfmpegMaxParallelJobs(int maxParallelJobs)
+    {
+        var value = Math.Clamp(maxParallelJobs, 1, 4);
+        return SetProperty(
+            _appSettings.Video.FfmpegMaxParallelJobs,
+            value,
+            v => _appSettings.Video.FfmpegMaxParallelJobs = v);
+    }
+}

--- a/DownKyi.Core/Utils/Format.cs
+++ b/DownKyi.Core/Utils/Format.cs
@@ -96,6 +96,12 @@ public static class Format
         };
     }
 
+    public static string FormatSpeedWithBandwidth(double bytesPerSecond)
+    {
+        var mbps = Math.Max(0, bytesPerSecond) * 8 / 1000 / 1000;
+        return $"{FormatSpeed((float)bytesPerSecond)} ({mbps:F2} Mbps)";
+    }
+
     /// <summary>
     /// 格式化字节大小，可用于文件大小的显示
     /// </summary>

--- a/DownKyi/Languanges/Default.axaml
+++ b/DownKyi/Languanges/Default.axaml
@@ -202,12 +202,16 @@
     <system:String x:Key="BuiltinDownloader">内建下载器</system:String>
     <system:String x:Key="Aria2cDownloader">Aria2下载器</system:String>
     <system:String x:Key="CustomAria2cDownloader">自定义Aria2下载器</system:String>
+    <system:String x:Key="HighSpeedDownloadMode">高速下载模式（套用推荐分片/连接参数）</system:String>
+    <system:String x:Key="HighSpeedDownloadModeTip">开启时会将内建线程数设为16，Aria最大线程数设为16，同服务器连接数设为16，最小分片设为1MB。</system:String>
     <system:String x:Key="AriaServerHost">Aria服务器地址：</system:String>
     <system:String x:Key="AriaServerPort">Aria服务器端口：</system:String>
     <system:String x:Key="AriaServerToken">Aria服务器Token：</system:String>
     <system:String x:Key="AriaLogLevel">Aria日志等级：</system:String>
     <system:String x:Key="AriaMaxConcurrentDownloads">Aria同时下载数：</system:String>
     <system:String x:Key="AriaSplit">Aria最大线程数：</system:String>
+    <system:String x:Key="AriaMaxConnectionPerServer">Aria同服务器连接数：</system:String>
+    <system:String x:Key="AriaMinSplitSize">Aria最小分片大小(MB)：</system:String>
     <system:String x:Key="AriaDownloadLimit">Aria下载速度限制(KB/s)</system:String>
     <system:String x:Key="AriaMaxOverallDownloadLimit">全局下载速度限制[0: 无限制]</system:String>
     <system:String x:Key="AriaMaxDownloadLimit">单任务下载速度限制[0: 无限制]</system:String>
@@ -224,6 +228,10 @@
     <system:String x:Key="VideoParseType">首选视频解析方式：</system:String>
     <system:String x:Key="IsTranscodingFlvToMp4">下载FLV视频后转码为mp4</system:String>
     <system:String x:Key="IsTranscodingAacToMp3">下载AAC音频后转码为mp3</system:String>
+    <system:String x:Key="FfmpegHardwareAcceleration">FFmpeg硬件加速：</system:String>
+    <system:String x:Key="FfmpegHardwareAccelerationTip">仅用于需要重新编码的步骤。普通音视频混流会优先无损复制，不会强制转码。</system:String>
+    <system:String x:Key="FfmpegMaxParallelJobs">FFmpeg最大并行任务：</system:String>
+    <system:String x:Key="FfmpegMaxParallelJobsTip">批量下载时限制同时运行的FFmpeg进程，避免CPU/内存占用过高导致崩溃。</system:String>
     <system:String x:Key="IsUseDefaultDirectory">使用默认下载目录</system:String>
     <system:String x:Key="GenerateVideoMetadata">生成视频元数据</system:String>
     <system:String x:Key="DefaultDirectory">默认下载目录：</system:String>

--- a/DownKyi/Models/VideoPlayUrlBasic.cs
+++ b/DownKyi/Models/VideoPlayUrlBasic.cs
@@ -14,5 +14,7 @@ namespace DownKyi.Models
         public int Id { get; set; }
 
         public string Codecs { get; set; } = string.Empty;
+
+        public long ExpectedSize { get; set; }
     }
 }

--- a/DownKyi/Services/Download/AriaDownloadService.cs
+++ b/DownKyi/Services/Download/AriaDownloadService.cs
@@ -81,7 +81,8 @@ public class AriaDownloadService : DownloadService, IDownloadService
             Id = downloadVideo.Id,
             Codecs = downloadVideo.Codecs,
             BaseUrl = downloadVideo.BaseUrl,
-            BackupUrl = downloadVideo.BackupUrl
+            BackupUrl = downloadVideo.BackupUrl,
+            ExpectedSize = downloadVideo.ExpectedSize
         } );
     }
 
@@ -129,9 +130,17 @@ public class AriaDownloadService : DownloadService, IDownloadService
 
             // 还要检查一下文件有没有被人删掉，删掉的话重新下载
             // 如果下载视频之后音频文件被人删了。此时gid还是视频的，会下错文件
-            if (downloading.Downloading.DownloadedFiles.Contains(key) && File.Exists(Path.Combine(path, fileName)))
+            var cachedFile = Path.Combine(path, fileName);
+            if (downloading.Downloading.DownloadedFiles.Contains(key) &&
+                IsDownloadedMediaFileUsable(cachedFile, downloadVideo.ExpectedSize))
             {
-                return Path.Combine(path, fileName);
+                return cachedFile;
+            }
+
+            if (downloading.Downloading.DownloadedFiles.Remove(key))
+            {
+                DeleteInvalidDownloadedMediaFile(cachedFile);
+                PersistDownloadingState(downloading);
             }
         }
         else
@@ -178,13 +187,22 @@ public class AriaDownloadService : DownloadService, IDownloadService
 
         // 开始下载
         var downloadStatus = DownloadByAria(downloading, urls, path, fileName);
+        var targetFile = Path.Combine(path, fileName);
         switch (downloadStatus)
         {
             case DownloadResult.SUCCESS:
-                downloading.Downloading.DownloadedFiles.Add(key);
+                if (IsDownloadedMediaFileUsable(targetFile, downloadVideo.ExpectedSize))
+                {
+                    downloading.Downloading.DownloadedFiles.Add(key);
+                    downloading.Downloading.Gid = null;
+                    PersistDownloadingState(downloading);
+                    return targetFile;
+                }
+
                 downloading.Downloading.Gid = null;
                 PersistDownloadingState(downloading);
-                return Path.Combine(path, fileName);
+                DeleteInvalidDownloadedMediaFile(targetFile);
+                return NullMark;
             case DownloadResult.FAILED:
             case DownloadResult.ABORT:
             default:
@@ -367,10 +385,10 @@ public class AriaDownloadService : DownloadService, IDownloadService
             Token = "downkyi",
             LogLevel = SettingsManager.GetInstance().GetAriaLogLevel(),
             MaxConcurrentDownloads = SettingsManager.GetInstance().GetMaxCurrentDownloads(),
-            MaxConnectionPerServer = 8, // 最大取16
+            MaxConnectionPerServer = SettingsManager.GetInstance().GetAriaMaxConnectionPerServer(),
             Split = SettingsManager.GetInstance().GetAriaSplit(),
             //MaxTries = 5,
-            MinSplitSize = 10, // 10MB
+            MinSplitSize = SettingsManager.GetInstance().GetAriaMinSplitSize(),
             MaxOverallDownloadLimit =
                 SettingsManager.GetInstance().GetAriaMaxOverallDownloadLimit() * 1024L, // 输入的单位是KB/s，所以需要乘以1024
             MaxDownloadLimit = SettingsManager.GetInstance().GetAriaMaxDownloadLimit() * 1024L, // 输入的单位是KB/s，所以需要乘以1024
@@ -378,6 +396,8 @@ public class AriaDownloadService : DownloadService, IDownloadService
             FileAllocation = SettingsManager.GetInstance().GetAriaFileAllocation(),
             Headers = header
         };
+
+        DownloadDiagnosticLogger.LogAriaServerConfig(Tag, config);
 
         var errorMessage = new StringBuilder();
         await AriaServer.StartServerAsync(config, output =>
@@ -485,6 +505,9 @@ public class AriaDownloadService : DownloadService, IDownloadService
                 //Header = $"cookie: {LoginHelper.GetLoginInfoCookiesString()}\nreferer: https://www.bilibili.com",
                 //UseHead = "true",
                 UserAgent = SettingsManager.GetInstance().GetUserAgent(),
+                Split = SettingsManager.GetInstance().GetAriaSplit().ToString(),
+                MaxConnectionPerServer = SettingsManager.GetInstance().GetAriaMaxConnectionPerServer().ToString(),
+                MinSplitSize = $"{SettingsManager.GetInstance().GetAriaMinSplitSize()}M",
             };
 
             // 如果设置了代理，则增加HttpProxy
@@ -510,6 +533,8 @@ public class AriaDownloadService : DownloadService, IDownloadService
         {
             var ariaUnpause = AriaClient.UnpauseAsync(downloading.Downloading.Gid);
         }
+
+        DownloadDiagnosticLogger.LogAriaTaskStart(Tag, downloading.Downloading.Gid, urls.Count);
 
         // 管理下载
         var ariaManager = new AriaManager();
@@ -570,7 +595,8 @@ public class AriaDownloadService : DownloadService, IDownloadService
         video.DownloadingFileSize = Format.FormatFileSize(completedLength) + "/" + Format.FormatFileSize(totalLength);
 
         // 下载速度
-        video.SpeedDisplay = Format.FormatSpeed(speed);
+        video.SpeedDisplay = Format.FormatSpeedWithBandwidth(speed);
+        DownloadDiagnosticLogger.LogSpeed(Tag, gid, completedLength, totalLength, speed);
 
         // 最大下载速度
         if (video.Downloading.MaxSpeed < speed)

--- a/DownKyi/Services/Download/BuiltinDownloadService.cs
+++ b/DownKyi/Services/Download/BuiltinDownloadService.cs
@@ -73,7 +73,8 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
             Id = downloadVideo.Id,
             Codecs = downloadVideo.Codecs,
             BaseUrl = downloadVideo.BaseUrl,
-            BackupUrl = downloadVideo.BackupUrl
+            BackupUrl = downloadVideo.BackupUrl,
+            ExpectedSize = downloadVideo.ExpectedSize
         });
     }
 
@@ -127,9 +128,17 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
 
             // 还要检查一下文件有没有被人删掉，删掉的话重新下载
             // 如果下载视频之后音频文件被人删了。此时gid还是视频的，会下错文件
-            if (downloading.Downloading.DownloadedFiles.Contains(key) && File.Exists(Path.Combine(path, fileName)))
+            var cachedFile = Path.Combine(path, fileName);
+            if (downloading.Downloading.DownloadedFiles.Contains(key) &&
+                IsDownloadedMediaFileUsable(cachedFile, downloadVideo.ExpectedSize))
             {
-                return Path.Combine(path, fileName);
+                return cachedFile;
+            }
+
+            if (downloading.Downloading.DownloadedFiles.Remove(key))
+            {
+                DeleteInvalidDownloadedMediaFile(cachedFile);
+                PersistDownloadingState(downloading);
             }
         }
         else
@@ -177,18 +186,22 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
         // 开始下载
         try
         {
-            var downloadStatus = DownloadByBuiltin(downloading, urls, path, fileName);
+            var targetFile = Path.Combine(path, fileName);
+            var downloadStatus = DownloadByBuiltin(downloading, urls, path, fileName, downloadVideo.ExpectedSize);
             if (downloadStatus)
             {
-                downloading.Downloading.DownloadedFiles.Add(key);
-                downloading.Downloading.Gid = null;
-                PersistDownloadingState(downloading);
-                return Path.Combine(path, fileName);
+                if (IsDownloadedMediaFileUsable(targetFile, downloadVideo.ExpectedSize))
+                {
+                    downloading.Downloading.DownloadedFiles.Add(key);
+                    downloading.Downloading.Gid = null;
+                    PersistDownloadingState(downloading);
+                    return targetFile;
+                }
+
+                DeleteInvalidDownloadedMediaFile(targetFile);
             }
-            else
-            {
-                return NullMark;
-            }
+
+            return NullMark;
         }
         catch (FileNotFoundException e)
         {
@@ -313,7 +326,12 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
     /// <param name="path"></param>
     /// <param name="localFileName"></param>
     /// <returns></returns>
-    private bool DownloadByBuiltin(DownloadingItem downloading, List<string> urls, string path, string localFileName)
+    private bool DownloadByBuiltin(
+        DownloadingItem downloading,
+        List<string> urls,
+        string path,
+        string localFileName,
+        long expectedBytes)
     {
         // path已斜杠结尾，去掉斜杠
         path = path.TrimEnd('/').TrimEnd('\\');
@@ -333,12 +351,13 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 SettingsManager.GetInstance().GetHttpProxyListenPort());
         }
 
+        var split = SettingsManager.GetInstance().GetSplit();
         var downloadOpt = new DownloadConfiguration
         {
-            ChunkCount = SettingsManager.GetInstance().GetSplit(),
+            ChunkCount = split,
             RequestConfiguration = requestConfiguration,
             ParallelDownload = true,
-            ParallelCount = 2,
+            ParallelCount = split,
             MaximumMemoryBufferBytes = 1024 * 1024 * 50,
             EnableAutoResumeDownload = true,
             ClearPackageOnCompletionWithFailure = false,
@@ -350,12 +369,29 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
             var isFinished = false;
             var isComplete = false;
             var targetFile = Path.Combine(path, localFileName);
+            var totalBytesToReceive = expectedBytes;
+            var receivedBytes = 0L;
             if (downloading.DownloadService == null)
             {
+                DownloadDiagnosticLogger.LogBuiltInTaskStart(Tag, localFileName, urls.Count, downloadOpt.ChunkCount,
+                    downloadOpt.ParallelCount);
                 downloader = new Downloader.DownloadService(downloadOpt);
+                downloader.DownloadStarted += (_, args) =>
+                {
+                    if (args.TotalBytesToReceive > 0)
+                    {
+                        totalBytesToReceive = (long)args.TotalBytesToReceive;
+                    }
+                };
                 downloader.DownloadFileCompleted += (_, args) =>
                 {
-                    isComplete = !args.Cancelled && args.Error == null && File.Exists(targetFile);
+                    isComplete = !args.Cancelled &&
+                                 args.Error == null &&
+                                 IsDownloadedMediaFileUsable(
+                                     targetFile,
+                                     expectedBytes,
+                                     receivedBytes,
+                                     totalBytesToReceive);
                     isFinished = true;
                     downloading.DownloadService = null;
                     if (args.Error != null)
@@ -365,6 +401,12 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 };
                 downloader.DownloadProgressChanged += (_, args) =>
                 {
+                    receivedBytes = (long)Math.Max(0, args.ReceivedBytesSize);
+                    if (args.TotalBytesToReceive > 0)
+                    {
+                        totalBytesToReceive = (long)args.TotalBytesToReceive;
+                    }
+
                     // 下载进度百分比
                     downloading.Progress = (float)args.ProgressPercentage;
 
@@ -373,7 +415,9 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
 
                     // 下载速度
                     var speed = (long)args.BytesPerSecondSpeed;
-                    downloading.SpeedDisplay = Format.FormatSpeed(speed);
+                    downloading.SpeedDisplay = Format.FormatSpeedWithBandwidth(speed);
+                    DownloadDiagnosticLogger.LogSpeed(Tag, localFileName, args.ReceivedBytesSize,
+                        args.TotalBytesToReceive, speed);
                     // 最大下载速度
                     if (downloading.Downloading.MaxSpeed < speed)
                     {
@@ -415,7 +459,13 @@ public class BuiltinDownloadService : DownloadService, IDownloadService
                 Task.Delay(100, CancellationToken.GetValueOrDefault()).GetAwaiter().GetResult();
             }
 
-            return isComplete;
+            if (isComplete)
+            {
+                return true;
+            }
+
+            DeleteInvalidDownloadedMediaFile(targetFile);
+            LogManager.Info(Tag, "Built-in download attempt was incomplete; trying next backup URL if available.");
         }
 
         return false;

--- a/DownKyi/Services/Download/CustomAriaDownloadService.cs
+++ b/DownKyi/Services/Download/CustomAriaDownloadService.cs
@@ -74,7 +74,8 @@ public class CustomAriaDownloadService : DownloadService, IDownloadService
             Id = downloadVideo.Id,
             Codecs = downloadVideo.Codecs,
             BaseUrl = downloadVideo.BaseUrl,
-            BackupUrl = downloadVideo.BackupUrl
+            BackupUrl = downloadVideo.BackupUrl,
+            ExpectedSize = downloadVideo.ExpectedSize
         });
     }
 
@@ -128,9 +129,17 @@ public class CustomAriaDownloadService : DownloadService, IDownloadService
 
             // 还要检查一下文件有没有被人删掉，删掉的话重新下载
             // 如果下载视频之后音频文件被人删了。此时gid还是视频的，会下错文件
-            if (downloading.Downloading.DownloadedFiles.Contains(key) && File.Exists(Path.Combine(path, fileName)))
+            string cachedFile = Path.Combine(path, fileName);
+            if (downloading.Downloading.DownloadedFiles.Contains(key) &&
+                IsDownloadedMediaFileUsable(cachedFile, downloadVideo.ExpectedSize))
             {
-                return Path.Combine(path, fileName);
+                return cachedFile;
+            }
+
+            if (downloading.Downloading.DownloadedFiles.Remove(key))
+            {
+                DeleteInvalidDownloadedMediaFile(cachedFile);
+                PersistDownloadingState(downloading);
             }
         }
         else
@@ -177,13 +186,22 @@ public class CustomAriaDownloadService : DownloadService, IDownloadService
 
         // 开始下载
         DownloadResult downloadStatus = DownloadByAria(downloading, urls, path, fileName);
+        string targetFile = Path.Combine(path, fileName);
         switch (downloadStatus)
         {
             case DownloadResult.SUCCESS:
-                downloading.Downloading.DownloadedFiles.Add(key);
+                if (IsDownloadedMediaFileUsable(targetFile, downloadVideo.ExpectedSize))
+                {
+                    downloading.Downloading.DownloadedFiles.Add(key);
+                    downloading.Downloading.Gid = null;
+                    PersistDownloadingState(downloading);
+                    return targetFile;
+                }
+
                 downloading.Downloading.Gid = null;
                 PersistDownloadingState(downloading);
-                return Path.Combine(path, fileName);
+                DeleteInvalidDownloadedMediaFile(targetFile);
+                return NullMark;
             case DownloadResult.FAILED:
             case DownloadResult.ABORT:
             default:
@@ -414,6 +432,9 @@ public class CustomAriaDownloadService : DownloadService, IDownloadService
                 //Header = $"cookie: {LoginHelper.GetLoginInfoCookiesString()}\nreferer: https://www.bilibili.com",
                 //UseHead = "true",
                 UserAgent = SettingsManager.GetInstance().GetUserAgent(),
+                Split = SettingsManager.GetInstance().GetAriaSplit().ToString(),
+                MaxConnectionPerServer = SettingsManager.GetInstance().GetAriaMaxConnectionPerServer().ToString(),
+                MinSplitSize = $"{SettingsManager.GetInstance().GetAriaMinSplitSize()}M",
             };
 
             //// 如果设置了代理，则增加HttpProxy
@@ -438,6 +459,8 @@ public class CustomAriaDownloadService : DownloadService, IDownloadService
         {
             Task<AriaPause> ariaUnpause = AriaClient.UnpauseAsync(downloading.Downloading.Gid);
         }
+
+        DownloadDiagnosticLogger.LogAriaTaskStart(Tag, downloading.Downloading.Gid, urls.Count);
 
         // 管理下载
         AriaManager ariaManager = new AriaManager();
@@ -498,7 +521,8 @@ public class CustomAriaDownloadService : DownloadService, IDownloadService
         video.DownloadingFileSize = Format.FormatFileSize(completedLength) + "/" + Format.FormatFileSize(totalLength);
 
         // 下载速度
-        video.SpeedDisplay = Format.FormatSpeed(speed);
+        video.SpeedDisplay = Format.FormatSpeedWithBandwidth(speed);
+        DownloadDiagnosticLogger.LogSpeed(Tag, gid, completedLength, totalLength, speed);
 
         // 最大下载速度
         if (video.Downloading.MaxSpeed < speed)

--- a/DownKyi/Services/Download/DownloadDiagnosticLogger.cs
+++ b/DownKyi/Services/Download/DownloadDiagnosticLogger.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Concurrent;
+using DownKyi.Core.Aria2cNet.Server;
+using DownKyi.Core.Logging;
+using DownKyi.Core.Settings;
+using DownKyi.Core.Utils;
+
+namespace DownKyi.Services.Download;
+
+internal static class DownloadDiagnosticLogger
+{
+    private static readonly TimeSpan SpeedLogInterval = TimeSpan.FromSeconds(30);
+    private static readonly ConcurrentDictionary<string, DateTimeOffset> LastSpeedLogTimes = new();
+
+    public static void LogAriaServerConfig(string source, AriaConfig config)
+    {
+        LogManager.Info(source,
+            "Aria config " +
+            $"highSpeed={IsHighSpeedEnabled()}; " +
+            $"maxTasks={config.MaxConcurrentDownloads}; " +
+            $"split={config.Split}; " +
+            $"maxConnectionPerServer={config.MaxConnectionPerServer}; " +
+            $"minSplitSize={config.MinSplitSize}MB; " +
+            $"globalLimit={FormatLimit(config.MaxOverallDownloadLimit)}; " +
+            $"taskLimit={FormatLimit(config.MaxDownloadLimit)}; " +
+            $"fileAllocation={config.FileAllocation}");
+    }
+
+    public static void LogAriaTaskStart(string source, string? gid, int urlCount)
+    {
+        var settings = SettingsManager.GetInstance();
+        LogManager.Info(source,
+            "Aria task started " +
+            $"task={ShortId(gid)}; " +
+            $"highSpeed={IsHighSpeedEnabled()}; " +
+            $"urlCount={urlCount}; " +
+            $"split={settings.GetAriaSplit()}; " +
+            $"maxConnectionPerServer={settings.GetAriaMaxConnectionPerServer()}; " +
+            $"minSplitSize={settings.GetAriaMinSplitSize()}MB; " +
+            $"globalLimit={settings.GetAriaMaxOverallDownloadLimit()}KB/s; " +
+            $"taskLimit={settings.GetAriaMaxDownloadLimit()}KB/s");
+    }
+
+    public static void LogBuiltInTaskStart(string source, string taskId, int urlCount, int chunkCount, int parallelCount)
+    {
+        LogManager.Info(source,
+            "Built-in task started " +
+            $"task={ShortId(taskId)}; " +
+            $"highSpeed={IsHighSpeedEnabled()}; " +
+            $"urlCount={urlCount}; " +
+            $"chunkCount={chunkCount}; " +
+            $"parallelCount={parallelCount}");
+    }
+
+    public static void LogSpeed(string source, string taskId, long completedLength, long totalLength, long bytesPerSecond)
+    {
+        var key = $"{source}:{taskId}";
+        var now = DateTimeOffset.UtcNow;
+
+        if (LastSpeedLogTimes.TryGetValue(key, out var last) && now - last < SpeedLogInterval)
+        {
+            return;
+        }
+
+        LastSpeedLogTimes[key] = now;
+        LogManager.Info(source,
+            "Download speed " +
+            $"task={ShortId(taskId)}; " +
+            $"speed={Format.FormatSpeedWithBandwidth(bytesPerSecond)}; " +
+            $"progress={Format.FormatFileSize(completedLength)}/{Format.FormatFileSize(totalLength)}");
+    }
+
+    private static bool IsHighSpeedEnabled()
+    {
+        return SettingsManager.GetInstance().GetHighSpeedDownloadMode() == AllowStatus.Yes;
+    }
+
+    private static string FormatLimit(long bytesPerSecond)
+    {
+        return bytesPerSecond <= 0 ? "unlimited" : Format.FormatSpeedWithBandwidth(bytesPerSecond);
+    }
+
+    private static string ShortId(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return "unknown";
+        }
+
+        return value.Length <= 8 ? value : value[..8];
+    }
+}

--- a/DownKyi/Services/Download/DownloadService.cs
+++ b/DownKyi/Services/Download/DownloadService.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml;
@@ -64,6 +65,92 @@ public abstract class DownloadService
         catch (Exception e)
         {
             LogManager.Debug(Tag, $"Persist downloading state failed: {e.Message}");
+        }
+    }
+
+    protected bool IsDownloadedMediaFileUsable(
+        string? file,
+        long expectedBytes = 0,
+        long receivedBytes = 0,
+        long totalBytesToReceive = 0)
+    {
+        if (string.IsNullOrWhiteSpace(file) || !File.Exists(file))
+        {
+            return false;
+        }
+
+        if (File.Exists($"{file}.aria2") || File.Exists($"{file}.download"))
+        {
+            LogManager.Info(Tag, "Downloaded media file still has an unfinished sidecar.");
+            return false;
+        }
+
+        var actualBytes = new FileInfo(file).Length;
+        var requiredBytes = expectedBytes > 0 ? expectedBytes : totalBytesToReceive;
+        if (actualBytes <= 0 ||
+            requiredBytes > 0 && actualBytes < requiredBytes ||
+            requiredBytes > 0 && receivedBytes > 0 && receivedBytes < requiredBytes)
+        {
+            LogManager.Info(Tag,
+                $"Downloaded media file is incomplete. expectedBytes={requiredBytes}; receivedBytes={receivedBytes}; actualBytes={actualBytes}");
+            return false;
+        }
+
+        if (LooksLikeErrorPayload(file))
+        {
+            LogManager.Info(Tag, "Downloaded media file looks like an error payload instead of media.");
+            return false;
+        }
+
+        return true;
+    }
+
+    protected void DeleteInvalidDownloadedMediaFile(string? file)
+    {
+        if (string.IsNullOrWhiteSpace(file))
+        {
+            return;
+        }
+
+        foreach (var path in new[] { file, $"{file}.aria2", $"{file}.download" })
+        {
+            try
+            {
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                }
+            }
+            catch (Exception e)
+            {
+                LogManager.Debug(Tag, $"Delete invalid media file failed: {e.Message}");
+            }
+        }
+    }
+
+    private static bool LooksLikeErrorPayload(string file)
+    {
+        try
+        {
+            var buffer = new byte[256];
+            using var stream = File.OpenRead(file);
+            var read = stream.Read(buffer, 0, buffer.Length);
+            if (read <= 0)
+            {
+                return true;
+            }
+
+            var sample = Encoding.UTF8.GetString(buffer, 0, read)
+                .TrimStart('\uFEFF', ' ', '\t', '\r', '\n');
+
+            return sample.StartsWith("<!DOCTYPE", StringComparison.OrdinalIgnoreCase) ||
+                   sample.StartsWith("<html", StringComparison.OrdinalIgnoreCase) ||
+                   sample.StartsWith("{\"code\"", StringComparison.OrdinalIgnoreCase) ||
+                   sample.StartsWith("{\"error\"", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
         }
     }
 
@@ -178,7 +265,8 @@ public abstract class DownloadService
                 BackupUrl = durl.BackupUrl,
                 BaseUrl = durl.Url,
                 Codecs = downloading.PlayUrl.VideoCodecid.GetHashCode().ToString(),
-                Id = downloading.DownloadBase.Bvid.GetHashCode()
+                Id = downloading.DownloadBase.Bvid.GetHashCode(),
+                ExpectedSize = durl.Size
             };
         }
 
@@ -885,7 +973,7 @@ public abstract class DownloadService
                 // 下载完成后处理
                 var downloaded = new Downloaded
                 {
-                    MaxSpeedDisplay = Format.FormatSpeed(downloading.Downloading.MaxSpeed),
+                    MaxSpeedDisplay = Format.FormatSpeedWithBandwidth(downloading.Downloading.MaxSpeed),
                 };
                 // 设置完成时间
                 downloaded.SetFinishedTimestamp(new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds());

--- a/DownKyi/ViewModels/Settings/ViewNetworkViewModel.cs
+++ b/DownKyi/ViewModels/Settings/ViewNetworkViewModel.cs
@@ -65,6 +65,14 @@ public class ViewNetworkViewModel : ViewModelBase
         set => SetProperty(ref _customAria2C, value);
     }
 
+    private bool _highSpeedDownloadMode;
+
+    public bool HighSpeedDownloadMode
+    {
+        get => _highSpeedDownloadMode;
+        set => SetProperty(ref _highSpeedDownloadMode, value);
+    }
+
     private List<int> _maxCurrentDownloads = new();
 
     public List<int> MaxCurrentDownloads
@@ -209,6 +217,38 @@ public class ViewNetworkViewModel : ViewModelBase
         set => SetProperty(ref _selectedAriaSplit, value);
     }
 
+    private List<int> _ariaMaxConnectionPerServers = new();
+
+    public List<int> AriaMaxConnectionPerServers
+    {
+        get => _ariaMaxConnectionPerServers;
+        set => SetProperty(ref _ariaMaxConnectionPerServers, value);
+    }
+
+    private int _selectedAriaMaxConnectionPerServer;
+
+    public int SelectedAriaMaxConnectionPerServer
+    {
+        get => _selectedAriaMaxConnectionPerServer;
+        set => SetProperty(ref _selectedAriaMaxConnectionPerServer, value);
+    }
+
+    private List<int> _ariaMinSplitSizes = new();
+
+    public List<int> AriaMinSplitSizes
+    {
+        get => _ariaMinSplitSizes;
+        set => SetProperty(ref _ariaMinSplitSizes, value);
+    }
+
+    private int _selectedAriaMinSplitSize;
+
+    public int SelectedAriaMinSplitSize
+    {
+        get => _selectedAriaMinSplitSize;
+        set => SetProperty(ref _selectedAriaMinSplitSize, value);
+    }
+
     private int _ariaMaxOverallDownloadLimit;
 
     public int AriaMaxOverallDownloadLimit
@@ -281,7 +321,7 @@ public class ViewNetworkViewModel : ViewModelBase
 
         // builtin最大线程数
         Splits = new List<int>();
-        for (var i = 1; i <= 10; i++)
+        for (var i = 1; i <= 16; i++)
         {
             Splits.Add(i);
         }
@@ -305,10 +345,29 @@ public class ViewNetworkViewModel : ViewModelBase
 
         // Aria最大线程数
         AriaSplits = new List<int>();
-        for (var i = 1; i <= 10; i++)
+        for (var i = 1; i <= 16; i++)
         {
             AriaSplits.Add(i);
         }
+
+        // Aria per-server connections
+        AriaMaxConnectionPerServers = new List<int>();
+        for (var i = 1; i <= 16; i++)
+        {
+            AriaMaxConnectionPerServers.Add(i);
+        }
+
+        AriaMinSplitSizes = new List<int>
+        {
+            1,
+            2,
+            4,
+            8,
+            10,
+            16,
+            32,
+            64
+        };
 
         // Aria文件预分配
         AriaFileAllocations = new List<string>
@@ -359,6 +418,8 @@ public class ViewNetworkViewModel : ViewModelBase
 
         CustomNetworkProxy = SettingsManager.GetInstance().GetCustomProxy();
 
+        HighSpeedDownloadMode = SettingsManager.GetInstance().GetHighSpeedDownloadMode() == AllowStatus.Yes;
+
         // builtin同时下载数
         SelectedMaxCurrentDownload = SettingsManager.GetInstance().GetMaxCurrentDownloads();
 
@@ -393,6 +454,10 @@ public class ViewNetworkViewModel : ViewModelBase
 
         // Aria最大线程数
         SelectedAriaSplit = SettingsManager.GetInstance().GetAriaSplit();
+
+        SelectedAriaMaxConnectionPerServer = SettingsManager.GetInstance().GetAriaMaxConnectionPerServer();
+
+        SelectedAriaMinSplitSize = SettingsManager.GetInstance().GetAriaMinSplitSize();
 
         // Aria下载速度限制
         AriaMaxOverallDownloadLimit = SettingsManager.GetInstance().GetAriaMaxOverallDownloadLimit();
@@ -492,6 +557,34 @@ public class ViewNetworkViewModel : ViewModelBase
             //     Process.Start($"{dir}/DownKyi");
             // }
         }
+    }
+
+    private DelegateCommand? _highSpeedDownloadModeCommand;
+
+    public DelegateCommand HighSpeedDownloadModeCommand =>
+        _highSpeedDownloadModeCommand ??= new DelegateCommand(ExecuteHighSpeedDownloadModeCommand);
+
+    private void ExecuteHighSpeedDownloadModeCommand()
+    {
+        var settings = SettingsManager.GetInstance();
+        var highSpeedDownloadMode = HighSpeedDownloadMode ? AllowStatus.Yes : AllowStatus.No;
+        var isSucceed = settings.SetHighSpeedDownloadMode(highSpeedDownloadMode);
+
+        if (HighSpeedDownloadMode)
+        {
+            SelectedSplit = SettingsManager.HighSpeedBuiltInSplit;
+            SelectedAriaSplit = SettingsManager.HighSpeedAriaSplit;
+            SelectedAriaMaxConnectionPerServer = SettingsManager.HighSpeedAriaMaxConnectionPerServer;
+            SelectedAriaMinSplitSize = SettingsManager.HighSpeedAriaMinSplitSize;
+
+            isSucceed = isSucceed &&
+                        settings.SetSplit(SelectedSplit) &&
+                        settings.SetAriaSplit(SelectedAriaSplit) &&
+                        settings.SetAriaMaxConnectionPerServer(SelectedAriaMaxConnectionPerServer) &&
+                        settings.SetAriaMinSplitSize(SelectedAriaMinSplitSize);
+        }
+
+        PublishTip(isSucceed);
     }
 
     private DownKyiAsyncDelegateCommand<object>? _networkProxyCommand;
@@ -734,6 +827,35 @@ public class ViewNetworkViewModel : ViewModelBase
         SelectedAriaSplit = (int)parameter;
 
         var isSucceed = SettingsManager.GetInstance().SetAriaSplit(SelectedAriaSplit);
+        PublishTip(isSucceed);
+    }
+
+    private DelegateCommand<object?>? _ariaMaxConnectionPerServersCommand;
+
+    public DelegateCommand<object?> AriaMaxConnectionPerServersCommand => _ariaMaxConnectionPerServersCommand ??=
+        new DelegateCommand<object?>(ExecuteAriaMaxConnectionPerServersCommand);
+
+    private void ExecuteAriaMaxConnectionPerServersCommand(object? parameter)
+    {
+        if (parameter == null) return;
+        SelectedAriaMaxConnectionPerServer = (int)parameter;
+
+        var isSucceed = SettingsManager.GetInstance()
+            .SetAriaMaxConnectionPerServer(SelectedAriaMaxConnectionPerServer);
+        PublishTip(isSucceed);
+    }
+
+    private DelegateCommand<object?>? _ariaMinSplitSizesCommand;
+
+    public DelegateCommand<object?> AriaMinSplitSizesCommand => _ariaMinSplitSizesCommand ??=
+        new DelegateCommand<object?>(ExecuteAriaMinSplitSizesCommand);
+
+    private void ExecuteAriaMinSplitSizesCommand(object? parameter)
+    {
+        if (parameter == null) return;
+        SelectedAriaMinSplitSize = (int)parameter;
+
+        var isSucceed = SettingsManager.GetInstance().SetAriaMinSplitSize(SelectedAriaMinSplitSize);
         PublishTip(isSucceed);
     }
 

--- a/DownKyi/ViewModels/Settings/ViewVideoViewModel.cs
+++ b/DownKyi/ViewModels/Settings/ViewVideoViewModel.cs
@@ -21,6 +21,12 @@ public class ViewVideoViewModel : ViewModelBase
 {
     public const string Tag = "PageSettingsVideo";
 
+    public sealed class FfmpegHardwareAccelerationItem
+    {
+        public string Name { get; init; } = string.Empty;
+        public FfmpegHardwareAcceleration Value { get; init; }
+    }
+
     private bool _isOnNavigatedTo;
 
     #region 页面属性申明
@@ -103,6 +109,38 @@ public class ViewVideoViewModel : ViewModelBase
     {
         get => _isTranscodingAacToMp3;
         set => SetProperty(ref _isTranscodingAacToMp3, value);
+    }
+
+    private List<FfmpegHardwareAccelerationItem> _ffmpegHardwareAccelerations = new();
+
+    public List<FfmpegHardwareAccelerationItem> FfmpegHardwareAccelerations
+    {
+        get => _ffmpegHardwareAccelerations;
+        set => SetProperty(ref _ffmpegHardwareAccelerations, value);
+    }
+
+    private FfmpegHardwareAccelerationItem _selectedFfmpegHardwareAcceleration = null!;
+
+    public FfmpegHardwareAccelerationItem SelectedFfmpegHardwareAcceleration
+    {
+        get => _selectedFfmpegHardwareAcceleration;
+        set => SetProperty(ref _selectedFfmpegHardwareAcceleration, value);
+    }
+
+    private List<int> _ffmpegMaxParallelJobs = new();
+
+    public List<int> FfmpegMaxParallelJobs
+    {
+        get => _ffmpegMaxParallelJobs;
+        set => SetProperty(ref _ffmpegMaxParallelJobs, value);
+    }
+
+    private int _selectedFfmpegMaxParallelJob;
+
+    public int SelectedFfmpegMaxParallelJob
+    {
+        get => _selectedFfmpegMaxParallelJob;
+        set => SetProperty(ref _selectedFfmpegMaxParallelJob, value);
     }
 
     private bool _isUseDefaultDirectory;
@@ -302,6 +340,19 @@ public class ViewVideoViewModel : ViewModelBase
             },
         };
 
+        FfmpegHardwareAccelerations = new List<FfmpegHardwareAccelerationItem>
+        {
+            new() { Name = "自动检测", Value = FfmpegHardwareAcceleration.Auto },
+            new() { Name = "禁用硬件加速", Value = FfmpegHardwareAcceleration.Disabled },
+            new() { Name = "NVIDIA NVENC", Value = FfmpegHardwareAcceleration.NvidiaNvenc },
+            new() { Name = "Intel QSV", Value = FfmpegHardwareAcceleration.IntelQsv },
+            new() { Name = "AMD AMF", Value = FfmpegHardwareAcceleration.AmdAmf },
+            new() { Name = "Linux VAAPI", Value = FfmpegHardwareAcceleration.Vaapi },
+            new() { Name = "macOS VideoToolbox", Value = FfmpegHardwareAcceleration.VideoToolbox },
+        };
+
+        FfmpegMaxParallelJobs = new List<int> { 1, 2, 3, 4 };
+
         #endregion
     }
 
@@ -339,6 +390,13 @@ public class ViewVideoViewModel : ViewModelBase
         // 是否下载aac音频后转码为mp3
         var isTranscodingAacToMp3 = SettingsManager.GetInstance().GetIsTranscodingAacToMp3();
         IsTranscodingAacToMp3 = isTranscodingAacToMp3 == AllowStatus.Yes;
+
+        var ffmpegHardwareAcceleration = SettingsManager.GetInstance().GetFfmpegHardwareAcceleration();
+        SelectedFfmpegHardwareAcceleration = FfmpegHardwareAccelerations
+                                                 .FirstOrDefault(t => t.Value == ffmpegHardwareAcceleration) ??
+                                             FfmpegHardwareAccelerations.First();
+
+        SelectedFfmpegMaxParallelJob = SettingsManager.GetInstance().GetFfmpegMaxParallelJobs();
 
         // 是否使用默认下载目录
         var isUseSaveVideoRootPath = SettingsManager.GetInstance().GetIsUseSaveVideoRootPath();
@@ -498,6 +556,38 @@ public class ViewVideoViewModel : ViewModelBase
         var isTranscodingAacToMp3 = IsTranscodingAacToMp3 ? AllowStatus.Yes : AllowStatus.No;
 
         var isSucceed = SettingsManager.GetInstance().SetIsTranscodingAacToMp3(isTranscodingAacToMp3);
+        PublishTip(isSucceed);
+    }
+
+    private DelegateCommand<object>? _ffmpegHardwareAccelerationCommand;
+
+    public DelegateCommand<object> FfmpegHardwareAccelerationCommand =>
+        _ffmpegHardwareAccelerationCommand ??= new DelegateCommand<object>(ExecuteFfmpegHardwareAccelerationCommand);
+
+    private void ExecuteFfmpegHardwareAccelerationCommand(object parameter)
+    {
+        if (parameter is not FfmpegHardwareAccelerationItem acceleration)
+        {
+            return;
+        }
+
+        var isSucceed = SettingsManager.GetInstance().SetFfmpegHardwareAcceleration(acceleration.Value);
+        PublishTip(isSucceed);
+    }
+
+    private DelegateCommand<object>? _ffmpegMaxParallelJobsCommand;
+
+    public DelegateCommand<object> FfmpegMaxParallelJobsCommand =>
+        _ffmpegMaxParallelJobsCommand ??= new DelegateCommand<object>(ExecuteFfmpegMaxParallelJobsCommand);
+
+    private void ExecuteFfmpegMaxParallelJobsCommand(object parameter)
+    {
+        if (parameter is not int maxParallelJobs)
+        {
+            return;
+        }
+
+        var isSucceed = SettingsManager.GetInstance().SetFfmpegMaxParallelJobs(maxParallelJobs);
         PublishTip(isSucceed);
     }
 

--- a/DownKyi/ViewModels/ViewVideoDetailViewModel.cs
+++ b/DownKyi/ViewModels/ViewVideoDetailViewModel.cs
@@ -194,7 +194,7 @@ public class ViewVideoDetailViewModel : ViewModelBase
         var parameter = new NavigationParam
         {
             ViewName = ViewDownloadManagerViewModel.Tag,
-            ParentViewName = Tag,
+            ParentViewName = string.IsNullOrWhiteSpace(ParentView) ? ViewIndexViewModel.Tag : ParentView,
             Parameter = null
         };
         EventAggregator.GetEvent<NavigationEvent>().Publish(parameter);

--- a/DownKyi/Views/Settings/ViewNetwork.axaml
+++ b/DownKyi/Views/Settings/ViewNetwork.axaml
@@ -140,6 +140,17 @@
                         IsChecked="{Binding CustomAria2C}" />
                 </StackPanel>
             </StackPanel>
+            <CheckBox
+                Name="NameHighSpeedDownloadMode"
+                Margin="0,20,0,0"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Top"
+                Command="{Binding HighSpeedDownloadModeCommand}"
+                Content="{DynamicResource HighSpeedDownloadMode}"
+                FontSize="12"
+                Foreground="{DynamicResource BrushTextDark}"
+                IsChecked="{Binding HighSpeedDownloadMode, Mode=TwoWay}"
+                ToolTip.Tip="{DynamicResource HighSpeedDownloadModeTip}" />
             <TextBlock
                 Height="1"
                 Margin="0,20,0,0"
@@ -335,6 +346,50 @@
                             <EventTriggerBehavior EventName="SelectionChanged">
                                 <InvokeCommandAction Command="{Binding AriaSplitsCommand}"
                                                      CommandParameter="{Binding ElementName=NameAriaSplits, Path=SelectedValue}" />
+                            </EventTriggerBehavior>
+                        </Interaction.Behaviors>
+                    </ComboBox>
+                </StackPanel>
+
+                <StackPanel Margin="0,20,0,0" Orientation="Horizontal">
+                    <TextBlock
+                        Width="150"
+                        VerticalAlignment="Center"
+                        FontSize="12"
+                        Foreground="{DynamicResource BrushTextDark}"
+                        Text="{DynamicResource AriaMaxConnectionPerServer}" />
+                    <ComboBox
+                        Name="NameAriaMaxConnectionPerServers"
+                        Width="100"
+                        VerticalContentAlignment="Center"
+                        ItemsSource="{Binding AriaMaxConnectionPerServers}"
+                        SelectedValue="{Binding SelectedAriaMaxConnectionPerServer}">
+                        <Interaction.Behaviors>
+                            <EventTriggerBehavior EventName="SelectionChanged">
+                                <InvokeCommandAction Command="{Binding AriaMaxConnectionPerServersCommand}"
+                                                     CommandParameter="{Binding ElementName=NameAriaMaxConnectionPerServers, Path=SelectedValue}" />
+                            </EventTriggerBehavior>
+                        </Interaction.Behaviors>
+                    </ComboBox>
+                </StackPanel>
+
+                <StackPanel Margin="0,20,0,0" Orientation="Horizontal">
+                    <TextBlock
+                        Width="150"
+                        VerticalAlignment="Center"
+                        FontSize="12"
+                        Foreground="{DynamicResource BrushTextDark}"
+                        Text="{DynamicResource AriaMinSplitSize}" />
+                    <ComboBox
+                        Name="NameAriaMinSplitSizes"
+                        Width="100"
+                        VerticalContentAlignment="Center"
+                        ItemsSource="{Binding AriaMinSplitSizes}"
+                        SelectedValue="{Binding SelectedAriaMinSplitSize}">
+                        <Interaction.Behaviors>
+                            <EventTriggerBehavior EventName="SelectionChanged">
+                                <InvokeCommandAction Command="{Binding AriaMinSplitSizesCommand}"
+                                                     CommandParameter="{Binding ElementName=NameAriaMinSplitSizes, Path=SelectedValue}" />
                             </EventTriggerBehavior>
                         </Interaction.Behaviors>
                     </ComboBox>

--- a/DownKyi/Views/Settings/ViewVideo.axaml
+++ b/DownKyi/Views/Settings/ViewVideo.axaml
@@ -115,6 +115,55 @@
                 Foreground="{DynamicResource BrushTextDark}"
                 IsChecked="{Binding IsTranscodingAacToMp3, Mode=TwoWay}" />
 
+            <StackPanel
+                Margin="0,20,0,0"
+                Orientation="Horizontal"
+                ToolTip.Tip="{DynamicResource FfmpegHardwareAccelerationTip}">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    FontSize="12"
+                    Foreground="{DynamicResource BrushTextDark}"
+                    Text="{DynamicResource FfmpegHardwareAcceleration}" />
+                <ComboBox
+                    Name="NameFfmpegHardwareAcceleration"
+                    Width="180"
+                    VerticalContentAlignment="Center"
+                    DisplayMemberBinding="{Binding Name}"
+                    ItemsSource="{Binding FfmpegHardwareAccelerations}"
+                    SelectedItem="{Binding SelectedFfmpegHardwareAcceleration}">
+                    <Interaction.Behaviors>
+                        <EventTriggerBehavior EventName="SelectionChanged">
+                            <InvokeCommandAction Command="{Binding FfmpegHardwareAccelerationCommand}"
+                                                 CommandParameter="{Binding ElementName=NameFfmpegHardwareAcceleration,Path=SelectedValue}" />
+                        </EventTriggerBehavior>
+                    </Interaction.Behaviors>
+                </ComboBox>
+            </StackPanel>
+
+            <StackPanel
+                Margin="0,20,0,0"
+                Orientation="Horizontal"
+                ToolTip.Tip="{DynamicResource FfmpegMaxParallelJobsTip}">
+                <TextBlock
+                    VerticalAlignment="Center"
+                    FontSize="12"
+                    Foreground="{DynamicResource BrushTextDark}"
+                    Text="{DynamicResource FfmpegMaxParallelJobs}" />
+                <ComboBox
+                    Name="NameFfmpegMaxParallelJobs"
+                    Width="80"
+                    VerticalContentAlignment="Center"
+                    ItemsSource="{Binding FfmpegMaxParallelJobs}"
+                    SelectedValue="{Binding SelectedFfmpegMaxParallelJob}">
+                    <Interaction.Behaviors>
+                        <EventTriggerBehavior EventName="SelectionChanged">
+                            <InvokeCommandAction Command="{Binding FfmpegMaxParallelJobsCommand}"
+                                                 CommandParameter="{Binding ElementName=NameFfmpegMaxParallelJobs,Path=SelectedValue}" />
+                        </EventTriggerBehavior>
+                    </Interaction.Behaviors>
+                </ComboBox>
+            </StackPanel>
+
             <TextBlock
                 Height="1"
                 Margin="0,20,0,0"

--- a/README.md
+++ b/README.md
@@ -1,39 +1,142 @@
-# 哔哩下载姬(跨平台版)
+# DownKyi Core
 
 <div align="center">
 
-[![GitHub Repo stars](https://img.shields.io/github/stars/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/stargazers)
-[![GitHub forks](https://img.shields.io/github/forks/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/network)
-[![GitHub issues](https://img.shields.io/github/issues/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/issues)
-[![LICENSE](https://img.shields.io/github/license/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/blob/main/LICENSE)
+[![GitHub Repo stars](https://img.shields.io/github/stars/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/network)
+[![GitHub issues](https://img.shields.io/github/issues/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/issues)
+[![LICENSE](https://img.shields.io/github/license/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/blob/main/LICENSE)
 
 </div>
 
+DownKyi Core 是基于哔哩下载姬 Windows 版与 Avalonia 的跨平台 B 站视频下载工具。当前项目已迁移到 .NET 10，并针对启动速度、下载续传、任务清理、日志诊断、SQLite 存储和 CI 发布流程做了维护。
+
 ## 下载
 
-[![GitHub release (latest by date)](https://img.shields.io/github/v/release/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/releases/latest)
-[![GitHub Release Date](https://img.shields.io/github/release-date/yaobiao131/downkyicore)](https://github.com/yaobiao131/downkyicore/releases/latest)
-[![GitHub all releases](https://img.shields.io/github/downloads/yaobiao131/downkyicore/total)](https://github.com/yaobiao131/downkyicore/releases/latest)
+[![GitHub release](https://img.shields.io/github/v/release/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub Release Date](https://img.shields.io/github/release-date/crazysmile-PhD/downkyicore)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
+[![GitHub downloads](https://img.shields.io/github/downloads/crazysmile-PhD/downkyicore/total)](https://github.com/crazysmile-PhD/downkyicore/releases/latest)
 
-[更新日志](CHANGELOG.md)
+- Windows: `DownKyi-*-win-x64.zip` 或 `DownKyi-*-win-x86.zip`
+- macOS: `DownKyi-*-osx-arm64.dmg` 或 `DownKyi-*-osx-x64.dmg`
+- Linux: AppImage / deb / rpm
 
-## 介绍
+更新内容见 [CHANGELOG.md](CHANGELOG.md)。
 
-- 基于[哔哩下载姬Windows版](https://github.com/leiurayer/downkyi)和[AvaloniaUI](https://github.com/AvaloniaUI/Avalonia)制作的跨平台版本(支持Windows、linux、macOS)。
-- 开发这个版本目的是由于本人日常使用macOS，当我想下载up视频是偶然间发现了[哔哩下载姬Windows版](https://github.com/leiurayer/downkyi)，发现很好用，就是不能支持macOS使用，就基于AvaloniaUI重新开发了一个跨平台版本。
+## 功能
 
-## 使用说明
-- 软件自带.NET6、ffmpeg、aria2运行环境、无需自行安装
-- 默认下载路径:
-  - Windows: 软件运行目录下的Media文件夹
-  - macOS: ~/Library/Application Support/DownKyi/Media
-  - linux: ~/.config/DownKyi/Media
+- 支持视频、合集、番剧、课程、收藏、历史记录、稍后再看等入口解析。
+- 支持音频、视频、封面、弹幕、普通字幕和 AI 字幕下载。
+- 支持 aria2 与内置下载器，并保留断点续传所需的临时文件与状态。
+- 下载中删除任务时会同步停止下载器并清理已产生的媒体、`.aria2`、`.download` 等临时文件。
+- 支持诊断日志导出，导出内容会脱敏 Cookie、token、邮箱、uid 和本机用户路径。
+- 默认使用 AppData / Application Support / XDG 配置目录保存数据，避免把用户数据写进程序目录。
 
+## 运行与数据目录
+
+发布包包含运行所需的 .NET、ffmpeg 和 aria2，不需要用户额外安装。Windows x64 与 Linux 使用 BtbN GPL FFmpeg build，macOS 使用同时提供 x64 / arm64 的静态 FFmpeg build；这些发布包会优先携带可用的硬件 encoder。Windows x86 仍保留兼容性 build，硬件加速不可用时会自动降级。
+
+FFmpeg 合并策略遵循“效能优先，但成功率更重要”：优先无损 stream copy；只有必须重新编码时才自动检测 NVENC / QSV / AMF / VAAPI / VideoToolbox；如果 GPU encoder 不存在、驱动不可用或参数失败，程序会记录原因并回退到低 CPU 软编码。
+
+默认数据目录：
+
+- Windows: `%APPDATA%\DownKyi`
+- macOS: `~/Library/Application Support/DownKyi`
+- Linux: `$XDG_CONFIG_HOME/DownKyi`，未设置时通常是 `~/.config/DownKyi`
+
+常用子目录：
+
+- `Media`: 默认下载目录
+- `Logs`: 应用日志和诊断日志
+- `Storage`: SQLite 下载数据库
+- `Config`: 设置与登录信息
+- `Cache`: 图片和运行缓存
+- `Aria`: aria2 session/log
+
+可选模式：
+
+- 设置 `DOWNKYI_DATA_DIR` 可指定完整数据根目录。
+- 设置 `DOWNKYI_PORTABLE=1`，或在程序目录放置 `portable` / `.portable` / `DownKyi.portable`，可启用便携模式。
+
+## 工作流程
+
+```mermaid
+flowchart TD
+    A["用户输入 BV/AV/番剧/收藏/历史入口"] --> B["SearchService 判断入口类型"]
+    B --> C["VideoInfoService / BangumiInfoService / CheeseInfoService"]
+    C --> D["BiliApi 请求视频详情、分 P、合集章节"]
+    D --> E["ViewModel 批次更新列表"]
+    E --> F{"解析范围"}
+    F -->|选中项| G["解析选中视频流"]
+    F -->|当前章节| H["解析当前章节"]
+    F -->|全部| I["顺序解析全部视频"]
+    G --> J["VideoStream.GetVideoPlayUrl"]
+    H --> J
+    I --> J
+    J --> K["选择画质、音质、编码"]
+    K --> L["AddToDownloadService 建立下载任务"]
+    L --> M["DownloadStorageService 写入 SQLite"]
+    M --> N["DownloadService 背景执行任务"]
+```
+
+```mermaid
+flowchart TD
+    A["下载任务"] --> B["解析播放地址"]
+    B --> C{"下载器"}
+    C -->|aria2| D["AriaDownloadService / CustomAriaDownloadService"]
+    C -->|内置| E["BuiltinDownloadService"]
+    D --> F["保存 gid、临时文件、进度状态"]
+    E --> F
+    F --> G["下载音频 / 视频 / 封面 / 弹幕 / 字幕"]
+    G --> H["字幕 JSON 转 SRT"]
+    G --> I["弹幕 protobuf 转 ASS"]
+    G --> J["FFmpeg 合并音视频：优先 copy，必要时 GPU/CPU fallback"]
+    H --> K["输出 Media 文件"]
+    I --> K
+    J --> K
+    K --> L["任务完成，写入 downloaded 表"]
+```
+
+## 诊断
+
+软件内可在关于页面打开日志目录或导出诊断日志。诊断日志用于快速排查：
+
+- 网络请求失败、超时、状态码异常
+- 下载器启动、暂停、续传、清理失败
+- 字幕、弹幕、封面、音视频合并异常
+- 退出时 aria2 或后台任务未按预期关闭
+
+导出的诊断日志会过滤大量普通调试噪音，并自动遮蔽敏感信息。
+
+## 开发
+
+需要 .NET 10 SDK。
+
+```powershell
+dotnet restore
+dotnet build .\DownKyi\DownKyi.csproj -c Release
+```
+
+本机运行：
+
+```powershell
+dotnet run --project .\DownKyi\DownKyi.csproj
+```
+
+发布由 GitHub Actions 触发 tag 完成：
+
+```powershell
+git tag -a v1.0.x -m "v1.0.x"
+git push origin main
+git push origin v1.0.x
+```
+
+当前 Windows 发布包使用正常 self-contained zip。由于 Avalonia / Prism / Xaml.Behaviors / Newtonsoft.Json 组合并不适合 full trim，项目暂不发布 Windows `-trimmed` 包。
 
 ## 免责申明
-1. 本软件只提供视频解析，不提供任何资源上传、存储到服务器的功能。
-2. 本软件仅解析来自B站的内容，不会对解析到的音视频进行二次编码，部分视频会进行有限的格式转换、拼接等操作。
-3. 本软件解析得到的所有内容均来自B站UP主上传、分享，其版权均归原作者所有。内容提供者、上传者(UP主)应对其提供、上传的内容承担全部责任。
-4. **本软件提供的所有内容，仅可用作学习交流使用，未经原作者授权，禁止用于其他用途。请在下载24小时内删除。为尊重作者版权，请前往资源的原始发布网站观看，支持原创，谢谢。**
-5. 因使用本软件产生的版权问题，软件作者概不负责。
 
+1. 本软件只提供视频解析，不提供任何资源上传、存储到服务器的功能。
+2. 本软件仅解析来自 B 站的内容，不会对解析到的音视频进行二次编码，部分视频会进行有限的格式转换、拼接等操作。
+3. 本软件解析得到的所有内容均来自 B 站 UP 主上传、分享，其版权均归原作者所有。内容提供者、上传者应对其提供、上传的内容承担全部责任。
+4. 本软件提供的所有内容，仅可用作学习交流使用，未经原作者授权，禁止用于其他用途。请在下载 24 小时内删除。为尊重作者版权，请前往资源的原始发布网站观看，支持原创。
+5. 因使用本软件产生的版权问题，软件作者概不负责。

--- a/script/assets/external-assets.json
+++ b/script/assets/external-assets.json
@@ -30,32 +30,32 @@
     }
   },
   "ffmpeg": {
-    "version": "continuous",
-    "repository": "https://github.com/yaobiao131/downkyi-ffmpeg-build",
+    "version": "btbn-autobuild-2026-07-08-13-30_martin-riedl-2026-07",
+    "repository": "Windows/Linux: https://github.com/BtbN/FFmpeg-Builds; macOS: https://ffmpeg.martin-riedl.de",
     "assets": {
       "win-x86": {
         "url": "https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/ffmpeg-i686-w64-mingw32_static.zip",
         "sha256": "969a75924bfaa642d54dafea771cc1cf77103915428b1eaeac061eda7f837471"
       },
       "win-x64": {
-        "url": "https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/ffmpeg-x86_64-w64-mingw32_static.zip",
-        "sha256": "563766d2f7a4fc16b69c1928966fa6867697bbed39aacf2db0decdf639ee66df"
+        "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-08-13-30/ffmpeg-N-125505-gc57660fb18-win64-gpl.zip",
+        "sha256": "21e3aa721313ee09ae2e05fe4335935047d111c97a9ab78c093f36c74bfdd206"
       },
       "linux-x64": {
-        "url": "https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/ffmpeg-x86_64-linux-musl_static.zip",
-        "sha256": "fd6709e6c39aa6cdeb8f98b51c434122a4ae7dc36d5b94765c695e96c64647f2"
+        "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-08-13-30/ffmpeg-N-125505-gc57660fb18-linux64-gpl.tar.xz",
+        "sha256": "d540a9b176456af5fae75a1aa4c388152e1b418fb4fa129fef83d98305f04f3c"
       },
       "linux-arm64": {
-        "url": "https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/ffmpeg-aarch64-linux-musl_static.zip",
-        "sha256": "89b5d5f1dc7832dd07a4f171a236c089b55b087062232b6845c8ae31c4f16e23"
+        "url": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-08-13-30/ffmpeg-N-125505-gc57660fb18-linuxarm64-gpl.tar.xz",
+        "sha256": "e7f52bcc7a42fef23a104b75b87462ba3588aa168f937115471b5200eed7ccb2"
       },
       "osx-x64": {
-        "url": "https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/ffmpeg-x86_64-apple-darwin_static.zip",
-        "sha256": "ba7cd3da928d9028b01cecc0fca915021afea47e9090552579d8da2919e7bde4"
+        "url": "https://ffmpeg.martin-riedl.de/download/macos/amd64/1767299902_N-122320-g38e89fe502/ffmpeg.zip",
+        "sha256": "6f0736d424b7426f8cbb7bba5c5448d94c976c138c669593b1f40ba534ed192f"
       },
       "osx-arm64": {
-        "url": "https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/ffmpeg-aarch64-apple-darwin_static.zip",
-        "sha256": "8fd7ea3126839dac99d8e631071ce8b08a1caa00d72171813b4e77aa1f68bb31"
+        "url": "https://ffmpeg.martin-riedl.de/download/macos/arm64/1783164229_N-125450-gfad2e0bc50/ffmpeg.zip",
+        "sha256": "b5ce8b77f8c0686e4f68a46f8e4d094fe7e6f4ded50bcfacd9944ad1efdf66e9"
       }
     }
   }

--- a/script/ffmpeg.ps1
+++ b/script/ffmpeg.ps1
@@ -30,10 +30,37 @@ if ($null -eq $asset) {
 }
 
 $archive = ".\downloads\ffmpeg-$arch.zip"
+if (Test-Path -LiteralPath $archive) {
+    Remove-Item -LiteralPath $archive -Force
+}
 Start-BitsTransfer -Source $asset.url -Destination $archive
 Verify-Asset $archive $asset.sha256
 
 $destDir = "..\DownKyi.Core\Binary\$rid\ffmpeg\"
 Create-Dir $destDir
+Get-ChildItem -LiteralPath $destDir -File | Remove-Item -Force
 
-Expand-Archive -Path $archive -DestinationPath $destDir -Force
+$extractDir = ".\downloads\ffmpeg-$arch-extract"
+if (Test-Path -LiteralPath $extractDir) {
+    Remove-Item -LiteralPath $extractDir -Recurse -Force
+}
+Create-Dir $extractDir
+
+Expand-Archive -Path $archive -DestinationPath $extractDir -Force
+$ffmpeg = Get-ChildItem -LiteralPath $extractDir -Recurse -File -Filter "ffmpeg.exe" | Select-Object -First 1
+if ($null -eq $ffmpeg) {
+    throw "ffmpeg.exe not found in $archive"
+}
+
+Copy-Item -LiteralPath $ffmpeg.FullName -Destination (Join-Path $destDir "ffmpeg.exe") -Force
+
+$extractRoot = (Resolve-Path -LiteralPath $extractDir).Path
+$current = $ffmpeg.Directory
+while ($null -ne $current -and $current.FullName.StartsWith($extractRoot, [StringComparison]::OrdinalIgnoreCase)) {
+    Get-ChildItem -LiteralPath $current.FullName -File |
+        Where-Object { $_.Name -match '^(LICENSE|COPYING|README)(\..*)?$' } |
+        ForEach-Object {
+            Copy-Item -LiteralPath $_.FullName -Destination (Join-Path $destDir $_.Name) -Force
+        }
+    $current = $current.Parent
+}

--- a/script/ffmpeg.sh
+++ b/script/ffmpeg.sh
@@ -6,6 +6,7 @@ arch=$2
 
 ffmpeg_save_path="../DownKyi.Core/Binary"
 download_dir="./downloads"
+manifest="./assets/external-assets.json"
 
 create_dir() {
   if [ ! -d "$1" ]; then
@@ -32,58 +33,95 @@ verify_asset() {
   fi
 }
 
+copy_license_files() {
+  local source_dir=$1
+  local destination=$2
+
+  while [[ "$source_dir" == "$extract_dir"* ]]; do
+    find "$source_dir" -maxdepth 1 -type f \( \
+      -iname 'LICENSE' -o -iname 'LICENSE.*' -o \
+      -iname 'COPYING' -o -iname 'COPYING.*' -o \
+      -iname 'README' -o -iname 'README.*' \
+    \) -exec cp {} "$destination/" \;
+    source_dir=$(dirname "$source_dir")
+  done
+}
+
+asset_value() {
+  local rid=$1
+  local key=$2
+  python3 - "$manifest" "$rid" "$key" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as f:
+    manifest = json.load(f)
+
+print(manifest["ffmpeg"]["assets"][sys.argv[2]][sys.argv[3]])
+PY
+}
+
+extract_ffmpeg() {
+  local archive=$1
+  local destination=$2
+  local extract_dir="$download_dir/ffmpeg-extract-$os-$arch"
+
+  rm -rf "$extract_dir"
+  create_dir "$extract_dir"
+  case "$archive" in
+  *.tar.xz)
+    tar -xJf "$archive" -C "$extract_dir"
+    ;;
+  *.zip)
+    unzip -q -d "$extract_dir" -o "$archive"
+    ;;
+  *)
+    echo "Unsupported ffmpeg archive: $archive" >&2
+    exit 1
+    ;;
+  esac
+
+  local ffmpeg_bin
+  ffmpeg_bin=$(find "$extract_dir" -type f -name ffmpeg | head -n 1)
+  if [ -z "$ffmpeg_bin" ]; then
+    echo "ffmpeg binary not found in $archive" >&2
+    exit 1
+  fi
+
+  create_dir "$destination"
+  find "$destination" -maxdepth 1 -type f -delete
+  cp "$ffmpeg_bin" "$destination/ffmpeg"
+  copy_license_files "$(dirname "$ffmpeg_bin")" "$destination"
+  chmod +x "$destination/ffmpeg"
+}
+
 create_dir "$download_dir"
 
 download_ffmpeg_macos() {
-  local filename=""
-  local expected_sha256=""
-  case $arch in
-  x64)
-    filename=ffmpeg-x86_64-apple-darwin_static.zip
-    expected_sha256="ba7cd3da928d9028b01cecc0fca915021afea47e9090552579d8da2919e7bde4"
-    ;;
-  arm64)
-    filename=ffmpeg-aarch64-apple-darwin_static.zip
-    expected_sha256="8fd7ea3126839dac99d8e631071ce8b08a1caa00d72171813b4e77aa1f68bb31"
-    ;;
-  *)
-    echo "Unsupported macOS ffmpeg architecture: $arch" >&2
-    exit 1
-    ;;
-  esac
-  local url="https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/$filename"
+  local rid="osx-$arch"
+  local url
+  local expected_sha256
+  url=$(asset_value "$rid" "url")
+  expected_sha256=$(asset_value "$rid" "sha256")
   local archive="$download_dir/ffmpeg-mac-$arch.zip"
-  create_dir "$ffmpeg_save_path/osx-$arch/ffmpeg"
   curl -kL "$url" -o "$archive"
   verify_asset "$archive" "$expected_sha256"
-  unzip -d "$ffmpeg_save_path/osx-$arch/ffmpeg/" -o "$archive"
-  chmod +x "$ffmpeg_save_path/osx-$arch/ffmpeg/ffmpeg"
+  extract_ffmpeg "$archive" "$ffmpeg_save_path/$rid/ffmpeg"
 }
 
 download_ffmpeg_linux() {
-  local filename=""
-  local expected_sha256=""
-  case $arch in
-  x64)
-    filename=ffmpeg-x86_64-linux-musl_static.zip
-    expected_sha256="fd6709e6c39aa6cdeb8f98b51c434122a4ae7dc36d5b94765c695e96c64647f2"
-    ;;
-  arm64)
-    filename=ffmpeg-aarch64-linux-musl_static.zip
-    expected_sha256="89b5d5f1dc7832dd07a4f171a236c089b55b087062232b6845c8ae31c4f16e23"
-    ;;
-  *)
-    echo "Unsupported Linux ffmpeg architecture: $arch" >&2
-    exit 1
-    ;;
-  esac
-  local url="https://github.com/yaobiao131/downkyi-ffmpeg-build/releases/download/continuous/$filename"
-  local archive="$download_dir/ffmpeg-linux-$arch.zip"
-  create_dir "$ffmpeg_save_path/linux-$arch/ffmpeg"
+  local rid="linux-$arch"
+  local url
+  local expected_sha256
+  url=$(asset_value "$rid" "url")
+  expected_sha256=$(asset_value "$rid" "sha256")
+  local archive="$download_dir/ffmpeg-linux-$arch.${url##*.}"
+  if [[ "$url" == *.tar.xz ]]; then
+    archive="$download_dir/ffmpeg-linux-$arch.tar.xz"
+  fi
   curl -kL "$url" -o "$archive"
   verify_asset "$archive" "$expected_sha256"
-  unzip -d "$ffmpeg_save_path/linux-$arch/ffmpeg/" -o "$archive"
-  chmod +x "$ffmpeg_save_path/linux-$arch/ffmpeg/ffmpeg"
+  extract_ffmpeg "$archive" "$ffmpeg_save_path/$rid/ffmpeg"
 }
 
 if [ "$os" == "mac" ]; then


### PR DESCRIPTION
## Summary

- Add high-speed download settings and sanitized download diagnostics for aria2 and the built-in downloader.
- Improve download reliability by validating completed media files, carrying DURL expected sizes, retrying built-in backup URLs, and rejecting unfinished sidecars or error payloads.
- Add FFmpeg hardware acceleration fallback logic: stream copy first, then NVENC/QSV/AMF/VAAPI/VideoToolbox when available, then low-CPU software fallback.
- Pin cross-platform FFmpeg package sources and checksums, include license files in release packages, and update README documentation/diagrams.
- Fix the video-detail download manager return target so users can return to the original parent page/main page.

## Why

This addresses slow/limited download configuration, incomplete media output, FFmpeg CPU pressure during batch tasks, cross-platform hardware encoder packaging, and the issue #62 class of failures where downloaded videos could be incomplete or the download manager navigation felt stuck.

## Validation

- `dotnet build .\DownKyi\DownKyi.csproj -c Release --no-restore --no-incremental -maxcpucount:1`
- `dotnet publish .\DownKyi\DownKyi.csproj -c Release -r win-x64 --self-contained --no-restore -p:DebugType=None -p:DebugSymbols=false -p:PublishDir=.\artifacts\win-x64\`
- `dotnet test .\DownKyi.sln -c Release --no-restore --no-build`
- `git diff --check`
- Verified pinned BtbN checksums for Windows/Linux FFmpeg assets.
- Verified published Windows FFmpeg contains `h264_nvenc`, `h264_qsv`, `h264_amf`, and the `concat` demuxer.
- Verified no generated diagnostic logs or temporary download artifacts are left in the worktree.