### PR TITLE
fix(navigation): use region history for deep back navigation

### DIFF
--- a/DownKyi/Images/NavigationIcon.cs
+++ b/DownKyi/Images/NavigationIcon.cs
@@ -3,14 +3,14 @@ namespace DownKyi.Images;
 internal class NavigationIcon
 {
     private static NavigationIcon? _instance;
+
     public static NavigationIcon Instance()
     {
         return _instance ??= new NavigationIcon();
     }
 
-    public NavigationIcon()
-    {
-        ArrowBack = new VectorImage
+    private readonly VectorImage _arrowBack =
+        new()
         {
             Height = 24,
             Width = 24,
@@ -19,7 +19,8 @@ internal class NavigationIcon
             Fill = "#FF000000"
         };
 
-        Logout = new VectorImage
+    private readonly VectorImage _logout =
+        new()
         {
             Height = 18.75,//100,
             Width = 24,//128,
@@ -34,9 +35,19 @@ internal class NavigationIcon
                  L16,18.2z",
             Fill = "#FF000000"
         };
+
+    public VectorImage ArrowBack => Clone(_arrowBack);
+
+    public VectorImage Logout => Clone(_logout);
+
+    private static VectorImage Clone(VectorImage source)
+    {
+        return new VectorImage
+        {
+            Width = source.Width,
+            Height = source.Height,
+            Data = source.Data,
+            Fill = source.Fill
+        };
     }
-
-    public VectorImage ArrowBack { get; private set; }
-    public VectorImage Logout { get; private set; }
-
 }

--- a/DownKyi/ViewModels/MainWindowViewModel.cs
+++ b/DownKyi/ViewModels/MainWindowViewModel.cs
@@ -132,6 +132,16 @@ internal sealed class MainWindowViewModel : BindableBase, IDisposable
 
         _eventAggregator.GetEvent<NavigationEvent>().Subscribe(view =>
         {
+            if (IsHistoryBackRequest(view))
+            {
+                var journal = regionManager.Regions[ContentRegion].NavigationService.Journal;
+                if (journal.CanGoBack)
+                {
+                    journal.GoBack();
+                    return;
+                }
+            }
+
             var param = new NavigationParameters
             {
                 { "Parent", view.ParentViewName ?? string.Empty },
@@ -178,6 +188,12 @@ internal sealed class MainWindowViewModel : BindableBase, IDisposable
             };
             _regionManager.RequestNavigate("ContentRegion", ViewIndexViewModel.Tag, param);
         });
+    }
+
+    internal static bool IsHistoryBackRequest(NavigationParam view)
+    {
+        ArgumentNullException.ThrowIfNull(view);
+        return view.ParentViewName == null && view.Parameter == null;
     }
 
     private static async Task DelayAsync(int milliseconds, CancellationToken cancellationToken)

