### PR TITLE
fix(api): audit and harden Bilibili contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,9 @@
 1. 在分析或修改 DownKyi 程式碼前，必須先閱讀 `docs/ai-knowledge-graph.md`，確認受影響節點、依賴、穩定契約、風險與測試。
 2. 閱讀 `ARCHITECTURE.md`，區分目前可執行拓樸與目標拓樸，不得把目標設計誤報為已完成。
 3. 執行重構前閱讀 `docs/refactoring-live-plan.md`，只處理目前分組，不得拆分或合併計畫指定的 PR 範圍。
-4. 涉及建置、依賴、外部 binary、分析器或發版時，再閱讀 `docs/maintenance.md` 與 `docs/operations/verification-and-rollback.md`。
-5. 新增、刪除、移動或重新導向模組責任的 PR，必須同步更新知識圖譜、架構文件與即時計畫。
+4. 涉及 Bilibili API、WBI、JSON envelope 或登入契約時，先閱讀並同步更新 `docs/operations/bilibili-api-audit.md`。
+5. 涉及建置、依賴、外部 binary、分析器或發版時，再閱讀 `docs/maintenance.md` 與 `docs/operations/verification-and-rollback.md`。
+6. 新增、刪除、移動或重新導向模組責任的 PR，必須同步更新知識圖譜、架構文件與即時計畫。
 
 ## 專案概況
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -79,7 +79,7 @@ flowchart LR
 
 Main region 的返回操作必須先縮減 `AvaloniaNavigationService` 的既有歷史，並恢復原本的 View/ViewModel instance；只有沒有歷史時才建立 typed parent route。UserSpace 的公開收藏夾由注入的 coordinator 一次映射到 snapshot，返回同一個 MID 時保留原頁面與清單狀態。失效收藏項目保留在 UI 供辨識，但不能選取、開啟或加入下載。
 
-投稿路由只接受 `PublicationNavigationPayload`。裸 `bilibili.com/list/<MID>` 代表該使用者全部投稿；帶 `sid` 的系列 URL 在 API contract audit 完成前不會被猜成全部投稿。投稿搜尋採 WBI 回應的精確 `page.count`；收藏搜尋的 `media_count` 是未篩選總數，因此分頁只能依 `has_more` 逐頁擴展。兩頁返回時保留 query、頁碼與既有 media instances；被取消的未完成頁才會補載。
+投稿路由只接受 `PublicationNavigationPayload`。裸 `bilibili.com/list/<MID>` 代表該使用者全部投稿；`x/series/archives` 契約已完成審查，但帶 `sid` 的 URL 在建立獨立 typed series payload 與產品測試前仍不得被猜成全部投稿。投稿搜尋採 WBI 回應的精確 `page.count`；收藏搜尋的 `media_count` 是未篩選總數，因此分頁只能依 `has_more` 逐頁擴展。兩頁返回時保留 query、頁碼與既有 media instances；被取消的未完成頁才會補載。
 
 導航箭頭 path 必須由 factory 建立獨立 geometry；不得讓不同 ViewModel 共用可變的 `PathIconData`，否則單頁主題更新會改壞其他頁面。
 
@@ -211,6 +211,7 @@ FinalizeStage
 - 既有 JSON property 名稱與 migration 必須保持可讀。
 - SQLite 下載紀錄、未完成任務、partial files、aria2 GID 與續傳資料不可遺失。
 - 外部 Bilibili envelope、WBI、DURL 與 protobuf contract 必須由 fixture 測試保護。
+- 固定 Bilibili 端點必須登錄於 `docs/operations/bilibili-api-audit.md`；匿名 live probe 只提供時點證據，不可取代 deterministic contract tests。
 - XAML resource URI、compiled binding 和 typed route 改名必須有 UI smoke coverage。
 - 任何跨層搬移都先建立 adapter 或 migration，再移除舊 owner。
 
@@ -219,7 +220,9 @@ FinalizeStage
 - `tests/DownKyi.Architecture.Tests/ProjectDependencyTests.cs`
 - `tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs`
 - `tests/DownKyi.Architecture.Tests/AgentEnvironmentArchitectureTests.cs`
+- `tests/DownKyi.Architecture.Tests/BilibiliApiInventoryArchitectureTests.cs`
 - `script/audit-module-boundaries.ps1`
+- `script/audit-bilibili-api.ps1`
 - `tests/DownKyi.Desktop.Tests/UiSmokeTests.cs`
 
 基線測試採 ratchet 模式：現有違規可以減少或移除，新增違規或擴大巨檔會失敗。基線不是豁免，也不能成為長期目標。

--- a/DownKyi.Core/BiliApi/BiliApiRequest.cs
+++ b/DownKyi.Core/BiliApi/BiliApiRequest.cs
@@ -77,6 +77,51 @@ internal static class BiliApiRequest
         JsonSerializerSettings? serializerSettings,
         CancellationToken cancellationToken = default)
     {
+        return RequestJsonCore<T>(
+            url,
+            referer,
+            operationName,
+            logTag,
+            serializerSettings,
+            allowedNonSuccessCode: null,
+            cancellationToken);
+    }
+
+    public static T RequestJsonAllowingCode<T>(
+        string url,
+        string? referer,
+        string operationName,
+        string logTag,
+        int allowedNonSuccessCode,
+        CancellationToken cancellationToken = default)
+    {
+        if (allowedNonSuccessCode == 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(allowedNonSuccessCode),
+                allowedNonSuccessCode,
+                "The explicit exception must be a non-success API code.");
+        }
+
+        return RequestJsonCore<T>(
+            url,
+            referer,
+            operationName,
+            logTag,
+            serializerSettings: null,
+            allowedNonSuccessCode,
+            cancellationToken);
+    }
+
+    private static T RequestJsonCore<T>(
+        string url,
+        string? referer,
+        string operationName,
+        string logTag,
+        JsonSerializerSettings? serializerSettings,
+        int? allowedNonSuccessCode,
+        CancellationToken cancellationToken)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
         ArgumentException.ThrowIfNullOrWhiteSpace(logTag);
         var response = WebClient.RequestWeb(url, referer, cancellationToken: cancellationToken);
@@ -85,7 +130,8 @@ internal static class BiliApiRequest
             var metadata = System.Text.Json.JsonSerializer.Deserialize(
                 response,
                 BilibiliWebJsonContext.Default.BilibiliResponseMetadata);
