### PR TITLE
feat(search): add numeric lists and in-list video search

### DIFF
--- a/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.cs
+++ b/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.cs
@@ -15,6 +15,7 @@ namespace DownKyi.Core.BiliApi.BiliUtils;
 /// 课程ss号：https://www.bilibili.com/cheese/play/ss205 <para/>
 /// 课程ep号：https://www.bilibili.com/cheese/play/ep3489 <para/>
 /// 收藏夹：ml1329019876, ML1329019876, https://www.bilibili.com/medialist/detail/ml1329019876, https://www.bilibili.com/medialist/play/ml1329019876/, https://www.bilibili.com/list/ml1329019876 <para/>
+/// UP主视频列表：https://www.bilibili.com/list/3546801722362343 <para/>
 /// 用户空间：uid928123, UID928123, uid:928123, UID:928123, https://space.bilibili.com/928123
 /// </summary>
 public static class ParseEntrance
@@ -389,6 +390,31 @@ public static class ParseEntrance
         }
 
         return -1;
+    }
+
+    #endregion
+
+    #region UP主视频列表
+
+    /// <summary>
+    /// 是否为UP主全部视频列表URL。
+    /// </summary>
+    public static bool IsUserVideoListUrl(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        var id = GetId(input, FavoritesUrl3);
+        return Regex.IsMatch(id, @"^\d+$");
+    }
+
+    /// <summary>
+    /// 获取UP主全部视频列表中的用户mid。
+    /// </summary>
+    public static long GetUserVideoListId(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        return IsUserVideoListUrl(input)
+            ? Number.GetInt(GetId(input, FavoritesUrl3))
+            : -1;
     }
 
     #endregion

--- a/DownKyi.Core/BiliApi/Favorites/FavoritesResource.cs
+++ b/DownKyi.Core/BiliApi/Favorites/FavoritesResource.cs
@@ -15,16 +15,40 @@ public static class FavoritesResource
     /// <returns></returns>
     public static IReadOnlyList<FavoritesMedia>? GetFavoritesMedia(long mediaId, int pn, int ps, CancellationToken cancellationToken = default)
     {
-        var url = $"https://api.bilibili.com/x/v3/fav/resource/list?media_id={mediaId}&pn={pn}&ps={ps}&platform=web";
+        return GetFavoritesMediaResource(mediaId, pn, ps, null, cancellationToken)?.Medias;
+    }
+
+    /// <summary>
+    /// 获取收藏夹内容和分页信息，可按视频名称搜索。
+    /// </summary>
+    public static FavoritesMediaResource? GetFavoritesMediaResource(
+        long mediaId,
+        int pn,
+        int ps,
+        string? keyword,
+        CancellationToken cancellationToken = default)
+    {
+        var url = BuildFavoritesMediaUrl(mediaId, pn, ps, keyword);
         const string referer = "https://www.bilibili.com";
         var resource = BiliApiRequest.RequestJson<FavoritesMediaResourceOrigin>(
             url,
             referer,
-            nameof(GetFavoritesMedia),
+            nameof(GetFavoritesMediaResource),
             "FavoritesResource",
             cancellationToken);
 
-        return resource?.Data?.Medias;
+        return resource?.Data;
+    }
+
+    internal static string BuildFavoritesMediaUrl(long mediaId, int pn, int ps, string? keyword)
+    {
+        var url = $"https://api.bilibili.com/x/v3/fav/resource/list?media_id={mediaId}&pn={pn}&ps={ps}&platform=web";
+        if (string.IsNullOrWhiteSpace(keyword))
+        {
+            return url;
+        }
+
+        return $"{url}&keyword={Uri.EscapeDataString(keyword.Trim())}";
     }
 
     /// <summary>

--- a/DownKyi.Core/BiliApi/Users/Models/UserVideoList.cs
+++ b/DownKyi.Core/BiliApi/Users/Models/UserVideoList.cs
@@ -1,0 +1,35 @@
+using DownKyi.Core.BiliApi.Models;
+using Newtonsoft.Json;
+
+namespace DownKyi.Core.BiliApi.Users.Models;
+
+public class UserVideoListOrigin : BaseModel
+{
+    [JsonProperty("data")] public UserVideoListData? Data { get; set; }
+}
+
+public class UserVideoListData : BaseModel
+{
+    [JsonProperty("archives")] public IReadOnlyList<UserVideoListArchive> Archives { get; set; } = Array.Empty<UserVideoListArchive>();
+    [JsonProperty("page")] public SpacePublicationPage Page { get; set; } = new();
+}
+
+public class UserVideoListArchive : BaseModel
+{
+    [JsonProperty("aid")] public long Aid { get; set; }
+    [JsonProperty("bvid")] public string Bvid { get; set; } = string.Empty;
+    [JsonProperty("pic")] public string Pic { get; set; } = string.Empty;
+    [JsonProperty("title")] public string Title { get; set; } = string.Empty;
+    [JsonProperty("duration")] public long Duration { get; set; }
+    [JsonProperty("pubdate")] public long Pubdate { get; set; }
+    [JsonProperty("attr")] public int Attr { get; set; }
+    [JsonProperty("author")] public UserVideoListAuthor Author { get; set; } = new();
+    [JsonProperty("stat")] public SpaceSeasonsSeriesStat Stat { get; set; } = new();
+}
+
+public class UserVideoListAuthor : BaseModel
+{
+    [JsonProperty("mid")] public long Mid { get; set; }
+    [JsonProperty("name")] public string Name { get; set; } = string.Empty;
+    [JsonProperty("face")] public string Face { get; set; } = string.Empty;
+}

