### PR TITLE
Fix download bandwidth display and version comparison

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <Nullable>enable</Nullable>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <Version Condition="Exists('$(MSBuildThisFileDirectory)version.txt')">$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)version.txt').Trim())</Version>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
   </PropertyGroup>

--- a/DownKyi/Models/AppInfo.cs
+++ b/DownKyi/Models/AppInfo.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace DownKyi.Models;
@@ -9,43 +10,69 @@ public class AppInfo
     public int VersionCode { get; }
     public string VersionName { get; }
 
-    private const int A = 1;
-    private const int B = 0;
-    private const int C = 31;
-
     public AppInfo()
     {
-        VersionCode = A * 10000 + B * 100 + C;
+        var versionName = ResolveVersionName();
+        VersionCode = VersionNameToCode(versionName);
 
 #if DEBUG
-        VersionName = $"{A}.{B}.{C}-debug";
+        VersionName = $"{versionName}-debug";
 #else
-        VersionName = $"{A}.{B}.{C}";
+        VersionName = versionName;
 #endif
+    }
+
+    public static string NormalizeVersionName(string? versionName)
+    {
+        if (string.IsNullOrWhiteSpace(versionName))
+        {
+            return string.Empty;
+        }
+
+        var match = Regex.Match(versionName, @"v?(\d+\.\d+\.\d+)", RegexOptions.IgnoreCase);
+        return match.Success ? match.Groups[1].Value : string.Empty;
     }
 
     public static int VersionNameToCode(string versionName)
     {
         var code = 0;
+        var normalizedVersion = NormalizeVersionName(versionName);
 
-        var isMatch = Regex.IsMatch(versionName, @"^v?([1-9]\d|\d).([1-9]\d|\d).([1-9]\d|\d)$");
+        var isMatch = Regex.IsMatch(normalizedVersion, @"^\d+\.\d+\.\d+$");
         if (!isMatch)
         {
             return 0;
         }
 
-        var pattern = @"([1-9]\d|\d)";
-        var m = Regex.Matches(versionName, pattern);
-        if (m.Count == 3)
+        var parts = normalizedVersion.Split('.');
+        if (parts.Length == 3)
         {
             var i = 2;
-            foreach (var item in m)
+            foreach (var item in parts)
             {
-                code += int.Parse(item.ToString()!) * (int)Math.Pow(100, i);
+                code += int.Parse(item) * (int)Math.Pow(100, i);
                 i--;
             }
         }
 
         return code;
+    }
+
+    private static string ResolveVersionName()
+    {
+        var informationalVersion = typeof(AppInfo)
+            .Assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+            ?.InformationalVersion;
+        var normalizedVersion = NormalizeVersionName(informationalVersion);
+        if (!string.IsNullOrEmpty(normalizedVersion))
+        {
+            return normalizedVersion;
+        }
+
+        var assemblyVersion = typeof(AppInfo).Assembly.GetName().Version;
+        return assemblyVersion == null
+            ? "0.0.0"
+            : $"{assemblyVersion.Major}.{assemblyVersion.Minor}.{Math.Max(0, assemblyVersion.Build)}";
     }
 }

--- a/DownKyi/Services/VersionCheckerService.cs
+++ b/DownKyi/Services/VersionCheckerService.cs
@@ -64,12 +64,14 @@ namespace DownKyi.Services
 
         public bool IsNewVersionAvailable(string latestVersion)
         {
-            string v = new AppInfo().VersionName;
-#if DEBUG
-            v = v.Replace("-debug", string.Empty);
-#endif
-            var current = new Version(v.TrimStart('v'));
-            var latest = new Version(latestVersion.TrimStart('v'));
+            var currentVersion = AppInfo.NormalizeVersionName(new AppInfo().VersionName);
+            var latestReleaseVersion = AppInfo.NormalizeVersionName(latestVersion);
+            if (!Version.TryParse(currentVersion, out var current) ||
+                !Version.TryParse(latestReleaseVersion, out var latest))
+            {
+                return false;
+            }
+
             return latest > current;
         }
 

--- a/DownKyi/Views/DownloadManager/ViewDownloading.axaml
+++ b/DownKyi/Views/DownloadManager/ViewDownloading.axaml
@@ -11,7 +11,7 @@
                         <Grid
                             Width="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBox}}, Path=Bounds.Width}"
                             Height="70">
