### PR TITLE
feat(user-space): add favorites, retain unavailable videos, and hide empty zones

### DIFF
--- a/DownKyi.Core/BiliApi/Favorites/Models/FavoritesMedia.cs
+++ b/DownKyi.Core/BiliApi/Favorites/Models/FavoritesMedia.cs
@@ -12,6 +12,7 @@ public class FavoritesMedia : BaseModel
     [JsonProperty("intro")] public string Intro { get; set; } = string.Empty;
     [JsonProperty("page")] public int Page { get; set; }
     [JsonProperty("duration")] public long Duration { get; set; }
+    [JsonProperty("attr")] public int Attr { get; set; }
 
     [JsonProperty("upper")] public FavUpper Upper { get; set; } = new();
 

--- a/DownKyi.Core/BiliApi/Users/UserSpace.cs
+++ b/DownKyi.Core/BiliApi/Users/UserSpace.cs
@@ -64,7 +64,7 @@ public static class UserSpace
         {
             if (item.Value == null) continue;
             var value = JsonConvert.DeserializeObject<SpacePublicationListTypeVideoZone>(item.Value.ToString());
-            if (value != null)
+            if (value is { Count: > 0 })
                 result.Add(value);
         }
 

--- a/DownKyi/App.axaml.cs
+++ b/DownKyi/App.axaml.cs
@@ -153,6 +153,7 @@ internal partial class App : PrismApplication, IDisposable
         containerRegistry.RegisterForNavigation<ViewArchive>(ViewArchiveViewModel.Tag);
         // containerRegistry.RegisterForNavigation<Views.UserSpace.ViewChannel>(ViewModels.UserSpace.ViewChannelViewModel.Tag);
         containerRegistry.RegisterForNavigation<Views.UserSpace.ViewSeasonsSeries>(ViewModels.UserSpace.ViewSeasonsSeriesViewModel.Tag);
+        containerRegistry.RegisterForNavigation<Views.UserSpace.ViewFavorites>(ViewModels.UserSpace.ViewFavoritesViewModel.Tag);
 
         // dialogs
         containerRegistry.RegisterDialog<ViewAlertDialog>(ViewAlertDialogViewModel.Tag);

--- a/DownKyi/Services/FavoritesService.cs
+++ b/DownKyi/Services/FavoritesService.cs
@@ -17,6 +17,8 @@ namespace DownKyi.Services;
 
 internal class FavoritesService : IFavoritesService
 {
+    private const string UnavailableMediaTitle = "已失效视频";
+
     /// <summary>
     /// 获取收藏夹元数据
     /// </summary>
@@ -111,44 +113,8 @@ internal class FavoritesService : IFavoritesService
         foreach (var media in medias)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            if (media.Title == "已失效视频")
-            {
-                continue;
-            }
-
             order++;
-
-            // 查询、保存封面
-            var coverUrl = media.Cover;
-
-            // 当地时区
-            var startTime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(1970, 1, 1), TimeZoneInfo.Local); ;
-
-            // 创建时间
-            var dateCTime = startTime.AddSeconds(media.Ctime);
-            var ctime = dateCTime.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
-
-            // 收藏时间
-            var dateFavTime = startTime.AddSeconds(media.FavTime);
-            var favTime = dateFavTime.ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
-
-            mappedMedias.Add(new ViewModels.PageViewModels.FavoritesMedia(eventAggregator)
-            {
-                Avid = media.Id,
-                Bvid = media.Bvid,
-                Order = order,
-                Cover = coverUrl,
-                Title = media.Title,
-                PlayNumber = media.CntInfo != null ? Format.FormatNumber(media.CntInfo.Play) : "0",
-                DanmakuNumber = media.CntInfo != null ? Format.FormatNumber(media.CntInfo.Danmaku) : "0",
-                FavoriteNumber = media.CntInfo != null ? Format.FormatNumber(media.CntInfo.Collect) : "0",
-                Duration = Format.FormatDuration2(media.Duration),
-                UpName = media.Upper != null ? media.Upper.Name : string.Empty,
-                UpMid = media.Upper != null ? media.Upper.Mid : -1,
-                CreateTime = ctime,
-                FavTime = favTime
-            });
+            mappedMedias.Add(MapFavoritesMedia(media, eventAggregator, order));
         }
 
         App.PropertyChangeAsync(() =>
@@ -166,6 +132,48 @@ internal class FavoritesService : IFavoritesService
                 result.Add(item);
             }
         });