--- a/DownKyi.Core/BiliApi/Users/UserSpace.cs
+++ b/DownKyi.Core/BiliApi/Users/UserSpace.cs
@@ -113,6 +113,20 @@ public static class UserSpace
     /// <returns></returns>
     public static SpacePublicationList? GetPublication(long mid, int pn, int ps, long tid = 0, PublicationOrder order = PublicationOrder.PUBDATE, string keyword = "")
     {
+        return GetPublicationResult(mid, pn, ps, tid, order, keyword)?.List;
+    }
+
+    /// <summary>
+    /// 查询用户投稿视频和筛选后的分页信息。
+    /// </summary>
+    public static SpacePublication? GetPublicationResult(
+        long mid,
+        int pn,
+        int ps,
+        long tid = 0,
+        PublicationOrder order = PublicationOrder.PUBDATE,
+        string keyword = "")
+    {
         var parameters = new Dictionary<string, object?>
         {
             { "mid", mid },
@@ -150,7 +164,7 @@ public static class UserSpace
             };
 
             var spacePublication = JsonConvert.DeserializeObject<SpacePublicationOrigin>(response, settings);
-            return spacePublication?.Data?.List;
+            return spacePublication?.Data;
         }
         catch (OperationCanceledException)
         {

--- a/DownKyi.Core/BiliApi/Users/UserSpace.cs
+++ b/DownKyi.Core/BiliApi/Users/UserSpace.cs
@@ -184,6 +184,31 @@ public static class UserSpace
 
     #endregion
 
+    #region UP主视频列表
+
+    /// <summary>
+    /// 查询 /list/{mid} 页面中的UP主全部视频。
+    /// </summary>
+    public static UserVideoListData? GetUserVideoList(
+        long mid,
+        int pageNumber,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var url = $"https://api.bilibili.com/x/space/arc/list?mid={mid}&pn={pageNumber}&ps={pageSize}";
+        var referer = $"https://www.bilibili.com/list/{mid}";
+        var origin = BiliApiRequest.RequestJson<UserVideoListOrigin>(
+            url,
+            referer,
+            nameof(GetUserVideoList),
+            "UserSpace",
+            cancellationToken);
+
+        return origin?.Data;
+    }
+
+    #endregion
+
     #region 频道
 
     /// <summary>

--- a/DownKyi/Languanges/Default.axaml
+++ b/DownKyi/Languanges/Default.axaml
@@ -57,6 +57,7 @@
     <system:String x:Key="ArticleViewCount">阅读数</system:String>
     <system:String x:Key="AllPublicationZones">全部</system:String>
     <system:String x:Key="Publication">投稿视频</system:String>
+    <system:String x:Key="UserVideoList">视频列表</system:String>
     <system:String x:Key="Channel">频道</system:String>
     <system:String x:Key="SeasonsSeries">合集和列表</system:String>
     <system:String x:Key="UserSpaceWait">请稍等，马上就好~</system:String>

--- a/DownKyi/Services/SearchService.cs
+++ b/DownKyi/Services/SearchService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using DownKyi.Core.BiliApi.BiliUtils;
 using DownKyi.Utils;
@@ -27,6 +28,7 @@ internal class SearchService
     /// 课程ss号：https://www.bilibili.com/cheese/play/ss205 <para/>
     /// 课程ep号：https://www.bilibili.com/cheese/play/ep3489 <para/>
     /// 收藏夹：ml1329019876, ML1329019876, https://www.bilibili.com/medialist/detail/ml1329019876, https://www.bilibili.com/medialist/play/ml1329019876/ <para/>
+    /// UP主视频列表：https://www.bilibili.com/list/3546801722362343 <para/>
     /// 用户空间：uid928123, UID928123, uid:928123, UID:928123, https://space.bilibili.com/928123
     /// </summary>
     /// <param name="input"></param>
@@ -100,6 +102,16 @@ internal class SearchService
         else if (ParseEntrance.IsUserUrl(justId))
         {
             NavigateToView.NavigateToViewUserSpace(eventAggregator, ViewIndexViewModel.Tag, ParseEntrance.GetUserId(justId));
+        }
+        // UP主全部视频列表
+        else if (ParseEntrance.IsUserVideoListUrl(justId))
+        {
+            var data = new Dictionary<string, object>
+            {
+                { "mid", ParseEntrance.GetUserVideoListId(justId) },
+                { "userVideoList", true }
+            };
+            NavigateToView.NavigationView(eventAggregator, ViewPublicationViewModel.Tag, parentViewName, data);
         }
         // 收藏夹
         else if (ParseEntrance.IsFavoritesId(justId))

--- a/DownKyi/Themes/Styles/StyleImageBtn.axaml
+++ b/DownKyi/Themes/Styles/StyleImageBtn.axaml
@@ -24,4 +24,34 @@
         </Setter>
     </ControlTheme>
 
+    <ControlTheme x:Key="SearchButtonStyle" TargetType="{x:Type Button}">
+        <Setter Property="Cursor" Value="Hand" />
+        <Setter Property="Background" Value="{DynamicResource BrushPrimary}" />
+        <Setter Property="BorderThickness" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type Button}">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        CornerRadius="14">
+                        <ContentPresenter
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Content="{TemplateBinding Content}" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Style Selector="^:pointerover">
+            <Setter Property="Background" Value="{DynamicResource BrushPrimaryTranslucent}" />
+        </Style>
+        <Style Selector="^:pressed">
+            <Setter Property="Background" Value="{DynamicResource BrushPrimaryTranslucent2}" />
+        </Style>
+        <Style Selector="^:disabled">
+            <Setter Property="Opacity" Value="0.5" />
+        </Style>
+    </ControlTheme>
+
 </ResourceDictionary>

--- a/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
@@ -42,11 +42,20 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
     #region 页面属性申明
 
     private string _pageName = Tag;
+    private string _activeSearchText = string.Empty;
 
     public string PageName
     {
         get => _pageName;
         set => SetProperty(ref _pageName, value);
+    }
+
+    private string _inputSearchText = string.Empty;
+
+    public string InputSearchText
+    {
+        get => _inputSearchText;
+        set => SetProperty(ref _inputSearchText, value);
     }
 
     private bool _contentVisibility;
@@ -129,6 +138,14 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
         set => SetProperty(ref _downloadManage, value);
     }
 
+    private VectorImage _searchIcon = null!;
+
+    public VectorImage SearchIcon
+    {
+        get => _searchIcon;
+        set => SetProperty(ref _searchIcon, value);
+    }
+
     private RangeObservableCollection<TabHeader> _tabHeaders = new();
 
     public RangeObservableCollection<TabHeader> TabHeaders
@@ -203,6 +220,9 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
         DownloadManage.Width = 24;
         DownloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
 
+        SearchIcon = ButtonIcon.Instance().GeneralSearch;
+        SearchIcon.Fill = DictionaryResource.GetColor("ColorPrimary");
+
         TabHeaders = new RangeObservableCollection<TabHeader>();
         Medias = new RangeObservableCollection<FavoritesMedia>();
 
@@ -274,12 +294,31 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
 
         // tab点击后，隐藏MediaContent
         MediaContentVisibility = false;
+        InputSearchText = string.Empty;
+        _activeSearchText = string.Empty;
 
         // 页面选择
         Pager = new CustomPagerViewModel(1, (int)Math.Ceiling(double.Parse(tabHeader.SubTitle, CultureInfo.CurrentCulture) / VideoNumberInPage));
         Pager.CurrentChanging += OnCurrentChangedPager;
         Pager.CountChanged += OnCountChangedPager;
         Pager.Current = 1;