-                            <Grid ColumnDefinitions="70,*,320,80,30">
+                            <Grid ColumnDefinitions="70,*,2*,80,30">
 
                                 <Image
                                     Grid.Column="0"
@@ -71,7 +71,7 @@
                                 <!--  进度条  -->
                                 <Grid Grid.Column="2" RowDefinitions="*,*">
 
-                                    <Grid Grid.Row="0" VerticalAlignment="Bottom" ColumnDefinitions="100,*">
+                                    <Grid Grid.Row="0" VerticalAlignment="Bottom" ColumnDefinitions="Auto,*">
 
                                         <StackPanel Grid.Column="0" Orientation="Horizontal">
                                             <TextBlock
@@ -96,6 +96,7 @@
 
                                         <TextBlock
                                             Grid.Column="1"
+                                            Margin="8,0,0,0"
                                             HorizontalAlignment="Right"
                                             FontSize="12"
                                             Foreground="{DynamicResource BrushTextGrey2}">

--- a/tests/DownKyi.Tests/VersionCheckerServiceTests.cs
+++ b/tests/DownKyi.Tests/VersionCheckerServiceTests.cs
@@ -1,0 +1,43 @@
+using DownKyi.Models;
+using DownKyi.Services;
+
+namespace DownKyi.Tests;
+
+public class VersionCheckerServiceTests
+{
+    [Theory]
+    [InlineData("v1.0.32", "1.0.32")]
+    [InlineData("1.0.32-debug", "1.0.32")]
+    [InlineData("1.0.32+abcdef", "1.0.32")]
+    [InlineData("v1.0.32-beta.1", "1.0.32")]
+    public void NormalizeVersionName_ReturnsComparableSemverCore(string input, string expected)
+    {
+        Assert.Equal(expected, AppInfo.NormalizeVersionName(input));
+    }
+
+    [Theory]
+    [InlineData("v1.0.32", 10032)]
+    [InlineData("1.2.3-debug", 10203)]
+    [InlineData("not-a-version", 0)]
+    public void VersionNameToCode_UsesNormalizedVersion(string input, int expected)
+    {
+        Assert.Equal(expected, AppInfo.VersionNameToCode(input));
+    }
+
+    [Fact]
+    public void IsNewVersionAvailable_ReturnsFalseForCurrentVersion()
+    {
+        var service = new VersionCheckerService("owner", "repo");
+        var currentVersion = new AppInfo().VersionName;
+
+        Assert.False(service.IsNewVersionAvailable($"v{currentVersion}"));
+    }
+
+    [Fact]
+    public void IsNewVersionAvailable_ReturnsTrueForGreaterVersion()
+    {
+        var service = new VersionCheckerService("owner", "repo");
+
+        Assert.True(service.IsNewVersionAvailable("v99.0.0"));
+    }
+}


### PR DESCRIPTION
## Summary
- make the active-download progress column responsive instead of fixed at 320px so the full speed string, including Mbps, has room to render
- read app version from MSBuild/assembly metadata generated from `version.txt` instead of hard-coded `AppInfo` constants
- normalize versions before comparing updates so `v1.0.32`, `1.0.32-debug`, and `1.0.32+sha` compare as `1.0.32`
- add tests for version normalization and update comparison

## Root Cause
- The downloading list used `ColumnDefinitions="70,*,320,80,30"`, so widening the window never widened the progress/speed area. Long strings like `3.30MB/s (26.40 Mbps)` were clipped.
- `AppInfo` was still hard-coded to `1.0.31`, so the v1.0.32 release package identified itself as 1.0.31 and prompted users to update to v1.0.32 again.

## Test Plan
- `dotnet restore .\DownKyi.sln`
- `dotnet format .\DownKyi.sln --verify-no-changes --no-restore`
- `dotnet build .\DownKyi.sln -c Release --no-restore --no-incremental -warnaserror -p:TreatWarningsAsErrors=true -p:CodeAnalysisTreatWarningsAsErrors=true -p:EnableNETAnalyzers=true -p:EnforceCodeStyleInBuild=true -p:UseSharedCompilation=false -maxcpucount:1`
- `dotnet test .\DownKyi.sln -c Release --no-restore --no-build`
- `dotnet package list --project .\DownKyi.sln --vulnerable --include-transitive`
- `git diff --check`
- Verified built assembly metadata: `AssemblyInformationalVersion=1.0.32+...`, `AppInfo.VersionName=1.0.32`, `AppInfo.VersionCode=10032`