--- a/DownKyi/ViewModels/ViewFriendsViewModel.cs
+++ b/DownKyi/ViewModels/ViewFriendsViewModel.cs
@@ -81,8 +81,6 @@ namespace DownKyi.ViewModels
         {
             //InitView();
 
-            ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
-
             var parameter = new NavigationParam
             {
                 ViewName = ParentView,

--- a/DownKyi/ViewModels/ViewMyBangumiFollowViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyBangumiFollowViewModel.cs
@@ -190,8 +190,6 @@ internal class ViewMyBangumiFollowViewModel : ViewModelBase
     {
         InitView();
 
-        ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
-
         // 结束任务
         _tokenSource?.Cancel();
 

--- a/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
@@ -222,8 +222,6 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
     protected internal override void ExecuteBackSpace()
     {
         InitView();
-
-        ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
         // 结束任务
         _tokenSource1?.Cancel();
         _tokenSource2?.Cancel();

--- a/DownKyi/ViewModels/ViewMyHistoryViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyHistoryViewModel.cs
@@ -152,8 +152,6 @@ internal class ViewMyHistoryViewModel : ViewModelBase
         _loadCancellation?.Cancel();
         InitView();
 
-        ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
-
         var parameter = new NavigationParam
         {
             ViewName = ParentView,

--- a/DownKyi/ViewModels/ViewMyToViewVideoViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyToViewVideoViewModel.cs
@@ -142,8 +142,6 @@ internal class ViewMyToViewVideoViewModel : ViewModelBase
     {
         InitView();
 
-        ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
-
         // 结束任务
         _tokenSource?.Cancel();
 

--- a/DownKyi/ViewModels/ViewPublicationViewModel.cs
+++ b/DownKyi/ViewModels/ViewPublicationViewModel.cs
@@ -178,8 +178,6 @@ namespace DownKyi.ViewModels
         /// </summary>
         protected internal override void ExecuteBackSpace()
         {
-            ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
-
             // 结束任务
             _tokenSource?.Cancel();
             _tokenSource?.Dispose();

--- a/DownKyi/ViewModels/ViewSeasonsSeriesViewModel.cs
+++ b/DownKyi/ViewModels/ViewSeasonsSeriesViewModel.cs
@@ -169,8 +169,6 @@ internal class ViewSeasonsSeriesViewModel : ViewModelBase
     /// </summary>
     protected internal override void ExecuteBackSpace()
     {
-        ArrowBack.Fill = DictionaryResource.GetColor("ColorText");
-
         // 结束任务
         tokenSource?.Cancel();
 

--- a/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
+++ b/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
@@ -4,6 +4,8 @@ using DownKyi.Application.Lifetime;
 using DownKyi.Composition;
 using DownKyi.Core.Storage;
 using DownKyi.Desktop.Composition;
+using DownKyi.Events;
+using DownKyi.Images;
 using DownKyi.PrismExtension.Dialog;
 using DownKyi.ViewModels;
 using DownKyi.Views;
@@ -18,6 +20,33 @@ namespace DownKyi.Desktop.Tests;
 
 public sealed class UiSmokeTests
 {
+    [Fact]
+    public void StandardReturnNavigationUsesTheRegionHistory()
+    {
+        Assert.True(MainWindowViewModel.IsHistoryBackRequest(new NavigationParam
+        {
+            ViewName = ViewVideoDetailViewModel.Tag
+        }));
+
+        Assert.False(MainWindowViewModel.IsHistoryBackRequest(new NavigationParam
+        {
+            ViewName = ViewIndexViewModel.Tag,
+            Parameter = "logout"
+        }));
+    }
+
+    [Fact]
+    public void NavigationIconsDoNotShareMutableFillState()
+    {
+        var first = NavigationIcon.Instance().ArrowBack;
+        var second = NavigationIcon.Instance().ArrowBack;
+
+        first.Fill = "#FFFFFFFF";
+
+        Assert.NotSame(first, second);
+        Assert.Equal("#FF000000", second.Fill);
+    }
+
     [Fact]
     public async Task RealHostResolvesShellAndKeyViewModelsWithoutGlobalContainerState()
     {


### PR DESCRIPTION
## Why

This is a follow-up to #75 for a deeper navigation path:

1. Logged-in user page -> video.
2. Video -> uploader profile.
3. Select any uploader category -> another video.
4. Press the top-left back button repeatedly.

Even after preserving parent parameters, reused view models and shared icon state could still make deep back navigation stop early or make the back arrow disappear.

## What Changed

- Treat a standard return event (`ParentViewName == null` and `Parameter == null`) as a Prism region-journal back operation.
- Return a fresh back-arrow image object instead of sharing mutable fill state across pages.
- Stop individual view models from resetting the shared back icon during navigation cleanup.
- Add focused tests for history-back detection and isolated navigation-icon state.

## Scope

- This PR contains only the follow-up delta.
- It deliberately excludes the already submitted changes from #75 and #77.
- #75 should be reviewed/merged first because it fixes the underlying missing-parent navigation state.

## Verification

- Release build: 0 warnings, 0 errors.
- Complete test suite: 108 passed, 0 failed.