### PR TITLE
feat(navigation): port list search and retained state

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -72,9 +72,14 @@ flowchart LR
     UserSpace["UserSpace coordinator snapshot"] --> Tabs["publications / collections / favorites"]
     Tabs --> FavoriteFolders["UserSpaceFavorites"]
     FavoriteFolders --> PublicFavorites["PublicFavorites"]
+    ListUrl["bare /list/mid input"] --> PublicationPayload["PublicationNavigationPayload"]
+    PublicationPayload --> PublicationPage["WBI publication search"]
+    PublicationPage --> History
 ```
 
 Main region 的返回操作必須先縮減 `AvaloniaNavigationService` 的既有歷史，並恢復原本的 View/ViewModel instance；只有沒有歷史時才建立 typed parent route。UserSpace 的公開收藏夾由注入的 coordinator 一次映射到 snapshot，返回同一個 MID 時保留原頁面與清單狀態。失效收藏項目保留在 UI 供辨識，但不能選取、開啟或加入下載。
+
+投稿路由只接受 `PublicationNavigationPayload`。裸 `bilibili.com/list/<MID>` 代表該使用者全部投稿；帶 `sid` 的系列 URL 在 API contract audit 完成前不會被猜成全部投稿。投稿搜尋採 WBI 回應的精確 `page.count`；收藏搜尋的 `media_count` 是未篩選總數，因此分頁只能依 `has_more` 逐頁擴展。兩頁返回時保留 query、頁碼與既有 media instances；被取消的未完成頁才會補載。
 
 導航箭頭 path 必須由 factory 建立獨立 geometry；不得讓不同 ViewModel 共用可變的 `PathIconData`，否則單頁主題更新會改壞其他頁面。
 

--- a/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.UserVideoList.cs
+++ b/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.UserVideoList.cs
@@ -1,0 +1,61 @@
+using System.Globalization;
+
+namespace DownKyi.Core.BiliApi.BiliUtils;
+
+public static partial class ParseEntrance
+{
+    /// <summary>
+    /// 是否为仅以UP主MID标识的全部投稿列表URL。
+    /// 带有sid的URL表示系列列表，不可误判为全部投稿。
+    /// </summary>
+    public static bool IsUserVideoListUrl(string input)
+    {
+        return GetUserVideoListId(input) > 0;
+    }
+
+    /// <summary>
+    /// 获取全部投稿列表URL中的UP主MID。
+    /// </summary>
+    public static long GetUserVideoListId(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        if (!Uri.TryCreate(input.Trim(), UriKind.Absolute, out var uri)
+            || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)
+            || !IsBilibiliWebHost(uri.Host)
+            || HasNonEmptyQueryValue(uri.Query, "sid"))
+        {
+            return -1;
+        }
+
+        var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length == 2
+            && string.Equals(segments[0], "list", StringComparison.Ordinal)
+            && long.TryParse(segments[1], NumberStyles.None, CultureInfo.InvariantCulture, out var mid)
+            && mid > 0
+                ? mid
+                : -1;
+    }
+
+    private static bool IsBilibiliWebHost(string host)
+    {
+        return string.Equals(host, "bilibili.com", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(host, "www.bilibili.com", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(host, "m.bilibili.com", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool HasNonEmptyQueryValue(string query, string name)
+    {
+        foreach (var item in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var pair = item.Split('=', 2);
+            if (string.Equals(Uri.UnescapeDataString(pair[0]), name, StringComparison.OrdinalIgnoreCase)
+                && pair.Length == 2
+                && !string.IsNullOrWhiteSpace(Uri.UnescapeDataString(pair[1])))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.cs
+++ b/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.cs
@@ -17,7 +17,7 @@ namespace DownKyi.Core.BiliApi.BiliUtils;
 /// 收藏夹：ml1329019876, ML1329019876, https://www.bilibili.com/medialist/detail/ml1329019876, https://www.bilibili.com/medialist/play/ml1329019876/, https://www.bilibili.com/list/ml1329019876 <para/>
 /// 用户空间：uid928123, UID928123, uid:928123, UID:928123, https://space.bilibili.com/928123
 /// </summary>
-public static class ParseEntrance
+public static partial class ParseEntrance
 {
     public static readonly string WwwUrl = "https://www.bilibili.com";
     public static readonly string ShareWwwUrl = "https://www.bilibili.com/s";

--- a/DownKyi.Core/BiliApi/Favorites/FavoritesResource.cs
+++ b/DownKyi.Core/BiliApi/Favorites/FavoritesResource.cs
@@ -15,7 +15,20 @@ public static class FavoritesResource
     /// <returns></returns>
     public static IReadOnlyList<FavoritesMedia>? GetFavoritesMedia(long mediaId, int pn, int ps, CancellationToken cancellationToken = default)
     {
-        var url = $"https://api.bilibili.com/x/v3/fav/resource/list?media_id={mediaId}&pn={pn}&ps={ps}&platform=web";
+        return GetFavoritesMediaResource(mediaId, pn, ps, null, cancellationToken).Medias;
+    }
+
+    /// <summary>
+    /// 获取收藏夹内容和服务端的后续分页标记。
+    /// </summary>
+    public static FavoritesMediaResource GetFavoritesMediaResource(
+        long mediaId,
+        int pn,
+        int ps,
+        string? keyword,
+        CancellationToken cancellationToken = default)
+    {
+        var url = BuildFavoritesMediaUrl(mediaId, pn, ps, keyword);
         const string referer = "https://www.bilibili.com";
         var resource = BiliApiRequest.RequestJson<FavoritesMediaResourceOrigin>(
             url,
@@ -24,7 +37,16 @@ public static class FavoritesResource
             "FavoritesResource",
             cancellationToken);
 
-        return BiliApiRequest.RequirePayload(resource.Data).Medias;
+        return BiliApiRequest.RequirePayload(resource.Data);
+    }
+
+    internal static string BuildFavoritesMediaUrl(long mediaId, int pn, int ps, string? keyword)
+    {
+        var url = $"https://api.bilibili.com/x/v3/fav/resource/list?media_id={mediaId}&pn={pn}&ps={ps}&platform=web";
+        var normalizedKeyword = keyword?.Trim();
+        return string.IsNullOrEmpty(normalizedKeyword)
+            ? url
+            : $"{url}&keyword={Uri.EscapeDataString(normalizedKeyword)}";
     }
 
     /// <summary>

--- a/DownKyi.Core/BiliApi/Users/UserSpace.cs
+++ b/DownKyi.Core/BiliApi/Users/UserSpace.cs
@@ -135,6 +135,32 @@ public static class UserSpace
         string keyword = "",
         CancellationToken cancellationToken = default)
     {
+        return GetPublicationPage(
+            keys,
+            unixTimeSeconds,
+            mid,
+            pn,
+            ps,
+            tid,
+            order,
+            keyword,
+            cancellationToken)?.List;
+    }
+
+    /// <summary>
+    /// 查询用户投稿视频及服务端分页信息。
+    /// </summary>
+    public static SpacePublication? GetPublicationPage(
+        WbiKeys keys,
+        long unixTimeSeconds,
+        long mid,
+        int pn,
+        int ps,
+        long tid = 0,
+        PublicationOrder order = PublicationOrder.PUBDATE,
+        string keyword = "",
+        CancellationToken cancellationToken = default)
+    {
         ArgumentNullException.ThrowIfNull(keys);
         var parameters = new Dictionary<string, object?>
         {
@@ -175,12 +201,12 @@ public static class UserSpace
         var spacePublication = BiliApiRequest.RequestJson<SpacePublicationOrigin>(
             url,
             referer,
-            nameof(GetPublication),
+            nameof(GetPublicationPage),
             "UserSpace",
             serializerSettings,
             cancellationToken);
 
-        return BiliApiRequest.RequirePayload(spacePublication.Data).List;
+        return BiliApiRequest.RequirePayload(spacePublication.Data);
     }
 
     internal static string GetPublicationOrderValue(PublicationOrder order)

--- a/DownKyi/Services/FavoritesCoordinator.cs
+++ b/DownKyi/Services/FavoritesCoordinator.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Application.Desktop;
-using DownKyi.Core.BiliApi.Favorites;
 using DownKyi.ViewModels.PageViewModels;
 
 namespace DownKyi.Services;
@@ -12,14 +11,19 @@ internal sealed record PublicFavoritesSnapshot(
     FavoritesPageItem Favorites,
     IReadOnlyList<FavoritesMedia> Medias);
 
+internal sealed record FavoritesMediaPageSnapshot(
+    IReadOnlyList<FavoritesMedia> Medias,
+    bool HasMore);
+
 internal interface IFavoritesCoordinator
 {
     Task<IReadOnlyList<TabHeader>> LoadFoldersAsync(long mid, CancellationToken cancellationToken);
 
-    Task<IReadOnlyList<FavoritesMedia>> LoadMediaPageAsync(
+    Task<FavoritesMediaPageSnapshot> LoadMediaPageAsync(
         long favoritesId,
         int page,
         int pageSize,
+        string? keyword,
         CancellationToken cancellationToken);
 
     Task<PublicFavoritesSnapshot?> LoadPublicFavoritesAsync(
@@ -50,23 +54,26 @@ internal sealed class FavoritesCoordinator : IFavoritesCoordinator
         }, cancellationToken);
     }
 
-    public Task<IReadOnlyList<FavoritesMedia>> LoadMediaPageAsync(
+    public Task<FavoritesMediaPageSnapshot> LoadMediaPageAsync(
         long favoritesId,
         int page,
         int pageSize,
+        string? keyword,
         CancellationToken cancellationToken)
     {
-        return Task.Run<IReadOnlyList<FavoritesMedia>>(() =>
+        return Task.Run(() =>
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var medias = FavoritesResource.GetFavoritesMedia(
+            var resource = _favoritesService.GetFavoritesMediaPage(
                 favoritesId,
                 page,
                 pageSize,
+                keyword,
                 cancellationToken);
-            return medias == null || medias.Count == 0
+            var mapped = resource.Medias.Count == 0
                 ? Array.Empty<FavoritesMedia>()
-                : _favoritesService.MapFavoritesMedia(medias, AppRoute.MyFavorites, cancellationToken);
+                : _favoritesService.MapFavoritesMedia(resource.Medias, AppRoute.MyFavorites, cancellationToken);
+            return new FavoritesMediaPageSnapshot(mapped, resource.HasMore);
         }, cancellationToken);
     }
 
@@ -83,7 +90,7 @@ internal sealed class FavoritesCoordinator : IFavoritesCoordinator
                 return null;
             }
 
-            var medias = FavoritesResource.GetAllFavoritesMedia(favoritesId, cancellationToken);
+            var medias = _favoritesService.GetAllFavoritesMedia(favoritesId, cancellationToken);
             var mapped = _favoritesService.MapFavoritesMedia(medias, AppRoute.PublicFavorites, cancellationToken);
             return new PublicFavoritesSnapshot(favorites, mapped);
         }, cancellationToken);

--- a/DownKyi/Services/FavoritesService.cs
+++ b/DownKyi/Services/FavoritesService.cs
@@ -8,6 +8,7 @@ using DownKyi.Core.Settings;
 using DownKyi.Core.Utils;
 using DownKyi.ViewModels.PageViewModels;
 using ApiFavoritesMedia = DownKyi.Core.BiliApi.Favorites.Models.FavoritesMedia;
+using ApiFavoritesMediaResource = DownKyi.Core.BiliApi.Favorites.Models.FavoritesMediaResource;
 
 namespace DownKyi.Services;
 
@@ -49,6 +50,28 @@ internal sealed class FavoritesService : IFavoritesService
             UpHeader = metadata.Upper?.Face ?? string.Empty,
             UpperMid = metadata.Upper?.Mid ?? -1
         };
+    }
+
+    public ApiFavoritesMediaResource GetFavoritesMediaPage(
+        long mediaId,
+        int page,
+        int pageSize,
+        string? keyword,
+        CancellationToken cancellationToken)
+    {
+        return FavoritesResource.GetFavoritesMediaResource(
+            mediaId,
+            page,
+            pageSize,
+            keyword,
+            cancellationToken);
+    }
+
+    public IReadOnlyList<ApiFavoritesMedia> GetAllFavoritesMedia(
+        long mediaId,
+        CancellationToken cancellationToken)
+    {
+        return FavoritesResource.GetAllFavoritesMedia(mediaId, cancellationToken);
     }
 
     public IReadOnlyList<FavoritesMedia> MapFavoritesMedia(

--- a/DownKyi/Services/IFavoritesService.cs
+++ b/DownKyi/Services/IFavoritesService.cs
@@ -3,12 +3,24 @@ using System.Threading;
 using DownKyi.Application.Desktop;
 using DownKyi.ViewModels.PageViewModels;
 using ApiFavoritesMedia = DownKyi.Core.BiliApi.Favorites.Models.FavoritesMedia;
+using ApiFavoritesMediaResource = DownKyi.Core.BiliApi.Favorites.Models.FavoritesMediaResource;
 
 namespace DownKyi.Services;
 
 internal interface IFavoritesService
 {
     FavoritesPageItem? GetFavorites(long mediaId, CancellationToken cancellationToken = default);
+
+    ApiFavoritesMediaResource GetFavoritesMediaPage(
+        long mediaId,
+        int page,
+        int pageSize,
+        string? keyword,
+        CancellationToken cancellationToken);
+
+    IReadOnlyList<ApiFavoritesMedia> GetAllFavoritesMedia(
+        long mediaId,
+        CancellationToken cancellationToken);
 
     IReadOnlyList<FavoritesMedia> MapFavoritesMedia(
         IReadOnlyList<ApiFavoritesMedia> medias,

--- a/DownKyi/Services/SearchService.cs
+++ b/DownKyi/Services/SearchService.cs
@@ -28,6 +28,7 @@ internal class SearchService
     /// 课程ss号：https://www.bilibili.com/cheese/play/ss205 <para/>
     /// 课程ep号：https://www.bilibili.com/cheese/play/ep3489 <para/>
     /// 收藏夹：ml1329019876, ML1329019876, https://www.bilibili.com/medialist/detail/ml1329019876, https://www.bilibili.com/medialist/play/ml1329019876/ <para/>
+    /// UP主全部投稿：https://www.bilibili.com/list/3546801722362343 <para/>
     /// 用户空间：uid928123, UID928123, uid:928123, UID:928123, https://space.bilibili.com/928123
     /// </summary>
     /// <param name="input"></param>
@@ -90,6 +91,14 @@ internal class SearchService
         else if (ParseEntrance.IsCheeseSeasonUrl(justId) || ParseEntrance.IsCheeseEpisodeUrl(justId))
         {
             NavigateToVideo(parentRoute, input);
+        }
+        // UP主全部投稿列表
+        else if (ParseEntrance.IsUserVideoListUrl(justId))
+        {
+            _navigationService.Navigate(new AppNavigationRequest(
+                AppRoute.Publication,
+                parentRoute,
+                PublicationNavigationPayload.All(ParseEntrance.GetUserVideoListId(justId))));
         }
         // 用户（参数传入mid）
         else if (ParseEntrance.IsUserId(justId))

--- a/DownKyi/Services/UserSpace/UserSpacePageCoordinator.cs
+++ b/DownKyi/Services/UserSpace/UserSpacePageCoordinator.cs
@@ -48,13 +48,18 @@ internal sealed record BangumiFollowPageSnapshot(
     IReadOnlyList<BangumiFollowMedia> Medias,
     int PageCount);
 
+internal sealed record PublicationPageSnapshot(
+    IReadOnlyList<PublicationMedia> Medias,
+    int TotalCount);
+
 internal interface IUserSpacePageCoordinator
 {
-    Task<IReadOnlyList<PublicationMedia>> LoadPublicationPageAsync(
+    Task<PublicationPageSnapshot> LoadPublicationPageAsync(
         long mid,
         int page,
         int pageSize,
         long typeId,
+        string? keyword,
         CancellationToken cancellationToken);
 
     Task<MySpaceProfileSnapshot?> LoadMyProfileAsync(long mid, CancellationToken cancellationToken);
@@ -88,60 +93,74 @@ internal sealed class UserSpacePageCoordinator : IUserSpacePageCoordinator
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public async Task<IReadOnlyList<PublicationMedia>> LoadPublicationPageAsync(
+    public async Task<PublicationPageSnapshot> LoadPublicationPageAsync(
         long mid,
         int page,
         int pageSize,
         long typeId,
+        string? keyword,
         CancellationToken cancellationToken)
     {
         var publication = await WbiRequestExecutor.ExecuteAsync(
             _wbiKeyProvider,
-            (keys, unixTimeSeconds) => BiliUserSpace.GetPublication(
+            (keys, unixTimeSeconds) => BiliUserSpace.GetPublicationPage(
                 keys,
                 unixTimeSeconds,
                 mid,
                 page,
                 pageSize,
                 typeId,
+                keyword: keyword?.Trim() ?? string.Empty,
                 cancellationToken: cancellationToken),
             TimeProvider.System,
             cancellationToken).ConfigureAwait(false);
-        return await Task.Run<IReadOnlyList<PublicationMedia>>(() =>
+        return await Task.Run(() => MapPublicationPage(
+            publication,
+            _navigationService,
+            _logger,
+            cancellationToken), cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static PublicationPageSnapshot MapPublicationPage(
+        SpacePublication? publication,
+        IAppNavigationService navigationService,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(navigationService);
+        ArgumentNullException.ThrowIfNull(logger);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (publication == null)
+        {
+            logger.LogWarningMessage("Bilibili publication page could not be loaded.");
+            return new PublicationPageSnapshot(Array.Empty<PublicationMedia>(), 0);
+        }
+
+        var videos = publication.List.Vlist;
+        if (videos == null || videos.Count == 0)
+        {
+            return new PublicationPageSnapshot(Array.Empty<PublicationMedia>(), publication.Page.Count);
+        }
+
+        var result = new List<PublicationMedia>(videos.Count);
+        foreach (var video in videos)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if (publication == null)
+            result.Add(new PublicationMedia(navigationService, AppRoute.Publication)
             {
-                _logger.LogWarningMessage("Bilibili publication page could not be loaded.");
-                return Array.Empty<PublicationMedia>();
-            }
+                Avid = video.Aid,
+                Bvid = video.Bvid,
+                Duration = video.Length,
+                Title = video.Title,
+                PlayNumber = video.Play > 0 ? Format.FormatNumber(video.Play) : "--",
+                CreateTime = DateTimeOffset.FromUnixTimeSeconds(video.Created)
+                    .ToLocalTime()
+                    .ToString("yyyy-MM-dd", CultureInfo.CurrentCulture),
+                CoverUrl = video.Pic
+            });
+        }
 
-            var videos = publication.Vlist;
-            if (videos == null || videos.Count == 0)
-            {
-                return Array.Empty<PublicationMedia>();
-            }
-
-            var result = new List<PublicationMedia>(videos.Count);
-            foreach (var video in videos)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                result.Add(new PublicationMedia(_navigationService, AppRoute.Publication)
-                {
-                    Avid = video.Aid,
-                    Bvid = video.Bvid,
-                    Duration = video.Length,
-                    Title = video.Title,
-                    PlayNumber = video.Play > 0 ? Format.FormatNumber(video.Play) : "--",
-                    CreateTime = DateTimeOffset.FromUnixTimeSeconds(video.Created)
-                        .ToLocalTime()
-                        .ToString("yyyy-MM-dd", CultureInfo.CurrentCulture),
-                    CoverUrl = video.Pic
-                });
-            }
-
-            return result;
-        }, cancellationToken).ConfigureAwait(false);
+        return new PublicationPageSnapshot(result, publication.Page.Count);
     }
 
     public Task<MySpaceProfileSnapshot?> LoadMyProfileAsync(long mid, CancellationToken cancellationToken)

--- a/DownKyi/ViewModels/UserSpace/ViewArchiveViewModel.cs
+++ b/DownKyi/ViewModels/UserSpace/ViewArchiveViewModel.cs
@@ -68,18 +68,18 @@ internal class ViewArchiveViewModel : ViewModelBase
             return;
         }
 
-        var data = new Dictionary<string, object>
-        {
-            { "mid", _mid },
-            { "tid", zone.Tid },
-            { "list", PublicationZones.ToList() }
-        };
+        var payload = new PublicationNavigationPayload(
+            _mid,
+            zone.Tid,
+            PublicationZones
+                .Select(item => new PublicationNavigationZone(item.Tid, item.Name, item.Count))
+                .ToArray());
 
         // 进入视频页面
         Navigation.Navigate(new AppNavigationRequest(
             AppRoute.Publication,
             AppRoute.UserSpace,
-            data));
+            payload));
 
         SelectedItem = -1;
     }

--- a/DownKyi/ViewModels/ViewMyFavoritesViewModel.Search.cs
+++ b/DownKyi/ViewModels/ViewMyFavoritesViewModel.Search.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Globalization;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using DownKyi.Application.Desktop;
+using DownKyi.Core.Logging;
+using DownKyi.CustomControl;
+using DownKyi.Images;
+using DownKyi.Utils;
+using DownKyi.ViewModels.PageViewModels;
+
+namespace DownKyi.ViewModels;
+
+internal partial class ViewMyFavoritesViewModel
+{
+    private string _inputSearchText = string.Empty;
+    private string _activeSearchText = string.Empty;
+    private long _loadedMid = -1;
+    private bool _foldersLoaded;
+    private bool _hasLoadedMediaPage;
+    private bool _suppressTabSelection;
+    private RelayCommand? _searchCommand;
+
+    public string InputSearchText
+    {
+        get => _inputSearchText;
+        set => SetProperty(ref _inputSearchText, value);
+    }
+
+    public RelayCommand SearchCommand => _searchCommand ??= new RelayCommand(ExecuteSearch, () => IsEnabled);
+
+    private void ExecuteSearch()
+    {
+        var query = InputSearchText.Trim();
+        _activeSearchText = query;
+        ConfigurePager(1, string.IsNullOrEmpty(query) ? GetSelectedFolderPageCount() : 1);
+    }
+
+    private void SelectFavoritesFolder(TabHeader tabHeader)
+    {
+        MediaContentVisibility = false;
+        InputSearchText = string.Empty;
+        _activeSearchText = string.Empty;
+        ConfigurePager(1, GetPageCount(tabHeader));
+    }
+
+    private void ConfigurePager(int current, int count)
+    {
+        _hasLoadedMediaPage = false;
+        Pager = new CustomPagerViewModel(current, Math.Max(1, count));
+        Pager.Current = current;
+    }
+
+    private int GetSelectedFolderPageCount()
+    {
+        return SelectTabId >= 0 && SelectTabId < TabHeaders.Count
+            ? GetPageCount(TabHeaders[SelectTabId])
+            : 1;
+    }
+
+    private static int GetPageCount(TabHeader tabHeader)
+    {
+        return int.TryParse(tabHeader.SubTitle, NumberStyles.Integer, CultureInfo.CurrentCulture, out var count)
+            ? Math.Max(1, (int)Math.Ceiling((double)count / VideoNumberInPage))
+            : 1;
+    }
+
+    private async Task UpdateFavoritesMediaListAsync(int current)
+    {
+        if (SelectTabId < 0 || SelectTabId >= TabHeaders.Count)
+        {
+            return;
+        }
+
+        var cancellationToken = ReplaceCancellationSource(ref _mediaLoadCancellation);
+        try
+        {
+            IsSelectAll = false;
+            MediaLoadingVisibility = true;
+            MediaNoDataVisibility = false;
+            IsEnabled = false;
+            SearchCommand.NotifyCanExecuteChanged();
+            _hasLoadedMediaPage = false;
+
+            var tab = TabHeaders[SelectTabId];
+            var page = await _favoritesCoordinator.LoadMediaPageAsync(
+                tab.Id,
+                current,
+                VideoNumberInPage,
+                _activeSearchText,
+                cancellationToken).ConfigureAwait(true);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Medias.Clear();
+            Medias.AddRange(page.Medias);
+            MediaContentVisibility = true;
+            MediaLoadingVisibility = false;
+            MediaNoDataVisibility = page.Medias.Count == 0;
+            _hasLoadedMediaPage = true;
+            if (!string.IsNullOrEmpty(_activeSearchText))
+            {
+                Pager.Count = current + (page.HasMore ? 1 : 0);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception e) when (e is System.Net.Http.HttpRequestException or InvalidOperationException or ArgumentException
+            or FormatException or Newtonsoft.Json.JsonException)
+        {
+            MediaLoadingVisibility = false;
+            MediaNoDataVisibility = Medias.Count == 0;
+            _logger.LogErrorMessage("Favorites media loading failed.", e);
+        }
+        finally
+        {
+            IsEnabled = true;
+            SearchCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private void InitView()
+    {
+        ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
+        DownloadManage = ButtonIcon.Instance().DownloadManage;
+        DownloadManage.Height = 24;
+        DownloadManage.Width = 24;
+        DownloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
+        ContentVisibility = false;
+        LoadingVisibility = true;
+        NoDataVisibility = false;
+        MediaLoadingVisibility = false;
+        MediaNoDataVisibility = false;
+        TabHeaders.Clear();
+        Medias.Clear();
+        SelectTabId = -1;
+        IsSelectAll = false;
+        InputSearchText = string.Empty;
+        _activeSearchText = string.Empty;
+        _foldersLoaded = false;
+        _hasLoadedMediaPage = false;
+    }
+
+    public override void OnNavigatedTo(AppNavigationContext navigationContext)
+    {
+        ArgumentNullException.ThrowIfNull(navigationContext);
+        base.OnNavigatedTo(navigationContext);
+        var mid = navigationContext.Parameter is long value ? value : 0;
+        if (mid <= 0)
+        {
+            NoDataVisibility = true;
+            return;
+        }
+
+        ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
+        if (_loadedMid == mid && _foldersLoaded)
+        {
+            if (!_hasLoadedMediaPage)
+            {
+                RunFireAndForget(
+                    UpdateFavoritesMediaListAsync(Pager.Current),
+                    nameof(UpdateFavoritesMediaListAsync),
+                    _logger);
+            }
+
+            return;
+        }
+
+        RunFireAndForget(LoadFoldersAsync(mid), nameof(LoadFoldersAsync), _logger);
+    }
+
+    private async Task LoadFoldersAsync(long mid)
+    {
+        InitView();
+        _mid = mid;
+        _loadedMid = mid;
+        var cancellationToken = ReplaceCancellationSource(ref _folderLoadCancellation);
+        try
+        {
+            var folders = await _favoritesCoordinator.LoadFoldersAsync(mid, cancellationToken).ConfigureAwait(true);
+            cancellationToken.ThrowIfCancellationRequested();
+            TabHeaders.AddRange(folders);
+            _foldersLoaded = true;
+            ContentVisibility = TabHeaders.Count > 0;
+            LoadingVisibility = false;
+            NoDataVisibility = TabHeaders.Count == 0;
+            if (TabHeaders.Count == 0)
+            {
+                return;
+            }
+
+            _suppressTabSelection = true;
+            try
+            {
+                SelectTabId = 0;
+            }
+            finally
+            {
+                _suppressTabSelection = false;
+            }
+
+            ConfigurePager(1, GetPageCount(TabHeaders[0]));
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception e) when (e is System.Net.Http.HttpRequestException or InvalidOperationException or ArgumentException
+            or FormatException or Newtonsoft.Json.JsonException)
+        {
+            LoadingVisibility = false;
+            NoDataVisibility = true;
+            _logger.LogErrorMessage("Favorites folder loading failed.", e);
+        }
+    }
+}

--- a/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -23,7 +21,7 @@ using Microsoft.Extensions.Logging;
 
 namespace DownKyi.ViewModels;
 
-internal class ViewMyFavoritesViewModel : ViewModelBase
+internal partial class ViewMyFavoritesViewModel : ViewModelBase
 {
     public const string Tag = "PageMyFavorites";
     private readonly IContentDownloadCoordinator _downloadCoordinator;
@@ -284,17 +282,12 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
     /// <param name="parameter"></param>
     private void ExecuteLeftTabHeadersCommand(object parameter)
     {
-        if (parameter is not TabHeader tabHeader)
+        if (_suppressTabSelection || parameter is not TabHeader tabHeader)
         {
             return;
         }
 
-        // tab点击后，隐藏MediaContent
-        MediaContentVisibility = false;
-
-        // 页面选择
-        Pager = new CustomPagerViewModel(1, (int)Math.Ceiling(double.Parse(tabHeader.SubTitle, CultureInfo.CurrentCulture) / VideoNumberInPage));
-        Pager.Current = 1;
+        SelectFavoritesFolder(tabHeader);
     }
 
     /// <summary>
@@ -407,138 +400,6 @@ internal class ViewMyFavoritesViewModel : ViewModelBase
         }
 
         RunFireAndForget(UpdateFavoritesMediaListAsync(((CustomPagerViewModel)sender!).ProposedCurrent), nameof(UpdateFavoritesMediaListAsync), _logger);
-    }
-
-    private async Task UpdateFavoritesMediaListAsync(int current)
-    {
-        try
-        {
-            Medias.Clear();
-            IsSelectAll = false;
-
-            MediaLoadingVisibility = true;
-            MediaNoDataVisibility = false;
-
-            // 是否正在获取数据
-            // 在所有的退出分支中都需要设为true
-            IsEnabled = false;
-
-            var tab = TabHeaders[SelectTabId];
-            var cancellationToken = ReplaceCancellationSource(ref _mediaLoadCancellation);
-            var medias = await _favoritesCoordinator.LoadMediaPageAsync(
-                tab.Id,
-                current,
-                VideoNumberInPage,
-                cancellationToken).ConfigureAwait(true);
-            cancellationToken.ThrowIfCancellationRequested();
-            MediaContentVisibility = true;
-            MediaLoadingVisibility = false;
-            if (medias.Count == 0)
-            {
-                MediaNoDataVisibility = true;
-                return;
-            }
-
-            MediaNoDataVisibility = false;
-            Medias.AddRange(medias);
-        }
-        catch (OperationCanceledException) when (_mediaLoadCancellation?.IsCancellationRequested != false)
-        {
-            return;
-        }
-        catch (Exception e) when (e is System.Net.Http.HttpRequestException or InvalidOperationException or ArgumentException
-            or FormatException or Newtonsoft.Json.JsonException)
-        {
-            _logger.LogErrorMessage("Favorites media loading failed.", e);
-        }
-        finally
-        {
-            IsEnabled = true;
-        }
-    }
-
-    /// <summary>
-    /// 初始化页面数据
-    /// </summary>
-    private void InitView()
-    {
-        ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
-
-        DownloadManage = ButtonIcon.Instance().DownloadManage;
-        DownloadManage.Height = 24;
-        DownloadManage.Width = 24;
-        DownloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
-
-        ContentVisibility = false;
-        LoadingVisibility = true;
-        NoDataVisibility = false;
-        MediaLoadingVisibility = false;
-        MediaNoDataVisibility = false;
-
-        TabHeaders.Clear();
-        Medias.Clear();
-        SelectTabId = -1;
-        IsSelectAll = false;
-    }
-
-    /// <summary>
-    /// 导航到页面时执行
-    /// </summary>
-    /// <param name="navigationContext"></param>
-    public override void OnNavigatedTo(AppNavigationContext navigationContext)
-    {
-        ArgumentNullException.ThrowIfNull(navigationContext);
-        base.OnNavigatedTo(navigationContext);
-        RunFireAndForget(OnNavigatedToAsync(navigationContext), nameof(OnNavigatedToAsync), _logger);
-    }
-
-    private async Task OnNavigatedToAsync(AppNavigationContext navigationContext)
-    {
-        try
-        {
-            // 根据传入参数不同执行不同任务
-            _mid = navigationContext.Parameters.GetValue<long>("Parameter");
-            if (_mid == 0)
-            {
-                return;
-            }
-
-            InitView();
-            var cancellationToken = ReplaceCancellationSource(ref _folderLoadCancellation);
-            var folders = await _favoritesCoordinator.LoadFoldersAsync(_mid, cancellationToken).ConfigureAwait(true);
-            cancellationToken.ThrowIfCancellationRequested();
-            TabHeaders.AddRange(folders);
-
-            if (TabHeaders.Count == 0)
-            {
-                ContentVisibility = false;
-                LoadingVisibility = false;
-                NoDataVisibility = true;
-
-                return;
-            }
-
-            ContentVisibility = true;
-            LoadingVisibility = false;
-            NoDataVisibility = false;
-
-            // 初始选中项
-            SelectTabId = 0;
-
-            // 页面选择
-            Pager = new CustomPagerViewModel(1,
-            (int)Math.Ceiling(double.Parse(TabHeaders[0].SubTitle, CultureInfo.CurrentCulture) / VideoNumberInPage));
-            Pager.Current = 1;
-        }
-        catch (OperationCanceledException) when (_folderLoadCancellation?.IsCancellationRequested != false)
-        {
-            return;
-        }
-        catch (Exception e) when (e is System.Net.Http.HttpRequestException or InvalidOperationException or ArgumentException
-            or FormatException or Newtonsoft.Json.JsonException)
-        {
-            _logger.LogErrorMessage("Favorites folder loading failed.", e);
-        }
     }
 
     public override void OnNavigatedFrom(AppNavigationContext navigationContext)

--- a/DownKyi/ViewModels/ViewPublicationViewModel.Search.cs
+++ b/DownKyi/ViewModels/ViewPublicationViewModel.Search.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using DownKyi.Application.Desktop;
+using DownKyi.Core.Logging;
+using DownKyi.CustomControl;
+using DownKyi.Images;
+using DownKyi.Utils;
+using DownKyi.ViewModels.PageViewModels;
+
+namespace DownKyi.ViewModels;
+
+internal partial class ViewPublicationViewModel
+{
+    private string _inputSearchText = string.Empty;
+    private string _activeSearchText = string.Empty;
+    private PublicationNavigationPayload? _loadedPayload;
+    private bool _hasLoadedPage;
+    private bool _suppressTabSelection;
+    private RelayCommand? _searchCommand;
+
+    public string InputSearchText
+    {
+        get => _inputSearchText;
+        set => SetProperty(ref _inputSearchText, value);
+    }
+
+    public RelayCommand SearchCommand => _searchCommand ??= new RelayCommand(ExecuteSearch, () => IsEnabled);
+
+    private void ExecuteSearch()
+    {
+        var query = InputSearchText.Trim();
+        _activeSearchText = query;
+        ConfigurePager(1, string.IsNullOrEmpty(query) ? GetSelectedTabPageCount() : 1);
+    }
+
+    private void SelectPublicationType(TabHeader tabHeader)
+    {
+        InputSearchText = string.Empty;
+        _activeSearchText = string.Empty;
+        ConfigurePager(1, GetPageCount(tabHeader));
+    }
+
+    private void ConfigurePager(int current, int count)
+    {
+        _hasLoadedPage = false;
+        Pager = new CustomPagerViewModel(current, Math.Max(1, count));
+        Pager.Current = current;
+    }
+
+    private int GetSelectedTabPageCount()
+    {
+        return SelectTabId >= 0 && SelectTabId < TabHeaders.Count
+            ? GetPageCount(TabHeaders[SelectTabId])
+            : 1;
+    }
+
+    private static int GetPageCount(TabHeader tabHeader)
+    {
+        return int.TryParse(tabHeader.SubTitle, NumberStyles.Integer, CultureInfo.CurrentCulture, out var count)
+            ? Math.Max(1, (int)Math.Ceiling((double)count / VideoNumberInPage))
+            : 1;
+    }
+
+    private async Task UpdatePublicationAsync(int current)
+    {
+        if (SelectTabId < 0 || SelectTabId >= TabHeaders.Count)
+        {
+            return;
+        }
+
+        IsEnabled = false;
+        SearchCommand.NotifyCanExecuteChanged();
+        LoadingVisibility = true;
+        NoDataVisibility = false;
+        _hasLoadedPage = false;
+        var cancellationToken = ReplaceCancellationSource(ref _loadCancellation);
+        var tab = TabHeaders[SelectTabId];
+        try
+        {
+            var page = await _userSpaceCoordinator.LoadPublicationPageAsync(
+                _mid,
+                current,
+                VideoNumberInPage,
+                tab.Id,
+                _activeSearchText,
+                cancellationToken).ConfigureAwait(true);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            Medias.Clear();
+            Medias.AddRange(page.Medias);
+            IsSelectAll = false;
+            LoadingVisibility = false;
+            NoDataVisibility = page.Medias.Count == 0;
+            _hasLoadedPage = true;
+
+            var pageCount = Math.Max(1, (int)Math.Ceiling((double)page.TotalCount / VideoNumberInPage));
+            Pager.Count = Math.Max(current, pageCount);
+            if (string.IsNullOrEmpty(_activeSearchText))
+            {
+                tab.SubTitle = page.TotalCount.ToString(CultureInfo.CurrentCulture);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception e) when (e is HttpRequestException or InvalidOperationException or ArgumentException
+            or FormatException or Newtonsoft.Json.JsonException)
+        {
+            LoadingVisibility = false;
+            NoDataVisibility = Medias.Count == 0;
+            _logger.LogErrorMessage("Publication page loading failed.", e);
+        }
+        finally
+        {
+            IsEnabled = true;
+            SearchCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    private void InitView()
+    {
+        ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
+        DownloadManage = ButtonIcon.Instance().DownloadManage;
+        DownloadManage.Height = 24;
+        DownloadManage.Width = 24;
+        DownloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
+        TabHeaders.Clear();
+        Medias.Clear();
+        SelectTabId = -1;
+        IsSelectAll = false;
+        InputSearchText = string.Empty;
+        _activeSearchText = string.Empty;
+        _hasLoadedPage = false;
+    }
+
+    public override void OnNavigatedTo(AppNavigationContext navigationContext)
+    {
+        ArgumentNullException.ThrowIfNull(navigationContext);
+        base.OnNavigatedTo(navigationContext);
+
+        if (navigationContext.Parameter is not PublicationNavigationPayload payload)
+        {
+            NoDataVisibility = true;
+            return;
+        }
+
+        ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
+        if (Equals(_loadedPayload, payload))
+        {
+            if (!_hasLoadedPage)
+            {
+                RunFireAndForget(UpdatePublicationAsync(Pager.Current), nameof(UpdatePublicationAsync), _logger);
+            }
+
+            return;
+        }
+
+        InitView();
+        _loadedPayload = payload;
+        _mid = payload.Mid;
+        if (payload.Zones.Count == 0)
+        {
+            TabHeaders.Add(new TabHeader
+            {
+                Id = 0,
+                Title = DictionaryResource.GetString("AllPublicationZones"),
+                SubTitle = "0"
+            });
+        }
+        else
+        {
+            foreach (var zone in payload.Zones)
+            {
+                TabHeaders.Add(new TabHeader
+                {
+                    Id = zone.TypeId,
+                    Title = zone.Name,
+                    SubTitle = zone.Count.ToString(CultureInfo.CurrentCulture)
+                });
+            }
+        }
+
+        var selectedTab = TabHeaders.FirstOrDefault(item => item.Id == payload.SelectedTypeId);
+        if (selectedTab == null)
+        {
+            NoDataVisibility = true;
+            return;
+        }
+
+        _suppressTabSelection = true;
+        try
+        {
+            SelectTabId = TabHeaders.IndexOf(selectedTab);
+        }
+        finally
+        {
+            _suppressTabSelection = false;
+        }
+
+        ConfigurePager(1, GetPageCount(selectedTab));
+    }
+}

--- a/DownKyi/ViewModels/ViewPublicationViewModel.cs
+++ b/DownKyi/ViewModels/ViewPublicationViewModel.cs
@@ -1,8 +1,6 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -20,12 +18,11 @@ using DownKyi.Services.Media;
 using DownKyi.Services.UserSpace;
 using DownKyi.Utils;
 using DownKyi.ViewModels.PageViewModels;
-using DownKyi.ViewModels.UserSpace;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.ViewModels
 {
-    internal class ViewPublicationViewModel : ViewModelBase
+    internal partial class ViewPublicationViewModel : ViewModelBase
     {
         public const string Tag = "PagePublication";
         private readonly IContentDownloadCoordinator _downloadCoordinator;
@@ -234,14 +231,12 @@ namespace DownKyi.ViewModels
         /// <param name="parameter"></param>
         private void ExecuteLeftTabHeadersCommand(object parameter)
         {
-            if (parameter is not TabHeader tabHeader)
+            if (_suppressTabSelection || parameter is not TabHeader tabHeader)
             {
                 return;
             }
 
-            // 页面选择
-            Pager = new CustomPagerViewModel(1, (int)Math.Ceiling(double.Parse(tabHeader.SubTitle, CultureInfo.CurrentCulture) / VideoNumberInPage));
-            Pager.Current = 1;
+            SelectPublicationType(tabHeader);
         }
 
         /// <summary>
@@ -377,113 +372,6 @@ namespace DownKyi.ViewModels
                 UpdatePublicationAsync(((CustomPagerViewModel)sender!).ProposedCurrent),
                 nameof(UpdatePublicationAsync),
                 _logger);
-        }
-
-        private async Task UpdatePublicationAsync(int current)
-        {
-            IsEnabled = false;
-            var cancellationToken = ReplaceCancellationSource(ref _loadCancellation);
-            var tab = TabHeaders[SelectTabId];
-            try
-            {
-                var medias = await _userSpaceCoordinator.LoadPublicationPageAsync(
-                    _mid,
-                    current,
-                    VideoNumberInPage,
-                    tab.Id,
-                    cancellationToken).ConfigureAwait(true);
-                cancellationToken.ThrowIfCancellationRequested();
-                LoadingVisibility = false;
-                if (medias.Count == 0)
-                {
-                    NoDataVisibility = true;
-                    return;
-                }
-
-                Medias.AddRange(medias);
-                NoDataVisibility = false;
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                return;
-            }
-            catch (Exception e) when (e is HttpRequestException or InvalidOperationException or ArgumentException
-                or FormatException or Newtonsoft.Json.JsonException)
-            {
-                LoadingVisibility = false;
-                NoDataVisibility = true;
-                _logger.LogErrorMessage("Publication page loading failed.", e);
-            }
-            finally
-            {
-                IsEnabled = true;
-            }
-        }
-
-        /// <summary>
-        /// 初始化页面数据
-        /// </summary>
-        private void InitView()
-        {
-            ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
-
-            DownloadManage = ButtonIcon.Instance().DownloadManage;
-            DownloadManage.Height = 24;
-            DownloadManage.Width = 24;
-            DownloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
-
-            TabHeaders.Clear();
-            Medias.Clear();
-            SelectTabId = -1;
-            IsSelectAll = false;
-        }
-
-        /// <summary>
-        /// 导航到页面时执行
-        /// </summary>
-        /// <param name="navigationContext"></param>
-        public override void OnNavigatedTo(AppNavigationContext navigationContext)
-        {
-            ArgumentNullException.ThrowIfNull(navigationContext);
-            base.OnNavigatedTo(navigationContext);
-
-            // 根据传入参数不同执行不同任务
-            var parameter = navigationContext.Parameters.GetValue<Dictionary<string, object>>("Parameter");
-            if (parameter == null)
-            {
-                return;
-            }
-
-            InitView();
-
-            _mid = (long)parameter["mid"];
-            var tid = (int)parameter["tid"];
-            var zones = (List<PublicationZone>)parameter["list"];
-
-            foreach (var item in zones)
-            {
-                TabHeaders.Add(new TabHeader
-                {
-                    Id = item.Tid,
-                    Title = item.Name,
-                    SubTitle = item.Count.ToString(CultureInfo.CurrentCulture)
-                });
-            }
-
-            // 初始选中项
-            var selectTab = TabHeaders.FirstOrDefault(item => item.Id == tid);
-            if (selectTab == null)
-            {
-                NoDataVisibility = true;
-                return;
-            }
-
-            SelectTabId = TabHeaders.IndexOf(selectTab);
-
-            // 页面选择
-            Pager = new CustomPagerViewModel(1,
-            (int)Math.Ceiling(double.Parse(selectTab.SubTitle, CultureInfo.CurrentCulture) / VideoNumberInPage));
-            Pager.Current = 1;
         }
 
         public override void OnNavigatedFrom(AppNavigationContext navigationContext)

--- a/DownKyi/Views/ViewMyFavorites.axaml
+++ b/DownKyi/Views/ViewMyFavorites.axaml
@@ -235,11 +235,30 @@
                 Name="NameMediaPanel"
                 Grid.Column="1"
                 IsVisible="{Binding MediaContentVisibility}"
-                RowDefinitions="*,1,50">
+                RowDefinitions="50,*,1,50">
+
+                <Grid Grid.Row="0" Margin="12,8" ColumnDefinitions="*,80">
+                    <TextBox
+                        Grid.Column="0"
+                        IsEnabled="{Binding IsEnabled}"
+                        PlaceholderText="{DynamicResource SearchVideoByName}"
+                        Text="{Binding InputSearchText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                        <TextBox.KeyBindings>
+                            <KeyBinding Command="{Binding SearchCommand}" Gesture="Enter" />
+                        </TextBox.KeyBindings>
+                    </TextBox>
+                    <Button
+                        Grid.Column="1"
+                        Margin="8,0,0,0"
+                        Command="{Binding SearchCommand}"
+                        Content="{DynamicResource Search}"
+                        Foreground="{DynamicResource BrushText}"
+                        Theme="{StaticResource BtnStyle}" />
+                </Grid>
 
                 <ListBox
                     x:Name="NameMedias"
-                    Grid.Row="0"
+                    Grid.Row="1"
                     BorderThickness="0"
                     ItemsSource="{Binding Medias}"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled"
@@ -279,9 +298,9 @@
                     </ListBox.Theme>
                 </ListBox>
 
-                <TextBlock Grid.Row="1" Background="{DynamicResource BrushBorder}" />
+                <TextBlock Grid.Row="2" Background="{DynamicResource BrushBorder}" />
 
-                <Grid Grid.Row="2" ColumnDefinitions="80,*,100,90">
+                <Grid Grid.Row="3" ColumnDefinitions="80,*,100,90">
                     <CheckBox
                         Grid.Column="0"
                         Margin="10,0,0,0"

--- a/DownKyi/Views/ViewPublication.axaml
+++ b/DownKyi/Views/ViewPublication.axaml
@@ -187,11 +187,30 @@
                 </Interaction.Behaviors>
             </ListBox>
 
-            <Grid Name="NameMediaPanel" Grid.Column="1" RowDefinitions="*,1,50">
+            <Grid Name="NameMediaPanel" Grid.Column="1" RowDefinitions="50,*,1,50">
+
+                <Grid Grid.Row="0" Margin="12,8" ColumnDefinitions="*,80">
+                    <TextBox
+                        Grid.Column="0"
+                        IsEnabled="{Binding IsEnabled}"
+                        PlaceholderText="{DynamicResource SearchVideoByName}"
+                        Text="{Binding InputSearchText, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}">
+                        <TextBox.KeyBindings>
+                            <KeyBinding Command="{Binding SearchCommand}" Gesture="Enter" />
+                        </TextBox.KeyBindings>
+                    </TextBox>
+                    <Button
+                        Grid.Column="1"
+                        Margin="8,0,0,0"
+                        Command="{Binding SearchCommand}"
+                        Content="{DynamicResource Search}"
+                        Foreground="{DynamicResource BrushText}"
+                        Theme="{StaticResource BtnStyle}" />
+                </Grid>
 
                 <ListBox
                     x:Name="NameMedias"
-                    Grid.Row="0"
+                    Grid.Row="1"
                     BorderThickness="0"
                     ItemsSource="{Binding Medias}"
                     ItemContainerTheme="{StaticResource MediaListStyle}"
@@ -232,7 +251,7 @@
 
                 <!--  加载gif  -->
                 <StackPanel
-                    Grid.Row="0"
+                    Grid.Row="1"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Vertical"
@@ -251,13 +270,13 @@
 
                 <!--  没有数据提示  -->
                 <Image
-                    Grid.Row="0"
+                    Grid.Row="1"
                     Width="256"
                     Height="256"
                     Source="/Resources/no-data.png"
                     IsVisible="{Binding NoDataVisibility}" />
-                <TextBlock Grid.Row="1" Background="{DynamicResource BrushBorder}" />
-                <Grid Grid.Row="2" ColumnDefinitions="80,*,100,90">
+                <TextBlock Grid.Row="2" Background="{DynamicResource BrushBorder}" />
+                <Grid Grid.Row="3" ColumnDefinitions="80,*,100,90">
                     <CheckBox
                         Grid.Column="0"
                         Margin="10,0,0,0"

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -710,6 +710,7 @@ id: viewmodel.favorites
 type: viewmodel
 paths:
   - DownKyi/ViewModels/ViewMyFavoritesViewModel.cs
+  - DownKyi/ViewModels/ViewMyFavoritesViewModel.Search.cs
   - DownKyi/ViewModels/ViewPublicFavoritesViewModel.cs
   - DownKyi/ViewModels/FavoritesSelectionPolicy.cs
   - DownKyi/Views/ViewMyFavorites.axaml
@@ -729,6 +730,8 @@ contracts:
   - Favorite lists use `Multiple,Toggle`, so an ordinary click toggles each selected item without a modifier key.
   - API media marked unavailable by `attr` or the exact masked title remain visible for diagnostics, but cannot be selected, opened, or converted into download items.
   - Selection and download projection pass through `FavoritesSelectionPolicy`; unavailable rows cannot re-enter the workflow through Select All or stale selection state.
+  - Private-favorite keyword search passes a trimmed query to the API; because `media_count` remains the unfiltered folder total, filtered paging expands only from the response `has_more` marker.
+  - Typed back navigation restores the same ViewModel, query, page, and media projection; a canceled page is reloaded on return without clearing a completed snapshot.
 hazards:
   - Mutating observable collections from the worker thread can fault Avalonia bindings and leave stale rows after navigation.
   - Starting parse/add before checking a null directory performs work after the user explicitly canceled.
@@ -758,6 +761,8 @@ contracts:
   - Pre-canceled requests cannot start legacy synchronous API work.
   - Unavailable favorite videos preserve API title, cover, identifier, and availability state instead of disappearing or being represented as valid media.
   - Timestamp/number projection preserves the existing UI contract.
+  - `IFavoritesService` is the injectable API boundary for page search and all-media retrieval; the coordinator does not call the static endpoint facade directly.
+  - Favorite page snapshots retain `has_more`; they never reinterpret the folder-wide `media_count` as a filtered total.
 hazards:
   - Legacy synchronous Bilibili calls cannot abort in flight; cancellation prevents subsequent calls and stale UI projection.
   - API model and UI model both use `FavoritesMedia`; aliases must remain explicit at the mapping boundary.
@@ -1017,6 +1022,7 @@ id: service.typed-navigation
 type: service
 paths:
   - src/DownKyi.Application/Desktop/IAppNavigationService.cs
+  - src/DownKyi.Application/Desktop/PublicationNavigationPayload.cs
   - DownKyi/Platform/AvaloniaNavigationService.cs
   - DownKyi/ViewModels/ViewModelBase.cs
 responsibility: Maps typed routes to DI-created ViewModels, owns bounded main-region instance history, and provides history-first back navigation with typed parent fallback.
@@ -1029,6 +1035,7 @@ contracts:
   - `GoBack` removes and disposes the current entry, restores the exact previous ViewModel instance, and never appends another entry.
   - Main-region history is bounded; nested regions replace and dispose content instead of accumulating back history.
   - A ViewModel calls its typed `ParentRoute` only after `TryNavigateBack()` reports that no previous entry exists.
+  - Publication navigation carries MID, selected type, and zones in `PublicationNavigationPayload`; raw dictionaries and UI-model payloads are prohibited on this route.
 hazards:
   - Calling parent navigation directly from a back command creates duplicate A/B instances and an ever-growing forward journal.
   - Sharing mutable icon state between page instances can make a restored page inherit another page's theme mutation.
@@ -1126,6 +1133,7 @@ id: viewmodel.user-space-pages
 type: viewmodel
 paths:
   - DownKyi/ViewModels/ViewPublicationViewModel.cs
+  - DownKyi/ViewModels/ViewPublicationViewModel.Search.cs
   - DownKyi/ViewModels/ViewMySpaceViewModel.cs
   - DownKyi/ViewModels/ViewMyBangumiFollowViewModel.cs
   - DownKyi/Views/ViewPublication.axaml
@@ -1143,6 +1151,8 @@ contracts:
   - Replacing/leaving publication or bangumi pagers detaches handlers and cancels page/download work.
   - My-space renders the primary profile first; balance/relation failure does not hide an already loaded profile.
   - Canceling publication directory selection returns before media parsing.
+  - Publication keyword search uses the WBI endpoint's exact `page.count` and applies one batch projection.
+  - Returning from a child route preserves the same query, page, and media instances; only an interrupted page request is resumed.
 hazards:
   - Per-item dispatcher calls stutter on large publication pages and can project stale rows after navigation.
   - Worker-thread mutation of profile properties and `StatusList` is unsafe for Avalonia bindings.
@@ -1163,6 +1173,7 @@ paths:
   - DownKyi.Core/BiliApi/Users/UserSpace.cs
   - DownKyi.Core/BiliApi/Users/UserInfo.cs
   - DownKyi.Core/BiliApi/Users/UserStatus.cs
+  - DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.UserVideoList.cs
 responsibility: Loads publication, signed-in profile, balance, and relation data off the UI thread and returns immutable snapshots.
 inbound:
   - viewmodel.user-space-pages
@@ -1172,6 +1183,8 @@ contracts:
   - Publication, bangumi-follow, settings, my-info, navigation-info, and relation-stat requests pass cancellation to the HTTP boundary.
   - Pre-canceled requests cannot start API work and mapping checks cancellation between publication items.
   - Profile and statistics are separate operations so secondary API latency does not delay first content.
+  - A bare `bilibili.com/list/<positive MID>` maps to all publications. A list URL with non-empty `sid` is a series contract and is not guessed as all publications.
+  - Publication page snapshots preserve the server's exact filtered total and the coordinator forwards the active keyword into WBI signing.
 hazards:
   - `Services.UserSpace` and the core `UserSpace` API share a name; use an explicit alias at the boundary.
   - Legacy custom publication JSON handling remains because Bilibili sometimes returns `"--"` for play counts.
@@ -1347,6 +1360,8 @@ type: core
 paths:
   - DownKyi.Core/BiliApi
   - DownKyi.Core/BiliApi/BiliApiRequest.cs
+  - DownKyi.Core/BiliApi/Favorites/FavoritesResource.cs
+  - DownKyi.Core/BiliApi/Users/UserSpace.cs
 responsibility: Wraps Bilibili API endpoints, response parsing, and shared request failure handling.
 inbound:
   - service.info-services
@@ -1367,6 +1382,7 @@ contracts:
   - WBI request signatures must match the fixed protocol vector; MD5 is limited to that external format.
   - WBI endpoint methods receive explicit keys and timestamp; signing cannot read settings or initialize user state.
   - Optional `data`/`result` fields remain nullable, and each endpoint selects its documented field before validating a non-empty payload.
+  - Publication search uses `x/space/wbi/arc/search` and retains `data.page.count`; favorite search uses `x/v3/fav/resource/list` and retains `data.has_more`.
 hazards:
   - Bilibili schema changes must fail at this boundary rather than deserialize into a plausible empty success object.
   - Logging full URLs can leak tokens, cookies, and personal query data.
@@ -2251,6 +2267,8 @@ test.favorites:
   paths:
     - tests/DownKyi.Tests/FavoritesCoordinatorTests.cs
     - tests/DownKyi.Tests/FavoritesServiceTests.cs
+    - tests/DownKyi.Core.Tests/FavoritesSearchContractTests.cs
+    - tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
     - tests/DownKyi.Architecture.Tests/MediaAndHttpRuntimeArchitectureTests.cs
   guards:
     - pre-canceled private/public favorite requests cannot start API work
@@ -2258,6 +2276,7 @@ test.favorites:
     - favorite services return snapshots rather than mutating observable collections
     - directory cancellation precedes shared download coordination and list selection remains click-toggle capable
     - unavailable media remains visible but cannot be opened, selected, or included in a download snapshot
+    - keyword encoding and `has_more` paging are deterministic and returning from a child route preserves the filtered page instance
 
 test.user-space-favorites:
   paths:
@@ -2279,6 +2298,7 @@ test.typed-navigation:
     - main-region back commands use history first and typed parent fallback only without history
     - repeated back operations cannot add forward navigation records
     - every production main-region ViewModel retains the history-first back pattern
+    - publication and private-favorite search state retains query, page, media identity, and the original ViewModel across typed back navigation
 
 test.personal-media:
   paths:
@@ -2293,12 +2313,17 @@ test.personal-media:
 test.user-space-pages:
   paths:
     - tests/DownKyi.Tests/UserSpacePageCoordinatorTests.cs
+    - tests/DownKyi.Core.Tests/UserVideoListUrlTests.cs
+    - tests/DownKyi.Core.Tests/PublicationSearchContractTests.cs
+    - tests/DownKyi.Core.Tests/BiliApi/JsonSamples/space-publication-search.json
     - tests/DownKyi.Architecture.Tests/MediaAndHttpRuntimeArchitectureTests.cs
   guards:
     - pre-canceled publication, bangumi-follow, profile, and statistics requests cannot start API work
     - publication, bangumi-follow, and my-space ViewModels cannot regain Task.Run, App dispatch, or worker-thread binding mutation
     - core user-space account/stat APIs preserve cancellation through the HTTP boundary
     - publication batching, pager cleanup, directory cancellation ordering, and click-toggle selection remain stable
+    - numeric list parsing rejects favorites, foreign hosts, malformed paths, and series `sid` URLs
+    - publication search preserves the WBI response total and typed media identity without a real network dependency
 
 test.legacy-upgrade:
   paths:

--- a/docs/design-docs/README.md
+++ b/docs/design-docs/README.md
@@ -3,6 +3,7 @@
 此目錄保存架構決策、邊界審查與設計方案。
 
 - `module-boundary-naming-audit.md`：目前模組邊界與命名一致性審查。
+- `list-search-navigation.md`：數字 list URL、投稿／收藏搜尋與返回狀態保留的 typed-navigation 決策。
 - 根層 `ARCHITECTURE.md`：目前與目標拓樸的權威入口。
 - `../ai-knowledge-graph.md`：細粒度節點、呼叫關係、契約與測試索引。
 

--- a/docs/design-docs/list-search-navigation.md
+++ b/docs/design-docs/list-search-navigation.md
@@ -1,0 +1,57 @@
+# List Search And Navigation State
+
+Status: implemented on Gate 2 branch
+Last updated: 2026-07-22
+
+## Goal
+
+Port the user-visible behavior requested by PR #79 and PR #80 into the current Microsoft DI, CommunityToolkit MVVM and typed-navigation architecture without merging their Prism-era implementation.
+
+## Stable Contracts
+
+- A bare `https://www.bilibili.com/list/<positive MID>` input navigates to all publications for that uploader.
+- A list URL with a non-empty `sid` is not treated as all publications. Its series contract remains pending the Bilibili API audit.
+- Publication navigation carries `PublicationNavigationPayload`; no dictionary parameters, string view names or Prism navigation objects are permitted.
+- Publication search uses the WBI response `page.count` as the filtered total.
+- Private-favorite search does not use `media_count` as a filtered total because the endpoint reports the folder total. The pager expands from `has_more` one page at a time.
+- Returning through main-region history restores the same View and ViewModel instances. Query, page number and media object identity remain unchanged.
+- Leaving a page cancels in-flight work. A canceled incomplete page reloads when restored; a completed snapshot does not issue a duplicate request.
+- These changes do not modify settings, SQLite schemas, download records, unfinished task state or resume files.
+
+## Flow
+
+```mermaid
+flowchart LR
+    Input["Search input"] --> Parser["ParseEntrance numeric list parser"]
+    Parser --> Payload["PublicationNavigationPayload"]
+    Payload --> Router["AvaloniaNavigationService"]
+    Router --> Publication["Publication ViewModel snapshot"]
+    Publication --> WBI["UserSpace publication API"]
+    WBI --> Projector["Publication media projection"]
+    Favorite["Private favorites ViewModel"] --> FavoriteApi["Injected favorites service"]
+    FavoriteApi --> FavoriteSnapshot["Media plus has_more"]
+    Child["Child media route"] --> Back["Typed history GoBack"]
+    Back --> Publication
+    Back --> Favorite
+```
+
+## Failure Behavior
+
+- Malformed, foreign-host, non-numeric, zero and series list inputs are rejected instead of being guessed.
+- Cancellation preserves cancellation semantics and is not logged as an operational failure.
+- HTTP, JSON and contract failures are logged with operation context; no empty DTO is manufactured as success.
+- Search state is changed only by explicit query or folder/type selection. Programmatic initial tab selection cannot trigger a duplicate API request.
+
+## Verification
+
+- Parser and routing tests cover valid and rejected list inputs.
+- Fixed JSON fixtures protect publication search totals and media mapping.
+- Coordinator tests protect keyword forwarding, `has_more`, exact totals and media identity.
+- Headless Avalonia tests navigate to a child route and back, then assert the original ViewModel, query, page and media object.
+- Architecture tests prevent Prism, legacy routes and source-file size debt from returning.
+
+Final Gate 2 local result: strict Release build `0 warning / 0 error`; `536/536` tests passed; format changed `0/738` files; NuGet reported no vulnerable or deprecated packages.
+
+## Rollback
+
+Revert the Gate 2 integration PR. No persistent user-data migration is required because this feature changes only input parsing, API projections and in-memory navigation state.

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -3,7 +3,7 @@
 Status: active
 Last updated: 2026-07-22
 Current group: PR #79/#80 typed integration