-            if (metadata?.Code is { } code and not 0)
+            if (metadata?.Code is { } code and not 0
+                && code != allowedNonSuccessCode)
             {
                 throw new BilibiliApiResponseException(
                     operationName,

--- a/DownKyi.Core/BiliApi/Users/UserInfo.cs
+++ b/DownKyi.Core/BiliApi/Users/UserInfo.cs
@@ -11,6 +11,8 @@ namespace DownKyi.Core.BiliApi.Users;
 /// </summary>
 public static class UserInfo
 {
+    private const int AnonymousNavigationCode = -101;
+
     /// <summary>
     /// 导航栏用户信息
     /// </summary>
@@ -19,11 +21,14 @@ public static class UserInfo
     {
         const string url = "https://api.bilibili.com/x/web-interface/nav";
         const string referer = "https://www.bilibili.com";
-        var userInfo = BiliApiRequest.RequestJson<UserInfoForNavigationOrigin>(
+        // The nav endpoint returns -101 for anonymous users while still supplying
+        // the public WBI metadata required to sign ordinary video requests.
+        var userInfo = BiliApiRequest.RequestJsonAllowingCode<UserInfoForNavigationOrigin>(
             url,
             referer,
             nameof(GetUserInfoForNavigation),
             "UserInfo",
+            AnonymousNavigationCode,
             cancellationToken);
 
         return BiliApiRequest.RequirePayload(userInfo.Data);

--- a/DownKyi.Core/BiliApi/VideoStream/BangumiPlayUrlV2Contract.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/BangumiPlayUrlV2Contract.cs
@@ -1,0 +1,32 @@
+using DownKyi.Core.BiliApi.VideoStream.Models;
+
+namespace DownKyi.Core.BiliApi.VideoStream;
+
+internal static class BangumiPlayUrlV2Contract
+{
+    public static PlayUrl SelectPayload(
+        BangumiPlayUrlV2Origin response,
+        string operationName)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        ArgumentException.ThrowIfNullOrWhiteSpace(operationName);
+        var result = BiliApiRequest.RequirePayload(
+            response.Result,
+            "result",
+            operationName);
+        var payload = BiliApiRequest.RequirePayload(
+            result.VideoInfo,
+            "result.video_info",
+            operationName);
+        if (payload.Durl.Count == 0
+            && payload.Dash.Video.Count == 0
+            && payload.Dash.Audio.Count == 0)
+        {
+            throw new BilibiliApiResponseException(
+                operationName,
+                $"{operationName} returned an empty 'result.video_info' playback payload.");
+        }
+
+        return payload;
+    }
+}

--- a/DownKyi.Core/BiliApi/VideoStream/Models/BangumiPlayUrlV2Origin.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/Models/BangumiPlayUrlV2Origin.cs
@@ -1,0 +1,16 @@
+using DownKyi.Core.BiliApi.Models;
+using Newtonsoft.Json;
+
+namespace DownKyi.Core.BiliApi.VideoStream.Models;
+
+public sealed class BangumiPlayUrlV2Origin : BaseModel
+{
+    [JsonProperty("result")]
+    public BangumiPlayUrlV2Result? Result { get; set; }
+}
+
+public sealed class BangumiPlayUrlV2Result : BaseModel
+{
+    [JsonProperty("video_info")]
+    public PlayUrl? VideoInfo { get; set; }
+}

--- a/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.cs
@@ -298,7 +298,7 @@ public static class VideoStreamApi
     // /// <returns></returns>
     public static PlayUrl? GetBangumiPlayUrl(long avid, string bvid, long cid, int quality = 125, CancellationToken cancellationToken = default)
     {
-        var baseUrl = $"https://api.bilibili.com/pgc/player/web/playurl?cid={cid}&qn={quality}&fourk=1&fnver=0&fnval=4048";
+        var baseUrl = $"https://api.bilibili.com/pgc/player/web/v2/playurl?cid={cid}&qn={quality}&fourk=1&fnver=0&fnval=4048";
         string url;
         if (bvid != null)
         {
@@ -313,11 +313,15 @@ public static class VideoStreamApi
             return null;
         }
 
-        return GetPlayUrl(
+        const string referer = "https://www.bilibili.com";
+        var response = BiliApiRequest.RequestJson<BangumiPlayUrlV2Origin>(
             url,
-            PlayUrlPayloadField.Result,
+            referer,
             nameof(GetBangumiPlayUrl),
+            "GetBangumiPlayUrl()",
             cancellationToken);
+
+        return BangumiPlayUrlV2Contract.SelectPayload(response, nameof(GetBangumiPlayUrl));
     }
 
     /// <summary>

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -1360,8 +1360,12 @@ type: core
 paths:
   - DownKyi.Core/BiliApi
   - DownKyi.Core/BiliApi/BiliApiRequest.cs
+  - DownKyi.Core/BiliApi/Users/UserInfo.cs
+  - DownKyi.Core/BiliApi/VideoStream/BangumiPlayUrlV2Contract.cs
+  - DownKyi.Core/BiliApi/VideoStream/Models/BangumiPlayUrlV2Origin.cs
   - DownKyi.Core/BiliApi/Favorites/FavoritesResource.cs
   - DownKyi.Core/BiliApi/Users/UserSpace.cs
+  - docs/operations/bilibili-api-audit.md
 responsibility: Wraps Bilibili API endpoints, response parsing, and shared request failure handling.
 inbound:
   - service.info-services
@@ -1383,6 +1387,9 @@ contracts:
   - WBI endpoint methods receive explicit keys and timestamp; signing cannot read settings or initialize user state.
   - Optional `data`/`result` fields remain nullable, and each endpoint selects its documented field before validating a non-empty payload.
   - Publication search uses `x/space/wbi/arc/search` and retains `data.page.count`; favorite search uses `x/v3/fav/resource/list` and retains `data.has_more`.
+  - Anonymous navigation alone may accept API code `-101` because `/x/web-interface/nav` still supplies public WBI metadata; the exception cannot spread to other endpoints.
+  - Ordinary playback selects `data`, bangumi v2 playback selects `result.video_info`, and cheese playback selects `data`.
+  - Every fixed endpoint literal in Core must appear in the API audit with status, evidence, alternative and deterministic coverage.
 hazards:
   - Bilibili schema changes must fail at this boundary rather than deserialize into a plausible empty success object.
   - Logging full URLs can leak tokens, cookies, and personal query data.
@@ -1390,6 +1397,30 @@ tests:
   - test.web-client
   - test.json-contracts
   - test.wbi-signature
+  - test.bilibili-api-contract-audit
+```
+
+### ops.bilibili-api-audit
+
+```yaml
+id: ops.bilibili-api-audit
+type: operations
+paths:
+  - docs/operations/bilibili-api-audit.md
+  - script/audit-bilibili-api.ps1
+responsibility: Records every fixed Bilibili Core endpoint and provides an explicit anonymous live probe that emits only sanitized contract diagnostics.
+inbound:
+  - core.bili-api
+outbound: []
+contracts:
+  - The probe never loads local settings, cookies, browser profiles, download data, or account identifiers.
+  - Authenticated endpoints remain auth-deferred unless a redacted deterministic fixture proves their payload contract.
+  - Conflicting external evidence is recorded as risk; it does not justify speculative endpoint replacement.
+hazards:
+  - Live responses are time-dependent evidence and never run as unit tests or PR CI prerequisites.
+  - HTTP 200 alone does not prove success; API code, envelope presence and usable payload remain separate checks.
+tests:
+  - test.bilibili-api-contract-audit
 ```
 
 ### core.wbi-key-provider
@@ -2413,6 +2444,20 @@ test.wbi-signature:
     - only one `-403` refresh/retry is allowed and non-signature failures never refresh
     - `BV1U7V66FEiK` fixtures retain video identity, page/CID, and non-empty playback streams without live network access
 
+test.bilibili-api-contract-audit:
+  paths:
+    - tests/DownKyi.Core.Tests/UserNavigationContractTests.cs
+    - tests/DownKyi.Core.Tests/PlayUrlEnvelopeContractTests.cs
+    - tests/DownKyi.Core.Tests/BiliApi/JsonSamples/user-navigation-anonymous.json
+    - tests/DownKyi.Core.Tests/BiliApi/JsonSamples/playurl-bangumi-v2-result.json
+    - tests/DownKyi.Architecture.Tests/BilibiliApiInventoryArchitectureTests.cs
+  guards:
+    - anonymous navigation preserves public WBI metadata while nonzero API codes remain rejected everywhere else
+    - bangumi v2 requires a non-empty `result.video_info` payload
+    - optional `data` and `result` envelopes cannot invent payloads with default initializers
+    - every hard-coded Core endpoint is listed in the maintained API audit
+    - the live probe requires explicit consent and cannot load local login state
+
 test.legacy-settings-migration:
   paths:
     - tests/DownKyi.Core.Tests/LegacySettingsDecryptorTests.cs
@@ -2487,6 +2532,7 @@ test.architecture-boundaries:
     - tests/DownKyi.Architecture.Tests/MediaAndHttpRuntimeArchitectureTests.cs
     - tests/DownKyi.Architecture.Tests/UiThemeArchitectureTests.cs
     - tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+    - tests/DownKyi.Architecture.Tests/BilibiliApiInventoryArchitectureTests.cs
   guards:
     - production project references remain acyclic
     - target Domain/Application/Infrastructure/Desktop dependency direction is enforced
@@ -2517,6 +2563,7 @@ test.architecture-boundaries:
     - aria2 manager/server/process supervision cannot restore static LogManager, static server ownership, synchronous HTTP send, or recursive retry
     - settings validation/persistence and legacy migration cannot restore static LogManager, Console diagnostics, or duplicate low-level SQLite logging
     - Bilibili Core facades cannot log or print request data; injected account and user-space coordinators own sanitized outcome diagnostics
+    - fixed Bilibili endpoint literals cannot escape the maintained audit, optional envelopes cannot invent payloads, and the anonymous navigation exception cannot become a global code policy
     - migrated update, disk, cookie serialization, and delayed-scroll files cannot restore static or terminal diagnostics
     - all production C# roots reject legacy LogManager, the removed Console wrapper, and terminal Print calls; legacy logging source files must remain deleted
     - async commands and ViewModel fire-and-forget observation require injected diagnostics and preserve normal cancellation semantics

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -116,8 +116,11 @@ PR 25-29 local result: the real headless Host resolves `MainWindow`, loads compl
 - `WbiSign` is a deterministic protocol function: callers supply both keys and the timestamp. It cannot read settings or initialize user state.
 - A WBI request may force one refresh and one retry only when Bilibili returns code `-403` from that signed request. A second rejection and all non-WBI/non-`-403` errors propagate with the original code and message.
 - Home-page account refresh may update profile and valid WBI keys, but a missing/partial navigation payload cannot erase previously validated keys. Public video parsing cannot depend on login or home-page timing.
-- Ordinary video playback uses `data`, bangumi playback uses `result`, and cheese playback uses `data`. Missing or structurally empty expected payloads are typed contract failures.
+- Ordinary video playback uses `data`, bangumi v2 playback uses `result.video_info`, and cheese playback uses `data`. Missing or structurally empty expected payloads are typed contract failures.
+- Anonymous `/x/web-interface/nav` may return code `-101` while still carrying public WBI metadata. That exception is endpoint-scoped; every other nonzero API code remains a typed failure.
 - Fixed fixtures under `tests/DownKyi.Core.Tests/BiliApi/JsonSamples` cover `BV1U7V66FEiK` video info, page/CID, and playback without using the live Bilibili network.
+- `docs/operations/bilibili-api-audit.md` is the endpoint inventory. Any endpoint/envelope change updates it and a deterministic fixture in the same PR; `BilibiliApiInventoryArchitectureTests` enforces coverage.
+- `pwsh ./script/audit-bilibili-api.ps1 -ConfirmLive` performs an explicitly requested anonymous probe. It never loads local login data and is not a CI test.
 
 ## Analyzer Policy
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,6 +1,7 @@
 # Operations
 
 - `verification-and-rollback.md`：本機與 CI 驗證、產物、失敗判讀及回滾。
+- `bilibili-api-audit.md`：Bilibili 端點、envelope、認證需求、證據、替代方案與回歸測試。
 - `../maintenance.md`：依賴、analyzers、external binaries、package 與 release 維護。
 - `../performance-baseline.md`：系統效能基準欄位與比較規則。
 

--- a/docs/operations/bilibili-api-audit.md
+++ b/docs/operations/bilibili-api-audit.md
@@ -1,0 +1,142 @@
+# Bilibili API Contract Audit
+
+Audit date: 2026-07-22  
+Code baseline: `3fbd31be95bf6e62287bb393b139b853260d36cf` plus Gate 3 changes  
+Scope: every fixed Bilibili HTTP endpoint under `DownKyi.Core/BiliApi`
+
+This is a runtime contract inventory, not an assertion that undocumented Bilibili APIs are stable. It records the best evidence available without copying or using a maintainer's personal login state.
+
+## Evidence And Status
+
+- **LIVE**: anonymous controlled request on 2026-07-22. Only HTTP status, API code/message, top-level keys, content type and byte count were inspected.
+- **YT**: current [yt-dlp Bilibili extractor](https://github.com/yt-dlp/yt-dlp/blob/master/yt_dlp/extractor/bilibili.py).
+- **NEMO**: maintained bilibili-api endpoint maps for [users](https://github.com/Nemo2011/bilibili-api/blob/main/bilibili_api/data/api/user.json), [favorites](https://github.com/Nemo2011/bilibili-api/blob/main/bilibili_api/data/api/favorite-list.json), [videos](https://github.com/Nemo2011/bilibili-api/blob/main/bilibili_api/data/api/video.json), [bangumi](https://github.com/Nemo2011/bilibili-api/blob/main/bilibili_api/data/api/bangumi.json), and [login](https://github.com/Nemo2011/bilibili-api/blob/main/bilibili_api/data/api/login.json).
+- **DOC**: maintained community protocol documentation, including [protobuf danmaku](https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/danmaku/danmaku_proto.md) and [history/watch-later](https://github.com/SocialSisterYi/bilibili-API-collect/tree/master/docs/historytoview).
+- **FIXTURE**: deterministic local JSON/protobuf/loopback contract test. Tests never call production Bilibili.
+- **Active** means a current application workflow calls the endpoint. **Compatibility** means the public facade remains but no current workflow calls it.
+- **Auth-deferred** means a personal Cookie would be required for a conclusive live payload check. No maintainer Cookie was read, copied, logged, or sent by this audit.
+
+Status values:
+
+- `current`: current sources and/or live response agree with the implemented contract.
+- `fixed`: a confirmed runtime contract defect was corrected in this gate.
+- `auth-deferred`: current sources agree, but payload validation requires a user session.
+- `legacy-working`: live today, but a newer contract exists and migration needs more ownership or fixture work.
+- `retired-unused`: live request confirms retirement and no production caller remains.
+- `invalid-unused`: the request contract is wrong, but no production caller exists and the replacement cannot be safely validated anonymously.
+
+## Bootstrap, Login And Account
+
+| Endpoint | Owner and purpose | Contract/auth | Status and evidence | Decision and regression coverage |
+|---|---|---|---|---|
+| `api.bilibili.com/x/frontend/finger/spi` | `WebClient.GetBuvid`; obtain public buvid values before API requests | GET, `data.b_3/b_4`, anonymous | `current`; LIVE returned HTTP 200/code 0 | Keep. Missing `data` is a typed failure; HTTP retry tests cover the request path. |
+| `api.bilibili.com/x/web-interface/nav` | `UserInfo.GetUserInfoForNavigation`; login snapshot and WBI image keys | GET, `data`; anonymous response is code `-101` but still carries public `data.wbi_img` | `fixed`; LIVE reproduced `-101` with valid 32-character WBI keys; YT also obtains WBI keys here | Only this endpoint may deserialize code `-101`. `UserNavigationContractTests` proves keys survive and all other endpoints still reject `-101`. |
+| `api.bilibili.com/x/space/myinfo` | `UserInfo.GetMyInfo`; current account details | GET, `data`, Cookie required | `auth-deferred`; NEMO marks authenticated | Keep. Generic nonzero-code rejection and required-payload behavior apply. |
+| `passport.bilibili.com/x/passport-login/web/qrcode/generate` | `LoginQR.GetLoginUrl`; create login QR session | GET, `data.url/qrcode_key`, anonymous | `current`; LIVE code 0; NEMO login map agrees | Keep. Probe never emits the generated key or URL. Existing login coordinator tests use stubs. |
+| `passport.bilibili.com/x/passport-login/web/qrcode/poll` | `LoginQR.GetLoginStatus`; poll QR state | GET, `data`, generated key required | `current`; NEMO login map agrees; full live poll intentionally not persisted | Keep. The generated key is treated as sensitive transient state. |
+
+## Ordinary Video, Playback And Media Metadata
+
+| Endpoint | Owner and purpose | Contract/auth | Status and evidence | Decision and regression coverage |
+|---|---|---|---|---|
+| `api.bilibili.com/x/web-interface/wbi/view` | `VideoInfo.VideoViewInfo`; ordinary video metadata | GET, WBI, `data` | `current`; NEMO and YT agree; `BV1U7V66FEiK` fixture covers identity/pages | Keep. `VideoView.Data` is nullable and missing payload throws. |
+| `api.bilibili.com/x/web-interface/archive/desc` | `VideoInfo.VideoDescription`; description | GET, `data` string, public | `current`; LIVE code 0; NEMO agrees | Keep. Empty/missing required payload remains distinguishable. |
+| `api.bilibili.com/x/player/pagelist` | `VideoInfo.VideoPagelist`; page/CID list | GET, `data[]`, public | `current`; LIVE code 0; NEMO/YT agree | Keep. `BV1U7V66FEiK` page fixture covers CID parsing. |
+| `api.bilibili.com/x/web-interface/view/detail/tag` | `VideoInfo.GetBiliTagInfo`; optional movie tags | GET, `data[]`, public/partly restricted | `current`; LIVE code 0 | Keep. Tag failures are optional metadata; cancellation still propagates. |
+| `api.bilibili.com/x/player/wbi/v2` | `VideoStreamApi.PlayerV2`; subtitles and player metadata | GET, WBI, `data` | `current`; NEMO and YT agree | Keep. Player payload is required; subtitle tests use deterministic responses. |
+| `api.bilibili.com/x/player/wbi/playurl` | `VideoStreamApi.GetVideoPlayUrl`; ordinary video streams | GET, WBI, `data` | `current`; NEMO/YT agree; fixed playback fixtures | Keep. `PlayUrlEnvelopeContractTests` rejects missing or empty `data`. |
+| `api.bilibili.com/x/v2/dm/web/seg.so` | `DanmakuProtobuf`; protobuf segments | GET, binary protobuf, semi-anonymous | `legacy-working`; LIVE returned HTTP 200 protobuf; DOC identifies newer WBI variant | Keep for compatibility in this gate. The WBI alternative also worked anonymously, but moving it requires injecting WBI ownership into the danmaku boundary. No current production caller was found. |
+
+Dynamic media dependencies are not fixed API endpoints: subtitle JSON addresses come from `PlayerV2`, media addresses come from `PlayUrl`, and the ordinary-video web fallback reads `www.bilibili.com/video/...`. They must remain opaque response values and must never be copied into diagnostic logs.
+
+## Bangumi And Cheese
+
+| Endpoint | Owner and purpose | Contract/auth | Status and evidence | Decision and regression coverage |
+|---|---|---|---|---|
+| `api.bilibili.com/pgc/review/user` | `BangumiInfo.BangumiMediaInfo`; media-to-season resolution | GET, `result` | `current`; YT/community implementations retain the media/season route | Keep. Optional `result` remains nullable and required by the caller. |
+| `api.bilibili.com/pgc/view/web/season` | `BangumiInfo.BangumiSeasonInfo`; season/episode metadata | GET, `result` | `current`; LIVE code 0 for multiple public episodes; YT agrees | Keep. Public episode fixtures cover field selection. |
+| `api.bilibili.com/pgc/player/web/v2/playurl` | `VideoStreamApi.GetBangumiPlayUrl`; bangumi streams | GET, `result.video_info`; auth/region rules vary | `fixed`; LIVE code 0 for ep 21495, 50188 and 678060; YT and NEMO use v2 | Replaced legacy v1 runtime URL. New nullable `BangumiPlayUrlV2Origin` contract rejects missing/empty `result.video_info`; v1 fixture remains only as wire compatibility coverage. |
+| `api.bilibili.com/pugv/view/web/season` | `CheeseInfo.CheeseViewInfo`; course metadata | GET, `data`; access varies | `current`; LIVE endpoint responds; NEMO/fixtures agree | Keep. Required `data` failure is typed. |
+| `api.bilibili.com/pugv/view/web/ep/list` | `CheeseInfo.CheeseEpisodeList`; course pages | GET, `data` | `current`; LIVE endpoint responds; NEMO agrees | Keep. Pagination remains explicit. |
+| `api.bilibili.com/pugv/player/web/playurl` | `VideoStreamApi.GetCheesePlayUrl`; course streams | GET, `data`, `ep_id` required | `current`; LIVE endpoint responds; YT uses the same route | Keep. `PlayUrlEnvelopeContractTests.CheeseEndpointUsesDataEnvelope` fixes the endpoint contract. |
+| `api.bilibili.com/pugv/app/web/season/page` | `UserSpace.GetCheese`; courses published by a user | GET, `data.items` | `current`; NEMO user map agrees | Keep. Active user-space flow; live payload may vary by account/catalog. |
+| `api.bilibili.com/x/space/bangumi/follow/list` | `UserSpace.GetBangumiFollow`; followed shows | GET, `data`, visibility/login dependent | `current`; NEMO user map agrees | Keep. Active paging coordinator preserves nonzero API failures. |
+
+## Favorites, History And Personal Lists
+
+| Endpoint | Owner and purpose | Contract/auth | Status and evidence | Decision and regression coverage |
+|---|---|---|---|---|
+| `api.bilibili.com/x/v3/fav/folder/info` | `FavoritesInfo.GetFavoritesInfo`; folder metadata | GET, `data` | `current`; NEMO and YT agree | Keep. Required payload. |
+| `api.bilibili.com/x/v3/fav/folder/created/list` | `FavoritesInfo.GetCreatedFavorites`; paged folders | GET, `data.list` | `current`; LIVE code 0 | Keep paged API. NEMO favors `created/list-all`, but anonymous `list-all` returned null for public probes, so replacement evidence is insufficient. |
+| `api.bilibili.com/x/v3/fav/folder/collected/list` | `FavoritesInfo.GetCollectedFavorites`; subscribed folders | GET, `data.list`, Cookie/visibility dependent | `auth-deferred`; NEMO agrees | Keep. No personal Cookie used for audit. |
+| `api.bilibili.com/x/v3/fav/resource/list` | `FavoritesResource.GetFavoritesMediaResource`; folder content and keyword search | GET, `data.medias/has_more` | `current`; NEMO/YT agree; search fixtures cover `has_more` | Keep. Search pagination does not trust the unfiltered folder total. |
+| `api.bilibili.com/x/v3/fav/resource/ids` | `FavoritesResource.GetFavoritesMediaId`; resource identities | GET, `data[]` | `current`; NEMO/YT agree | Keep. Required payload semantics apply. |
+| `api.bilibili.com/x/web-interface/history/cursor` | `HistoryApi.GetHistory`; watch history | GET, `data.cursor/list`, Cookie required | `auth-deferred`; anonymous LIVE returned `-101`; NEMO and DOC agree | Keep. Cancellation and typed API errors are preserved. |
+| `api.bilibili.com/x/v2/history/toview` | `ToView.GetToView`; watch later | GET, `data.list`, Cookie required | `auth-deferred`; anonymous LIVE returned `-101`; DOC and maintained UI implementations still use it | Keep. YT uses `/web`; both variants returned `-101` anonymously, so switching without an authenticated fixture would be speculative. |
+
+## User Space, Collections And Relations
+
+| Endpoint | Owner and purpose | Contract/auth | Status and evidence | Decision and regression coverage |
+|---|---|---|---|---|
+| `space.bilibili.com/ajax/settings/getSettings` | `UserSpace.GetSpaceSettings`; space banner settings | GET, legacy `{status,data}` | `legacy-working`; LIVE returned HTTP 200 with expected envelope | Keep while active. No maintained replacement with equivalent banner semantics was confirmed. |
+| `api.bilibili.com/x/space/wbi/acc/info` | `UserInfo.GetUserInfoForSpace`; public profile | GET, WBI, `data` | `current`; NEMO agrees; unsigned LIVE control was risk-rejected | Keep. WBI provider owns refresh/retry; schema failure is typed. |
+| `api.bilibili.com/x/space/wbi/arc/search` | `UserSpace.GetPublicationPage`; publications and search | GET, WBI, `data` | `current`; NEMO/YT agree; deterministic publication fixtures | Keep. Gate 2 tests cover query/page retention and exact totals. |
+| `api.bilibili.com/x/polymer/web-space/seasons_series_list` | `UserSpace.GetSeasonsSeries`; collection index | GET, `data` | `current`; LIVE code 0; NEMO/YT agree | Keep. This is the replacement family for retired channels. |
+| `api.bilibili.com/x/polymer/web-space/seasons_archives_list` | `UserSpace.GetSeasonsDetail`; season collection pages | GET, `data` | `current`; NEMO/YT agree | Keep. Typed `SeasonsSeriesKind` selects this route. |
+| `api.bilibili.com/x/series/series` | `UserSpace.GetSeriesMeta`; series metadata | GET, `data` | `current`; LIVE endpoint responds; NEMO/YT agree | Keep. |
+| `api.bilibili.com/x/series/archives` | `UserSpace.GetSeriesDetail`; series pages and `/list/<mid>?sid=...` family | GET, `data` | `current`; NEMO/YT agree | Keep. Bare `/list/<mid>` remains publication navigation; `sid` must use typed series input before enabling. |
+| `api.bilibili.com/x/space/channel/list` | compatibility `UserSpace.GetChannelList` | GET, former `data.list` | `retired-unused`; LIVE HTTP 404; no production caller | Do not invoke or silently redirect because channel IDs do not map one-to-one to seasons/series. Retain public compatibility surface until the planned legacy-removal gate. |
+| `api.bilibili.com/x/space/channel/video` | compatibility `UserSpace.GetChannelVideoList` | GET, former `data.list` | `retired-unused`; endpoint family is retired; no production caller | Same decision as channel list. Use polymer/series APIs in active flows. |
+| `api.bilibili.com/x/relation/stat` | `UserStatus.GetUserRelationStat`; following/follower counts | GET `vmid`, `data` | `current`; LIVE code 0; NEMO agrees | Keep active numeric-ID contract. The unused `Nickname.CheckNickname` query against this route returned `-400` and is classified `invalid-unused`; no anonymous name lookup replacement was proven. |
+| `api.bilibili.com/x/space/upstat` | `UserStatus.GetUpStat`; view/like totals | GET, `data` | `current`; LIVE code 0; NEMO agrees | Keep. Cancellation ownership remains Gate 7 HTTP work. |
+| `api.bilibili.com/x/relation/followers` | `UserRelation.GetFollowers`; followers | GET, `data`, visibility/login limits | `auth-deferred`; NEMO agrees | Keep compatibility and coordinator path. API-imposed page limits remain visible. |
+| `api.bilibili.com/x/relation/followings` | `UserRelation.GetFollowings`; following list | GET, `data`, visibility/login limits | `auth-deferred`; NEMO agrees | Keep. |
+| `api.bilibili.com/x/relation/whispers` | `UserRelation.GetWhispers`; private follows | GET, `data`, Cookie required | `auth-deferred`; NEMO agrees | Keep. No personal session probe. |
+| `api.bilibili.com/x/relation/blacks` | `UserRelation.GetBlacks`; block list | GET, `data`, Cookie required | `auth-deferred`; NEMO agrees | Keep. No personal session probe. |
+| `api.bilibili.com/x/relation/tags` | `UserRelation.GetFollowingGroup`; own groups | GET, `data`, Cookie required | `auth-deferred`; NEMO agrees | Keep. |
+| `api.bilibili.com/x/relation/tag` | `UserRelation.GetFollowingGroupContent`; group members | GET, `data`, Cookie required | `auth-deferred`; NEMO agrees | Keep. |
+
+## Compatibility Discovery APIs
+
+| Endpoint | Owner and purpose | Contract/auth | Status and evidence | Decision and regression coverage |
+|---|---|---|---|---|
+| `api.bilibili.com/x/web-interface/ranking/region` | `Ranking.RegionRankingList`; regional ranking | GET, `data[]` | `legacy-working`; LIVE code 0; no production caller | Retain compatibility only. Current product has no ranking workflow, so replacing it would add untested behavior. |
+| `api.bilibili.com/x/web-interface/dynamic/region` | `DynamicApi.RegionDynamicList`; regional dynamic list | GET, `data` | `legacy-working/risk`; LIVE returned API `-404` for an empty sample; no production caller | Retain compatibility and typed failure. Do not interpret an empty region as endpoint retirement. |
+
+## Confirmed Changes
+
+1. Anonymous navigation now accepts only API code `-101` at the `/nav` contract, then requires `data`. This repairs WBI bootstrap for public videos without weakening global API error handling.
+2. Bangumi playback now uses `/pgc/player/web/v2/playurl` and explicitly selects `result.video_info`. The v2 DTO does not create default payloads.
+3. The audit records the retired channel family, invalid nickname query, legacy danmaku path, and watch-later ambiguity without speculative remapping.
+4. `BilibiliApiInventoryArchitectureTests` fails when a fixed Core endpoint is not present in this document or when the `/nav` nonzero-code exception spreads to another source file.
+5. `script/audit-bilibili-api.ps1 -ConfirmLive` reproduces the anonymous subset and outputs only sanitized diagnostics. It is an operator tool, not a CI test.
+
+## Deterministic Tests
+
+- `UserNavigationContractTests.AnonymousNavigationResponsePreservesPublicWbiMetadata`
+- `UserNavigationContractTests.AnonymousCodeRemainsRejectedOutsideTheNavigationContract`
+- `PlayUrlEnvelopeContractTests.BangumiEndpointUsesResultVideoInfoEnvelope`
+- `PlayUrlEnvelopeContractTests.BangumiV2MissingVideoInfoThrowsTypedContractFailure`
+- existing `PlayUrlEnvelopeContractTests` for ordinary video and cheese
+- existing `BvFixtureContractTests` for `BV1U7V66FEiK`
+- `BilibiliApiInventoryArchitectureTests.EveryHardCodedBilibiliApiEndpointIsRecordedInTheAudit`
+- `BilibiliApiInventoryArchitectureTests.AnonymousNonSuccessCodeExceptionIsScopedToNavigation`
+- `BilibiliApiInventoryArchitectureTests.OptionalJsonEnvelopeFieldsCannotInventPayloads`
+- `BilibiliApiInventoryArchitectureTests.LiveProbeIsExplicitAndDoesNotLoadCookies`
+
+## Maintenance Procedure
+
+1. Update the endpoint row and deterministic fixture in the same PR as any endpoint or envelope change.
+2. Run `pwsh ./script/audit-bilibili-api.ps1 -ConfirmLive` only when a live audit is intended. Do not load a browser profile, login file, or Cookie into the script.
+3. Treat HTTP success and JSON parse success as insufficient: check API code, required envelope and usable payload.
+4. For authenticated contracts, use synthetic/recorded redacted fixtures. A maintainer's live session is never a release prerequisite.
+5. If sources conflict, keep the working contract and record the alternative until equivalent payload behavior is proven.
+
+## Gate 3 Local Verification
+
+- Strict .NET 10 Release build with `AnalysisMode=All`: 0 warnings, 0 errors.
+- Full solution tests: 543 passed, 0 failed, 0 skipped.
+- Format verification: 0 of 742 files changed.
+- NuGet vulnerable and deprecated package reports: empty for every solution project.
+- Anonymous live probe: 27 results, no transport failures, no local authentication loaded.
+- Module boundary audit and `git diff --check`: passed with no new baseline finding.

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -2,8 +2,8 @@
 
 Status: active
 Last updated: 2026-07-22
-Current group: PR #79/#80 typed integration
-Current branch: `refactor/gate-02-list-search-navigation`
+Current group: Gate 3 Bilibili API contract audit
+Current branch: `audit/gate-03-bilibili-api-contracts`
 
 This file contains only unfinished or not-yet-integrated work. Completed PR 02-32 items are not restored. Design rationale belongs in `design-docs`; product acceptance belongs in `product-specs`.
 
@@ -14,55 +14,27 @@ The previous `Status: complete` was incorrect.
 - `origin/refactor/pr-30-32-release-hardening` is not an ancestor of `origin/main`.
 - PR #78 was merged into the stacked base `refactor/pr-25-29-remove-legacy`, not into `main`.
 - PR #75 and PR #77 are closed after their replacement was validated in PR #82.
-- PR #79 and PR #80 remain open against old `main` architecture; Gate 2 replaces both without merging their Prism-era code.
+- PR #79 and PR #80 were superseded by green PR #83, closed, and their typed replacement was merged into the stacked release-hardening base.
 - `version.txt` remains `1.0.32`; v1.1.0 has not passed its release gate.
 
 No release tag may be created while any release blocker below remains.
 
 ## Execution Order
 
-### Gate 2: Port PR #79 And PR #80 As One Integration PR
+### Gate 3: Bilibili API Inventory And Runtime Contract Audit
 
-Required base: `refactor/pr-30-32-release-hardening` or its approved successor after Gate 0/1.
-
-Owner branch: `refactor/gate-02-list-search-navigation`
+Owner branch: `audit/gate-03-bilibili-api-contracts` from the latest integrated architecture head.
 
 Progress (2026-07-22):
 
-- Implemented strict bare `/list/<mid>` parsing and typed publication navigation; series URLs with `sid` are intentionally rejected until Gate 3 audits their endpoint contract.
-- Implemented private-favorites and publication search with cancellation-aware page snapshots.
-- Implemented exact publication totals and `has_more`-driven incremental favorite search paging because the favorite API reports the unfiltered folder total during keyword search.
-- Added headless back-navigation tests proving query, page number, media object identity, and the original ViewModel instance survive child navigation.
-- Final local verification is green: strict Release build `0 warning / 0 error`, all `536/536` tests, architecture tests `169/169`, format `0/738` changed files, clean dependency vulnerability/deprecation audits, module-boundary inventory, and `git diff --check`.
-- The remaining Gate 2 work is publishing the integration PR, waiting for remote CI, superseding PR #79/#80, and merging into the stacked architecture base.
-
-Scope:
-
-- Support `bilibili.com/list/<number>` input.
-- Add favorites and publication list search.
-- Preserve page number, query and list snapshot after back navigation.
-- Fix nested back navigation and arrow-state isolation using current navigation history.
-- Do not merge or rebase PR #79/#80 and do not reintroduce Prism.
-
-Verification:
-
-- parser fixtures cover numeric list URLs and invalid list inputs.
-- search, paging and retained-state tests run without real network.
-- deep navigation history tests prove instance reuse, disposal and no duplicate forward records.
-- strict full solution verification passes.
-
-Completion:
-
-- Create one integration PR whose description says it supersedes #79 and #80.
-- After the new PR is green, comment `Superseded by #<new number>` on both old PRs and close them.
-
-Rollback:
-
-- Revert the integration PR. Persisted user data format must remain unchanged.
-
-### Gate 3: Bilibili API Inventory And Runtime Contract Audit
-
-Owner branch: new API-audit branch from the latest integrated architecture head.
+- Inventoried all 47 fixed Bilibili endpoints in Core with method, envelope, authentication/WBI requirement, runtime use, evidence, alternative, decision and tests.
+- Added an explicit anonymous live-probe script that records Runtime, OS, architecture and Commit SHA while refusing to load local cookies or account state.
+- Confirmed and fixed anonymous WBI bootstrap: `/x/web-interface/nav` returns `-101` with valid public WBI metadata, so only this endpoint may deserialize that code.
+- Cross-checked maintained yt-dlp, bilibili-api endpoint maps, community protocol docs and controlled live probes.
+- Migrated bangumi playback from the working legacy v1 route to current v2 and made `result.video_info` a nullable required contract.
+- Recorded retired channel APIs, the invalid unused nickname query, legacy danmaku and authenticated watch-later ambiguity without speculative remapping.
+- Full local gates are green: strict Release build `0 warning / 0 error`, all `543/543` tests, format `0/742` changed files, clean vulnerable/deprecated package audits, module-boundary inventory, anonymous live-probe `27/27` HTTP results, and `git diff --check`.
+- Remaining Gate 3 work is commit/PR publication, remote Windows/Linux/macOS CI, review, and merge into the stacked release-hardening base.
 
 Scope:
 

--- a/script/audit-bilibili-api.ps1
+++ b/script/audit-bilibili-api.ps1
@@ -1,0 +1,147 @@
+[CmdletBinding()]
+param(
+    [switch]$ConfirmLive,
+    [string]$OutputPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+if (-not $ConfirmLive) {
+    throw 'This script sends anonymous requests to public Bilibili endpoints. Re-run with -ConfirmLive.'
+}
+
+$headers = @{
+    'User-Agent' = 'Mozilla/5.0 (compatible; DownKyi-Api-Audit/1.0)'
+    'Referer' = 'https://www.bilibili.com/'
+}
+
+$probes = @(
+    @{ Name = 'finger-spi'; Uri = 'https://api.bilibili.com/x/frontend/finger/spi'; Kind = 'json' }
+    @{ Name = 'navigation'; Uri = 'https://api.bilibili.com/x/web-interface/nav'; Kind = 'json' }
+    @{ Name = 'ordinary-view-public-control'; Uri = 'https://api.bilibili.com/x/web-interface/view?bvid=BV17x411w7KC'; Kind = 'json' }
+    @{ Name = 'ordinary-description'; Uri = 'https://api.bilibili.com/x/web-interface/archive/desc?bvid=BV17x411w7KC'; Kind = 'json' }
+    @{ Name = 'ordinary-page-list'; Uri = 'https://api.bilibili.com/x/player/pagelist?bvid=BV17x411w7KC'; Kind = 'json' }
+    @{ Name = 'ordinary-tags'; Uri = 'https://api.bilibili.com/x/web-interface/view/detail/tag?bvid=BV17x411w7KC&cid=279786'; Kind = 'json' }
+    @{ Name = 'relation-stat'; Uri = 'https://api.bilibili.com/x/relation/stat?vmid=2'; Kind = 'json' }
+    @{ Name = 'up-stat'; Uri = 'https://api.bilibili.com/x/space/upstat?mid=2'; Kind = 'json' }
+    @{ Name = 'space-settings'; Uri = 'https://space.bilibili.com/ajax/settings/getSettings?mid=2'; Kind = 'json' }
+    @{ Name = 'retired-channel-list'; Uri = 'https://api.bilibili.com/x/space/channel/list?mid=2'; Kind = 'json' }
+    @{ Name = 'seasons-series'; Uri = 'https://api.bilibili.com/x/polymer/web-space/seasons_series_list?mid=2&page_num=1&page_size=1'; Kind = 'json' }
+    @{ Name = 'series-metadata'; Uri = 'https://api.bilibili.com/x/series/series?series_id=1'; Kind = 'json' }
+    @{ Name = 'ranking-region'; Uri = 'https://api.bilibili.com/x/web-interface/ranking/region?rid=1&day=3&ps=0'; Kind = 'json' }
+    @{ Name = 'dynamic-region'; Uri = 'https://api.bilibili.com/x/web-interface/dynamic/region?rid=1&pn=1&ps=1'; Kind = 'json' }
+    @{ Name = 'bangumi-season'; Uri = 'https://api.bilibili.com/pgc/view/web/season?ep_id=21495'; Kind = 'json' }
+    @{ Name = 'bangumi-play-v2'; Uri = 'https://api.bilibili.com/pgc/player/web/v2/playurl?ep_id=21495&qn=64&fnver=0&fnval=4048'; Kind = 'json' }
+    @{ Name = 'cheese-season'; Uri = 'https://api.bilibili.com/pugv/view/web/season?ep_id=3489'; Kind = 'json' }
+    @{ Name = 'cheese-episode-list'; Uri = 'https://api.bilibili.com/pugv/view/web/ep/list?season_id=205&pn=1&ps=1'; Kind = 'json' }
+    @{ Name = 'cheese-play'; Uri = 'https://api.bilibili.com/pugv/player/web/playurl?ep_id=3489&qn=64&fnver=0&fnval=4048'; Kind = 'json' }
+    @{ Name = 'favorites-created-page'; Uri = 'https://api.bilibili.com/x/v3/fav/folder/created/list?up_mid=2&pn=1&ps=1'; Kind = 'json' }
+    @{ Name = 'favorites-created-all-alternative'; Uri = 'https://api.bilibili.com/x/v3/fav/folder/created/list-all?up_mid=2'; Kind = 'json' }
+    @{ Name = 'login-qr-generate'; Uri = 'https://passport.bilibili.com/x/passport-login/web/qrcode/generate'; Kind = 'json' }
+    @{ Name = 'history-cursor-auth-control'; Uri = 'https://api.bilibili.com/x/web-interface/history/cursor?ps=1'; Kind = 'json' }
+    @{ Name = 'watch-later-auth-control'; Uri = 'https://api.bilibili.com/x/v2/history/toview'; Kind = 'json' }
+    @{ Name = 'watch-later-web-alternative'; Uri = 'https://api.bilibili.com/x/v2/history/toview/web?jsonp=jsonp'; Kind = 'json' }
+    @{ Name = 'danmaku-segment'; Uri = 'https://api.bilibili.com/x/v2/dm/web/seg.so?type=1&oid=279786&pid=170001&segment_index=1'; Kind = 'binary' }
+    @{ Name = 'danmaku-segment-wbi-alternative'; Uri = 'https://api.bilibili.com/x/v2/dm/wbi/web/seg.so?type=1&oid=279786&pid=170001&segment_index=1'; Kind = 'binary' }
+)
+
+function Get-SafeMessage {
+    param([object]$Value)
+
+    if ($null -eq $Value) {
+        return $null
+    }
+
+    $message = ([string]$Value) -replace '[\r\n]+', ' '
+    if ($message.Length -gt 160) {
+        return $message.Substring(0, 160)
+    }
+
+    return $message
+}
+
+$results = foreach ($probe in $probes) {
+    try {
+        $response = Invoke-WebRequest `
+            -Uri $probe.Uri `
+            -Headers $headers `
+            -Method Get `
+            -MaximumRedirection 3 `
+            -SkipHttpErrorCheck `
+            -TimeoutSec 20
+
+        $contentType = [string]$response.Headers.'Content-Type'
+        $result = [ordered]@{
+            Name = $probe.Name
+            HttpStatus = [int]$response.StatusCode
+            ApiCode = $null
+            Message = $null
+            Envelope = $null
+            ContentType = $contentType
+            Bytes = $response.RawContentLength
+        }
+
+        if ($probe.Kind -eq 'json' -and -not [string]::IsNullOrWhiteSpace($response.Content)) {
+            try {
+                $json = $response.Content | ConvertFrom-Json
+                $codeProperty = $json.PSObject.Properties['code']
+                $messageProperty = $json.PSObject.Properties['message']
+                $result.ApiCode = if ($null -eq $codeProperty) { $null } else { $codeProperty.Value }
+                $result.Message = if ($null -eq $messageProperty) {
+                    $null
+                }
+                else {
+                    Get-SafeMessage $messageProperty.Value
+                }
+                $result.Envelope = @($json.PSObject.Properties.Name) -join ','
+            }
+            catch {
+                $result.Message = 'non-JSON response'
+            }
+        }
+
+        [pscustomobject]$result
+    }
+    catch {
+        [pscustomobject][ordered]@{
+            Name = $probe.Name
+            HttpStatus = $null
+            ApiCode = $null
+            Message = Get-SafeMessage $_.Exception.Message
+            Envelope = $null
+            ContentType = $null
+            Bytes = 0
+        }
+    }
+}
+
+$commit = try {
+    (& git rev-parse HEAD 2>$null).Trim()
+}
+catch {
+    'unknown'
+}
+
+$report = [ordered]@{
+    CapturedAtUtc = [DateTimeOffset]::UtcNow.ToString('O')
+    Runtime = $PSVersionTable.PSVersion.ToString()
+    OperatingSystem = [System.Runtime.InteropServices.RuntimeInformation]::OSDescription
+    Architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    Commit = $commit
+    Authentication = 'anonymous; no Cookie header or local login state is loaded'
+    Results = @($results)
+}
+
+$jsonReport = $report | ConvertTo-Json -Depth 6
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    $resolvedOutput = [System.IO.Path]::GetFullPath($OutputPath)
+    $parent = [System.IO.Path]::GetDirectoryName($resolvedOutput)
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        [System.IO.Directory]::CreateDirectory($parent) | Out-Null
+    }
+
+    Set-Content -LiteralPath $resolvedOutput -Value $jsonReport -Encoding utf8NoBOM
+}
+
+$jsonReport

--- a/tests/DownKyi.Architecture.Tests/BilibiliApiInventoryArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/BilibiliApiInventoryArchitectureTests.cs
@@ -1,0 +1,166 @@
+using System.Text.RegularExpressions;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed partial class BilibiliApiInventoryArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    public void EveryHardCodedBilibiliApiEndpointIsRecordedInTheAudit()
+    {
+        var report = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "docs",
+            "operations",
+            "bilibili-api-audit.md"));
+        var endpoints = Directory
+            .EnumerateFiles(
+                Path.Combine(RepositoryRoot, "DownKyi.Core", "BiliApi"),
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => !path.Contains(
+                $"{Path.DirectorySeparatorChar}Models{Path.DirectorySeparatorChar}",
+                StringComparison.Ordinal))
+            .SelectMany(ExtractEndpoints)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var missing = endpoints
+            .Where(endpoint => !report.Contains($"`{endpoint}`", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(
+            missing.Length == 0,
+            $"Bilibili API audit is missing source endpoints: {string.Join(", ", missing)}");
+    }
+
+    [Fact]
+    public void AnonymousNonSuccessCodeExceptionIsScopedToNavigation()
+    {
+        var usages = Directory
+            .EnumerateFiles(
+                Path.Combine(RepositoryRoot, "DownKyi.Core"),
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => File.ReadAllText(path).Contains(
+                "RequestJsonAllowingCode<",
+                StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(RepositoryRoot, path).Replace('\\', '/'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(
+            [
+                "DownKyi.Core/BiliApi/BiliApiRequest.cs",
+                "DownKyi.Core/BiliApi/Users/UserInfo.cs"
+            ],
+            usages);
+    }
+
+    [Fact]
+    public void OptionalJsonEnvelopeFieldsCannotInventPayloads()
+    {
+        var violations = new List<string>();
+        foreach (var path in Directory.EnumerateFiles(
+                     Path.Combine(RepositoryRoot, "DownKyi.Core", "BiliApi"),
+                     "*.cs",
+                     SearchOption.AllDirectories))
+        {
+            var lines = File.ReadAllLines(path);
+            for (var index = 0; index < lines.Length; index++)
+            {
+                if (!IsOptionalEnvelopeAttribute(lines[index]))
+                {
+                    continue;
+                }
+
+                var declaration = lines[index];
+                if (!declaration.Contains("public ", StringComparison.Ordinal)
+                    && index + 1 < lines.Length)
+                {
+                    declaration += lines[index + 1];
+                }
+
+                var propertyEnd = declaration.IndexOf('}', StringComparison.Ordinal);
+                if (propertyEnd >= 0)
+                {
+                    declaration = declaration[..(propertyEnd + 1)];
+                }
+
+                if (declaration.Contains("= new", StringComparison.Ordinal)
+                    || declaration.Contains("= Array.Empty", StringComparison.Ordinal)
+                    || declaration.Contains("= []", StringComparison.Ordinal))
+                {
+                    violations.Add(
+                        $"{Path.GetRelativePath(RepositoryRoot, path)}:{index + 1}");
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            $"Optional JSON envelopes must preserve missing fields: {string.Join(", ", violations)}");
+    }
+
+    [Fact]
+    public void LiveProbeIsExplicitAndDoesNotLoadCookies()
+    {
+        var script = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "script",
+            "audit-bilibili-api.ps1"));
+
+        Assert.Contains("[switch]$ConfirmLive", script, StringComparison.Ordinal);
+        Assert.Contains("Authentication = 'anonymous", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("SESSDATA", script, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("GetLoginInfoCookies", script, StringComparison.Ordinal);
+    }
+
+    private static bool IsOptionalEnvelopeAttribute(string line)
+    {
+        return line.Contains("[JsonProperty(\"data\")]", StringComparison.Ordinal)
+               || line.Contains("[JsonProperty(\"result\")]", StringComparison.Ordinal)
+               || line.Contains("[JsonPropertyName(\"data\")]", StringComparison.Ordinal)
+               || line.Contains("[JsonPropertyName(\"result\")]", StringComparison.Ordinal);
+    }
+
+    private static IEnumerable<string> ExtractEndpoints(string path)
+    {
+        foreach (var line in File.ReadLines(path))
+        {
+            var trimmed = line.TrimStart();
+            if (trimmed.StartsWith("//", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            foreach (Match match in EndpointPattern().Matches(line))
+            {
+                yield return $"{match.Groups["host"].Value}{match.Groups["path"].Value}";
+            }
+        }
+    }
+
+    [GeneratedRegex(
+        "https://(?<host>(?:api|passport|space)\\.bilibili\\.com)(?<path>/(?:x|pgc|pugv|ajax)/[^\\\"?]*)",
+        RegexOptions.CultureInvariant,
+        1000)]
+    private static partial Regex EndpointPattern();
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the DownKyi repository root.");
+    }
+}

--- a/tests/DownKyi.Core.Tests/BiliApi/JsonSamples/playurl-bangumi-v2-result.json
+++ b/tests/DownKyi.Core.Tests/BiliApi/JsonSamples/playurl-bangumi-v2-result.json
@@ -1,0 +1,17 @@
+{
+  "code": 0,
+  "message": "success",
+  "result": {
+    "video_info": {
+      "quality": 80,
+      "durl": [
+        {
+          "order": 1,
+          "length": 240000,
+          "size": 4096,
+          "url": "https://media.example.test/segment.flv"
+        }
+      ]
+    }
+  }
+}

--- a/tests/DownKyi.Core.Tests/BiliApi/JsonSamples/user-navigation-anonymous.json
+++ b/tests/DownKyi.Core.Tests/BiliApi/JsonSamples/user-navigation-anonymous.json
@@ -1,0 +1,14 @@
+{
+  "code": -101,
+  "message": "account not logged in",
+  "ttl": 1,
+  "data": {
+    "isLogin": false,
+    "mid": 0,
+    "uname": "",
+    "wbi_img": {
+      "img_url": "https://i0.hdslb.com/bfs/wbi/11111111111111111111111111111111.png",
+      "sub_url": "https://i0.hdslb.com/bfs/wbi/22222222222222222222222222222222.png"
+    }
+  }
+}

--- a/tests/DownKyi.Core.Tests/PlayUrlEnvelopeContractTests.cs
+++ b/tests/DownKyi.Core.Tests/PlayUrlEnvelopeContractTests.cs
@@ -106,9 +106,9 @@ public sealed class PlayUrlEnvelopeContractTests : IDisposable
     }
 
     [Fact]
-    public void BangumiEndpointUsesResultEnvelope()
+    public void BangumiEndpointUsesResultVideoInfoEnvelope()
     {
-        ConfigureResponse("playurl-bangumi-result.json");
+        ConfigureResponse("playurl-bangumi-v2-result.json");
 
         var payload = VideoStreamApi.GetBangumiPlayUrl(
             1,
@@ -117,6 +117,21 @@ public sealed class PlayUrlEnvelopeContractTests : IDisposable
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, Assert.Single(payload?.Durl ?? []).Order);
+    }
+
+    [Fact]
+    public void BangumiV2MissingVideoInfoThrowsTypedContractFailure()
+    {
+        var response = new BangumiPlayUrlV2Origin
+        {
+            Result = new BangumiPlayUrlV2Result()
+        };
+
+        var exception = Assert.Throws<BilibiliApiResponseException>(() =>
+            BangumiPlayUrlV2Contract.SelectPayload(response, "bangumi-v2"));
+
+        Assert.Equal("bangumi-v2", exception.Operation);
+        Assert.Contains("result.video_info", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/DownKyi.Core.Tests/UserNavigationContractTests.cs
+++ b/tests/DownKyi.Core.Tests/UserNavigationContractTests.cs
@@ -1,0 +1,80 @@
+using System.Net;
+using DownKyi.Core.BiliApi;
+using DownKyi.Core.BiliApi.Sign;
+using DownKyi.Core.BiliApi.Users;
+using DownKyi.Core.BiliApi.Users.Models;
+using BiliWebClient = DownKyi.Core.BiliApi.WebClient;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class UserNavigationContractTests : IDisposable
+{
+    private readonly WebClientTestContext _context = new();
+
+    [Fact]
+    public void AnonymousNavigationResponsePreservesPublicWbiMetadata()
+    {
+        ConfigureAnonymousResponse();
+
+        var navigation = UserInfo.GetUserInfoForNavigation(TestContext.Current.CancellationToken);
+
+        Assert.NotNull(navigation);
+        Assert.False(navigation.IsLogin);
+        Assert.Equal(0, navigation.Mid);
+        Assert.Equal("11111111111111111111111111111111", WbiKeyProvider.ExtractKey(navigation.Wbi?.ImageAddress));
+        Assert.Equal("22222222222222222222222222222222", WbiKeyProvider.ExtractKey(navigation.Wbi?.SubAddress));
+    }
+
+    [Fact]
+    public void AnonymousCodeRemainsRejectedOutsideTheNavigationContract()
+    {
+        ConfigureAnonymousResponse();
+
+        var exception = Assert.Throws<BilibiliApiResponseException>(() =>
+            BiliApiRequest.RequestJson<UserInfoForNavigationOrigin>(
+                "https://example.test/not-nav",
+                referer: null,
+                operationName: "ordinary-contract",
+                logTag: nameof(UserNavigationContractTests),
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(-101, exception.Code);
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private static void ConfigureAnonymousResponse()
+    {
+        var body = File.ReadAllText(Path.Combine(
+            FindRepositoryRoot(),
+            "tests",
+            "DownKyi.Core.Tests",
+            "BiliApi",
+            "JsonSamples",
+            "user-navigation-anonymous.json"));
+        BiliWebClient.SendOverrideForTests = (_, _) => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(body)
+        };
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}


### PR DESCRIPTION
## Summary

- inventory all 47 fixed Bilibili endpoints in Core with owners, envelopes, auth/WBI requirements, runtime use, evidence, alternatives, and tests
- preserve public WBI bootstrap when anonymous /nav returns code -101 with valid data.wbi_img
- migrate bangumi playback to /pgc/player/web/v2/playurl and require a non-empty result.video_info payload
- add an explicit anonymous live-probe script plus architecture ratchets for endpoint inventory and optional JSON envelopes
- document retired channel APIs, the invalid unused nickname query, legacy danmaku, and authenticated watch-later uncertainty without speculative replacements

## Privacy and evidence

The live audit used anonymous requests only. It did not read, copy, log, or send local cookies, settings, account IDs, browser profiles, download records, or personal paths. Authenticated-only contracts remain marked auth-deferred and are protected by deterministic fixtures instead of a maintainer account.

Evidence was cross-checked against current yt-dlp, maintained Nemo2011/bilibili-api endpoint maps, maintained community protocol documentation, controlled public requests, and local fixtures.

## Validation

- strict .NET 10 Release build with AnalysisMode=All: 0 warnings, 0 errors
- full solution tests: 543 passed, 0 failed, 0 skipped
- dotnet format: 0/742 files changed
- anonymous live probe: 27 results, 0 transport failures
- vulnerable package audit: empty
- deprecated package audit: empty
- module-boundary audit: no new baseline finding
- git diff --check: passed

## Compatibility

No settings, SQLite schema, download record, resume state, aria2 session, or user-data format changed. Revert this PR to restore the prior endpoint behavior; the audit document can be retained independently if an endpoint rollback is required.