+    }
+
+    private DelegateCommand? _searchCommand;
+
+    public DelegateCommand SearchCommand => _searchCommand ??= new DelegateCommand(ExecuteSearchCommand);
+
+    private void ExecuteSearchCommand()
+    {
+        if (!IsEnabled || SelectTabId < 0 || SelectTabId >= TabHeaders.Count)
+        {
+            return;
+        }
+
+        _activeSearchText = InputSearchText.Trim();
+        RunFireAndForget(
+            UpdateFavoritesMediaListAsync(1, true),
+            nameof(UpdateFavoritesMediaListAsync));
     }
 
     /// <summary>
@@ -422,7 +461,7 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
         RunFireAndForget(UpdateFavoritesMediaListAsync(((CustomPagerViewModel)sender!).ProposedCurrent), nameof(UpdateFavoritesMediaListAsync));
     }
 
-    private async Task UpdateFavoritesMediaListAsync(int current)
+    private async Task UpdateFavoritesMediaListAsync(int current, bool updatePager = false)
     {
         try
         {
@@ -439,21 +478,35 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
             var tab = TabHeaders[SelectTabId];
             var cancellationToken = ReplaceCancellationSource(ref _tokenSource2);
 
-            await Task.Run(() =>
-            {
-                var medias = FavoritesResource.GetFavoritesMedia(tab.Id, current, VideoNumberInPage, cancellationToken);
-                if (medias == null || medias.Count == 0)
-                {
-                    MediaContentVisibility = true;
-                    MediaLoadingVisibility = false;
-                    MediaNoDataVisibility = true;
-                    return;
-                }
+            var resource = await Task.Run(
+                () => FavoritesResource.GetFavoritesMediaResource(
+                    tab.Id,
+                    current,
+                    VideoNumberInPage,
+                    _activeSearchText,
+                    cancellationToken),
+                cancellationToken).ConfigureAwait(true);
 
+            if (updatePager)
+            {
+                ConfigurePager(resource?.Info.MediaCount ?? 0);
+            }
+
+            var medias = resource?.Medias;
+            if (medias == null || medias.Count == 0)
+            {
                 MediaContentVisibility = true;
                 MediaLoadingVisibility = false;
-                MediaNoDataVisibility = false;
+                MediaNoDataVisibility = true;
+                return;
+            }
 
+            MediaContentVisibility = true;
+            MediaLoadingVisibility = false;
+            MediaNoDataVisibility = false;
+
+            await Task.Run(() =>
+            {
                 var service = new FavoritesService();
                 service.GetFavoritesMediaList(medias, Medias, EventAggregator, cancellationToken);
             }, cancellationToken).ConfigureAwait(true);
@@ -467,6 +520,15 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
         {
             IsEnabled = true;
         }
+    }
+
+    private void ConfigurePager(int itemCount)
+    {
+        Pager = new CustomPagerViewModel(
+            1,
+            Math.Max(1, (int)Math.Ceiling((double)itemCount / VideoNumberInPage)));
+        Pager.CurrentChanging += OnCurrentChangedPager;
+        Pager.CountChanged += OnCountChangedPager;
     }
 
     /// <summary>
@@ -486,6 +548,8 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
         NoDataVisibility = false;
         MediaLoadingVisibility = false;
         MediaNoDataVisibility = false;
+        InputSearchText = string.Empty;
+        _activeSearchText = string.Empty;
 
         TabHeaders.Clear();
         Medias.Clear();

--- a/DownKyi/ViewModels/ViewPublicationViewModel.cs
+++ b/DownKyi/ViewModels/ViewPublicationViewModel.cs
@@ -39,6 +39,8 @@ namespace DownKyi.ViewModels
         private string _activeSearchText = string.Empty;
         private IReadOnlyList<UserVideoListArchive>? _allUserVideoListArchives;
         private IReadOnlyList<UserVideoListArchive>? _userVideoSearchResults;
+        private bool _preserveStateOnReturn;
+        private bool _resetStateOnNavigationAway;
 
         // 每页视频数量，暂时在此写死，以后在设置中增加选项
         private const int VideoNumberInPage = 30;
@@ -217,6 +219,7 @@ namespace DownKyi.ViewModels
             _tokenSource?.Cancel();
             _tokenSource?.Dispose();
             _tokenSource = null;
+            _resetStateOnNavigationAway = true;
             var parameter = new NavigationParam
             {
                 ViewName = ParentView,
@@ -680,6 +683,20 @@ namespace DownKyi.ViewModels
                 .ToList();
         }
 
+        internal static bool ShouldRestoreListState(
+            bool preserveStateOnReturn,
+            long currentMid,
+            bool currentIsUserVideoList,
+            long incomingMid,
+            bool incomingIsUserVideoList,
+            int loadedTabCount)
+        {
+            return preserveStateOnReturn
+                && loadedTabCount > 0
+                && currentMid == incomingMid
+                && currentIsUserVideoList == incomingIsUserVideoList;
+        }
+
         private void ConfigurePager(int itemCount)
         {
             Pager = new CustomPagerViewModel(
@@ -787,6 +804,15 @@ namespace DownKyi.ViewModels
         /// 导航到页面时执行
         /// </summary>
         /// <param name="navigationContext"></param>
+        public override void OnNavigatedFrom(NavigationContext navigationContext)
+        {
+            ArgumentNullException.ThrowIfNull(navigationContext);
+            base.OnNavigatedFrom(navigationContext);
+
+            _preserveStateOnReturn = !_resetStateOnNavigationAway;
+            _resetStateOnNavigationAway = false;
+        }
+
         public override void OnNavigatedTo(NavigationContext navigationContext)
         {
             ArgumentNullException.ThrowIfNull(navigationContext);
@@ -796,14 +822,31 @@ namespace DownKyi.ViewModels
             var parameter = navigationContext.Parameters.GetValue<Dictionary<string, object>>("Parameter");
             if (parameter == null)
             {
+                _preserveStateOnReturn = false;
                 return;
             }
 
+            var incomingMid = (long)parameter["mid"];
+            var incomingIsUserVideoList = parameter.TryGetValue("userVideoList", out var source)
+                && source is true;
+            if (ShouldRestoreListState(
+                    _preserveStateOnReturn,
+                    _mid,
+                    _isUserVideoList,
+                    incomingMid,
+                    incomingIsUserVideoList,
+                    TabHeaders.Count))
+            {
+                _preserveStateOnReturn = false;
+                return;
+            }
+
+            _preserveStateOnReturn = false;
+
             InitView();
 
-            _mid = (long)parameter["mid"];
-            _isUserVideoList = parameter.TryGetValue("userVideoList", out var source)
-                && source is true;
+            _mid = incomingMid;
+            _isUserVideoList = incomingIsUserVideoList;
             if (_isUserVideoList)
             {
                 PageTitle = DictionaryResource.GetString("UserVideoList");

--- a/DownKyi/ViewModels/ViewPublicationViewModel.cs
+++ b/DownKyi/ViewModels/ViewPublicationViewModel.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
 using DownKyi.Commands;
+using DownKyi.Core.BiliApi.Users.Models;
 using DownKyi.Core.BiliApi.VideoStream;
 using DownKyi.Core.Utils;
 using DownKyi.CustomControl;
@@ -34,6 +35,7 @@ namespace DownKyi.ViewModels
         private CancellationTokenSource? _tokenSource;
 
         private long _mid = -1;
+        private bool _isUserVideoList;
 
         // 每页视频数量，暂时在此写死，以后在设置中增加选项
         private const int VideoNumberInPage = 30;
@@ -46,6 +48,14 @@ namespace DownKyi.ViewModels
         {
             get => _pageName;
             set => SetProperty(ref _pageName, value);
+        }
+
+        private string _pageTitle = string.Empty;
+
+        public string PageTitle
+        {
+            get => _pageTitle;
+            set => SetProperty(ref _pageTitle, value);
         }
 
         private bool _loading;
@@ -149,6 +159,7 @@ namespace DownKyi.ViewModels
             Loading = true;
             LoadingVisibility = false;
             NoDataVisibility = false;
+            PageTitle = DictionaryResource.GetString("Publication");
 
             _arrowBack = NavigationIcon.Instance().ArrowBack;
             _arrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
@@ -405,6 +416,29 @@ namespace DownKyi.ViewModels
             {
                 await Task.Run(() =>
                 {
+                    if (_isUserVideoList)
+                    {
+                        var userVideoList = Core.BiliApi.Users.UserSpace.GetUserVideoList(
+                            _mid,
+                            current,
+                            VideoNumberInPage,
+                            cancellationToken);
+                        if (userVideoList == null || userVideoList.Archives.Count == 0)
+                        {
+                            LoadingVisibility = false;
+                            NoDataVisibility = true;
+                            return;
+                        }
+
+                        foreach (var video in userVideoList.Archives)
+                        {
+                            AddUserVideoListMedia(video);
+                            cancellationToken.ThrowIfCancellationRequested();
+                        }
+
+                        return;
+                    }
+
                     var publications = Core.BiliApi.Users.UserSpace.GetPublication(_mid, current, VideoNumberInPage, tab.Id);
                     if (publications == null)
                     {
@@ -477,6 +511,75 @@ namespace DownKyi.ViewModels
             }
         }
 
+        private void AddUserVideoListMedia(UserVideoListArchive video)
+        {
+            var play = video.Stat.View > 0 ? Format.FormatNumber(video.Stat.View) : "--";
+            var createTime = DateTimeOffset.FromUnixTimeSeconds(video.Pubdate)
+                .ToLocalTime()
+                .ToString("yyyy-MM-dd", CultureInfo.CurrentCulture);
+
+            App.PropertyChangeAsync(() =>
+            {
+                Medias.Add(new PublicationMedia(EventAggregator)
+                {
+                    Avid = video.Aid,
+                    Bvid = video.Bvid,
+                    Cover = _defaultPic,
+                    Duration = Format.FormatDuration2(video.Duration),
+                    Title = video.Title,
+                    PlayNumber = play,
+                    CreateTime = createTime,
+                    CoverUrl = video.Pic
+                });
+
+                LoadingVisibility = false;
+                NoDataVisibility = false;
+            });
+        }
+
+        private async Task InitializeUserVideoListAsync()
+        {
+            var cancellationToken = ReplaceCancellationSource(ref _tokenSource);
+            try
+            {
+                LoadingVisibility = true;
+                IsEnabled = false;
+                var list = await Task.Run(
+                    () => Core.BiliApi.Users.UserSpace.GetUserVideoList(_mid, 1, 1, cancellationToken),
+                    cancellationToken).ConfigureAwait(true);
+                if (list == null || list.Page.Count <= 0)
+                {
+                    LoadingVisibility = false;
+                    NoDataVisibility = true;
+                    return;
+                }
+
+                TabHeaders.Add(new TabHeader
+                {
+                    Id = 0,
+                    Title = DictionaryResource.GetString("AllPublicationZones"),
+                    SubTitle = list.Page.Count.ToString(CultureInfo.CurrentCulture)
+                });
+                SelectTabId = 0;
+
+                Pager = new CustomPagerViewModel(
+                    1,
+                    (int)Math.Ceiling((double)list.Page.Count / VideoNumberInPage));
+                Pager.CurrentChanging += OnCurrentChangedPager;
+                Pager.CountChanged += OnCountChangedPager;
+
+                IsEnabled = true;
+                await UpdatePublication(1).ConfigureAwait(true);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                IsEnabled = true;
+            }
+        }
+
         /// <summary>
         /// 初始化页面数据
         /// </summary>
@@ -514,6 +617,15 @@ namespace DownKyi.ViewModels
             InitView();
 
             _mid = (long)parameter["mid"];
+            _isUserVideoList = parameter.TryGetValue("userVideoList", out var source)
+                && source is true;
+            if (_isUserVideoList)
+            {
+                PageTitle = DictionaryResource.GetString("UserVideoList");
+                RunFireAndForget(InitializeUserVideoListAsync(), nameof(InitializeUserVideoListAsync));
+                return;
+            }
+
             var tid = (int)parameter["tid"];
             var zones = (List<PublicationZone>)parameter["list"];
 

--- a/DownKyi/ViewModels/ViewPublicationViewModel.cs
+++ b/DownKyi/ViewModels/ViewPublicationViewModel.cs
@@ -36,6 +36,9 @@ namespace DownKyi.ViewModels
 
         private long _mid = -1;
         private bool _isUserVideoList;
+        private string _activeSearchText = string.Empty;
+        private IReadOnlyList<UserVideoListArchive>? _allUserVideoListArchives;
+        private IReadOnlyList<UserVideoListArchive>? _userVideoSearchResults;
 
         // 每页视频数量，暂时在此写死，以后在设置中增加选项
         private const int VideoNumberInPage = 30;
@@ -56,6 +59,14 @@ namespace DownKyi.ViewModels
         {
             get => _pageTitle;
             set => SetProperty(ref _pageTitle, value);
+        }
+
+        private string _inputSearchText = string.Empty;
+
+        public string InputSearchText
+        {
+            get => _inputSearchText;
+            set => SetProperty(ref _inputSearchText, value);
         }
 
         private bool _loading;
@@ -96,6 +107,14 @@ namespace DownKyi.ViewModels
         {
             get => _downloadManage;
             set => SetProperty(ref _downloadManage, value);
+        }
+
+        private VectorImage _searchIcon = null!;
+
+        public VectorImage SearchIcon
+        {
+            get => _searchIcon;
+            set => SetProperty(ref _searchIcon, value);
         }
 
         private ObservableCollection<TabHeader> _tabHeaders;
@@ -170,6 +189,9 @@ namespace DownKyi.ViewModels
             _downloadManage.Width = 24;
             _downloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
 
+            SearchIcon = ButtonIcon.Instance().GeneralSearch;
+            SearchIcon.Fill = DictionaryResource.GetColor("ColorPrimary");
+
             _tabHeaders = new ObservableCollection<TabHeader>();
             _medias = new ObservableCollection<PublicationMedia>();
             _pager = new CustomPagerViewModel(1, 1);
@@ -240,11 +262,42 @@ namespace DownKyi.ViewModels
                 return;
             }
 
+            InputSearchText = string.Empty;
+            _activeSearchText = string.Empty;
+            _userVideoSearchResults = null;
+
             // 页面选择
             Pager = new CustomPagerViewModel(1, (int)Math.Ceiling(double.Parse(tabHeader.SubTitle, CultureInfo.CurrentCulture) / VideoNumberInPage));
             Pager.CurrentChanging += OnCurrentChangedPager;
             Pager.CountChanged += OnCountChangedPager;
             Pager.Current = 1;
+        }
+
+        private DelegateCommand? _searchCommand;
+
+        public DelegateCommand SearchCommand => _searchCommand ??= new DelegateCommand(ExecuteSearchCommand);
+
+        private void ExecuteSearchCommand()
+        {
+            if (!IsEnabled || SelectTabId < 0 || SelectTabId >= TabHeaders.Count)
+            {
+                return;
+            }
+
+            _activeSearchText = InputSearchText.Trim();
+            Medias.Clear();
+            IsSelectAll = false;
+            LoadingVisibility = true;
+            NoDataVisibility = false;
+
+            if (_isUserVideoList && !string.IsNullOrWhiteSpace(_activeSearchText))
+            {
+                RunFireAndForget(SearchUserVideoListAsync(), nameof(SearchUserVideoListAsync));
+                return;
+            }
+
+            _userVideoSearchResults = null;
+            RunFireAndForget(UpdatePublication(1, true), nameof(UpdatePublication));
         }
 
         /// <summary>
@@ -399,7 +452,7 @@ namespace DownKyi.ViewModels
 
         private readonly Bitmap _defaultPic = ImageHelper.LoadFromResource(new Uri("avares://DownKyi/Resources/video-placeholder.png"));
 
-        private async Task UpdatePublication(int current)
+        private async Task UpdatePublication(int current, bool updatePager = false)
         {
             if (_tokenSource != null)
             {
@@ -418,11 +471,38 @@ namespace DownKyi.ViewModels
                 {
                     if (_isUserVideoList)
                     {
+                        if (_userVideoSearchResults != null)
+                        {
+                            var page = _userVideoSearchResults
+                                .Skip((current - 1) * VideoNumberInPage)
+                                .Take(VideoNumberInPage)
+                                .ToList();
+                            if (page.Count == 0)
+                            {
+                                LoadingVisibility = false;
+                                NoDataVisibility = true;
+                                return;
+                            }
+
+                            foreach (var video in page)
+                            {
+                                AddUserVideoListMedia(video);
+                                cancellationToken.ThrowIfCancellationRequested();
+                            }
+
+                            return;
+                        }
+
                         var userVideoList = Core.BiliApi.Users.UserSpace.GetUserVideoList(
                             _mid,
                             current,
                             VideoNumberInPage,
                             cancellationToken);
+                        if (updatePager)
+                        {
+                            App.PropertyChangeAsync(() => ConfigurePager(userVideoList?.Page.Count ?? 0));
+                        }
+
                         if (userVideoList == null || userVideoList.Archives.Count == 0)
                         {
                             LoadingVisibility = false;
@@ -439,7 +519,18 @@ namespace DownKyi.ViewModels
                         return;
                     }
 
-                    var publications = Core.BiliApi.Users.UserSpace.GetPublication(_mid, current, VideoNumberInPage, tab.Id);
+                    var publication = Core.BiliApi.Users.UserSpace.GetPublicationResult(
+                        _mid,
+                        current,
+                        VideoNumberInPage,
+                        tab.Id,
+                        keyword: _activeSearchText);
+                    if (updatePager)
+                    {
+                        App.PropertyChangeAsync(() => ConfigurePager(publication?.Page.Count ?? 0));
+                    }
+
+                    var publications = publication?.List;
                     if (publications == null)
                     {
                         // 没有数据，UI提示
@@ -509,6 +600,93 @@ namespace DownKyi.ViewModels
             {
                 IsEnabled = true;
             }
+        }
+
+        private async Task SearchUserVideoListAsync()
+        {
+            var cancellationToken = ReplaceCancellationSource(ref _tokenSource);
+            try
+            {
+                IsEnabled = false;
+                if (_allUserVideoListArchives == null)
+                {
+                    _allUserVideoListArchives = await Task.Run(
+                        () => GetAllUserVideoListArchives(_mid, cancellationToken),
+                        cancellationToken).ConfigureAwait(true);
+                }
+
+                _userVideoSearchResults = FilterUserVideoList(
+                    _allUserVideoListArchives,
+                    _activeSearchText);
+                ConfigurePager(_userVideoSearchResults.Count);
+
+                IsEnabled = true;
+                await UpdatePublication(1).ConfigureAwait(true);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                IsEnabled = true;
+            }
+        }
+
+        private static IReadOnlyList<UserVideoListArchive> GetAllUserVideoListArchives(
+            long mid,
+            CancellationToken cancellationToken)
+        {
+            const int pageSize = 50;
+            var first = Core.BiliApi.Users.UserSpace.GetUserVideoList(mid, 1, pageSize, cancellationToken);
+            if (first == null || first.Archives.Count == 0)
+            {
+                return Array.Empty<UserVideoListArchive>();
+            }
+
+            var result = new List<UserVideoListArchive>(first.Archives);
+            var pageCount = (int)Math.Ceiling((double)first.Page.Count / pageSize);
+            for (var page = 2; page <= pageCount; page++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var data = Core.BiliApi.Users.UserSpace.GetUserVideoList(
+                    mid,
+                    page,
+                    pageSize,
+                    cancellationToken);
+                if (data == null || data.Archives.Count == 0)
+                {
+                    break;
+                }
+
+                result.AddRange(data.Archives);
+            }
+
+            return result;
+        }
+
+        internal static IReadOnlyList<UserVideoListArchive> FilterUserVideoList(
+            IEnumerable<UserVideoListArchive> videos,
+            string keyword)
+        {
+            ArgumentNullException.ThrowIfNull(videos);
+            if (string.IsNullOrWhiteSpace(keyword))
+            {
+                return videos.ToList();
+            }
+
+            var normalized = keyword.Trim();
+            return videos
+                .Where(video => video.Title.Contains(normalized, StringComparison.OrdinalIgnoreCase))
+                .ToList();
+        }
+
+        private void ConfigurePager(int itemCount)
+        {
+            Pager = new CustomPagerViewModel(
+                1,
+                Math.Max(1, (int)Math.Ceiling((double)itemCount / VideoNumberInPage)));
+            Pager.CurrentChanging += OnCurrentChangedPager;
+            Pager.CountChanged += OnCountChangedPager;
         }
 
         private void AddUserVideoListMedia(UserVideoListArchive video)
@@ -592,10 +770,17 @@ namespace DownKyi.ViewModels
             DownloadManage.Width = 24;
             DownloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
 
+            SearchIcon = ButtonIcon.Instance().GeneralSearch;
+            SearchIcon.Fill = DictionaryResource.GetColor("ColorPrimary");
+
             TabHeaders.Clear();
             Medias.Clear();
             SelectTabId = -1;
             IsSelectAll = false;
+            InputSearchText = string.Empty;
+            _activeSearchText = string.Empty;
+            _allUserVideoListArchives = null;
+            _userVideoSearchResults = null;
         }
 
         /// <summary>

--- a/DownKyi/Views/ViewMyFavorites.axaml
+++ b/DownKyi/Views/ViewMyFavorites.axaml
@@ -195,20 +195,37 @@
 
             <Grid
                 Grid.Column="1"
-                Width="420"
-                Height="34"
+                Width="380"
+                Height="36"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 IsEnabled="{Binding ContentVisibility}">
+                <Grid.Styles>
+                    <Style Selector="Border.searchBorder">
+                        <Setter Property="Background" Value="{DynamicResource BrushBackground}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushBorderTranslucent}" />
+                    </Style>
+                    <Style Selector="Grid:pointerover Border.searchBorder">
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushPrimaryTranslucent2}" />
+                    </Style>
+                    <Style Selector="Grid:focus-within Border.searchBorder">
+                        <Setter Property="Background" Value="{DynamicResource BrushPrimaryTranslucent3}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushPrimary}" />
+                    </Style>
+                </Grid.Styles>
                 <Border
-                    BorderBrush="{DynamicResource BrushPrimary}"
+                    Classes="searchBorder"
                     BorderThickness="1"
-                    CornerRadius="17">
+                    CornerRadius="18">
                     <TextBox
-                        Height="32"
-                        Margin="14,0,40,0"
+                        Height="34"
+                        Margin="16,0,44,0"
                         VerticalContentAlignment="Center"
+                        Background="Transparent"
                         BorderThickness="0"
+                        FontSize="13"
+                        Foreground="{DynamicResource BrushTextDark}"
+                        Padding="0"
                         PlaceholderText="{DynamicResource SearchVideoByName}"
                         Text="{Binding InputSearchText, Mode=TwoWay}">
                         <TextBox.KeyBindings>
@@ -217,19 +234,19 @@
                     </TextBox>
                 </Border>
                 <Button
-                    Width="18"
-                    Height="18"
-                    Margin="0,0,12,0"
+                    Width="28"
+                    Height="28"
+                    Margin="0,0,4,0"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
                     Command="{Binding SearchCommand}"
-                    Theme="{StaticResource ImageBtnStyle}"
+                    Theme="{StaticResource SearchButtonStyle}"
                     ToolTip.Tip="{DynamicResource Search}">
                     <Path
-                        Width="{Binding SearchIcon.Width}"
-                        Height="{Binding SearchIcon.Height}"
+                        Width="14"
+                        Height="14"
                         Data="{Binding SearchIcon.Data}"
-                        Fill="{Binding SearchIcon.Fill}"
+                        Fill="{DynamicResource BrushForegroundDark}"
                         Stretch="Uniform" />
                 </Button>
             </Grid>

--- a/DownKyi/Views/ViewMyFavorites.axaml
+++ b/DownKyi/Views/ViewMyFavorites.axaml
@@ -168,7 +168,7 @@
         </ControlTheme>
     </UserControl.Resources>
     <Grid RowDefinitions="50,1,*">
-        <Grid Grid.Row="0" ColumnDefinitions="100,*,100">
+        <Grid Grid.Row="0" ColumnDefinitions="120,*,100">
             <Button
                 Grid.Column="0"
                 Margin="10,5,0,5"
@@ -192,6 +192,47 @@
                         Text="{DynamicResource PublicFavorites}" />
                 </StackPanel>
             </Button>
+
+            <Grid
+                Grid.Column="1"
+                Width="420"
+                Height="34"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsEnabled="{Binding ContentVisibility}">
+                <Border
+                    BorderBrush="{DynamicResource BrushPrimary}"
+                    BorderThickness="1"
+                    CornerRadius="17">
+                    <TextBox
+                        Height="32"
+                        Margin="14,0,40,0"
+                        VerticalContentAlignment="Center"
+                        BorderThickness="0"
+                        PlaceholderText="{DynamicResource SearchVideoByName}"
+                        Text="{Binding InputSearchText, Mode=TwoWay}">
+                        <TextBox.KeyBindings>
+                            <KeyBinding Command="{Binding SearchCommand}" Gesture="Enter" />
+                        </TextBox.KeyBindings>
+                    </TextBox>
+                </Border>
+                <Button
+                    Width="18"
+                    Height="18"
+                    Margin="0,0,12,0"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Command="{Binding SearchCommand}"
+                    Theme="{StaticResource ImageBtnStyle}"
+                    ToolTip.Tip="{DynamicResource Search}">
+                    <Path
+                        Width="{Binding SearchIcon.Width}"
+                        Height="{Binding SearchIcon.Height}"
+                        Data="{Binding SearchIcon.Data}"
+                        Fill="{Binding SearchIcon.Fill}"
+                        Stretch="Uniform" />
+                </Button>
+            </Grid>
 
             <Button
                 Grid.Column="2"

--- a/DownKyi/Views/ViewPublication.axaml
+++ b/DownKyi/Views/ViewPublication.axaml
@@ -119,7 +119,7 @@
     </UserControl.Resources>
     <Grid RowDefinitions="50,1,*">
 
-        <Grid Grid.Row="0" ColumnDefinitions="100,*,100">
+        <Grid Grid.Row="0" ColumnDefinitions="120,*,100">
 
             <Button
                 Grid.Column="0"
@@ -144,6 +144,48 @@
                         Text="{Binding PageTitle}" />
                 </StackPanel>
             </Button>
+
+            <Grid
+                Grid.Column="1"
+                Width="420"
+                Height="34"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center"
+                IsEnabled="{Binding IsEnabled}">
+                <Border
+                    BorderBrush="{DynamicResource BrushPrimary}"
+                    BorderThickness="1"
+                    CornerRadius="17">
+                    <TextBox
+                        Height="32"
+                        Margin="14,0,40,0"
+                        VerticalContentAlignment="Center"
+                        BorderThickness="0"
+                        PlaceholderText="{DynamicResource SearchVideoByName}"
+                        Text="{Binding InputSearchText, Mode=TwoWay}">
+                        <TextBox.KeyBindings>
+                            <KeyBinding Command="{Binding SearchCommand}" Gesture="Enter" />
+                        </TextBox.KeyBindings>
+                    </TextBox>
+                </Border>
+                <Button
+                    Width="18"
+                    Height="18"
+                    Margin="0,0,12,0"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Center"
+                    Command="{Binding SearchCommand}"
+                    Theme="{StaticResource ImageBtnStyle}"
+                    ToolTip.Tip="{DynamicResource Search}">
+                    <Path
+                        Width="{Binding SearchIcon.Width}"
+                        Height="{Binding SearchIcon.Height}"
+                        Data="{Binding SearchIcon.Data}"
+                        Fill="{Binding SearchIcon.Fill}"
+                        Stretch="Uniform" />
+                </Button>
+            </Grid>
+
             <Button
                 Grid.Column="2"
                 Width="24"

--- a/DownKyi/Views/ViewPublication.axaml
+++ b/DownKyi/Views/ViewPublication.axaml
@@ -141,7 +141,7 @@
                         VerticalAlignment="Center"
                         FontSize="16"
                         Foreground="{DynamicResource BrushTextDark}"
-                        Text="{DynamicResource Publication}" />
+                        Text="{Binding PageTitle}" />
                 </StackPanel>
             </Button>
             <Button

--- a/DownKyi/Views/ViewPublication.axaml
+++ b/DownKyi/Views/ViewPublication.axaml
@@ -147,20 +147,37 @@
 
             <Grid
                 Grid.Column="1"
-                Width="420"
-                Height="34"
+                Width="380"
+                Height="36"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center"
                 IsEnabled="{Binding IsEnabled}">
+                <Grid.Styles>
+                    <Style Selector="Border.searchBorder">
+                        <Setter Property="Background" Value="{DynamicResource BrushBackground}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushBorderTranslucent}" />
+                    </Style>
+                    <Style Selector="Grid:pointerover Border.searchBorder">
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushPrimaryTranslucent2}" />
+                    </Style>
+                    <Style Selector="Grid:focus-within Border.searchBorder">
+                        <Setter Property="Background" Value="{DynamicResource BrushPrimaryTranslucent3}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushPrimary}" />
+                    </Style>
+                </Grid.Styles>
                 <Border
-                    BorderBrush="{DynamicResource BrushPrimary}"
+                    Classes="searchBorder"
                     BorderThickness="1"
-                    CornerRadius="17">
+                    CornerRadius="18">
                     <TextBox
-                        Height="32"
-                        Margin="14,0,40,0"
+                        Height="34"
+                        Margin="16,0,44,0"
                         VerticalContentAlignment="Center"
+                        Background="Transparent"
                         BorderThickness="0"
+                        FontSize="13"
+                        Foreground="{DynamicResource BrushTextDark}"
+                        Padding="0"
                         PlaceholderText="{DynamicResource SearchVideoByName}"
                         Text="{Binding InputSearchText, Mode=TwoWay}">
                         <TextBox.KeyBindings>
@@ -169,19 +186,19 @@
                     </TextBox>
                 </Border>
                 <Button
-                    Width="18"
-                    Height="18"
-                    Margin="0,0,12,0"
+                    Width="28"
+                    Height="28"
+                    Margin="0,0,4,0"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Center"
                     Command="{Binding SearchCommand}"
-                    Theme="{StaticResource ImageBtnStyle}"
+                    Theme="{StaticResource SearchButtonStyle}"
                     ToolTip.Tip="{DynamicResource Search}">
                     <Path
-                        Width="{Binding SearchIcon.Width}"
-                        Height="{Binding SearchIcon.Height}"
+                        Width="14"
+                        Height="14"
                         Data="{Binding SearchIcon.Data}"
-                        Fill="{Binding SearchIcon.Fill}"
+                        Fill="{DynamicResource BrushForegroundDark}"
                         Stretch="Uniform" />
                 </Button>
             </Grid>

--- a/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
+++ b/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
@@ -133,4 +133,52 @@ public sealed class BiliApiModelContractTests
         Assert.Equal(20, page.PageSize);
         Assert.Equal(42, page.Total);
     }
+    [Theory]
+    [InlineData("https://www.bilibili.com/list/3546801722362343")]
+    [InlineData("https://www.bilibili.com/list/3546801722362343?oid=114070741065497")]
+    [InlineData("https://m.bilibili.com/list/3546801722362343/")]
+    public void UserVideoListUrlsExposeTheUploaderMid(string input)
+    {
+        Assert.True(ParseEntrance.IsUserVideoListUrl(input));
+        Assert.Equal(3546801722362343, ParseEntrance.GetUserVideoListId(input));
+    }
+
+    [Theory]
+    [InlineData("https://www.bilibili.com/list/ml1329019876")]
+    [InlineData("https://www.bilibili.com/list/not-a-mid")]
+    public void UserVideoListUrlsRejectOtherListTypes(string input)
+    {
+        Assert.False(ParseEntrance.IsUserVideoListUrl(input));
+        Assert.Equal(-1, ParseEntrance.GetUserVideoListId(input));
+    }
+
+    [Fact]
+    public void UserVideoListResponsePreservesPagingAndArchiveMetadata()
+    {
+        var response = JsonConvert.DeserializeObject<UserVideoListOrigin>("""
+            {
+              "data": {
+                "archives": [{
+                  "aid": 114070741065497,
+                  "bvid": "BV1T7P7eFEn5",
+                  "pic": "https://example.invalid/cover.jpg",
+                  "title": "Sample video",
+                  "duration": 294,
+                  "pubdate": 1740582876,
+                  "attr": 0,
+                  "author": { "mid": 3546801722362343, "name": "Uploader" },
+                  "stat": { "view": 405 }
+                }],
+                "page": { "count": 1224, "pn": 1, "ps": 20 }
+              }
+            }
+            """);
+
+        Assert.NotNull(response?.Data);
+        Assert.Equal(1224, response.Data.Page.Count);
+        var archive = Assert.Single(response.Data.Archives);
+        Assert.Equal("BV1T7P7eFEn5", archive.Bvid);
+        Assert.Equal(3546801722362343, archive.Author.Mid);
+        Assert.Equal(405, archive.Stat.View);
+    }
 }

--- a/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
+++ b/tests/DownKyi.Core.Tests/BiliApiModelContractTests.cs
@@ -1,6 +1,7 @@
 using DownKyi.Core.Aria2cNet.Client.Entity;
 using DownKyi.Core.BiliApi.Bangumi.Models;
 using DownKyi.Core.BiliApi.BiliUtils;
+using DownKyi.Core.BiliApi.Favorites;
 using DownKyi.Core.BiliApi.Favorites.Models;
 using DownKyi.Core.BiliApi.Login.Models;
 using DownKyi.Core.BiliApi.Users.Models;
@@ -180,5 +181,18 @@ public sealed class BiliApiModelContractTests
         Assert.Equal("BV1T7P7eFEn5", archive.Bvid);
         Assert.Equal(3546801722362343, archive.Author.Mid);
         Assert.Equal(405, archive.Stat.View);
+    }
+
+    [Fact]
+    public void FavoritesSearchUrlEncodesTheCurrentFolderKeyword()
+    {
+        var url = FavoritesResource.BuildFavoritesMediaUrl(123, 2, 20, "  猫 & 狗  ");
+
+        Assert.Contains("media_id=123", url, StringComparison.Ordinal);
+        Assert.Contains("pn=2", url, StringComparison.Ordinal);
+        Assert.EndsWith(
+            $"&keyword={Uri.EscapeDataString("猫 & 狗")}",
+            url,
+            StringComparison.Ordinal);
     }
 }

--- a/tests/DownKyi.Tests/UserVideoListNavigationTests.cs
+++ b/tests/DownKyi.Tests/UserVideoListNavigationTests.cs
@@ -9,6 +9,34 @@ namespace DownKyi.Tests;
 public sealed class UserVideoListNavigationTests
 {
     [Fact]
+    public void ReturningFromAChildPageRestoresTheCurrentNumericListState()
+    {
+        Assert.True(ViewPublicationViewModel.ShouldRestoreListState(
+            preserveStateOnReturn: true,
+            currentMid: 3546801722362343,
+            currentIsUserVideoList: true,
+            incomingMid: 3546801722362343,
+            incomingIsUserVideoList: true,
+            loadedTabCount: 1));
+
+        Assert.False(ViewPublicationViewModel.ShouldRestoreListState(
+            preserveStateOnReturn: true,
+            currentMid: 3546801722362343,
+            currentIsUserVideoList: true,
+            incomingMid: 42,
+            incomingIsUserVideoList: true,
+            loadedTabCount: 1));
+
+        Assert.False(ViewPublicationViewModel.ShouldRestoreListState(
+            preserveStateOnReturn: false,
+            currentMid: 3546801722362343,
+            currentIsUserVideoList: true,
+            incomingMid: 3546801722362343,
+            incomingIsUserVideoList: true,
+            loadedTabCount: 1));
+    }
+
+    [Fact]
     public void NumericUserVideoSearchFiltersTitlesCaseInsensitively()
     {
         var videos = new[]

--- a/tests/DownKyi.Tests/UserVideoListNavigationTests.cs
+++ b/tests/DownKyi.Tests/UserVideoListNavigationTests.cs
@@ -1,0 +1,32 @@
+using DownKyi.Events;
+using DownKyi.Services;
+using DownKyi.ViewModels;
+using Prism.Events;
+
+namespace DownKyi.Tests;
+
+#pragma warning disable CA1515 // xUnit requires public test classes.
+public sealed class UserVideoListNavigationTests
+{
+    [Fact]
+    public void NumericListUrlNavigatesToTheUploaderVideoList()
+    {
+        var eventAggregator = new EventAggregator();
+        NavigationParam? navigation = null;
+        eventAggregator.GetEvent<NavigationEvent>().Subscribe(value => navigation = value);
+        var service = new SearchService(eventAggregator);
+
+        var handled = service.BiliInput(
+            "https://www.bilibili.com/list/3546801722362343",
+            ViewIndexViewModel.Tag);
+
+        Assert.True(handled);
+        Assert.NotNull(navigation);
+        Assert.Equal(ViewPublicationViewModel.Tag, navigation.ViewName);
+        Assert.Equal(ViewIndexViewModel.Tag, navigation.ParentViewName);
+        var data = Assert.IsType<Dictionary<string, object>>(navigation.Parameter);
+        Assert.Equal(3546801722362343, data["mid"]);
+        Assert.Equal(true, data["userVideoList"]);
+    }
+}
+#pragma warning restore CA1515

--- a/tests/DownKyi.Tests/UserVideoListNavigationTests.cs
+++ b/tests/DownKyi.Tests/UserVideoListNavigationTests.cs
@@ -9,6 +9,23 @@ namespace DownKyi.Tests;
 public sealed class UserVideoListNavigationTests
 {
     [Fact]
+    public void NumericUserVideoSearchFiltersTitlesCaseInsensitively()
+    {
+        var videos = new[]
+        {
+            new DownKyi.Core.BiliApi.Users.Models.UserVideoListArchive { Title = "Aespa Lemonade" },
+            new DownKyi.Core.BiliApi.Users.Models.UserVideoListArchive { Title = "其他视频" },
+            new DownKyi.Core.BiliApi.Users.Models.UserVideoListArchive { Title = "AESPA Drama" }
+        };
+
+        var result = ViewPublicationViewModel.FilterUserVideoList(videos, " aespa ");
+
+        Assert.Equal(2, result.Count);
+        Assert.All(result, video =>
+            Assert.Contains("aespa", video.Title, StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
     public void NumericListUrlNavigatesToTheUploaderVideoList()
     {
         var eventAggregator = new EventAggregator();


### PR DESCRIPTION
## Summary

Add numeric Bilibili list support and search within the currently displayed video collection.

## New Features

### Numeric list URLs

- Recognize URLs such as `https://www.bilibili.com/list/3546801722362343`.
- Resolve the uploader ID and display the list archives in the publication view.
- Preserve paging metadata and support the existing open/download workflow.

### Search the current collection

- Search by video title inside the currently selected personal favorite folder.
- Search by video title inside the currently selected uploader publication category.
- Support Enter and the search button.
- Clear the active keyword when switching categories and restore all results when the keyword is cleared.
- Cache and locally filter numeric-list archives because Bilibili's public `/x/space/arc/list` endpoint ignores `keyword` for these lists.

### Search UI

- Add a compact header search box to favorites and publication views.
- Add hover/focus feedback and a circular themed search button.

### List state restoration

- Preserve the current page, loaded results, and active search when opening a child page such as Download Manager and returning.
- Reinitialize normally after explicitly leaving the list through its own back button.

## Scope

- This PR contains only functionality added after #77.
- It deliberately excludes the user-space favorites, unavailable-video, empty-zone, and back-icon changes already submitted in #77.
- Navigation bug fixes remain in #75 and its follow-up PR.

## Verification

- Release build: 0 warnings, 0 errors.
- Complete test suite: 116 passed, 0 failed.