+    }
+
+    internal static ViewModels.PageViewModels.FavoritesMedia MapFavoritesMedia(
+        FavoritesMedia media,
+        IEventAggregator eventAggregator,
+        int order)
+    {
+        ArgumentNullException.ThrowIfNull(media);
+        ArgumentNullException.ThrowIfNull(eventAggregator);
+
+        var startTime = TimeZoneInfo.ConvertTimeFromUtc(new DateTime(1970, 1, 1), TimeZoneInfo.Local);
+        var createTime = startTime.AddSeconds(media.Ctime).ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
+        var favoriteTime = startTime.AddSeconds(media.FavTime).ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
+
+        var isUnavailable = IsUnavailable(media);
+        var title = isUnavailable && string.IsNullOrWhiteSpace(media.Title)
+            ? UnavailableMediaTitle
+            : media.Title;
+
+        return new ViewModels.PageViewModels.FavoritesMedia(eventAggregator)
+        {
+            Avid = media.Id,
+            Bvid = media.Bvid,
+            Order = order,
+            Cover = media.Cover,
+            Title = title,
+            IsUnavailable = isUnavailable,
+            PlayNumber = media.CntInfo != null ? Format.FormatNumber(media.CntInfo.Play) : "0",
+            DanmakuNumber = media.CntInfo != null ? Format.FormatNumber(media.CntInfo.Danmaku) : "0",
+            FavoriteNumber = media.CntInfo != null ? Format.FormatNumber(media.CntInfo.Collect) : "0",
+            Duration = Format.FormatDuration2(media.Duration),
+            UpName = media.Upper != null ? media.Upper.Name : string.Empty,
+            UpMid = media.Upper != null ? media.Upper.Mid : -1,
+            CreateTime = createTime,
+            FavTime = favoriteTime
+        };
+    }
+
+    internal static bool IsUnavailable(FavoritesMedia media)
+    {
+        ArgumentNullException.ThrowIfNull(media);
+        return media.Attr != 0 || string.Equals(media.Title, UnavailableMediaTitle, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/DownKyi/ViewModels/PageViewModels/FavoritesMedia.cs
+++ b/DownKyi/ViewModels/PageViewModels/FavoritesMedia.cs
@@ -27,7 +27,29 @@ internal class FavoritesMedia : BindableBase
     public bool IsSelected
     {
         get => isSelected;
-        set => SetProperty(ref isSelected, value);
+        set
+        {
+            if (IsUnavailable && value)
+            {
+                return;
+            }
+
+            SetProperty(ref isSelected, value);
+        }
+    }
+
+    private bool _isUnavailable;
+
+    public bool IsUnavailable
+    {
+        get => _isUnavailable;
+        set
+        {
+            if (SetProperty(ref _isUnavailable, value) && value)
+            {
+                IsSelected = false;
+            }
+        }
     }
 
     private int order;
@@ -125,7 +147,7 @@ internal class FavoritesMedia : BindableBase
     /// <param name="parameter"></param>
     private void ExecuteTitleCommand(object parameter)
     {
-        if (parameter is not string tag)
+        if (IsUnavailable || parameter is not string tag)
         {
             return;
         }

--- a/DownKyi/ViewModels/UserSpace/FavoriteFolder.cs
+++ b/DownKyi/ViewModels/UserSpace/FavoriteFolder.cs
@@ -1,0 +1,49 @@
+using DownKyi.Images;
+using Prism.Mvvm;
+
+namespace DownKyi.ViewModels.UserSpace;
+
+internal class FavoriteFolder : BindableBase
+{
+    public long Id { get; set; }
+
+    private string _cover = string.Empty;
+
+    public string Cover
+    {
+        get => _cover;
+        set => SetProperty(ref _cover, value);
+    }
+
+    private VectorImage _typeImage = null!;
+
+    public VectorImage TypeImage
+    {
+        get => _typeImage;
+        set => SetProperty(ref _typeImage, value);
+    }
+
+    private string _title = string.Empty;
+
+    public string Title
+    {
+        get => _title;
+        set => SetProperty(ref _title, value);
+    }
+
+    private int _count;
+
+    public int Count
+    {
+        get => _count;
+        set => SetProperty(ref _count, value);
+    }
+
+    private string _updatedAt = string.Empty;
+
+    public string UpdatedAt
+    {
+        get => _updatedAt;
+        set => SetProperty(ref _updatedAt, value);
+    }
+}

--- a/DownKyi/ViewModels/UserSpace/ViewArchiveViewModel.cs
+++ b/DownKyi/ViewModels/UserSpace/ViewArchiveViewModel.cs
@@ -116,6 +116,11 @@ internal class ViewArchiveViewModel : ViewModelBase
         var videoCount = 0;
         foreach (var zone in parameter)
         {
+            if (zone.Count <= 0)
+            {
+                continue;
+            }
+
             videoCount += zone.Count;
             var iconKey = VideoZoneIcon.Instance().GetZoneImageKey(zone.Tid);
 

--- a/DownKyi/ViewModels/UserSpace/ViewFavoritesViewModel.cs
+++ b/DownKyi/ViewModels/UserSpace/ViewFavoritesViewModel.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using DownKyi.Core.BiliApi.Favorites.Models;
+using DownKyi.Images;
+using DownKyi.Utils;
+using Prism.Commands;
+using Prism.Events;
+using Prism.Navigation.Regions;
+
+namespace DownKyi.ViewModels.UserSpace;
+
+/// <summary>
+/// 用户公开收藏夹列表。
+/// </summary>
+internal class ViewFavoritesViewModel : ViewModelBase
+{
+    public const string Tag = "PageUserSpaceFavorites";
+
+    private ObservableCollection<FavoriteFolder> _favorites = new();
+
+    public ObservableCollection<FavoriteFolder> Favorites
+    {
+        get => _favorites;
+        private set => SetProperty(ref _favorites, value);
+    }
+
+    private int _selectedItem = -1;
+
+    public int SelectedItem
+    {
+        get => _selectedItem;
+        set => SetProperty(ref _selectedItem, value);
+    }
+
+    public ViewFavoritesViewModel(IEventAggregator eventAggregator) : base(eventAggregator)
+    {
+        Favorites = new ObservableCollection<FavoriteFolder>();
+    }
+
+    private DelegateCommand<object>? _favoritesCommand;
+
+    public DelegateCommand<object> FavoritesCommand =>
+        _favoritesCommand ??= new DelegateCommand<object>(ExecuteFavoritesCommand);
+
+    private void ExecuteFavoritesCommand(object parameter)
+    {
+        if (parameter is not FavoriteFolder favorite)
+        {
+            return;
+        }
+
+        NavigateToView.NavigationView(
+            EventAggregator,
+            ViewPublicFavoritesViewModel.Tag,
+            ViewUserSpaceViewModel.Tag,
+            favorite.Id);
+        SelectedItem = -1;
+    }
+
+    public override void OnNavigatedFrom(NavigationContext navigationContext)
+    {
+        base.OnNavigatedFrom(navigationContext);
+        Favorites.Clear();
+        SelectedItem = -1;
+    }
+
+    public override void OnNavigatedTo(NavigationContext navigationContext)
+    {
+        ArgumentNullException.ThrowIfNull(navigationContext);
+        base.OnNavigatedTo(navigationContext);
+
+        Favorites.Clear();
+        SelectedItem = -1;
+
+        var parameter = navigationContext.Parameters.GetValue<IReadOnlyList<FavoritesMetaInfo>>("object");
+        if (parameter == null)
+        {
+            return;
+        }
+
+        foreach (var item in parameter)
+        {
+            if (item.MediaCount <= 0)
+            {
+                continue;
+            }
+
+            var cover = string.IsNullOrWhiteSpace(item.Cover)
+                ? "avares://DownKyi/Resources/video-placeholder.png"
+                : item.Cover;
+            var updatedAt = DateTimeOffset.FromUnixTimeSeconds(item.Mtime)
+                .ToLocalTime()
+                .ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
+
+            Favorites.Add(new FavoriteFolder
+            {
+                Id = item.Id,
+                Cover = cover,
+                TypeImage = NormalIcon.Instance().Favorite,
+                Title = item.Title,
+                Count = item.MediaCount,
+                UpdatedAt = updatedAt
+            });
+        }
+    }
+}

--- a/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
@@ -305,7 +305,7 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
     {
         if (IsSelectAll)
         {
-            foreach (var item in Medias)
+            foreach (var item in Medias.Where(item => !item.IsUnavailable))
             {
                 item.IsSelected = true;
             }
@@ -335,7 +335,11 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
             return;
         }
 
-        IsSelectAll = selectedMedia.Count == Medias.Count;
+        var availableCount = Medias.Count(item => !item.IsUnavailable);
+        var selectedAvailableCount = selectedMedia
+            .Cast<FavoritesMedia>()
+            .Count(item => !item.IsUnavailable);
+        IsSelectAll = availableCount > 0 && selectedAvailableCount == availableCount;
     }
 
     // 添加选中项到下载列表事件
@@ -379,6 +383,11 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
             // 添加到下载
             foreach (var media in list)
             {
+                if (media.IsUnavailable)
+                {
+                    continue;
+                }
+
                 // 只下载选中项，跳过未选中项
                 if (isOnlySelected && !media.IsSelected)
                 {

--- a/DownKyi/ViewModels/ViewPublicFavoritesViewModel.cs
+++ b/DownKyi/ViewModels/ViewPublicFavoritesViewModel.cs
@@ -301,6 +301,11 @@ internal class ViewPublicFavoritesViewModel : ViewModelBase
             // 添加到下载
             foreach (var media in list)
             {
+                if (media.IsUnavailable)
+                {
+                    continue;
+                }
+
                 // 只下载选中项，跳过未选中项
                 if (isOnlySelected && !media.IsSelected)
                 {

--- a/DownKyi/ViewModels/ViewUserSpaceViewModel.cs
+++ b/DownKyi/ViewModels/ViewUserSpaceViewModel.cs
@@ -1,8 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
+using DownKyi.Core.BiliApi.Favorites;
+using DownKyi.Core.BiliApi.Favorites.Models;
 using DownKyi.Core.BiliApi.Users;
 using DownKyi.Core.BiliApi.Users.Models;
 using DownKyi.Core.Storage;
@@ -259,6 +262,9 @@ internal class ViewUserSpaceViewModel : ViewModelBase
                 _regionManager.RequestNavigate("UserSpaceContentRegion", UserSpace.ViewSeasonsSeriesViewModel.Tag,
                     param);
                 break;
+            case 3: // 收藏夹
+                _regionManager.RequestNavigate("UserSpaceContentRegion", UserSpace.ViewFavoritesViewModel.Tag, param);
+                break;
         }
     }
 
@@ -481,6 +487,25 @@ internal class ViewUserSpaceViewModel : ViewModelBase
         }
 
         // 收藏夹
+        IReadOnlyList<FavoritesMetaInfo>? favorites = null;
+        await Task.Run(() =>
+        {
+            favorites = FavoritesInfo.GetAllCreatedFavorites(mid)
+                .Where(item => item.MediaCount > 0)
+                .ToList();
+        }).ConfigureAwait(true);
+        if (favorites is { Count: > 0 })
+        {
+            TabLeftBanners.Add(new TabLeftBanner
+            {
+                NavigationData = favorites,
+                Id = 3,
+                Icon = NormalIcon.Instance().FavoriteOutline,
+                IconColor = "#FFFF6699",
+                Title = DictionaryResource.GetString("PublicFavorites")
+            });
+        }
+
         // 订阅
 
         // 关系状态数

--- a/DownKyi/Views/UserSpace/ViewFavorites.axaml
+++ b/DownKyi/Views/UserSpace/ViewFavorites.axaml
@@ -1,0 +1,117 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="DownKyi.Views.UserSpace.ViewFavorites"
+             xmlns:vmu="clr-namespace:DownKyi.ViewModels.UserSpace"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:asyncImageLoader="clr-namespace:DownKyi.CustomControl.AsyncImageLoader"
+             prism:ViewModelLocator.AutoWireViewModel="True"
+             x:DataType="vmu:ViewFavoritesViewModel">
+    <ListBox
+        x:Name="NameFavorites"
+        ItemsSource="{Binding Favorites}"
+        ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+        SelectedIndex="{Binding SelectedItem}">
+        <Interaction.Behaviors>
+            <EventTriggerBehavior EventName="SelectionChanged">
+                <InvokeCommandAction
+                    Command="{Binding FavoritesCommand}"
+                    CommandParameter="{Binding ElementName=NameFavorites, Path=SelectedItem}" />
+            </EventTriggerBehavior>
+        </Interaction.Behaviors>
+        <ListBox.ItemsPanel>
+            <ItemsPanelTemplate>
+                <WrapPanel />
+            </ItemsPanelTemplate>
+        </ListBox.ItemsPanel>
+        <ListBox.Theme>
+            <ControlTheme TargetType="ListBox">
+                <Setter Property="BorderThickness" Value="0" />
+                <Setter Property="Template">
+                    <ControlTemplate TargetType="ListBox">
+                        <Border
+                            Padding="0"
+                            BorderBrush="{TemplateBinding BorderBrush}"
+                            BorderThickness="{TemplateBinding BorderThickness}">
+                            <ScrollViewer Focusable="False">
+                                <ItemsPresenter ItemsPanel="{TemplateBinding ItemsPanel}" />
+                            </ScrollViewer>
+                        </Border>
+                    </ControlTemplate>
+                </Setter>
+            </ControlTheme>
+        </ListBox.Theme>
+        <ListBox.ItemContainerTheme>
+            <ControlTheme TargetType="ListBoxItem" x:DataType="vmu:FavoriteFolder">
+                <Setter Property="Template">
+                    <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                        <StackPanel
+                            Margin="30,0,30,10"
+                            HorizontalAlignment="Left"
+                            Orientation="Vertical">
+                            <Border
+                                Width="190"
+                                Height="119"
+                                HorizontalAlignment="Center"
+                                CornerRadius="5"
+                                Cursor="Hand">
+                                <Border.Background>
+                                    <ImageBrush
+                                        asyncImageLoader:ImageBrushLoader.Source="{Binding Cover}"
+                                        asyncImageLoader:ImageBrushLoader.Width="190"
+                                        asyncImageLoader:ImageBrushLoader.Height="119"
+                                        Stretch="UniformToFill" />
+                                </Border.Background>
+                                <Border
+                                    Width="70"
+                                    HorizontalAlignment="Right"
+                                    Background="{DynamicResource BrushBorderTranslucent100}"
+                                    CornerRadius="0 5 5 0">
+                                    <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
+                                        <TextBlock
+                                            FontSize="16"
+                                            Foreground="{DynamicResource BrushText}"
+                                            Text="{Binding Count}" />
+                                        <ContentControl
+                                            Width="20"
+                                            Height="20"
+                                            Margin="0,10,0,0"
+                                            VerticalAlignment="Center">
+                                            <Path
+                                                Width="20"
+                                                Height="20"
+                                                Data="{Binding TypeImage.Data}"
+                                                Fill="#E5E9EF"
+                                                Stretch="Uniform" />
+                                        </ContentControl>
+                                    </StackPanel>
+                                </Border>
+                            </Border>
+                            <TextBlock
+                                MaxWidth="190"
+                                Margin="0,5,0,0"
+                                HorizontalAlignment="Left"
+                                Cursor="Hand"
+                                Text="{Binding Title}"
+                                TextTrimming="CharacterEllipsis"
+                                ToolTip.Tip="{Binding Title}">
+                                <TextBlock.Styles>
+                                    <Style Selector="TextBlock">
+                                        <Setter Property="Foreground" Value="{DynamicResource BrushTextDark}" />
+                                    </Style>
+                                    <Style Selector="TextBlock:pointerover">
+                                        <Setter Property="Foreground" Value="{DynamicResource BrushPrimary}" />
+                                    </Style>
+                                </TextBlock.Styles>
+                            </TextBlock>
+                            <TextBlock
+                                Margin="0,5,0,0"
+                                HorizontalAlignment="Left"
+                                Foreground="{DynamicResource BrushTextGrey2}"
+                                Text="{Binding UpdatedAt}" />
+                        </StackPanel>
+                    </ControlTemplate>
+                </Setter>
+            </ControlTheme>
+        </ListBox.ItemContainerTheme>
+    </ListBox>
+</UserControl>

--- a/DownKyi/Views/UserSpace/ViewFavorites.axaml.cs
+++ b/DownKyi/Views/UserSpace/ViewFavorites.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace DownKyi.Views.UserSpace;
+
+internal partial class ViewFavorites : UserControl
+{
+    public ViewFavorites()
+    {
+        InitializeComponent();
+    }
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/DownKyi/Views/ViewMyFavorites.axaml
+++ b/DownKyi/Views/ViewMyFavorites.axaml
@@ -112,6 +112,7 @@
                                 Width="185"
                                 Height="35"
                                 Margin="0,5"
+                                Classes.unavailable="{Binding IsUnavailable}"
                                 Cursor="Hand"
                                 Foreground="{DynamicResource BrushTextDark}"
                                 Text="{Binding Title}"
@@ -164,6 +165,14 @@
             </Style>
             <Style Selector="^ /template/ TextBlock#NameTitle:pointerover">
                 <Setter Property="Foreground" Value="{DynamicResource BrushPrimary}" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#NameTitle.unavailable">
+                <Setter Property="Cursor" Value="Arrow" />
+                <Setter Property="Foreground" Value="Red" />
+                <Setter Property="TextDecorations" Value="Strikethrough" />
+            </Style>
+            <Style Selector="^ /template/ TextBlock#NameTitle.unavailable:pointerover">
+                <Setter Property="Foreground" Value="Red" />
             </Style>
         </ControlTheme>
     </UserControl.Resources>

--- a/DownKyi/Views/ViewPublicFavorites.axaml
+++ b/DownKyi/Views/ViewPublicFavorites.axaml
@@ -28,7 +28,7 @@
                             Width="{Binding ArrowBack.Width}"
                             Height="{Binding ArrowBack.Height}"
                             Data="{Binding ArrowBack.Data}"
-                            Fill="{Binding ArrowBack.Fill}"
+                            Fill="{DynamicResource BrushTextDark}"
                             Stretch="None" />
                     </ContentControl>
                     <TextBlock

--- a/DownKyi/Views/ViewPublicFavorites.axaml
+++ b/DownKyi/Views/ViewPublicFavorites.axaml
@@ -348,6 +348,7 @@
                                                 Grid.Row="0"
                                                 HorizontalAlignment="Left"
                                                 VerticalAlignment="Top"
+                                                Classes.unavailable="{Binding IsUnavailable}"
                                                 Cursor="Hand"
                                                 FontSize="14"
                                                 Text="{Binding Title}"
@@ -366,6 +367,14 @@
                                                         <Style Selector="^:pointerover">
                                                             <Setter Property="Foreground"
                                                                     Value="{DynamicResource BrushPrimary}" />
+                                                        </Style>
+                                                        <Style Selector="^.unavailable">
+                                                            <Setter Property="Cursor" Value="Arrow" />
+                                                            <Setter Property="Foreground" Value="Red" />
+                                                            <Setter Property="TextDecorations" Value="Strikethrough" />
+                                                        </Style>
+                                                        <Style Selector="^.unavailable:pointerover">
+                                                            <Setter Property="Foreground" Value="Red" />
                                                         </Style>
                                                     </Style>
                                                 </TextBlock.Styles>

--- a/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
+++ b/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
@@ -3,6 +3,7 @@ using DownKyi.Core.BiliApi.Bangumi.Models;
 using DownKyi.Core.BiliApi.BiliUtils;
 using DownKyi.Core.BiliApi.Favorites.Models;
 using DownKyi.Core.BiliApi.Login.Models;
+using DownKyi.Core.BiliApi.Users;
 using DownKyi.Core.BiliApi.Users.Models;
 using DownKyi.Core.BiliApi.VideoStream;
 using DownKyi.Core.BiliApi.VideoStream.Models;
@@ -132,5 +133,34 @@ public sealed class BiliApiModelContractTests
         Assert.Equal(2, page.PageNum);
         Assert.Equal(20, page.PageSize);
         Assert.Equal(42, page.Total);
+    }
+
+    [Fact]
+    public void PublicationTypesExcludeEmptyDefaultZones()
+    {
+        var publication = new SpacePublicationList
+        {
+            Tlist = new SpacePublicationListType
+            {
+                Dance = new SpacePublicationListTypeVideoZone { Tid = 129, Name = "舞蹈", Count = 68 },
+                Life = new SpacePublicationListTypeVideoZone { Tid = 160, Name = "生活", Count = 34 }
+            }
+        };
+
+        var zones = UserSpace.GetPublicationType(publication);
+
+        Assert.NotNull(zones);
+        Assert.Collection(
+            zones,
+            zone =>
+            {
+                Assert.Equal(129, zone.Tid);
+                Assert.Equal(68, zone.Count);
+            },
+            zone =>
+            {
+                Assert.Equal(160, zone.Tid);
+                Assert.Equal(34, zone.Count);
+            });
     }
 }

--- a/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
+++ b/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
@@ -16,13 +16,14 @@ public sealed class BiliApiModelContractTests
     [Fact]
     public void FavoritesBvidFieldsRemainDistinct()
     {
-        const string json = """{"bv_id":"legacy","bvid":"current"}""";
+        const string json = """{"bv_id":"legacy","bvid":"current","attr":9}""";
 
         var media = JsonConvert.DeserializeObject<FavoritesMedia>(json);
         var mediaId = JsonConvert.DeserializeObject<FavoritesMediaId>(json);
 
         Assert.Equal("legacy", media?.LegacyBvid);
         Assert.Equal("current", media?.Bvid);
+        Assert.Equal(9, media?.Attr);
         Assert.Equal("legacy", mediaId?.LegacyBvid);
         Assert.Equal("current", mediaId?.Bvid);
     }

--- a/tests/DownKyi.Tests/FavoritesServiceTests.cs
+++ b/tests/DownKyi.Tests/FavoritesServiceTests.cs
@@ -1,0 +1,49 @@
+using DownKyi.Core.BiliApi.Favorites.Models;
+using DownKyi.Services;
+using Prism.Events;
+
+namespace DownKyi.Tests;
+
+public sealed class FavoritesServiceTests
+{
+    [Fact]
+    public void UnavailableMediaKeepsMetadataAndCannotBeSelected()
+    {
+        var source = new FavoritesMedia
+        {
+            Id = 170001,
+            Bvid = "BV17x411w7KC",
+            Title = "原始标题（接口可用时）",
+            Cover = "https://example.invalid/cover.jpg",
+            Attr = 9,
+            FavTime = 1_700_000_000
+        };
+
+        var mapped = FavoritesService.MapFavoritesMedia(source, new EventAggregator(), 3);
+        mapped.IsSelected = true;
+
+        Assert.True(mapped.IsUnavailable);
+        Assert.False(mapped.IsSelected);
+        Assert.Equal(source.Title, mapped.Title);
+        Assert.Equal(source.Cover, mapped.Cover);
+        Assert.Equal(3, mapped.Order);
+    }
+
+    [Fact]
+    public void MaskedUnavailableTitleIsRecognizedWithoutAttr()
+    {
+        var source = new FavoritesMedia { Title = "已失效视频" };
+
+        Assert.True(FavoritesService.IsUnavailable(source));
+    }
+
+    [Fact]
+    public void UnavailableMediaWithoutTitleGetsStatusFallback()
+    {
+        var source = new FavoritesMedia { Attr = 1 };
+
+        var mapped = FavoritesService.MapFavoritesMedia(source, new EventAggregator(), 1);
+
+        Assert.Equal("已失效视频", mapped.Title);
+    }
+}


### PR DESCRIPTION
## Why

The user-space page does not expose a user's public favorite folders, so users cannot browse those folders from the uploader profile even though the existing public-favorites detail page can display and download their contents.

The publication-zone list also shows many entries with a count of `0`. `SpacePublicationListType` initializes every known zone with a default object; the conversion code previously enumerated all of those defaults and sent them to the UI, including zones with no videos.

Favorite media whose title equals `已失效视频` were discarded entirely. This made folder counts disagree with the visible list and also discarded metadata that Bilibili still returns, such as the title when available, cover, uploader, and favorite time. The shared back-arrow icon could additionally retain the white fill used on the user-space cover, making it invisible on the white public-favorites page.

## What Changed

- Add a **Favorites** tab immediately after **Seasons and series** when the target user has visible, non-empty created favorite folders.
- Add a user-space favorite-folder view with cover, title, media count, and update date; selecting a folder opens the existing public-favorites detail page.
- Register the new Prism navigation target and reuse the existing favorites API and download flow.
- Preserve unavailable favorite media and detect them from the API `attr` flag or masked title.
- Render unavailable titles in red with a strikethrough in both personal and public favorite lists, while retaining any title and cover returned by the API.
- Prevent unavailable media from opening, being selected, or entering selected/all download operations.
- Filter publication zones with `Count <= 0` both while converting the API response and defensively in the archive view model.
- Bind the public-favorites back arrow to the current theme brush so shared icon state cannot hide it.
- Add regression coverage for default zero-count zones and unavailable favorite metadata/selection behavior.

## Verification

- `PublicationTypesExcludeEmptyDefaultZones` constructs the reported scenario with `68` dance videos, `34` life videos, and default empty zones, then verifies that only the two populated zones remain.
- Favorites regressions verify that unavailable entries retain API-provided titles and covers, cannot be selected, are recognized even when `attr` is absent, and receive a status fallback when Bilibili returns an empty title.