-Current branch: `refactor/gate-02-list-search-navigation` (create after PR #82 merges)
+Current branch: `refactor/gate-02-list-search-navigation`
 
 This file contains only unfinished or not-yet-integrated work. Completed PR 02-32 items are not restored. Design rationale belongs in `design-docs`; product acceptance belongs in `product-specs`.
 
@@ -26,6 +26,15 @@ No release tag may be created while any release blocker below remains.
 Required base: `refactor/pr-30-32-release-hardening` or its approved successor after Gate 0/1.
 
 Owner branch: `refactor/gate-02-list-search-navigation`
+
+Progress (2026-07-22):
+
+- Implemented strict bare `/list/<mid>` parsing and typed publication navigation; series URLs with `sid` are intentionally rejected until Gate 3 audits their endpoint contract.
+- Implemented private-favorites and publication search with cancellation-aware page snapshots.
+- Implemented exact publication totals and `has_more`-driven incremental favorite search paging because the favorite API reports the unfiltered folder total during keyword search.
+- Added headless back-navigation tests proving query, page number, media object identity, and the original ViewModel instance survive child navigation.
+- Final local verification is green: strict Release build `0 warning / 0 error`, all `536/536` tests, architecture tests `169/169`, format `0/738` changed files, clean dependency vulnerability/deprecation audits, module-boundary inventory, and `git diff --check`.
+- The remaining Gate 2 work is publishing the integration PR, waiting for remote CI, superseding PR #79/#80, and merging into the stacked architecture base.
 
 Scope:
 

--- a/src/DownKyi.Application/Desktop/PublicationNavigationPayload.cs
+++ b/src/DownKyi.Application/Desktop/PublicationNavigationPayload.cs
@@ -1,0 +1,22 @@
+namespace DownKyi.Application.Desktop;
+
+public sealed record PublicationNavigationZone(
+    long TypeId,
+    string Name,
+    int Count);
+
+public sealed record PublicationNavigationPayload(
+    long Mid,
+    long SelectedTypeId,
+    IReadOnlyList<PublicationNavigationZone> Zones)
+{
+    public static PublicationNavigationPayload All(long mid)
+    {
+        if (mid <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(mid), mid, "The uploader MID must be positive.");
+        }
+
+        return new PublicationNavigationPayload(mid, 0, Array.Empty<PublicationNavigationZone>());
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/MediaAndHttpRuntimeArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/MediaAndHttpRuntimeArchitectureTests.cs
@@ -549,6 +549,11 @@ public sealed class MediaAndHttpRuntimeArchitectureTests
             "DownKyi",
             "ViewModels",
             "ViewPublicationViewModel.cs");
+        var publicationSearchPath = Path.Combine(
+            RepositoryRoot,
+            "DownKyi",
+            "ViewModels",
+            "ViewPublicationViewModel.Search.cs");
         var mySpacePath = Path.Combine(
             RepositoryRoot,
             "DownKyi",
@@ -559,9 +564,13 @@ public sealed class MediaAndHttpRuntimeArchitectureTests
             "DownKyi",
             "ViewModels",
             "ViewMyBangumiFollowViewModel.cs");
-        var viewModelSource = string.Join(
+        var publicationSource = string.Join(
             Environment.NewLine,
             File.ReadAllText(publicationPath),
+            File.ReadAllText(publicationSearchPath));
+        var viewModelSource = string.Join(
+            Environment.NewLine,
+            publicationSource,
             File.ReadAllText(mySpacePath),
             File.ReadAllText(bangumiPath));
         var coordinatorSource = File.ReadAllText(Path.Combine(
@@ -576,8 +585,8 @@ public sealed class MediaAndHttpRuntimeArchitectureTests
         Assert.DoesNotContain("PropertyChangeAsync(", viewModelSource, StringComparison.Ordinal);
         Assert.Contains("IUserSpacePageCoordinator", viewModelSource, StringComparison.Ordinal);
         Assert.Contains("IContentDownloadCoordinator", File.ReadAllText(publicationPath), StringComparison.Ordinal);
-        Assert.Contains("Medias.AddRange", File.ReadAllText(publicationPath), StringComparison.Ordinal);
-        Assert.Contains("CurrentChanging -=", File.ReadAllText(publicationPath), StringComparison.Ordinal);
+        Assert.Contains("Medias.AddRange", publicationSource, StringComparison.Ordinal);
+        Assert.Contains("CurrentChanging -=", publicationSource, StringComparison.Ordinal);
         Assert.Contains("LoadMyProfileAsync", File.ReadAllText(mySpacePath), StringComparison.Ordinal);
         Assert.Contains("LoadMyStatsAsync", File.ReadAllText(mySpacePath), StringComparison.Ordinal);
         Assert.Contains("LoadBangumiFollowPageAsync", File.ReadAllText(bangumiPath), StringComparison.Ordinal);

--- a/tests/DownKyi.Core.Tests/BiliApi/JsonSamples/space-publication-search.json
+++ b/tests/DownKyi.Core.Tests/BiliApi/JsonSamples/space-publication-search.json
@@ -1,0 +1,28 @@
+{
+  "code": 0,
+  "message": "0",
+  "ttl": 1,
+  "data": {
+    "list": {
+      "tlist": {},
+      "vlist": [
+        {
+          "typeid": 1,
+          "play": 12,
+          "pic": "https://example.invalid/cover.jpg",
+          "title": "fixture publication",
+          "mid": 42,
+          "created": 1700000000,
+          "length": "01:30",
+          "aid": 100,
+          "bvid": "BV1fixture01"
+        }
+      ]
+    },
+    "page": {
+      "pn": 2,
+      "ps": 30,
+      "count": 35
+    }
+  }
+}

--- a/tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj
+++ b/tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj
@@ -24,6 +24,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="BiliApi\JsonSamples\space-publication-search.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/tests/DownKyi.Core.Tests/FavoritesSearchContractTests.cs
+++ b/tests/DownKyi.Core.Tests/FavoritesSearchContractTests.cs
@@ -1,0 +1,27 @@
+using DownKyi.Core.BiliApi.Favorites;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class FavoritesSearchContractTests
+{
+    [Fact]
+    public void SearchUrlTrimsAndEscapesKeyword()
+    {
+        var url = FavoritesResource.BuildFavoritesMediaUrl(42, 2, 20, "  C# 教程  ");
+
+        Assert.Equal(
+            "https://api.bilibili.com/x/v3/fav/resource/list?media_id=42&pn=2&ps=20&platform=web&keyword=C%23%20%E6%95%99%E7%A8%8B",
+            url);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EmptySearchDoesNotAddKeyword(string? keyword)
+    {
+        var url = FavoritesResource.BuildFavoritesMediaUrl(42, 1, 20, keyword);
+
+        Assert.DoesNotContain("keyword=", url, StringComparison.Ordinal);
+    }
+}

--- a/tests/DownKyi.Core.Tests/PublicationSearchContractTests.cs
+++ b/tests/DownKyi.Core.Tests/PublicationSearchContractTests.cs
@@ -1,0 +1,23 @@
+using DownKyi.Core.BiliApi.Users.Models;
+using Newtonsoft.Json;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class PublicationSearchContractTests
+{
+    [Fact]
+    public void FixturePreservesSearchPageCountAndMedia()
+    {
+        var json = File.ReadAllText(Path.Combine(
+            AppContext.BaseDirectory,
+            "BiliApi",
+            "JsonSamples",
+            "space-publication-search.json"));
+        var origin = JsonConvert.DeserializeObject<SpacePublicationOrigin>(json);
+
+        Assert.NotNull(origin?.Data);
+        Assert.Equal(35, origin.Data.Page.Count);
+        Assert.Equal(2, origin.Data.Page.Pn);
+        Assert.Equal("BV1fixture01", Assert.Single(origin.Data.List.Vlist!).Bvid);
+    }
+}

--- a/tests/DownKyi.Core.Tests/UserVideoListUrlTests.cs
+++ b/tests/DownKyi.Core.Tests/UserVideoListUrlTests.cs
@@ -1,0 +1,31 @@
+using DownKyi.Core.BiliApi.BiliUtils;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class UserVideoListUrlTests
+{
+    [Theory]
+    [InlineData("https://www.bilibili.com/list/3546801722362343", 3546801722362343)]
+    [InlineData("https://www.bilibili.com/list/42/", 42)]
+    [InlineData("https://m.bilibili.com/list/42?spm_id_from=333.999.0.0", 42)]
+    [InlineData("http://bilibili.com/list/42", 42)]
+    public void BareNumericListUrlReturnsUploaderMid(string input, long expectedMid)
+    {
+        Assert.True(ParseEntrance.IsUserVideoListUrl(input));
+        Assert.Equal(expectedMid, ParseEntrance.GetUserVideoListId(input));
+    }
+
+    [Theory]
+    [InlineData("https://www.bilibili.com/list/ml1329019876")]
+    [InlineData("https://www.bilibili.com/list/42?sid=99")]
+    [InlineData("https://www.bilibili.com/list/42/video")]
+    [InlineData("https://evil.example/list/42")]
+    [InlineData("https://www.bilibili.com/list/0")]
+    [InlineData("https://www.bilibili.com/list/-1")]
+    [InlineData("not a url")]
+    public void NonUploaderListInputIsRejected(string input)
+    {
+        Assert.False(ParseEntrance.IsUserVideoListUrl(input));
+        Assert.Equal(-1, ParseEntrance.GetUserVideoListId(input));
+    }
+}

--- a/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
+++ b/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
@@ -19,6 +19,8 @@ using DownKyi.Infrastructure.Downloads;
 using DownKyi.Platform;
 using DownKyi.Services;
 using DownKyi.Services.Download;
+using DownKyi.Services.Media;
+using DownKyi.Services.UserSpace;
 using DownKyi.ViewModels;
 using DownKyi.ViewModels.PageViewModels;
 using DownKyi.ViewModels.Settings;
@@ -32,6 +34,101 @@ namespace DownKyi.Desktop.Tests;
 
 public sealed class UiSmokeTests
 {
+    [Fact]
+    public async Task PublicationSearchPageAndSnapshotSurviveTypedBackNavigation()
+    {
+        await HeadlessUiTestHost.RunAsync(() =>
+        {
+            EnsureProductThemeResources();
+            ViewPublicationViewModel? publication = null;
+            using var navigation = new AvaloniaNavigationService(
+                route => route switch
+                {
+                    AppRoute.Publication => publication!,
+                    AppRoute.VideoDetail => new NavigationProbe(route),
+                    _ => throw new InvalidOperationException($"Unexpected route {route}.")
+                },
+                static action => action());
+            var coordinator = new PublicationPageCoordinatorStub(navigation);
+            publication = new ViewPublicationViewModel(
+                new DesktopInteractionContextStub(navigation),
+                new ContentDownloadCoordinatorStub(),
+                coordinator,
+                NullLogger<ViewPublicationViewModel>.Instance);
+            var payload = PublicationNavigationPayload.All(42);
+
+            navigation.Navigate(new AppNavigationRequest(AppRoute.Publication, AppRoute.Index, payload));
+            publication.InputSearchText = "needle";
+            publication.SearchCommand.Execute(null);
+            publication.Pager.Current = 2;
+            var originalMedia = Assert.Single(publication.Medias);
+
+            navigation.Navigate(new AppNavigationRequest(AppRoute.VideoDetail, AppRoute.Publication, "video"));
+            navigation.GoBack(AppNavigationRegion.Main);
+
+            Assert.Same(publication, navigation.GetActiveView(AppNavigationRegion.Main));
+            Assert.Equal("needle", publication.InputSearchText);
+            Assert.Equal(2, publication.Pager.Current);
+            Assert.Same(originalMedia, Assert.Single(publication.Medias));
+            Assert.Equal("needle", coordinator.LastKeyword);
+            Assert.Equal(2, coordinator.LastPage);
+        }).ConfigureAwait(true);
+    }
+
+    [Fact]
+    public async Task FavoritesSearchPageAndSnapshotSurviveTypedBackNavigation()
+    {
+        await HeadlessUiTestHost.RunAsync(async () =>
+        {
+            EnsureProductThemeResources();
+            var directory = Path.Combine(Path.GetTempPath(), $"downkyi-favorites-state-{Guid.NewGuid():N}");
+            var settings = new SettingsStore(Path.Combine(directory, "settings.json"));
+            try
+            {
+                ViewMyFavoritesViewModel? favorites = null;
+                using var navigation = new AvaloniaNavigationService(
+                    route => route switch
+                    {
+                        AppRoute.MyFavorites => favorites!,
+                        AppRoute.VideoDetail => new NavigationProbe(route),
+                        _ => throw new InvalidOperationException($"Unexpected route {route}.")
+                    },
+                    static action => action());
+                var coordinator = new FavoritesCoordinatorStub(navigation, settings);
+                favorites = new ViewMyFavoritesViewModel(
+                    new DesktopInteractionContextStub(navigation),
+                    new ContentDownloadCoordinatorStub(),
+                    coordinator,
+                    NullLogger<ViewMyFavoritesViewModel>.Instance);
+
+                navigation.Navigate(new AppNavigationRequest(AppRoute.MyFavorites, AppRoute.Index, 42L));
+                favorites.InputSearchText = "needle";
+                favorites.SearchCommand.Execute(null);
+                favorites.Pager.Current = 2;
+                var originalMedia = Assert.Single(favorites.Medias);
+
+                navigation.Navigate(new AppNavigationRequest(AppRoute.VideoDetail, AppRoute.MyFavorites, "video"));
+                navigation.GoBack(AppNavigationRegion.Main);
+
+                Assert.Same(favorites, navigation.GetActiveView(AppNavigationRegion.Main));
+                Assert.Equal("needle", favorites.InputSearchText);
+                Assert.Equal(2, favorites.Pager.Current);
+                Assert.Same(originalMedia, Assert.Single(favorites.Medias));
+                Assert.Equal("needle", coordinator.LastKeyword);
+                Assert.Equal(2, coordinator.LastPage);
+            }
+            finally
+            {
+                await settings.DisposeAsync().ConfigureAwait(true);
+            }
+
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }).ConfigureAwait(true);
+    }
+
     [Fact]
     public Task PublicFavoritesBackArrowRemainsVisibleInLightAndDarkThemes()
     {
@@ -447,6 +544,143 @@ public sealed class UiSmokeTests
         public void Dispose()
         {
             IsDisposed = true;
+        }
+    }
+
+    private sealed class PublicationPageCoordinatorStub(IAppNavigationService navigation) : IUserSpacePageCoordinator
+    {
+        private readonly Dictionary<(string Keyword, int Page), PublicationMedia> _medias = [];
+
+        public string? LastKeyword { get; private set; }
+
+        public int LastPage { get; private set; }
+
+        public Task<PublicationPageSnapshot> LoadPublicationPageAsync(
+            long mid,
+            int page,
+            int pageSize,
+            long typeId,
+            string? keyword,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LastKeyword = keyword;
+            LastPage = page;
+            var key = (keyword ?? string.Empty, page);
+            if (!_medias.TryGetValue(key, out var media))
+            {
+                media = new PublicationMedia(navigation, AppRoute.Publication)
+                {
+                    Bvid = $"BV1fixture{page}",
+                    Title = $"fixture {page}"
+                };
+                _medias.Add(key, media);
+            }
+
+            return Task.FromResult(new PublicationPageSnapshot([media], string.IsNullOrEmpty(keyword) ? 60 : 35));
+        }
+
+        public Task<MySpaceProfileSnapshot?> LoadMyProfileAsync(long mid, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<MySpaceStatsSnapshot> LoadMyStatsAsync(long mid, CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
+        public Task<BangumiFollowPageSnapshot> LoadBangumiFollowPageAsync(
+            long mid,
+            DownKyi.Core.BiliApi.Users.Models.BangumiType type,
+            int page,
+            int pageSize,
+            CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+
+    private sealed class FavoritesCoordinatorStub(
+        IAppNavigationService navigation,
+        ISettingsStore settingsStore) : IFavoritesCoordinator
+    {
+        private readonly Dictionary<(string Keyword, int Page), FavoritesMedia> _medias = [];
+
+        public string? LastKeyword { get; private set; }
+
+        public int LastPage { get; private set; }
+
+        public Task<IReadOnlyList<TabHeader>> LoadFoldersAsync(long mid, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<IReadOnlyList<TabHeader>>(
+                [new TabHeader { Id = 7, Title = "fixture folder", SubTitle = "60" }]);
+        }
+
+        public Task<FavoritesMediaPageSnapshot> LoadMediaPageAsync(
+            long favoritesId,
+            int page,
+            int pageSize,
+            string? keyword,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LastKeyword = keyword;
+            LastPage = page;
+            var key = (keyword ?? string.Empty, page);
+            if (!_medias.TryGetValue(key, out var media))
+            {
+                media = new FavoritesMedia(navigation, AppRoute.MyFavorites, settingsStore)
+                {
+                    Bvid = $"BV1fixture{page}",
+                    Title = $"fixture {page}"
+                };
+                _medias.Add(key, media);
+            }
+
+            return Task.FromResult(new FavoritesMediaPageSnapshot([media], !string.IsNullOrEmpty(keyword) && page == 1));
+        }
+
+        public Task<PublicFavoritesSnapshot?> LoadPublicFavoritesAsync(
+            long favoritesId,
+            CancellationToken cancellationToken) => throw new NotSupportedException();
+    }
+
+    private sealed class ContentDownloadCoordinatorStub : IContentDownloadCoordinator
+    {
+        public Task<int?> AddAsync(
+            IReadOnlyList<ContentDownloadItem> items,
+            bool onlySelected,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult<int?>(0);
+        }
+    }
+
+    private sealed class DesktopInteractionContextStub(IAppNavigationService navigation) : IDesktopInteractionContext
+    {
+        public IUserNotificationService Notifications { get; } = new NotificationServiceStub();
+
+        public IAppNavigationService Navigation { get; } = navigation;
+
+        public IAppDialogService Dialogs { get; } = new DialogServiceStub();
+    }
+
+    private sealed class NotificationServiceStub : IUserNotificationService
+    {
+        public event EventHandler<UserNotificationEventArgs>? NotificationRaised;
+
+        public void Show(string message)
+        {
+            NotificationRaised?.Invoke(this, new UserNotificationEventArgs(message));
+        }
+    }
+
+    private sealed class DialogServiceStub : IAppDialogService
+    {
+        public Task<AppDialogResult> ShowAsync(
+            AppDialogRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new AppDialogResult(
+                AppDialogOutcome.Canceled,
+                new Dictionary<string, object?>()));
         }
     }
 }

--- a/tests/DownKyi.Tests/DesktopInteractionServiceTests.cs
+++ b/tests/DownKyi.Tests/DesktopInteractionServiceTests.cs
@@ -84,6 +84,35 @@ public sealed class DesktopInteractionServiceTests
         Assert.Empty(navigation.Requests);
     }
 
+    [Fact]
+    public void NumericListUrlUsesTypedPublicationPayload()
+    {
+        using var settings = new TestSettingsStore();
+        var navigation = new RecordingNavigationService();
+        var search = new SearchService(settings.Store, navigation);
+
+        Assert.True(search.BiliInput("https://www.bilibili.com/list/3546801722362343", AppRoute.Index));
+
+        var request = Assert.Single(navigation.Requests);
+        Assert.Equal(AppRoute.Publication, request.Route);
+        Assert.Equal(AppRoute.Index, request.Parent);
+        var payload = Assert.IsType<PublicationNavigationPayload>(request.Parameter);
+        Assert.Equal(3546801722362343, payload.Mid);
+        Assert.Equal(0, payload.SelectedTypeId);
+        Assert.Empty(payload.Zones);
+    }
+
+    [Fact]
+    public void SeriesListUrlDoesNotMasqueradeAsUploaderList()
+    {
+        using var settings = new TestSettingsStore();
+        var navigation = new RecordingNavigationService();
+        var search = new SearchService(settings.Store, navigation);
+
+        Assert.False(search.BiliInput("https://www.bilibili.com/list/42?sid=99", AppRoute.Index));
+        Assert.Empty(navigation.Requests);
+    }
+
     private sealed class RecordingNavigationService : IAppNavigationService
     {
         public event EventHandler<AppNavigationChangedEventArgs>? NavigationChanged

--- a/tests/DownKyi.Tests/FavoritesCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/FavoritesCoordinatorTests.cs
@@ -29,9 +29,40 @@ public sealed class FavoritesCoordinatorTests
             () => coordinator.LoadPublicFavoritesAsync(42, cancellation.Token));
     }
 
+    [Fact]
+    public async Task SearchPassesKeywordAndPreservesHasMore()
+    {
+        using var settings = new TestSettingsStore();
+        var service = new RecordingFavoritesService(settings);
+        var coordinator = new FavoritesCoordinator(service);
+
+        var page = await coordinator.LoadMediaPageAsync(42, 2, 20, "needle", CancellationToken.None);
+
+        Assert.Equal((42L, 2, 20, "needle"), service.LastRequest);
+        Assert.True(page.HasMore);
+        Assert.Single(page.Medias);
+    }
+
     private sealed class ThrowingFavoritesService : IFavoritesService
     {
         public FavoritesPageItem? GetFavorites(long mediaId, CancellationToken cancellationToken = default)
+        {
+            throw new InvalidOperationException("The API should not be called for a canceled request.");
+        }
+
+        public DownKyi.Core.BiliApi.Favorites.Models.FavoritesMediaResource GetFavoritesMediaPage(
+            long mediaId,
+            int page,
+            int pageSize,
+            string? keyword,
+            CancellationToken cancellationToken)
+        {
+            throw new InvalidOperationException("The API should not be called for a canceled request.");
+        }
+
+        public IReadOnlyList<ApiFavoritesMedia> GetAllFavoritesMedia(
+            long mediaId,
+            CancellationToken cancellationToken)
         {
             throw new InvalidOperationException("The API should not be called for a canceled request.");
         }
@@ -53,5 +84,54 @@ public sealed class FavoritesCoordinatorTests
         {
             throw new InvalidOperationException("The API should not be called for a canceled request.");
         }
+    }
+
+    private sealed class RecordingFavoritesService : IFavoritesService
+    {
+        private readonly TestSettingsStore _settings;
+
+        public RecordingFavoritesService(TestSettingsStore settings)
+        {
+            _settings = settings;
+        }
+
+        public (long MediaId, int Page, int PageSize, string? Keyword) LastRequest { get; private set; }
+
+        public FavoritesPageItem? GetFavorites(long mediaId, CancellationToken cancellationToken = default) => null;
+
+        public DownKyi.Core.BiliApi.Favorites.Models.FavoritesMediaResource GetFavoritesMediaPage(
+            long mediaId,
+            int page,
+            int pageSize,
+            string? keyword,
+            CancellationToken cancellationToken)
+        {
+            LastRequest = (mediaId, page, pageSize, keyword);
+            return new DownKyi.Core.BiliApi.Favorites.Models.FavoritesMediaResource
+            {
+                HasMore = true,
+                Medias = [new ApiFavoritesMedia { Id = 1, Bvid = "BV1fixture01", Title = "fixture" }]
+            };
+        }
+
+        public IReadOnlyList<ApiFavoritesMedia> GetAllFavoritesMedia(
+            long mediaId,
+            CancellationToken cancellationToken) => Array.Empty<ApiFavoritesMedia>();
+
+        public IReadOnlyList<FavoritesMedia> MapFavoritesMedia(
+            IReadOnlyList<ApiFavoritesMedia> medias,
+            AppRoute parentRoute,
+            CancellationToken cancellationToken)
+        {
+            return [new FavoritesMedia(new TestNavigationService(), parentRoute, _settings.Store)
+            {
+                Bvid = medias[0].Bvid,
+                Title = medias[0].Title
+            }];
+        }
+
+        public IReadOnlyList<TabHeader> GetCreatedFavorites(long mid, CancellationToken cancellationToken) => [];
+
+        public IReadOnlyList<TabHeader> GetCollectedFavorites(long mid, CancellationToken cancellationToken) => [];
     }
 }

--- a/tests/DownKyi.Tests/UserSpacePageCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/UserSpacePageCoordinatorTests.cs
@@ -19,7 +19,42 @@ public sealed class UserSpacePageCoordinatorTests
             1,
             30,
             0,
+            null,
             cancellation.Token));
+    }
+
+    [Fact]
+    public void PublicationMappingPreservesServerTotalAndMediaIdentity()
+    {
+        var publication = new SpacePublication
+        {
+            Page = new SpacePublicationPage { Count = 35, Pn = 2, Ps = 30 },
+            List = new SpacePublicationList
+            {
+                Vlist =
+                [
+                    new SpacePublicationListVideo
+                    {
+                        Aid = 100,
+                        Bvid = "BV1fixture01",
+                        Title = "fixture",
+                        Length = "01:30",
+                        Created = 1_700_000_000,
+                        Play = 12,
+                        Pic = "cover"
+                    }
+                ]
+            }
+        };
+
+        var result = UserSpacePageCoordinator.MapPublicationPage(
+            publication,
+            new TestNavigationService(),
+            NullLogger.Instance,
+            CancellationToken.None);
+
+        Assert.Equal(35, result.TotalCount);
+        Assert.Equal("BV1fixture01", Assert.Single(result.Medias).Bvid);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Ports the valid user-facing requirements from PR #79 and PR #80 onto the current Microsoft DI, CommunityToolkit MVVM, and typed-navigation architecture. Their Prism-era implementations are not merged or rebased.

Supersedes #79 and #80.

## Changes

- support strict bare `bilibili.com/list/<positive MID>` inputs through `PublicationNavigationPayload`
- reject malformed, foreign-host, playlist, and non-empty `sid` series inputs instead of guessing their API contract
- add publication search with exact WBI `page.count` pagination
- add private-favorites search with `has_more`-driven pagination because `media_count` remains the unfiltered folder total
- retain query, page number, media instances, and the original ViewModel when typed history returns from a child route
- prevent programmatic initial tab selection from issuing duplicate API calls
- move favorites endpoint access behind the injected service/coordinator boundary
- update `ARCHITECTURE.md`, `docs/ai-knowledge-graph.md`, the live plan, and the Gate 2 design record

## Stable contracts

- no Prism, DryIoc, EventAggregator, string ViewName, or legacy region navigation is restored
- settings, SQLite schemas, download records, unfinished tasks, GIDs, partial files, and resume state are unchanged
- cancellation remains distinct from operational failure
- unit tests use fixed fixtures and injected fakes, not production Bilibili availability

## Verification

- strict Release build with `AnalysisMode=All` and warnings-as-errors: 0 warnings, 0 errors
- full solution tests: 536/536 passed
- architecture tests: 169/169 passed
- desktop smoke tests: 11/11 passed
- `dotnet format --verify-no-changes`: 0/738 files changed
- module-boundary audit completed
- NuGet vulnerable audit: no vulnerable packages
- NuGet deprecated audit: no deprecated packages
- `git diff --check`: passed

## Rollback

Revert this integration PR. No persistent user-data migration is required because the changes affect input parsing, API projections, and in-memory navigation state only.