### PR TITLE
refactor: make Domain download tasks authoritative

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,17 +117,21 @@ DownloadBootstrapHostedService
   -> DownloadPipeline                     task workflow and media stages
      -> ITransferBackend                  Builtin or Aria2
      -> DownloadArtifactWriter            cover, subtitle, danmaku, NFO
-     -> DownloadTaskStateWriter           projection persistence boundary
-  -> DownloadTaskProjectionStore
+     -> DownloadTaskStateWriter           typed command adapter
+  -> IDownloadTaskApplicationService      Domain load/transition/persist/event
   -> IDownloadTaskStore / SqliteDownloadTaskStore
+  -> DownloadTaskProjectionStore          committed Domain -> UI projection
 ```
 
-此鏈仍有已追蹤的過渡債：orchestrator 每 500 ms 掃描 UI download collection，channel 元素仍是 `DownloadingItem`，Domain aggregate 主要由 projection store 反向重建。這些不是穩定契約，必須依 live plan 改成 `DownloadTaskId` event-driven queue 與 Domain-authoritative state flow。
+Durable 下載狀態只能由 `IDownloadTaskApplicationService` 依 `DownloadTaskId` 載入 aggregate、執行 transition、persist，成功後才發布 projection event。`DownloadTaskProjectionStore` 不得從既有 UI 狀態反向重建 runtime Domain；`DownloadTask.Restore` 只允許 SQLite materializer 與明確 legacy migration adapter。
+
+此鏈仍有已追蹤的過渡債：orchestrator 每 500 ms 掃描 UI download collection，channel 元素仍是 `DownloadingItem`，pipeline 內部 media stage 仍讀取 projection。這些不是穩定契約，Gate 5/6 必須改成 `DownloadTaskId` event-driven queue 與 typed stages。
 
 穩定契約：
 
 - 未完成任務、GID、partial file map、已完成分段 key、pause/progress 與 optimistic version 必須跨重啟保存。
-- 關閉取消不能跳過 `Downloading -> WaitForDownload` 的恢復寫入。
+- 關閉取消不能跳過 `Downloading/Pausing -> Queued` 的 Domain 恢復寫入。
+- 使用者暫停必須先進入 `Pausing`；只有 transfer worker 真正停止且 partial/resume files 已保留後才能確認為 `Paused`。
 - DURL 依 `Order` 排序且每段 key 包含 order；多段輸出必須經 ffprobe 驗證 seek/decode。
 - 刪除下載中任務必須清除實體暫存與 sidecar；取消與失敗不得把空檔或錯誤頁標記為成功。
 - 進度寫入走 bounded write-behind；UI 通知與 SQLite 寫入不得退回每個 byte/chunk 一次。
@@ -199,8 +203,8 @@ dotnet build .\DownKyi.sln `
 dotnet test .\DownKyi.sln -c Release --no-restore --no-build
 dotnet format .\DownKyi.sln --no-restore --verify-no-changes
 git diff --check
-dotnet package list .\DownKyi.sln --vulnerable --include-transitive
-dotnet package list .\DownKyi.sln --deprecated
+dotnet package list --project .\DownKyi.sln --vulnerable --include-transitive
+dotnet package list --project .\DownKyi.sln --deprecated
 ```
 
 關鍵永久防線：

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,7 +41,7 @@ flowchart TD
 - `DownKyi.exe` 同時是啟動入口、Avalonia Desktop 層與多數 runtime implementation owner。
 - `DownKyi.Desktop` 只含 Host builder，尚未形成完整 Desktop assembly boundary。
 - `DownKyi.Core` 仍直接依賴 Avalonia QR bitmap 與 XAML resources，尚未是 headless core。
-- `DownKyi.Domain.DownloadTask` 目前主要出現在 store/projection 邊界，下載 worker 仍操作 `DownloadingItem`。
+- `DownKyi.Domain.DownloadTask` 已是持久化狀態轉換的權威；worker 與 pipeline 入口使用 `DownloadTaskId`，但 orchestrator channel 與部分 media stage 仍暫時持有 UI projection。
 - `DownKyi.Application` 和 `DownKyi.Infrastructure` 已建立正確的依賴方向，但只承接部分實際產品責任。
 - Prism、DryIoc、EventAggregator、RegionManager 和 ContainerLocator 已從 production source 移除，不得重新引入。
 
@@ -87,19 +87,26 @@ Main region 的返回操作必須先縮減 `AvaloniaNavigationService` 的既有
 
 ```mermaid
 flowchart LR
-    Add["AddToDownloadService"] --> UiList["DownloadingItem collection"]
-    Add --> Projection["DownloadTaskProjectionStore"]
-    Projection --> Domain["Domain DownloadTask"]
-    Domain --> Store["IDownloadTaskStore / SQLite"]
+    Add["AddToDownloadService"] --> NewProjection["new DownloadingItem input"]
+    NewProjection --> Projection["DownloadTaskProjectionStore"]
+    Projection --> Commands["IDownloadTaskApplicationService"]
+    Commands --> Domain["Domain DownloadTask transitions"]
+    Commands --> Store["IDownloadTaskStore / SQLite"]
+    Commands -->|"committed TaskChanged"| Projection
+    Projection --> UiList["DownloadingItem collection"]
     UiList --> Poll["500 ms polling dispatcher"]
     Poll --> Channel["bounded Channel<DownloadingItem>"]
-    Channel --> Pipeline["DownloadPipeline"]
+    Channel --> Worker["worker extracts DownloadTaskId"]
+    Worker --> Commands
+    Worker --> Pipeline["DownloadPipeline(DownloadTaskId)"]
     Pipeline --> Backend["Builtin or aria2 backend"]
     Pipeline --> Ffmpeg["FFmpeg / validation"]
-    Pipeline --> Projection
+    Pipeline --> Commands
 ```
 
-這條流程可運作且保留既有資料相容性，但它不是目標架構。主要缺口是 UI projection 仍是 runtime source of truth，Domain aggregate 只在持久化前後參與轉換。
+目前所有 durable command 都先載入 Domain aggregate、執行合法 transition、以 optimistic version 寫入 SQLite，再發布 committed snapshot。一般 runtime 不再從 mutable UI model 反向重建 Domain；`DownloadTask.Restore` 只允許出現在 SQLite materializer 與 legacy migration adapter。
+
+這條流程仍不是最終架構。`DownloadOrchestrator` 會每 500 ms 掃描 UI collection，channel 元素仍是 `DownloadingItem`，而 pipeline 內部 media stage 仍以 projection 作為播放流和畫面上下文。Gate 5 會把 queue 改成事件驅動 `DownloadTaskId`；Gate 6/8 分別拆 stage 與建立 UI dispatcher/projector owner。
 
 ## 目標拓樸
 
@@ -187,6 +194,7 @@ FinalizeStage
 
 - 不依賴 Avalonia 或 `DownKyi.ViewModels`。
 - command/query/coordinator contract 使用 Domain 或 Application DTO。
+- `DownloadTaskApplicationService` 是下載狀態命令的唯一 owner；事件只能在 store 成功後發布 committed snapshot。
 - cancellation、錯誤分類及 retry decision 必須可測。
 
 ### Infrastructure

--- a/DownKyi/Composition/DesktopComposition.cs
+++ b/DownKyi/Composition/DesktopComposition.cs
@@ -73,7 +73,9 @@ internal static class DesktopComposition
         services.AddSingleton<IWbiKeyProvider, WbiKeyProvider>();
         services.AddSingleton<FfmpegProcessor>();
         services.AddSingleton<IDownloadTaskStore, SqliteDownloadTaskStore>();
+        services.AddSingleton<IDownloadTaskApplicationService, DownloadTaskApplicationService>();
         services.AddSingleton<DownloadTaskProjectionStore>();
+        services.AddSingleton<DownloadTaskStateWriter>();
         services.AddSingleton<DownloadListState>();
         services.AddSingleton<DownloadTaskFileService>();
         services.AddSingleton<AriaRuntimeClientRegistry>();

--- a/DownKyi/Services/Download/Aria2TransferBackend.cs
+++ b/DownKyi/Services/Download/Aria2TransferBackend.cs
@@ -15,6 +15,7 @@ using DownKyi.Core.BiliApi.Login;
 using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
 using DownKyi.Core.Utils;
+using DownKyi.Domain.Downloads;
 using DownKyi.Models;
 using DownKyi.Utils;
 using Microsoft.Extensions.Logging;
@@ -96,7 +97,6 @@ internal sealed class Aria2TransferBackend : ITransferBackend
     public async Task<DownloadTransferOutcome> TransferAsync(DownloadTransferRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var downloading = request.Download;
         var activeGid = await EnsureAriaTaskAsync(
             request).ConfigureAwait(true);
         if (activeGid == null)
@@ -108,8 +108,16 @@ internal sealed class Aria2TransferBackend : ITransferBackend
         var ariaManager = new AriaManager(
             _ariaClient,
             _loggerFactory.CreateLogger<AriaManager>());
+        DownloadProgress? lastProgress = null;
         EventHandler<AriaProgressEventArgs> progressHandler = (_, eventArgs) =>
-            UpdateProgress(downloading, eventArgs);
+        {
+            var progress = CreateProgress(activeGid, eventArgs);
+            if (progress != null)
+            {
+                lastProgress = progress;
+                request.PublishProgress(progress);
+            }
+        };
         ariaManager.TellStatus += progressHandler;
         try
         {
@@ -118,12 +126,13 @@ internal sealed class Aria2TransferBackend : ITransferBackend
                 async cancellationToken =>
                 {
                     cancellationToken.ThrowIfCancellationRequested();
-                    request.EnsureActive();
-                    if (downloading.Downloading.DownloadStatus == DownloadStatus.Pause)
+                    if (request.IsPauseRequested())
                     {
                         await _ariaClient.PauseAsync(activeGid).ConfigureAwait(false);
                         throw new OperationCanceledException("Download was paused.");
                     }
+
+                    request.EnsureActive();
                 },
                 request.CancellationToken).ConfigureAwait(true);
 
@@ -134,16 +143,25 @@ internal sealed class Aria2TransferBackend : ITransferBackend
                 _ => DownloadTransferOutcome.Failed
             };
         }
+        catch (OperationCanceledException) when (
+            !request.CancellationToken.IsCancellationRequested && request.IsPauseRequested())
+        {
+            return DownloadTransferOutcome.Paused;
+        }
         finally
         {
             ariaManager.TellStatus -= progressHandler;
+            if (lastProgress != null)
+            {
+                await request.PersistProgressAsync(lastProgress, CancellationToken.None)
+                    .ConfigureAwait(true);
+            }
         }
     }
 
     private async Task<string?> EnsureAriaTaskAsync(DownloadTransferRequest request)
     {
-        var downloading = request.Download;
-        var gid = downloading.Downloading.Gid;
+        var gid = request.BackendIdentity;
         if (!string.IsNullOrWhiteSpace(gid))
         {
             var status = await _ariaClient.TellStatus(gid).ConfigureAwait(true);
@@ -151,8 +169,7 @@ internal sealed class Aria2TransferBackend : ITransferBackend
                 status.Error?.Message.Contains("is not found", StringComparison.OrdinalIgnoreCase) == true)
             {
                 gid = null;
-                downloading.Downloading.Gid = null;
-                await request.PersistStateAsync(request.CancellationToken).ConfigureAwait(true);
+                await request.SetBackendIdentityAsync(null, request.CancellationToken).ConfigureAwait(true);
             }
         }
 
@@ -183,8 +200,7 @@ internal sealed class Aria2TransferBackend : ITransferBackend
             }
 
             gid = added.Result;
-            downloading.Downloading.Gid = gid;
-            await request.PersistStateAsync(request.CancellationToken).ConfigureAwait(true);
+            await request.SetBackendIdentityAsync(gid, request.CancellationToken).ConfigureAwait(true);
         }
         else
         {
@@ -272,31 +288,29 @@ internal sealed class Aria2TransferBackend : ITransferBackend
         }
     }
 
-    private void UpdateProgress(DownKyi.ViewModels.DownloadManager.DownloadingItem video, AriaProgressEventArgs eventArgs)
+    private DownloadProgress? CreateProgress(string activeGid, AriaProgressEventArgs eventArgs)
     {
-        if (!string.Equals(video.Downloading.Gid, eventArgs.Gid, StringComparison.Ordinal))
+        if (!string.Equals(activeGid, eventArgs.Gid, StringComparison.Ordinal))
         {
-            return;
+            return null;
         }
 
         var percent = eventArgs.TotalLength == 0
             ? 0
             : (float)eventArgs.CompletedLength / eventArgs.TotalLength * 100;
-        if (Math.Abs(percent - video.Progress) < 0.01)
-        {
-            return;
-        }
-
-        video.Progress = percent;
-        video.DownloadingFileSize = $"{Format.FormatFileSize(eventArgs.CompletedLength)}/{Format.FormatFileSize(eventArgs.TotalLength)}";
-        video.SpeedDisplay = Format.FormatSpeedWithBandwidth(eventArgs.Speed);
         _diagnosticLogger.LogSpeed(
             Name,
             eventArgs.Gid,
             eventArgs.CompletedLength,
             eventArgs.TotalLength,
             eventArgs.Speed);
-        video.Downloading.MaxSpeed = Math.Max(video.Downloading.MaxSpeed, eventArgs.Speed);
+        return new DownloadProgress(
+            Math.Clamp(percent, 0, 100),
+            eventArgs.CompletedLength,
+            Math.Max(eventArgs.CompletedLength, eventArgs.TotalLength),
+            eventArgs.Speed,
+            $"{Format.FormatFileSize(eventArgs.CompletedLength)}/{Format.FormatFileSize(eventArgs.TotalLength)}",
+            Format.FormatSpeedWithBandwidth(eventArgs.Speed));
     }
 
     public void Dispose()

--- a/DownKyi/Services/Download/BuiltinTransferBackend.cs
+++ b/DownKyi/Services/Download/BuiltinTransferBackend.cs
@@ -9,10 +9,10 @@ using DownKyi.Core.BiliApi.Login;
 using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
 using DownKyi.Core.Utils;
+using DownKyi.Domain.Downloads;
 using DownKyi.Utils;
 using Downloader;
 using Microsoft.Extensions.Logging;
-using DownloadStatus = DownKyi.Models.DownloadStatus;
 
 namespace DownKyi.Services.Download;
 
@@ -49,7 +49,6 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
     public async Task<DownloadTransferOutcome> TransferAsync(DownloadTransferRequest request)
     {
         ArgumentNullException.ThrowIfNull(request);
-        var downloading = request.Download;
         var urls = request.Urls;
         var path = request.Directory;
         var localFileName = request.FileName;
@@ -92,6 +91,7 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
             var progressUpdater = new DownloadProgressUiUpdater(
                 TimeProvider.System,
                 DownloadProgressUiUpdater.DefaultMinimumInterval);
+            DownloadProgress? lastProgress = null;
             var completion = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
             _diagnosticLogger.LogBuiltInTaskStart(
                 Name,
@@ -101,7 +101,7 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
                 configuration.ParallelCount,
                 network);
 
-            var downloader = new Downloader.DownloadService(configuration);
+            using var downloader = new Downloader.DownloadService(configuration);
             downloader.DownloadStarted += (_, args) =>
             {
                 if (args.TotalBytesToReceive > 0)
@@ -118,13 +118,15 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
                 }
 
                 var speed = (long)args.BytesPerSecondSpeed;
-                if (progressUpdater.TryUpdate(
-                        downloading,
+                if (progressUpdater.TryCreate(
                         args.ProgressPercentage,
                         args.ReceivedBytesSize,
                         args.TotalBytesToReceive,
-                        speed))
+                        speed,
+                        out var progress))
                 {
+                    lastProgress = progress;
+                    request.PublishProgress(progress);
                     _diagnosticLogger.LogSpeed(
                         Name,
                         localFileName,
@@ -147,41 +149,102 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
                                     expectedBytes,
                                     receivedBytes,
                                     totalBytesToReceive);
-                downloading.DownloadService = null;
+                request.SetBuiltinDownloadService(null);
                 completion.TrySetResult(succeeded);
             };
 
-            downloading.DownloadService = downloader;
-            var transferTask = RunDownloadAsync(
-                downloader,
+            request.SetBuiltinDownloadService(downloader);
+            var transferTask = downloader.DownloadFileTaskAsync(
                 url,
                 targetFile,
                 request.CancellationToken);
-            while (!completion.Task.IsCompleted && !transferTask.IsCompleted)
+            var taskSucceeded = false;
+            try
             {
-                request.EnsureActive();
-                if (downloading.Downloading.DownloadStatus == DownloadStatus.Pause)
+                while (!completion.Task.IsCompleted && !transferTask.IsCompleted)
                 {
-                    downloader.Pause();
-                    downloader.CancelAsync();
-                    downloading.DownloadService = null;
-                    throw new OperationCanceledException("Download was paused.");
+                    if (request.IsPauseRequested())
+                    {
+                        downloader.Pause();
+                        downloader.CancelAsync();
+                        request.SetBuiltinDownloadService(null);
+                        if (lastProgress != null)
+                        {
+                            await request.PersistProgressAsync(lastProgress, CancellationToken.None)
+                                .ConfigureAwait(true);
+                        }
+
+                        throw new OperationCanceledException("Download was paused.");
+                    }
+
+                    request.EnsureActive();
+
+                    await Task.Delay(
+                        TimeSpan.FromMilliseconds(100),
+                        request.CancellationToken).ConfigureAwait(true);
                 }
 
-                await Task.Delay(
-                    TimeSpan.FromMilliseconds(100),
-                    request.CancellationToken).ConfigureAwait(true);
+                await transferTask.ConfigureAwait(true);
+                taskSucceeded = true;
+            }
+            catch (OperationCanceledException) when (request.CancellationToken.IsCancellationRequested)
+            {
+                downloader.CancelAsync();
+                request.SetBuiltinDownloadService(null);
+                try
+                {
+                    await transferTask.ConfigureAwait(true);
+                }
+                catch (OperationCanceledException)
+                {
+                    taskSucceeded = false;
+                }
+
+                throw;
+            }
+            catch (OperationCanceledException)
+            {
+                downloader.CancelAsync();
+                try
+                {
+                    await transferTask.ConfigureAwait(true);
+                }
+                catch (OperationCanceledException)
+                {
+                    taskSucceeded = false;
+                }
+
+                taskSucceeded = false;
+            }
+            catch (Exception e) when (e is IOException or HttpRequestException or InvalidOperationException)
+            {
+                _logger.LogErrorMessage("Built-in transfer failed.", e);
+                taskSucceeded = false;
+            }
+            finally
+            {
+                request.SetBuiltinDownloadService(null);
             }
 
-            var taskSucceeded = await transferTask.ConfigureAwait(true);
             completion.TrySetResult(taskSucceeded && IsDownloadedMediaFileUsable(
                 targetFile,
                 expectedBytes,
                 receivedBytes,
                 totalBytesToReceive));
+            if (lastProgress != null)
+            {
+                await request.PersistProgressAsync(lastProgress, CancellationToken.None)
+                    .ConfigureAwait(true);
+            }
+
             if (await completion.Task.ConfigureAwait(true))
             {
                 return DownloadTransferOutcome.Succeeded;
+            }
+
+            if (request.IsPauseRequested())
+            {
+                return DownloadTransferOutcome.Paused;
             }
 
             DeleteInvalidDownloadedMediaFile(targetFile);
@@ -189,32 +252,6 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
         }
 
         return DownloadTransferOutcome.Failed;
-    }
-
-    private async Task<bool> RunDownloadAsync(
-        Downloader.DownloadService downloader,
-        string url,
-        string targetFile,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            await downloader.DownloadFileTaskAsync(url, targetFile, cancellationToken).ConfigureAwait(false);
-            return true;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (OperationCanceledException)
-        {
-            return false;
-        }
-        catch (Exception e) when (e is IOException or HttpRequestException or InvalidOperationException)
-        {
-            _logger.LogErrorMessage("Built-in transfer failed.", e);
-            return false;
-        }
     }
 
     public void Dispose()

--- a/DownKyi/Services/Download/DownloadArtifactWriter.cs
+++ b/DownKyi/Services/Download/DownloadArtifactWriter.cs
@@ -12,6 +12,7 @@ using DownKyi.Core.BiliApi.VideoStream;
 using DownKyi.Core.Danmaku2Ass;
 using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
+using DownKyi.Domain.Downloads;
 using DownKyi.Models;
 using DownKyi.Utils;
 using DownKyi.ViewModels.DownloadManager;
@@ -46,6 +47,12 @@ internal sealed class DownloadArtifactWriter
         downloading.DownloadContent = DictionaryResource.GetString("DownloadingCover");
         downloading.DownloadingFileSize = string.Empty;
         downloading.SpeedDisplay = string.Empty;
+        var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
+        await _stateWriter.UpdateActivityAsync(
+            taskId,
+            downloading.DownloadContent,
+            downloading.DownloadStatusTitle,
+            cancellationToken).ConfigureAwait(false);
 
         try
         {
@@ -55,10 +62,11 @@ internal sealed class DownloadArtifactWriter
             }
 
             WebClient.DownloadFile(coverUrl, fileName, cancellationToken: cancellationToken);
-            if (downloading.Downloading.DownloadFiles.TryAdd(coverUrl, fileName))
-            {
-                await _stateWriter.UpdateAsync(downloading, cancellationToken).ConfigureAwait(false);
-            }
+            await _stateWriter.RecordTransferFileAsync(
+                taskId,
+                coverUrl,
+                fileName,
+                cancellationToken).ConfigureAwait(false);
 
             return fileName;
         }
@@ -93,12 +101,19 @@ internal sealed class DownloadArtifactWriter
         downloading.DownloadContent = DictionaryResource.GetString("DownloadingDanmaku");
         downloading.DownloadingFileSize = string.Empty;
         downloading.SpeedDisplay = string.Empty;
+        var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
+        await _stateWriter.UpdateActivityAsync(
+            taskId,
+            downloading.DownloadContent,
+            downloading.DownloadStatusTitle,
+            cancellationToken).ConfigureAwait(false);
 
         var assFile = $"{downloading.DownloadBase?.FilePath}.ass";
-        if (downloading.Downloading.DownloadFiles.TryAdd("danmaku", assFile))
-        {
-            await _stateWriter.UpdateAsync(downloading, cancellationToken).ConfigureAwait(false);
-        }
+        await _stateWriter.RecordTransferFileAsync(
+            taskId,
+            "danmaku",
+            assFile,
+            cancellationToken).ConfigureAwait(false);
 
         var subtitleConfig = new Config
         {
@@ -134,6 +149,12 @@ internal sealed class DownloadArtifactWriter
         downloading.DownloadContent = DictionaryResource.GetString("DownloadingSubtitle");
         downloading.DownloadingFileSize = string.Empty;
         downloading.SpeedDisplay = string.Empty;
+        var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
+        await _stateWriter.UpdateActivityAsync(
+            taskId,
+            downloading.DownloadContent,
+            downloading.DownloadStatusTitle,
+            cancellationToken).ConfigureAwait(false);
 
         var srtFiles = new List<string>();
         var subRipTexts = await WbiRequestExecutor.ExecuteAsync(
@@ -159,10 +180,11 @@ internal sealed class DownloadArtifactWriter
             try
             {
                 await File.WriteAllTextAsync(srtFile, subRip.SrtString, cancellationToken).ConfigureAwait(false);
-                if (downloading.Downloading.DownloadFiles.TryAdd("subtitle", srtFile))
-                {
-                    await _stateWriter.UpdateAsync(downloading, cancellationToken).ConfigureAwait(false);
-                }
+                await _stateWriter.RecordTransferFileAsync(
+                    taskId,
+                    "subtitle",
+                    srtFile,
+                    cancellationToken).ConfigureAwait(false);
 
                 srtFiles.Add(srtFile);
             }

--- a/DownKyi/Services/Download/DownloadManagerCoordinator.cs
+++ b/DownKyi/Services/Download/DownloadManagerCoordinator.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Application.Desktop;
+using DownKyi.Domain.Downloads;
 using DownKyi.Models;
 using DownKyi.ViewModels;
 using DownKyi.ViewModels.DownloadManager;
@@ -64,17 +65,20 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         }.ToFrozenDictionary(StringComparer.Ordinal);
 
     private readonly DownloadTaskProjectionStore _storage;
+    private readonly DownloadTaskStateWriter _stateWriter;
     private readonly DownloadTaskFileService _fileService;
     private readonly DownloadListState _downloadLists;
     private readonly IPlatformLauncher _platformLauncher;
 
     public DownloadManagerCoordinator(
         DownloadTaskProjectionStore storage,
+        DownloadTaskStateWriter stateWriter,
         DownloadTaskFileService fileService,
         DownloadListState downloadLists,
         IPlatformLauncher platformLauncher)
     {
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
+        _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _platformLauncher = platformLauncher ?? throw new ArgumentNullException(nameof(platformLauncher));
@@ -92,9 +96,8 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
                 or DownloadStatus.WaitForDownload
                 or DownloadStatus.Downloading)
             {
-                await ApplyAndPersistStatusAsync(
-                    item,
-                    DownloadStatus.Pause,
+                await _stateWriter.PauseAsync(
+                    GetTaskId(item),
                     cancellationToken).ConfigureAwait(true);
             }
         }
@@ -114,9 +117,8 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
                 or DownloadStatus.Pause
                 or DownloadStatus.DownloadFailed)
             {
-                await ApplyAndPersistStatusAsync(
-                    item,
-                    DownloadStatus.WaitForDownload,
+                await _stateWriter.ResumeAsync(
+                    GetTaskId(item),
                     cancellationToken).ConfigureAwait(true);
             }
         }
@@ -127,18 +129,15 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(item);
-        var target = item.Downloading.DownloadStatus switch
+        return item.Downloading.DownloadStatus switch
         {
-            DownloadStatus.NotStarted or DownloadStatus.WaitForDownload => DownloadStatus.PauseStarted,
+            DownloadStatus.NotStarted or DownloadStatus.WaitForDownload =>
+                _stateWriter.PauseAsync(GetTaskId(item), cancellationToken),
             DownloadStatus.PauseStarted or DownloadStatus.Pause or DownloadStatus.DownloadFailed =>
-                DownloadStatus.WaitForDownload,
-            DownloadStatus.Downloading => DownloadStatus.Pause,
-            _ => item.Downloading.DownloadStatus
+                _stateWriter.ResumeAsync(GetTaskId(item), cancellationToken),
+            DownloadStatus.Downloading => _stateWriter.PauseAsync(GetTaskId(item), cancellationToken),
+            _ => Task.FromResult(_storage.GetRequiredSnapshot(GetTaskId(item)))
         };
-
-        return target == item.Downloading.DownloadStatus
-            ? Task.CompletedTask
-            : ApplyAndPersistStatusAsync(item, target, cancellationToken);
     }
 
     public async Task DeleteAsync(
@@ -148,8 +147,12 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         ArgumentNullException.ThrowIfNull(item);
         cancellationToken.ThrowIfCancellationRequested();
 
-        await ApplyAndPersistStatusAsync(item, DownloadStatus.Pause, cancellationToken)
-            .ConfigureAwait(true);
+        var taskId = GetTaskId(item);
+        if (_storage.GetRequiredSnapshot(taskId).Phase != DownloadPhase.Canceled)
+        {
+            await _stateWriter.CancelAsync(taskId, cancellationToken).ConfigureAwait(true);
+        }
+
         await _fileService.CancelActiveDownloadAsync(item).ConfigureAwait(true);
 
         // Once physical deletion starts, finish the database/list transaction even if app shutdown is requested.
@@ -161,9 +164,7 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
             throw new IOException("One or more generated download files could not be deleted.");
         }
 
-        await _storage
-            .RemoveDownloadingAsync(item, cascadeRemove: true, CancellationToken.None)
-            .ConfigureAwait(true);
+        await _stateWriter.DeleteAsync(taskId, CancellationToken.None).ConfigureAwait(true);
         _downloadLists.Downloading.Remove(item);
     }
 
@@ -237,25 +238,6 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         return DownloadArtifactOpenResult.NotFound;
     }
 
-    private async Task ApplyAndPersistStatusAsync(
-        DownloadingItem item,
-        DownloadStatus target,
-        CancellationToken cancellationToken)
-    {
-        var previousStatus = item.Downloading.DownloadStatus;
-        var previousTitle = item.DownloadStatusTitle;
-        item.ApplyControlStatus(target);
-        try
-        {
-            await _storage.UpdateDownloadingAsync(item, cancellationToken).ConfigureAwait(true);
-        }
-        catch
-        {
-            item.RestoreControlStatus(previousStatus, previousTitle);
-            throw;
-        }
-    }
-
     private async Task<DownloadArtifactOpenResult> OpenFirstFileAsync(
         string? basePath,
         IEnumerable<string> suffixes,
@@ -289,5 +271,10 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         return downloadBase.NeedDownloadContent
             .Where(item => item.Value && FileSuffixMap.ContainsKey(item.Key))
             .SelectMany(item => FileSuffixMap[item.Key]);
+    }
+
+    private static DownloadTaskId GetTaskId(DownloadingItem item)
+    {
+        return new DownloadTaskId(item.DownloadBase.Id);
     }
 }

--- a/DownKyi/Services/Download/DownloadOrchestrator.cs
+++ b/DownKyi/Services/Download/DownloadOrchestrator.cs
@@ -8,6 +8,7 @@ using System.Threading.Channels;
 using System.Threading.Tasks;
 using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
+using DownKyi.Domain.Downloads;
 using DownKyi.Models;
 using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
@@ -153,18 +154,17 @@ internal sealed class DownloadOrchestrator : IDownloadRuntime
         {
             await foreach (var downloading in reader.ReadAllAsync(cancellationToken).ConfigureAwait(false))
             {
+                var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
                 try
                 {
                     if (!_downloadLists.Downloading.Contains(downloading) ||
-                        downloading.Downloading.DownloadStatus is not (
-                            DownloadStatus.NotStarted or DownloadStatus.WaitForDownload))
+                        _pipeline.GetTaskPhase(taskId) != DownloadPhase.Queued)
                     {
                         continue;
                     }
 
-                    downloading.Downloading.DownloadStatus = DownloadStatus.Downloading;
-                    await _stateWriter.UpdateAsync(downloading, cancellationToken).ConfigureAwait(false);
-                    await _pipeline.ExecuteAsync(downloading, cancellationToken).ConfigureAwait(false);
+                    await _stateWriter.StartAsync(taskId, cancellationToken).ConfigureAwait(false);
+                    await _pipeline.ExecuteAsync(taskId, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -174,10 +174,12 @@ internal sealed class DownloadOrchestrator : IDownloadRuntime
                     or InvalidOperationException or HttpRequestException or Newtonsoft.Json.JsonException)
                 {
                     _logger.LogErrorMessage("Download worker failed.", exception);
-                    await _pipeline.MarkFailedAsync(downloading).ConfigureAwait(false);
+                    await _pipeline.MarkFailedAsync(
+                        taskId).ConfigureAwait(false);
                 }
                 finally
                 {
+                    await ConfirmPauseAfterWorkerStopsAsync(taskId).ConfigureAwait(false);
                     UnmarkQueued(downloading);
                 }
             }
@@ -185,6 +187,22 @@ internal sealed class DownloadOrchestrator : IDownloadRuntime
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
             return;
+        }
+    }
+
+    private async Task ConfirmPauseAfterWorkerStopsAsync(DownloadTaskId taskId)
+    {
+        try
+        {
+            if (_pipeline.GetTaskPhase(taskId) == DownloadPhase.Pausing)
+            {
+                await _stateWriter.ConfirmPausedAsync(taskId, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (InvalidOperationException exception)
+        {
+            _logger.LogErrorMessage("Download pause acknowledgement failed.", exception);
         }
     }
 

--- a/DownKyi/Services/Download/DownloadOutputRecorder.cs
+++ b/DownKyi/Services/Download/DownloadOutputRecorder.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DownKyi.Core.Utils;
+using DownKyi.Domain.Downloads;
+
+namespace DownKyi.Services.Download;
+
+internal static class DownloadOutputRecorder
+{
+    public static async Task<string> RecordFileSizeAsync(
+        DownloadTaskId taskId,
+        string? filePath,
+        DownloadTaskStateWriter stateWriter,
+        CancellationToken cancellationToken)
+    {
+        var fileSize = File.Exists(filePath)
+            ? Format.FormatFileSize(new FileInfo(filePath).Length)
+            : Format.FormatFileSize(0);
+        await stateWriter.UpdateOutputFileSizeAsync(taskId, fileSize, cancellationToken)
+            .ConfigureAwait(true);
+        return fileSize;
+    }
+}

--- a/DownKyi/Services/Download/DownloadPipeline.cs
+++ b/DownKyi/Services/Download/DownloadPipeline.cs
@@ -17,6 +17,7 @@ using DownKyi.Core.Logging;
 using DownKyi.Core.Settings;
 using DownKyi.Core.Storage;
 using DownKyi.Core.Utils;
+using DownKyi.Domain.Downloads;
 using DownKyi.Images;
 using DownKyi.Models;
 using DownKyi.Platform;
@@ -42,6 +43,7 @@ internal sealed class DownloadPipeline : IDisposable
     private FfmpegProcessor FfmpegProcessor { get; }
     private DownloadArtifactWriter ArtifactWriter { get; }
     private DownloadTaskStateWriter StateWriter { get; }
+    private DownloadTaskShutdownRecovery ShutdownRecovery { get; }
     private ISettingsStore SettingsStore { get; }
     private IWbiKeyProvider WbiKeyProvider { get; }
     private ILogger Logger { get; }
@@ -52,11 +54,16 @@ internal sealed class DownloadPipeline : IDisposable
     private const int Retry = 5;
     private const string NullMark = "<null>";
 
-    private void EnsureDownloadIsActive(DownloadingItem downloading)
+    private void EnsureDownloadIsActive(DownloadTaskId taskId)
     {
-        ArgumentNullException.ThrowIfNull(downloading);
+        ArgumentNullException.ThrowIfNull(taskId);
         CancellationToken?.ThrowIfCancellationRequested();
-        if (downloading.Downloading.DownloadStatus == DownloadStatus.Pause || !DownloadingList.Contains(downloading))
+        var task = ProjectionStore.GetRequiredSnapshot(taskId);
+        if (task.Phase != DownloadPhase.Downloading ||
+            !DownloadingList.Any(item => string.Equals(
+                item.DownloadBase.Id,
+                taskId.Value,
+                StringComparison.Ordinal)))
         {
             throw new OperationCanceledException("Task is paused or deleted");
         }
@@ -122,6 +129,7 @@ internal sealed class DownloadPipeline : IDisposable
         FfmpegProcessor ffmpegProcessor,
         DownloadArtifactWriter artifactWriter,
         DownloadTaskStateWriter stateWriter,
+        DownloadTaskShutdownRecovery shutdownRecovery,
         ITransferBackend transferBackend,
         ILogger logger)
     {
@@ -137,6 +145,7 @@ internal sealed class DownloadPipeline : IDisposable
         FfmpegProcessor = ffmpegProcessor ?? throw new ArgumentNullException(nameof(ffmpegProcessor));
         ArtifactWriter = artifactWriter ?? throw new ArgumentNullException(nameof(artifactWriter));
         StateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
+        ShutdownRecovery = shutdownRecovery ?? throw new ArgumentNullException(nameof(shutdownRecovery));
         _transferBackend = transferBackend ?? throw new ArgumentNullException(nameof(transferBackend));
         Logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -290,7 +299,8 @@ internal sealed class DownloadPipeline : IDisposable
             return null;
         }
 
-        EnsureDownloadIsActive(downloading);
+        var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
+        EnsureDownloadIsActive(taskId);
         var urls = new List<string>();
         if (!string.IsNullOrWhiteSpace(media.BaseAddress))
         {
@@ -314,37 +324,39 @@ internal sealed class DownloadPipeline : IDisposable
 
         var fileName = Guid.NewGuid().ToString("N");
         var key = VideoPlayUrlBasic.CreateDownloadKey(media.Id, media.Codecs);
-        downloading.Downloading.DownloadedFiles ??= [];
-        if (downloading.Downloading.DownloadFiles.TryGetValue(key, out var existingFileName))
+        var snapshot = ProjectionStore.GetRequiredSnapshot(taskId);
+        if (snapshot.Plan.TransferFiles.TryGetValue(key, out var existingFileName))
         {
             fileName = existingFileName;
             var cachedFile = Path.Combine(path, fileName);
-            if (downloading.Downloading.DownloadedFiles.Contains(key) &&
+            if (snapshot.Transfer.CompletedFileKeys.Contains(key, StringComparer.Ordinal) &&
                 IsDownloadedMediaFileUsable(cachedFile, media.ExpectedSize))
             {
                 return cachedFile;
             }
 
-            if (downloading.Downloading.DownloadedFiles.Remove(key))
+            if (snapshot.Transfer.CompletedFileKeys.Contains(key, StringComparer.Ordinal))
             {
                 DeleteInvalidDownloadedMediaFile(cachedFile);
-                await StateWriter.UpdateAsync(
-                    downloading,
+                await StateWriter.InvalidateCompletedFileAsync(
+                    taskId,
+                    key,
                     CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
             }
         }
-        else if (downloading.Downloading.DownloadFiles.TryAdd(key, fileName))
+        else
         {
-            downloading.Downloading.Gid = null;
-            await StateWriter.UpdateAsync(
-                downloading,
+            await StateWriter.RecordTransferFileAsync(
+                taskId,
+                key,
+                fileName,
                 CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
         }
 
         NormalizeTransferSchemes(urls, settings.Network.UseSsl == AllowStatus.Yes);
         var targetFile = Path.Combine(path, fileName);
         var outcome = await TransferAsync(
-            downloading,
+            taskId,
             urls,
             path,
             fileName,
@@ -352,26 +364,23 @@ internal sealed class DownloadPipeline : IDisposable
         if (outcome == DownloadTransferOutcome.Succeeded &&
             IsDownloadedMediaFileUsable(targetFile, media.ExpectedSize))
         {
-            if (!downloading.Downloading.DownloadedFiles.Contains(key))
-            {
-                downloading.Downloading.DownloadedFiles.Add(key);
-            }
-
-            downloading.Downloading.Gid = null;
-            await StateWriter.UpdateAsync(
-                downloading,
+            await StateWriter.CompleteTransferFileAsync(
+                taskId,
+                key,
                 CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
             return targetFile;
         }
 
-        if (outcome != DownloadTransferOutcome.Paused)
+        if (outcome == DownloadTransferOutcome.Paused)
         {
-            downloading.Downloading.Gid = null;
-            DeleteInvalidDownloadedMediaFile(targetFile);
-            await StateWriter.UpdateAsync(
-                downloading,
-                CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
+            throw new OperationCanceledException("Download was paused.");
         }
+
+        DeleteInvalidDownloadedMediaFile(targetFile);
+        await StateWriter.SetBackendIdentityAsync(
+            taskId,
+            null,
+            CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
 
         return NullMark;
     }
@@ -400,7 +409,8 @@ internal sealed class DownloadPipeline : IDisposable
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(downloading);
-        EnsureDownloadIsActive(downloading);
+        var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
+        EnsureDownloadIsActive(taskId);
 
         // 更新状态显示
         downloading.DownloadStatusTitle = DictionaryResource.GetString("MixedFlow");
@@ -409,6 +419,11 @@ internal sealed class DownloadPipeline : IDisposable
         downloading.DownloadingFileSize = string.Empty;
         // 下载速度
         downloading.SpeedDisplay = string.Empty;
+        await StateWriter.UpdateActivityAsync(
+            taskId,
+            downloading.DownloadContent,
+            downloading.DownloadStatusTitle,
+            cancellationToken).ConfigureAwait(true);
 
         var finalFile = $"{downloading.DownloadBase.FilePath}.mp4";
         if (videoUid == null)
@@ -424,24 +439,12 @@ internal sealed class DownloadPipeline : IDisposable
         var succeeded = await FfmpegProcessor
             .MergeVideoAsync(videoSettings, audioUid, videoUid, finalFile, cancellationToken)
             .ConfigureAwait(true);
-        if (!succeeded)
-        {
-            downloading.FileSize = Format.FormatFileSize(0);
-            return null;
-        }
-
-        // 获取文件大小
-        if (File.Exists(finalFile))
-        {
-            var info = new FileInfo(finalFile);
-            downloading.FileSize = Format.FormatFileSize(info.Length);
-        }
-        else
-        {
-            downloading.FileSize = Format.FormatFileSize(0);
-        }
-
-        return finalFile;
+        downloading.FileSize = await DownloadOutputRecorder.RecordFileSizeAsync(
+            taskId,
+            succeeded ? finalFile : null,
+            StateWriter,
+            cancellationToken).ConfigureAwait(true);
+        return succeeded ? finalFile : null;
     }
 
 
@@ -451,10 +454,16 @@ internal sealed class DownloadPipeline : IDisposable
         VideoApplicationSettings videoSettings,
         CancellationToken cancellationToken)
     {
+        var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
         downloading.DownloadStatusTitle = DictionaryResource.GetString("ConcatVideos");
         downloading.DownloadContent = DictionaryResource.GetString("DownloadingVideo");
         downloading.DownloadingFileSize = string.Empty;
         downloading.SpeedDisplay = string.Empty;
+        await StateWriter.UpdateActivityAsync(
+            taskId,
+            downloading.DownloadContent,
+            downloading.DownloadStatusTitle,
+            cancellationToken).ConfigureAwait(true);
 
         var finalFile = $"{downloading.DownloadBase.FilePath}.mp4";
         var segments = downloads
@@ -471,15 +480,11 @@ internal sealed class DownloadPipeline : IDisposable
                 finalFile,
                 cancellationToken: cancellationToken)
             .ConfigureAwait(true);
-        if (result.Succeeded && result.OutputPath != null)
-        {
-            var info = new FileInfo(result.OutputPath);
-            downloading.FileSize = Format.FormatFileSize(info.Length);
-        }
-        else
-        {
-            downloading.FileSize = Format.FormatFileSize(0);
-        }
+        downloading.FileSize = await DownloadOutputRecorder.RecordFileSizeAsync(
+            taskId,
+            result.Succeeded ? result.OutputPath : null,
+            StateWriter,
+            cancellationToken).ConfigureAwait(true);
 
         return result;
     }
@@ -488,6 +493,7 @@ internal sealed class DownloadPipeline : IDisposable
 
 
     private async Task ParseAsync(
+        DownloadTaskId taskId,
         DownloadingItem downloading,
         ApplicationSettings settings)
     {
@@ -501,23 +507,22 @@ internal sealed class DownloadPipeline : IDisposable
         downloading.Progress = 0;
         // 下载速度
         downloading.SpeedDisplay = string.Empty;
+        await StateWriter.UpdateActivityAsync(
+            taskId,
+            downloading.DownloadContent,
+            downloading.DownloadStatusTitle,
+            CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
 
-        if (downloading.PlayUrl != null && downloading.Downloading.DownloadStatus == DownloadStatus.NotStarted)
+        if (downloading.PlayUrl != null)
         {
-            // 设置下载状态
-            downloading.Downloading.DownloadStatus = DownloadStatus.Downloading;
-
             return;
         }
-
-        // 设置下载状态
-        downloading.Downloading.DownloadStatus = DownloadStatus.Downloading;
 
         PlayUrl? playUrl = null;
         switch (downloading.Downloading.PlayStreamType)
         {
             case PlayStreamType.Video:
-                playUrl = downloading.PlayUrl ?? await WbiRequestExecutor.ExecuteAsync(
+                playUrl = await WbiRequestExecutor.ExecuteAsync(
                     WbiKeyProvider,
                     (keys, unixTimeSeconds) => settings.Video.VideoParseType switch
                 {
@@ -531,11 +536,11 @@ internal sealed class DownloadPipeline : IDisposable
                     CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
                 break;
             case PlayStreamType.Bangumi:
-                playUrl = downloading.PlayUrl ?? VideoStreamApi.GetBangumiPlayUrl(downloading.DownloadBase.Avid, downloading.DownloadBase.Bvid,
+                playUrl = VideoStreamApi.GetBangumiPlayUrl(downloading.DownloadBase.Avid, downloading.DownloadBase.Bvid,
                     downloading.DownloadBase.Cid, cancellationToken: CancellationToken.GetValueOrDefault());
                 break;
             case PlayStreamType.Cheese:
-                playUrl = downloading.PlayUrl ?? VideoStreamApi.GetCheesePlayUrl(downloading.DownloadBase.Avid,
+                playUrl = VideoStreamApi.GetCheesePlayUrl(downloading.DownloadBase.Avid,
                     downloading.DownloadBase.Bvid, downloading.DownloadBase.Cid,
                     downloading.DownloadBase.EpisodeId, cancellationToken: CancellationToken.GetValueOrDefault());
                 break;
@@ -545,7 +550,7 @@ internal sealed class DownloadPipeline : IDisposable
 
         if (playUrl == null)
         {
-            await MarkFailedAsync(downloading).ConfigureAwait(true);
+            await MarkFailedAsync(taskId).ConfigureAwait(true);
             return;
         }
 
@@ -555,12 +560,14 @@ internal sealed class DownloadPipeline : IDisposable
     /// <summary>
     /// 下载一个视频
     /// </summary>
-    /// <param name="downloading"></param>
+    /// <param name="taskId"></param>
     /// <returns></returns>
     internal async Task ExecuteAsync(
-        DownloadingItem downloading,
+        DownloadTaskId taskId,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(taskId);
+        var downloading = ProjectionStore.GetRequiredDownloadingProjection(taskId);
         CancellationToken = cancellationToken;
         var settings = SettingsStore.Current;
         downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath.Replace("\\", "/", StringComparison.Ordinal);
@@ -578,7 +585,7 @@ internal sealed class DownloadPipeline : IDisposable
                 Logger.LogDebugMessage(e.Message);
 
                 NotificationService.Show($"{path}{DictionaryResource.GetString("DirectoryError")}");
-
+                await MarkFailedAsync(taskId).ConfigureAwait(true);
                 return;
             }
             catch (UnauthorizedAccessException e)
@@ -586,7 +593,7 @@ internal sealed class DownloadPipeline : IDisposable
                 Logger.LogDebugMessage(e.Message);
 
                 NotificationService.Show($"{path}{DictionaryResource.GetString("DirectoryError")}");
-
+                await MarkFailedAsync(taskId).ConfigureAwait(true);
                 return;
             }
         }
@@ -599,10 +606,10 @@ internal sealed class DownloadPipeline : IDisposable
                 downloading.DownloadContent = string.Empty;
 
                 // 解析并依次下载音频、视频、弹幕、字幕、封面等内容
-                await ParseAsync(downloading, settings).ConfigureAwait(true);
+                await ParseAsync(taskId, downloading, settings).ConfigureAwait(true);
 
                 // 暂停
-                EnsureDownloadIsActive(downloading);
+                EnsureDownloadIsActive(taskId);
 
                 var isMediaSuccess = true;
 
@@ -626,11 +633,11 @@ internal sealed class DownloadPipeline : IDisposable
 
                     if (audioUid == NullMark)
                     {
-                        await MarkFailedAsync(downloading).ConfigureAwait(true);
+                        await MarkFailedAsync(taskId).ConfigureAwait(true);
                         return;
                     }
 
-                    EnsureDownloadIsActive(downloading);
+                    EnsureDownloadIsActive(taskId);
 
 
                     // 如果需要下载视频
@@ -649,11 +656,11 @@ internal sealed class DownloadPipeline : IDisposable
 
                     if (videoUid == NullMark)
                     {
-                        await MarkFailedAsync(downloading).ConfigureAwait(true);
+                        await MarkFailedAsync(taskId).ConfigureAwait(true);
                         return;
                     }
 
-                    EnsureDownloadIsActive(downloading);
+                    EnsureDownloadIsActive(taskId);
 
                     // 混流
                     var outputMedia = string.Empty;
@@ -730,11 +737,11 @@ internal sealed class DownloadPipeline : IDisposable
 
                         if (downloadStatus.Any(download => download.FilePath == NullMark))
                         {
-                            await MarkFailedAsync(downloading).ConfigureAwait(true);
+                            await MarkFailedAsync(taskId).ConfigureAwait(true);
                             return;
                         }
 
-                        EnsureDownloadIsActive(downloading);
+                        EnsureDownloadIsActive(taskId);
 
                         if (durls.Count > 1)
                         {
@@ -764,11 +771,11 @@ internal sealed class DownloadPipeline : IDisposable
                         //音频分离？
                     }
 
-                    EnsureDownloadIsActive(downloading);
+                    EnsureDownloadIsActive(taskId);
                 }
                 else
                 {
-                    await MarkFailedAsync(downloading).ConfigureAwait(true);
+                    await MarkFailedAsync(taskId).ConfigureAwait(true);
                     return;
                 }
 
@@ -790,7 +797,7 @@ internal sealed class DownloadPipeline : IDisposable
                 }
 
                 // 暂停
-                EnsureDownloadIsActive(downloading);
+                EnsureDownloadIsActive(taskId);
 
                 IReadOnlyList<string>? outputSubtitles = null;
                 // 如果需要下载字幕
@@ -802,7 +809,7 @@ internal sealed class DownloadPipeline : IDisposable
                 }
 
                 // 暂停
-                EnsureDownloadIsActive(downloading);
+                EnsureDownloadIsActive(taskId);
 
                 string? outputCover = null;
                 string? outputPageCover = null;
@@ -828,7 +835,7 @@ internal sealed class DownloadPipeline : IDisposable
                 }
 
                 // 暂停
-                EnsureDownloadIsActive(downloading);
+                EnsureDownloadIsActive(taskId);
 
                 // 检测弹幕是否下载成功
                 var isDanmakuSuccess = true;
@@ -876,27 +883,27 @@ internal sealed class DownloadPipeline : IDisposable
 
                 if (!isMediaSuccess || !isDanmakuSuccess || !isSubtitleSuccess || !isCover)
                 {
-                    await MarkFailedAsync(downloading).ConfigureAwait(true);
+                    await MarkFailedAsync(taskId).ConfigureAwait(true);
                     return;
                 }
 
                 // 下载完成后处理
                 var downloaded = new Downloaded
                 {
-                    MaxSpeedDisplay = Format.FormatSpeedWithBandwidth(downloading.Downloading.MaxSpeed),
+                    MaxSpeedDisplay = Format.FormatSpeedWithBandwidth(
+                        ProjectionStore.GetRequiredSnapshot(taskId).Transfer.MaximumBytesPerSecond),
                 };
                 // 设置完成时间
                 downloaded.SetFinishedTimestamp(new DateTimeOffset(DateTime.UtcNow).ToUnixTimeSeconds());
 
-                var downloadedItem = new DownloadedItem
-                {
-                    DownloadBase = downloading.DownloadBase,
-                    Downloaded = downloaded
-                };
-
-                await ProjectionStore
-                    .AddDownloadedAsync(downloadedItem, cancellationToken)
-                    .ConfigureAwait(true);
+                var completedTask = await StateWriter.CompleteAsync(
+                    taskId,
+                    new DownloadCompletion(
+                        downloaded.FinishedTimestamp,
+                        downloaded.FinishedTime,
+                        downloaded.MaxSpeedDisplay),
+                    cancellationToken).ConfigureAwait(true);
+                var downloadedItem = DownloadTaskProjectionStore.CreateDownloadedProjection(completedTask);
                 await UiDispatcher.InvokeAsync(() =>
                 {
                     // 加入到下载完成list中，并从下载中list去除
@@ -912,31 +919,22 @@ internal sealed class DownloadPipeline : IDisposable
         catch (OperationCanceledException e)
         {
             Logger.LogDebugMessage(e.Message);
-            await StateWriter.UpdateAsync(
-                downloading,
-                System.Threading.CancellationToken.None).ConfigureAwait(true);
         }
     }
 
     /// <summary>
     /// 下载失败后的处理
     /// </summary>
-    /// <param name="downloading"></param>
-    internal async Task MarkFailedAsync(DownloadingItem downloading)
+    /// <param name="taskId"></param>
+    internal async Task MarkFailedAsync(DownloadTaskId taskId)
     {
-        ArgumentNullException.ThrowIfNull(downloading);
-
-        downloading.DownloadStatusTitle = DictionaryResource.GetString("DownloadFailed");
-        downloading.DownloadContent = string.Empty;
-        downloading.DownloadingFileSize = string.Empty;
-        downloading.SpeedDisplay = string.Empty;
-        downloading.Progress = 0;
-
-        downloading.Downloading.DownloadStatus = DownloadStatus.DownloadFailed;
-        downloading.StartOrPause = ButtonIcon.Instance().Retry;
-        downloading.StartOrPause.Fill = DictionaryResource.GetColor("ColorPrimary");
-        await StateWriter.UpdateAsync(
-            downloading,
+        ArgumentNullException.ThrowIfNull(taskId);
+        await StateWriter.FailAsync(
+            taskId,
+            new DownloadFailure(
+                "download.runtime.failed",
+                DictionaryResource.GetString("DownloadFailed"),
+                true),
             CancellationToken.GetValueOrDefault()).ConfigureAwait(true);
     }
 
@@ -968,32 +966,14 @@ internal sealed class DownloadPipeline : IDisposable
                ?? throw new ArgumentException("Download file path must include a directory.", nameof(filePath));
     }
 
+    internal DownloadPhase GetTaskPhase(DownloadTaskId taskId)
+    {
+        return ProjectionStore.GetRequiredSnapshot(taskId).Phase;
+    }
+
     internal async Task PersistShutdownStateAsync()
     {
-        foreach (var item in DownloadingList)
-        {
-            switch (item.Downloading.DownloadStatus)
-            {
-                case DownloadStatus.NotStarted:
-                case DownloadStatus.WaitForDownload:
-                case DownloadStatus.PauseStarted:
-                case DownloadStatus.Pause:
-                    break;
-                case DownloadStatus.Downloading:
-                    item.Downloading.DownloadStatus = DownloadStatus.WaitForDownload;
-                    break;
-                case DownloadStatus.DownloadSucceed:
-                case DownloadStatus.DownloadFailed:
-                default:
-                    break;
-            }
-
-            item.SpeedDisplay = string.Empty;
-
-            await StateWriter.UpdateAsync(
-                item,
-                System.Threading.CancellationToken.None).ConfigureAwait(true);
-        }
+        await ShutdownRecovery.PersistAsync().ConfigureAwait(true);
     }
 
     public void Dispose()
@@ -1019,22 +999,21 @@ internal sealed class DownloadPipeline : IDisposable
     }
 
     private Task<DownloadTransferOutcome> TransferAsync(
-        DownloadingItem downloading,
+        DownloadTaskId taskId,
         IReadOnlyList<string> urls,
         string path,
         string localFileName,
         long expectedBytes)
     {
-        return _transferBackend.TransferAsync(new DownloadTransferRequest(
-            downloading,
+        return _transferBackend.TransferAsync(DownloadTransferRequestFactory.Create(
+            taskId,
             urls,
             path,
             localFileName,
             expectedBytes,
-            () => EnsureDownloadIsActive(downloading),
-            cancellationToken => StateWriter.UpdateAsync(
-                downloading,
-                cancellationToken),
+            ProjectionStore,
+            StateWriter,
+            () => EnsureDownloadIsActive(taskId),
             CancellationToken.GetValueOrDefault()));
     }
 

--- a/DownKyi/Services/Download/DownloadProgressUiUpdater.cs
+++ b/DownKyi/Services/Download/DownloadProgressUiUpdater.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading;
 using DownKyi.Core.Utils;
-using DownKyi.ViewModels.DownloadManager;
+using DownKyi.Domain.Downloads;
 
 namespace DownKyi.Services.Download;
 
@@ -20,18 +20,14 @@ internal sealed class DownloadProgressUiUpdater
         _minimumInterval = minimumInterval;
     }
 
-    public bool TryUpdate(
-        DownloadingItem downloading,
+    public bool TryCreate(
         double progressPercentage,
         double receivedBytes,
         double totalBytes,
-        long bytesPerSecond)
+        long bytesPerSecond,
+        out DownloadProgress progress)
     {
-        ArgumentNullException.ThrowIfNull(downloading);
         bytesPerSecond = Math.Max(0, bytesPerSecond);
-        downloading.Downloading.MaxSpeed = Math.Max(
-            downloading.Downloading.MaxSpeed,
-            bytesPerSecond);
         var nowUtc = _timeProvider.GetUtcNow().ToUniversalTime();
         lock (_sync)
         {
@@ -40,16 +36,22 @@ internal sealed class DownloadProgressUiUpdater
                 && nowUtc >= lastPublishedAtUtc
                 && nowUtc - lastPublishedAtUtc < _minimumInterval)
             {
+                progress = DownloadProgress.None;
                 return false;
             }
 
             _lastPublishedAtUtc = nowUtc;
         }
 
-        downloading.Progress = checked((float)progressPercentage);
-        downloading.DownloadingFileSize =
-            $"{Format.FormatFileSize(NormalizeByteCount(receivedBytes))}/{Format.FormatFileSize(NormalizeByteCount(totalBytes))}";
-        downloading.SpeedDisplay = Format.FormatSpeedWithBandwidth(bytesPerSecond);
+        var downloadedBytes = NormalizeByteCount(receivedBytes);
+        var totalByteCount = NormalizeByteCount(totalBytes);
+        progress = new DownloadProgress(
+            Math.Clamp(progressPercentage, 0, 100),
+            downloadedBytes,
+            Math.Max(downloadedBytes, totalByteCount),
+            bytesPerSecond,
+            $"{Format.FormatFileSize(downloadedBytes)}/{Format.FormatFileSize(totalByteCount)}",
+            Format.FormatSpeedWithBandwidth(bytesPerSecond));
         return true;
     }
 

--- a/DownKyi/Services/Download/DownloadRuntimeFactory.cs
+++ b/DownKyi/Services/Download/DownloadRuntimeFactory.cs
@@ -22,6 +22,7 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
     private readonly AriaRuntimeClientRegistry _ariaClientRegistry;
     private readonly AriaServer _ariaServer;
     private readonly DownloadTaskProjectionStore _projectionStore;
+    private readonly DownloadTaskStateWriter _stateWriter;
     private readonly IUserNotificationService _notificationService;
     private readonly DownloadDiagnosticLogger _diagnosticLogger;
     private readonly FfmpegProcessor _ffmpegProcessor;
@@ -33,6 +34,7 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
     public DownloadRuntimeFactory(
         DownloadListState downloadLists,
         DownloadTaskProjectionStore projectionStore,
+        DownloadTaskStateWriter stateWriter,
         IUserNotificationService notificationService,
         IUiDispatcher uiDispatcher,
         ISettingsStore settingsStore,
@@ -46,6 +48,7 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _projectionStore = projectionStore
             ?? throw new ArgumentNullException(nameof(projectionStore));
+        _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
         _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
         _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
@@ -95,13 +98,14 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
             return null;
         }
 
-        var stateWriter = new DownloadTaskStateWriter(
-            _projectionStore,
-            _loggerFactory.CreateLogger<DownloadTaskStateWriter>());
         var artifactWriter = new DownloadArtifactWriter(
             _wbiKeyProvider,
-            stateWriter,
+            _stateWriter,
             _loggerFactory.CreateLogger<DownloadArtifactWriter>());
+        var shutdownRecovery = new DownloadTaskShutdownRecovery(
+            _downloadLists,
+            _projectionStore,
+            _stateWriter);
         var pipeline = new DownloadPipeline(
                 _downloadLists,
                 _projectionStore,
@@ -112,12 +116,13 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
                 _diagnosticLogger,
                 _ffmpegProcessor,
                 artifactWriter,
-                stateWriter,
+                _stateWriter,
+                shutdownRecovery,
                 transferBackend,
                 _loggerFactory.CreateLogger<DownloadPipeline>());
         return new DownloadOrchestrator(
             pipeline,
-            stateWriter,
+            _stateWriter,
             _downloadLists,
             _settingsStore,
             _loggerFactory.CreateLogger<DownloadOrchestrator>());

--- a/DownKyi/Services/Download/DownloadTaskFileService.cs
+++ b/DownKyi/Services/Download/DownloadTaskFileService.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Core.Logging;
-using DownKyi.Models;
 using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
 
@@ -34,8 +33,6 @@ internal sealed class DownloadTaskFileService
     {
         ArgumentNullException.ThrowIfNull(downloading);
 
-        downloading.Downloading.DownloadStatus = DownloadStatus.Pause;
-
         try
         {
             downloading.DownloadService?.CancelAsync();
@@ -55,7 +52,6 @@ internal sealed class DownloadTaskFileService
             return;
         }
 
-        var removed = false;
         var ariaClient = _ariaClientRegistry.Current;
         if (ariaClient == null)
         {
@@ -67,7 +63,6 @@ internal sealed class DownloadTaskFileService
         {
             await ariaClient.RemoveAsync(gid).WaitAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
             await ariaClient.RemoveDownloadResultAsync(gid).WaitAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false);
-            removed = true;
         }
         catch (TimeoutException e)
         {
@@ -76,13 +71,6 @@ internal sealed class DownloadTaskFileService
         catch (HttpRequestException e)
         {
             _logger.LogDebugMessage($"Cancel aria downloader failed: {e.Message}");
-        }
-        finally
-        {
-            if (removed)
-            {
-                downloading.Downloading.Gid = null;
-            }
         }
     }
 

--- a/DownKyi/Services/Download/DownloadTaskProjectionMapper.cs
+++ b/DownKyi/Services/Download/DownloadTaskProjectionMapper.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Linq;
+using DownKyi.Core.BiliApi.BiliUtils;
+using DownKyi.Core.BiliApi.VideoStream;
+using DownKyi.Domain.Downloads;
+using DownKyi.Models;
+using DownKyi.Utils;
+using DownKyi.ViewModels.DownloadManager;
+using LegacyDownloadStatus = DownKyi.Models.DownloadStatus;
+
+namespace DownKyi.Services.Download;
+
+internal static class DownloadTaskProjectionMapper
+{
+    public static DownloadTask CreateNewTask(DownloadingItem item, DateTimeOffset createdAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var downloadBase = item.DownloadBase
+            ?? throw new ArgumentException("A new download requires base metadata.", nameof(item));
+        var downloading = item.Downloading
+            ?? throw new ArgumentException("A new download requires runtime data.", nameof(item));
+        if (downloading.DownloadStatus is not (
+                LegacyDownloadStatus.NotStarted or LegacyDownloadStatus.WaitForDownload))
+        {
+            throw new ArgumentException(
+                "New downloads must enter through the queued Domain state.",
+                nameof(item));
+        }
+
+        return DownloadTask.Create(
+            new DownloadTaskId(downloadBase.Id),
+            ToMetadata(downloadBase),
+            new DownloadPlan(
+                downloadBase.NeedDownloadContent,
+                downloading.DownloadFiles,
+                (int)downloading.PlayStreamType),
+            new DownloadOutput(downloadBase.FilePath, downloadBase.FileSize),
+            createdAtUtc);
+    }
+
+    public static DownloadingItem ToDownloadingItem(DownloadTask task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        var item = new DownloadingItem();
+        Apply(task, item);
+        return item;
+    }
+
+    public static DownloadedItem ToDownloadedItem(DownloadTask task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        var completion = task.Completion
+            ?? throw new InvalidOperationException("Completed download is missing completion details.");
+        var downloadBase = ToDownloadBase(task);
+        return new DownloadedItem
+        {
+            DownloadBase = downloadBase,
+            Downloaded = new Downloaded
+            {
+                Id = task.Id.Value,
+                MaxSpeedDisplay = completion.MaximumSpeedText,
+                FinishedTimestamp = completion.FinishedTimestamp,
+                FinishedTime = completion.FinishedTimeText,
+                DownloadBase = downloadBase
+            }
+        };
+    }
+
+    public static void Apply(DownloadTask task, DownloadingItem item)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ArgumentNullException.ThrowIfNull(item);
+        var downloadBase = ToDownloadBase(task);
+        item.DownloadBase = downloadBase;
+        item.Downloading = new Downloading
+        {
+            Id = task.Id.Value,
+            Gid = task.Transfer.BackendIdentity,
+            DownloadFiles = task.Plan.TransferFiles.ToDictionary(entry => entry.Key, entry => entry.Value),
+            DownloadedFiles = task.Transfer.CompletedFileKeys.ToList(),
+            PlayStreamType = (PlayStreamType)task.Plan.StreamType,
+            DownloadStatus = MapPhase(task.Phase),
+            DownloadContent = task.Transfer.ActiveContent,
+            DownloadStatusTitle = MapStatusText(task),
+            Progress = checked((float)task.Progress.Percentage),
+            DownloadingFileSize = task.Progress.DownloadedSizeText,
+            MaxSpeed = task.Transfer.MaximumBytesPerSecond,
+            SpeedDisplay = task.Progress.SpeedText,
+            DownloadBase = downloadBase
+        };
+    }
+
+    public static void ApplyLiveProgress(DownloadProgress progress, DownloadingItem item)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(item);
+        item.Progress = checked((float)progress.Percentage);
+        item.DownloadingFileSize = progress.DownloadedSizeText;
+        item.SpeedDisplay = progress.SpeedText;
+        item.Downloading.MaxSpeed = Math.Max(
+            item.Downloading.MaxSpeed,
+            progress.BytesPerSecond);
+    }
+
+    private static DownloadTaskMetadata ToMetadata(DownloadBase downloadBase)
+    {
+        return new DownloadTaskMetadata(
+            new DownloadMediaIdentity(
+                downloadBase.Bvid,
+                downloadBase.Avid,
+                downloadBase.Cid,
+                downloadBase.EpisodeId,
+                downloadBase.Page,
+                downloadBase.Order),
+            downloadBase.MainTitle,
+            downloadBase.Name,
+            downloadBase.Duration,
+            downloadBase.VideoCodecName,
+            new DownloadQuality(downloadBase.Resolution.Id, downloadBase.Resolution.Name),
+            new DownloadQuality(downloadBase.AudioCodec.Id, downloadBase.AudioCodec.Name),
+            downloadBase.CoverUrl,
+            downloadBase.PageCoverUrl,
+            downloadBase.ZoneId);
+    }
+
+    private static DownloadBase ToDownloadBase(DownloadTask task)
+    {
+        return new DownloadBase
+        {
+            Id = task.Id.Value,
+            NeedDownloadContent = task.Plan.RequestedAssets.ToDictionary(entry => entry.Key, entry => entry.Value),
+            Bvid = task.Metadata.Media.Bvid,
+            Avid = task.Metadata.Media.Avid,
+            Cid = task.Metadata.Media.Cid,
+            EpisodeId = task.Metadata.Media.EpisodeId,
+            CoverUrl = task.Metadata.CoverAddress,
+            PageCoverUrl = task.Metadata.PageCoverAddress,
+            ZoneId = task.Metadata.ZoneId,
+            Order = task.Metadata.Media.Order,
+            MainTitle = task.Metadata.MainTitle,
+            Name = task.Metadata.Name,
+            Duration = task.Metadata.DurationText,
+            VideoCodecName = task.Metadata.VideoCodecName,
+            Resolution = new Quality
+            {
+                Id = task.Metadata.Resolution.Id,
+                Name = task.Metadata.Resolution.Name
+            },
+            AudioCodec = new Quality
+            {
+                Id = task.Metadata.AudioCodec.Id,
+                Name = task.Metadata.AudioCodec.Name
+            },
+            FilePath = task.Output.BasePath,
+            FileSize = task.Output.FileSizeText,
+            Page = task.Metadata.Media.Page
+        };
+    }
+
+    private static LegacyDownloadStatus MapPhase(DownloadPhase phase)
+    {
+        return phase switch
+        {
+            DownloadPhase.Pausing => LegacyDownloadStatus.PauseStarted,
+            DownloadPhase.Paused or DownloadPhase.Canceled => LegacyDownloadStatus.Pause,
+            DownloadPhase.Downloading => LegacyDownloadStatus.Downloading,
+            DownloadPhase.Failed => LegacyDownloadStatus.DownloadFailed,
+            DownloadPhase.Completed => LegacyDownloadStatus.DownloadSucceed,
+            _ => LegacyDownloadStatus.WaitForDownload
+        };
+    }
+
+    private static string? MapStatusText(DownloadTask task)
+    {
+        return task.Phase switch
+        {
+            DownloadPhase.Queued => DictionaryResource.GetString("Waiting"),
+            DownloadPhase.Pausing or DownloadPhase.Paused => DictionaryResource.GetString("Pausing"),
+            DownloadPhase.Failed => DictionaryResource.GetString("DownloadFailed"),
+            DownloadPhase.Downloading when string.IsNullOrWhiteSpace(task.Transfer.StatusText) =>
+                DictionaryResource.GetString("WhileDownloading"),
+            _ => task.Transfer.StatusText
+        };
+    }
+}

--- a/DownKyi/Services/Download/DownloadTaskProjectionStore.cs
+++ b/DownKyi/Services/Download/DownloadTaskProjectionStore.cs
@@ -7,37 +7,28 @@ using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
-using DownKyi.Core.BiliApi.BiliUtils;
-using DownKyi.Core.BiliApi.VideoStream;
 using DownKyi.Domain.Downloads;
-using DownKyi.Models;
 using DownKyi.ViewModels.DownloadManager;
-using DomainDownloadTask = DownKyi.Domain.Downloads.DownloadTask;
-using DomainQuality = DownKyi.Domain.Downloads.DownloadQuality;
-using LegacyDownloadStatus = DownKyi.Models.DownloadStatus;
-using LegacyQuality = DownKyi.Core.BiliApi.BiliUtils.Quality;
 
 namespace DownKyi.Services.Download;
 
 /// <summary>
-/// Persists download aggregates and projects them into desktop list items.
-/// SQLite access and schema ownership remain exclusively behind <see cref="IDownloadTaskStore"/>.
+/// Projects persisted Domain aggregates into desktop list items.
+/// Runtime state changes enter through <see cref="IDownloadTaskApplicationService"/>.
 /// </summary>
 internal sealed class DownloadTaskProjectionStore : IDisposable
 {
-    private const int MaximumUpdateAttempts = 2;
-    private readonly IDownloadTaskStore _store;
+    private readonly IDownloadTaskApplicationService _tasks;
     private readonly IClock _clock;
-    private readonly ConcurrentDictionary<string, DomainDownloadTask> _snapshots = new(StringComparer.Ordinal);
-    private readonly ConcurrentDictionary<string, SemaphoreSlim> _taskGates = new(StringComparer.Ordinal);
+    private readonly ConcurrentDictionary<DownloadTaskId, DownloadTask> _snapshots = new();
+    private readonly ConcurrentDictionary<DownloadTaskId, DownloadingItem> _downloadingProjections = new();
     private bool _disposed;
 
-    public DownloadTaskProjectionStore(IDownloadTaskStore store, IClock clock)
+    public DownloadTaskProjectionStore(IDownloadTaskApplicationService tasks, IClock clock)
     {
-        ArgumentNullException.ThrowIfNull(store);
-        ArgumentNullException.ThrowIfNull(clock);
-        _store = store;
-        _clock = clock;
+        _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
+        _tasks.TaskChanged += OnTaskChanged;
     }
 
     public async Task AddDownloadingAsync(
@@ -49,210 +40,56 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
             return;
         }
 
-        var task = CreateUnfinishedTask(downloadingItem, _clock.UtcNow);
-        var result = await _store.AddAsync(task, cancellationToken).ConfigureAwait(true);
+        var task = DownloadTaskProjectionMapper.CreateNewTask(downloadingItem, _clock.UtcNow);
+        _downloadingProjections[task.Id] = downloadingItem;
+        var result = await _tasks.AddAsync(task, cancellationToken).ConfigureAwait(true);
         if (result.IsSuccess)
         {
-            _snapshots[task.Id.Value] = task;
             return;
         }
 
-        var existing = await _store.FindAsync(task.Id, cancellationToken).ConfigureAwait(true);
+        var existing = await _tasks.FindAsync(task.Id, cancellationToken).ConfigureAwait(true);
         if (existing != null)
         {
-            _snapshots[task.Id.Value] = existing;
+            Publish(existing);
             return;
         }
 
+        _downloadingProjections.TryRemove(task.Id, out _);
         ThrowStoreFailure(result.Error?.Message);
-    }
-
-    public async Task RemoveDownloadingAsync(
-        DownloadingItem? downloadingItem,
-        bool cascadeRemove = false,
-        CancellationToken cancellationToken = default)
-    {
-        if (downloadingItem?.DownloadBase == null || !cascadeRemove)
-        {
-            // A non-cascading removal is followed by AddDownloadedAsync. The new store performs
-            // that table move atomically when the completed aggregate is persisted.
-            return;
-        }
-
-        await DeleteAsync(downloadingItem.DownloadBase.Id, cancellationToken).ConfigureAwait(true);
     }
 
     public async Task<IReadOnlyList<DownloadingItem>> GetDownloadingAsync(
         CancellationToken cancellationToken = default)
     {
-        var tasks = await _store.GetUnfinishedAsync(cancellationToken).ConfigureAwait(true);
-        foreach (var task in tasks)
-        {
-            _snapshots[task.Id.Value] = task;
-        }
-
-        return tasks.Select(ToDownloadingItem).ToArray();
+        var tasks = await _tasks.GetUnfinishedAsync(cancellationToken).ConfigureAwait(true);
+        return tasks.Select(CreateDownloadingProjection).ToArray();
     }
 
-    public async Task UpdateDownloadingAsync(
-        DownloadingItem? downloadingItem,
+    public async Task AddMigratedCompletedAsync(
+        DownloadTask task,
         CancellationToken cancellationToken = default)
     {
-        if (downloadingItem?.DownloadBase == null)
+        ArgumentNullException.ThrowIfNull(task);
+        if (task.Phase != DownloadPhase.Completed)
+        {
+            throw new ArgumentException("A migrated history task must be completed.", nameof(task));
+        }
+
+        var result = await _tasks.AddAsync(task, cancellationToken).ConfigureAwait(true);
+        if (result.IsSuccess)
         {
             return;
         }
 
-        var id = downloadingItem.DownloadBase.Id;
-        var gate = GetTaskGate(id);
-        await gate.WaitAsync(cancellationToken).ConfigureAwait(true);
-        try
+        var existing = await _tasks.FindAsync(task.Id, cancellationToken).ConfigureAwait(true);
+        if (existing?.Phase == DownloadPhase.Completed)
         {
-            for (var attempt = 0; attempt < MaximumUpdateAttempts; attempt++)
-            {
-                var current = await GetCurrentTaskAsync(id, cancellationToken).ConfigureAwait(true);
-                if (current == null)
-                {
-                    await AddDownloadingAsync(downloadingItem, cancellationToken).ConfigureAwait(true);
-                    return;
-                }
-
-                var updated = CreateUnfinishedTask(
-                    downloadingItem,
-                    current.CreatedAtUtc,
-                    checked(current.Version + 1),
-                    LaterOf(_clock.UtcNow, current.UpdatedAtUtc),
-                    current.Progress);
-                var result = await _store
-                    .UpdateAsync(updated, current.Version, cancellationToken)
-                    .ConfigureAwait(true);
-                if (result.IsSuccess)
-                {
-                    _snapshots[id] = updated;
-                    return;
-                }
-
-                _snapshots.TryRemove(id, out _);
-            }
-
-            ThrowStoreFailure($"Download task '{id}' changed while it was being saved.");
-        }
-        finally
-        {
-            gate.Release();
-        }
-    }
-
-    public async Task AddDownloadedAsync(
-        DownloadedItem? downloadedItem,
-        CancellationToken cancellationToken = default)
-    {
-        if (downloadedItem?.DownloadBase == null)
-        {
+            Publish(existing);
             return;
         }
 
-        var id = downloadedItem.DownloadBase.Id;
-        var gate = GetTaskGate(id);
-        await gate.WaitAsync(cancellationToken).ConfigureAwait(true);
-        try
-        {
-            for (var attempt = 0; attempt < MaximumUpdateAttempts; attempt++)
-            {
-                var current = await GetCurrentTaskAsync(id, cancellationToken).ConfigureAwait(true);
-                if (current == null)
-                {
-                    var completed = CreateCompletedTask(downloadedItem, _clock.UtcNow);
-                    var addResult = await _store.AddAsync(completed, cancellationToken).ConfigureAwait(true);
-                    if (addResult.IsSuccess)
-                    {
-                        _snapshots[id] = completed;
-                        return;
-                    }
-                }
-                else
-                {
-                    var completed = CreateCompletedTask(
-                        downloadedItem,
-                        current.CreatedAtUtc,
-                        checked(current.Version + 1),
-                        LaterOf(_clock.UtcNow, current.UpdatedAtUtc),
-                        current.Progress,
-                        current.Transfer,
-                        current.Plan);
-                    var updateResult = await _store
-                        .UpdateAsync(completed, current.Version, cancellationToken)
-                        .ConfigureAwait(true);
-                    if (updateResult.IsSuccess)
-                    {
-                        _snapshots[id] = completed;
-                        return;
-                    }
-                }
-
-                _snapshots.TryRemove(id, out _);
-            }
-
-            ThrowStoreFailure($"Completed download '{id}' could not be saved.");
-        }
-        finally
-        {
-            gate.Release();
-        }
-    }
-
-    public async Task AddDownloadedBatchAsync(
-        IEnumerable<Downloaded> items,
-        CancellationToken cancellationToken = default)
-    {
-        ArgumentNullException.ThrowIfNull(items);
-        foreach (var item in items)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (item.DownloadBase == null)
-            {
-                continue;
-            }
-
-            var completed = CreateCompletedTask(item, item.DownloadBase, _clock.UtcNow);
-            var result = await _store.AddAsync(completed, cancellationToken).ConfigureAwait(true);
-            if (result.IsSuccess)
-            {
-                _snapshots[completed.Id.Value] = completed;
-                continue;
-            }
-
-            var existing = await _store.FindAsync(completed.Id, cancellationToken).ConfigureAwait(true);
-            if (existing == null)
-            {
-                ThrowStoreFailure(result.Error?.Message);
-            }
-
-            if (existing.Phase == DownloadPhase.Completed)
-            {
-                _snapshots[existing.Id.Value] = existing;
-                continue;
-            }
-
-            completed = CreateCompletedTask(
-                item,
-                item.DownloadBase,
-                existing.CreatedAtUtc,
-                checked(existing.Version + 1),
-                LaterOf(_clock.UtcNow, existing.UpdatedAtUtc),
-                existing.Progress,
-                existing.Transfer,
-                existing.Plan);
-            result = await _store
-                .UpdateAsync(completed, existing.Version, cancellationToken)
-                .ConfigureAwait(true);
-            if (!result.IsSuccess)
-            {
-                ThrowStoreFailure(result.Error?.Message);
-            }
-
-            _snapshots[completed.Id.Value] = completed;
-        }
+        ThrowStoreFailure(result.Error?.Message);
     }
 
     public async Task RemoveDownloadedAsync(
@@ -264,7 +101,10 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
             return;
         }
 
-        await DeleteAsync(downloadedItem.DownloadBase.Id, cancellationToken).ConfigureAwait(true);
+        var result = await _tasks
+            .DeleteAsync(new DownloadTaskId(downloadedItem.DownloadBase.Id), cancellationToken)
+            .ConfigureAwait(true);
+        RequireSuccess(result.IsSuccess, result.Error?.Message);
     }
 
     public async Task<DownloadHistoryPage> GetDownloadedPageAsync(
@@ -272,12 +112,12 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
         int pageSize,
         CancellationToken cancellationToken = default)
     {
-        var page = await _store
+        var page = await _tasks
             .GetHistoryPageAsync(cursor, pageSize, cancellationToken)
             .ConfigureAwait(true);
         foreach (var task in page.Items)
         {
-            _snapshots[task.Id.Value] = task;
+            _snapshots[task.Id] = task;
         }
 
         return page;
@@ -291,7 +131,7 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
         do
         {
             var page = await GetDownloadedPageAsync(cursor, 500, cancellationToken).ConfigureAwait(true);
-            items.AddRange(page.Items.Select(ToDownloadedItem));
+            items.AddRange(page.Items.Select(DownloadTaskProjectionMapper.ToDownloadedItem));
             cursor = page.NextCursor;
         }
         while (cursor != null);
@@ -304,28 +144,45 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
         CancellationToken cancellationToken = default)
     {
         var page = await GetDownloadedPageAsync(null, pageSize, cancellationToken).ConfigureAwait(true);
-        return page.Items.Select(ToDownloadedItem).ToArray();
-    }
-
-    public Task UpdateDownloadedAsync(
-        DownloadedItem? downloadedItem,
-        CancellationToken cancellationToken = default)
-    {
-        return AddDownloadedAsync(downloadedItem, cancellationToken);
+        return page.Items.Select(DownloadTaskProjectionMapper.ToDownloadedItem).ToArray();
     }
 
     public async Task ClearDownloadedAsync(CancellationToken cancellationToken = default)
     {
-        var result = await _store.ClearHistoryAsync(cancellationToken).ConfigureAwait(true);
-        if (!result.IsSuccess)
-        {
-            ThrowStoreFailure(result.Error?.Message);
-        }
+        var result = await _tasks.ClearHistoryAsync(cancellationToken).ConfigureAwait(true);
+        RequireSuccess(result.IsSuccess, result.Error?.Message);
+    }
 
-        foreach (var snapshot in _snapshots.Where(item => item.Value.Phase == DownloadPhase.Completed).ToArray())
+    public DownloadTask GetRequiredSnapshot(DownloadTaskId taskId)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        return _snapshots.TryGetValue(taskId, out var task)
+            ? task
+            : throw new InvalidOperationException($"Download task '{taskId.Value}' is not loaded.");
+    }
+
+    public DownloadingItem GetRequiredDownloadingProjection(DownloadTaskId taskId)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        return _downloadingProjections.TryGetValue(taskId, out var item)
+            ? item
+            : throw new InvalidOperationException($"Download task '{taskId.Value}' has no active projection.");
+    }
+
+    public void PublishLiveProgress(DownloadTaskId taskId, DownloadProgress progress)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        ArgumentNullException.ThrowIfNull(progress);
+        if (_downloadingProjections.TryGetValue(taskId, out var item))
         {
-            _snapshots.TryRemove(snapshot.Key, out _);
+            DownloadTaskProjectionMapper.ApplyLiveProgress(progress, item);
         }
+    }
+
+    public static DownloadedItem CreateDownloadedProjection(DownloadTask task)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        return DownloadTaskProjectionMapper.ToDownloadedItem(task);
     }
 
     public void Dispose()
@@ -335,266 +192,63 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
             return;
         }
 
-        foreach (var gate in _taskGates.Values)
-        {
-            gate.Dispose();
-        }
-
-        _taskGates.Clear();
+        _tasks.TaskChanged -= OnTaskChanged;
+        _downloadingProjections.Clear();
+        _snapshots.Clear();
         _disposed = true;
     }
 
-    internal static DownloadingItem ToDownloadingItem(DomainDownloadTask task)
+    private DownloadingItem CreateDownloadingProjection(DownloadTask task)
     {
-        var downloadBase = ToDownloadBase(task);
-        var downloading = new Downloading
-        {
-            Id = task.Id.Value,
-            Gid = task.Transfer.BackendIdentity,
-            DownloadFiles = task.Plan.TransferFiles.ToDictionary(item => item.Key, item => item.Value),
-            DownloadedFiles = task.Transfer.CompletedFileKeys.ToList(),
-            PlayStreamType = (PlayStreamType)task.Plan.StreamType,
-            DownloadStatus = ToLegacyStatus(task.Phase),
-            DownloadContent = task.Transfer.ActiveContent,
-            DownloadStatusTitle = task.Transfer.StatusText,
-            Progress = checked((float)task.Progress.Percentage),
-            DownloadingFileSize = task.Progress.DownloadedSizeText,
-            MaxSpeed = task.Transfer.MaximumBytesPerSecond,
-            SpeedDisplay = task.Progress.SpeedText,
-            DownloadBase = downloadBase
-        };
-        return new DownloadingItem { DownloadBase = downloadBase, Downloading = downloading };
+        _snapshots[task.Id] = task;
+        return _downloadingProjections.GetOrAdd(
+            task.Id,
+            _ => DownloadTaskProjectionMapper.ToDownloadingItem(task));
     }
 
-    internal static DownloadedItem ToDownloadedItem(DomainDownloadTask task)
+    private void OnTaskChanged(object? sender, DownloadTaskChangedEventArgs args)
     {
-        var completion = task.Completion
-            ?? throw new InvalidOperationException("Completed download is missing completion details.");
-        var downloadBase = ToDownloadBase(task);
-        var downloaded = new Downloaded
+        if (args.Kind == DownloadTaskChangeKind.HistoryCleared)
         {
-            Id = task.Id.Value,
-            MaxSpeedDisplay = completion.MaximumSpeedText,
-            FinishedTimestamp = completion.FinishedTimestamp,
-            FinishedTime = completion.FinishedTimeText,
-            DownloadBase = downloadBase
-        };
-        return new DownloadedItem { DownloadBase = downloadBase, Downloaded = downloaded };
-    }
+            foreach (var completed in _snapshots
+                         .Where(entry => entry.Value.Phase == DownloadPhase.Completed)
+                         .Select(entry => entry.Key)
+                         .ToArray())
+            {
+                _snapshots.TryRemove(completed, out _);
+            }
 
-    private async Task DeleteAsync(string id, CancellationToken cancellationToken)
-    {
-        var taskId = new DownloadTaskId(id);
-        var result = await _store.DeleteAsync(taskId, cancellationToken).ConfigureAwait(true);
-        if (!result.IsSuccess && result.Error?.Code != "download.store.not_found")
-        {
-            ThrowStoreFailure(result.Error?.Message);
+            return;
         }
 
-        _snapshots.TryRemove(id, out _);
-    }
-
-    private async Task<DomainDownloadTask?> GetCurrentTaskAsync(
-        string id,
-        CancellationToken cancellationToken)
-    {
-        if (_snapshots.TryGetValue(id, out var snapshot))
+        if (args.Kind == DownloadTaskChangeKind.Deleted)
         {
-            return snapshot;
+            _snapshots.TryRemove(args.TaskId, out _);
+            _downloadingProjections.TryRemove(args.TaskId, out _);
+            return;
         }
 
-        var loaded = await _store.FindAsync(new DownloadTaskId(id), cancellationToken).ConfigureAwait(true);
-        if (loaded != null)
+        if (args.Snapshot != null)
         {
-            _snapshots[id] = loaded;
+            Publish(args.Snapshot);
         }
-
-        return loaded;
     }
 
-    private SemaphoreSlim GetTaskGate(string id)
+    private void Publish(DownloadTask task)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        return _taskGates.GetOrAdd(id, static _ => new SemaphoreSlim(1, 1));
-    }
-
-    private static DomainDownloadTask CreateUnfinishedTask(
-        DownloadingItem item,
-        DateTimeOffset createdAtUtc,
-        long version = 0,
-        DateTimeOffset? updatedAtUtc = null,
-        DownloadProgress? existingProgress = null)
-    {
-        var downloading = item.Downloading;
-        var phase = ToDomainPhase(downloading.DownloadStatus);
-        var failure = phase == DownloadPhase.Failed
-            ? new DownloadFailure(
-                "download.legacy.failed",
-                downloading.DownloadStatusTitle ?? "Download failed.",
-                true)
-            : null;
-        return DomainDownloadTask.Restore(
-            new DownloadTaskId(item.DownloadBase.Id),
-            ToMetadata(item.DownloadBase),
-            new DownloadPlan(
-                item.DownloadBase.NeedDownloadContent,
-                downloading.DownloadFiles,
-                (int)downloading.PlayStreamType),
-            new DownloadOutput(item.DownloadBase.FilePath, item.DownloadBase.FileSize),
-            phase,
-            new DownloadProgress(
-                downloading.Progress,
-                existingProgress?.DownloadedBytes,
-                existingProgress?.TotalBytes,
-                existingProgress?.BytesPerSecond ?? 0,
-                downloadedSizeText: downloading.DownloadingFileSize,
-                speedText: downloading.SpeedDisplay),
-            new DownloadTransferState(
-                downloading.Gid,
-                downloading.DownloadedFiles,
-                downloading.DownloadContent,
-                downloading.DownloadStatusTitle,
-                downloading.MaxSpeed),
-            failure,
-            null,
-            version,
-            createdAtUtc,
-            updatedAtUtc ?? createdAtUtc);
-    }
-
-    private static DomainDownloadTask CreateCompletedTask(
-        DownloadedItem item,
-        DateTimeOffset createdAtUtc,
-        long version = 0,
-        DateTimeOffset? updatedAtUtc = null,
-        DownloadProgress? progress = null,
-        DownloadTransferState? transfer = null,
-        DownloadPlan? plan = null)
-    {
-        return CreateCompletedTask(
-            item.Downloaded,
-            item.DownloadBase,
-            createdAtUtc,
-            version,
-            updatedAtUtc,
-            progress,
-            transfer,
-            plan);
-    }
-
-    private static DomainDownloadTask CreateCompletedTask(
-        Downloaded downloaded,
-        DownloadBase downloadBase,
-        DateTimeOffset createdAtUtc,
-        long version = 0,
-        DateTimeOffset? updatedAtUtc = null,
-        DownloadProgress? progress = null,
-        DownloadTransferState? transfer = null,
-        DownloadPlan? plan = null)
-    {
-        return DomainDownloadTask.Restore(
-            new DownloadTaskId(downloadBase.Id),
-            ToMetadata(downloadBase),
-            plan ?? new DownloadPlan(downloadBase.NeedDownloadContent, [], 0),
-            new DownloadOutput(downloadBase.FilePath, downloadBase.FileSize),
-            DownloadPhase.Completed,
-            progress ?? DownloadProgress.None,
-            transfer ?? DownloadTransferState.Empty,
-            null,
-            new DownloadCompletion(
-                downloaded.FinishedTimestamp,
-                downloaded.FinishedTime,
-                downloaded.MaxSpeedDisplay),
-            version,
-            createdAtUtc,
-            updatedAtUtc ?? createdAtUtc);
-    }
-
-    private static DownloadTaskMetadata ToMetadata(DownloadBase downloadBase)
-    {
-        return new DownloadTaskMetadata(
-            new DownloadMediaIdentity(
-                downloadBase.Bvid,
-                downloadBase.Avid,
-                downloadBase.Cid,
-                downloadBase.EpisodeId,
-                downloadBase.Page,
-                downloadBase.Order),
-            downloadBase.MainTitle,
-            downloadBase.Name,
-            downloadBase.Duration,
-            downloadBase.VideoCodecName,
-            ToDomainQuality(downloadBase.Resolution),
-            ToDomainQuality(downloadBase.AudioCodec),
-            downloadBase.CoverUrl,
-            downloadBase.PageCoverUrl,
-            downloadBase.ZoneId);
-    }
-
-    private static DownloadBase ToDownloadBase(DomainDownloadTask task)
-    {
-        return new DownloadBase
+        _snapshots[task.Id] = task;
+        if (_downloadingProjections.TryGetValue(task.Id, out var item))
         {
-            Id = task.Id.Value,
-            NeedDownloadContent = task.Plan.RequestedAssets.ToDictionary(item => item.Key, item => item.Value),
-            Bvid = task.Metadata.Media.Bvid,
-            Avid = task.Metadata.Media.Avid,
-            Cid = task.Metadata.Media.Cid,
-            EpisodeId = task.Metadata.Media.EpisodeId,
-            CoverUrl = task.Metadata.CoverAddress,
-            PageCoverUrl = task.Metadata.PageCoverAddress,
-            ZoneId = task.Metadata.ZoneId,
-            Order = task.Metadata.Media.Order,
-            MainTitle = task.Metadata.MainTitle,
-            Name = task.Metadata.Name,
-            Duration = task.Metadata.DurationText,
-            VideoCodecName = task.Metadata.VideoCodecName,
-            Resolution = ToLegacyQuality(task.Metadata.Resolution),
-            AudioCodec = ToLegacyQuality(task.Metadata.AudioCodec),
-            FilePath = task.Output.BasePath,
-            FileSize = task.Output.FileSizeText,
-            Page = task.Metadata.Media.Page
-        };
+            DownloadTaskProjectionMapper.Apply(task, item);
+        }
     }
 
-    private static DomainQuality ToDomainQuality(LegacyQuality quality)
+    private static void RequireSuccess(bool isSuccess, string? message)
     {
-        return new DomainQuality(quality.Id, quality.Name);
-    }
-
-    private static LegacyQuality ToLegacyQuality(DomainQuality quality)
-    {
-        return new LegacyQuality { Id = quality.Id, Name = quality.Name };
-    }
-
-    private static DownloadPhase ToDomainPhase(LegacyDownloadStatus status)
-    {
-        return status switch
+        if (!isSuccess)
         {
-            LegacyDownloadStatus.PauseStarted => DownloadPhase.Pausing,
-            LegacyDownloadStatus.Pause => DownloadPhase.Paused,
-            LegacyDownloadStatus.Downloading => DownloadPhase.Downloading,
-            LegacyDownloadStatus.DownloadFailed => DownloadPhase.Failed,
-            _ => DownloadPhase.Queued
-        };
-    }
-
-    private static LegacyDownloadStatus ToLegacyStatus(DownloadPhase phase)
-    {
-        return phase switch
-        {
-            DownloadPhase.Pausing => LegacyDownloadStatus.PauseStarted,
-            DownloadPhase.Paused or DownloadPhase.Canceled => LegacyDownloadStatus.Pause,
-            DownloadPhase.Downloading => LegacyDownloadStatus.Downloading,
-            DownloadPhase.Failed => LegacyDownloadStatus.DownloadFailed,
-            DownloadPhase.Completed => LegacyDownloadStatus.DownloadSucceed,
-            _ => LegacyDownloadStatus.WaitForDownload
-        };
-    }
-
-    private static DateTimeOffset LaterOf(DateTimeOffset first, DateTimeOffset second)
-    {
-        return first >= second ? first : second;
+            ThrowStoreFailure(message);
+        }
     }
 
     [DoesNotReturn]

--- a/DownKyi/Services/Download/DownloadTaskShutdownRecovery.cs
+++ b/DownKyi/Services/Download/DownloadTaskShutdownRecovery.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DownKyi.Domain.Downloads;
+
+namespace DownKyi.Services.Download;
+
+internal sealed class DownloadTaskShutdownRecovery
+{
+    private readonly DownloadListState _downloadLists;
+    private readonly DownloadTaskProjectionStore _projections;
+    private readonly DownloadTaskStateWriter _stateWriter;
+
+    public DownloadTaskShutdownRecovery(
+        DownloadListState downloadLists,
+        DownloadTaskProjectionStore projections,
+        DownloadTaskStateWriter stateWriter)
+    {
+        _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
+        _projections = projections ?? throw new ArgumentNullException(nameof(projections));
+        _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
+    }
+
+    public async Task PersistAsync()
+    {
+        foreach (var item in _downloadLists.Downloading)
+        {
+            var taskId = new DownloadTaskId(item.DownloadBase.Id);
+            var phase = _projections.GetRequiredSnapshot(taskId).Phase;
+            if (phase is DownloadPhase.Downloading or DownloadPhase.Pausing)
+            {
+                await _stateWriter.RecoverInterruptedAsync(taskId, CancellationToken.None)
+                    .ConfigureAwait(true);
+            }
+        }
+    }
+}

--- a/DownKyi/Services/Download/DownloadTaskStateWriter.cs
+++ b/DownKyi/Services/Download/DownloadTaskStateWriter.cs
@@ -1,47 +1,144 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using DownKyi.Core.Logging;
-using DownKyi.ViewModels.DownloadManager;
-using Microsoft.Data.Sqlite;
-using Microsoft.Extensions.Logging;
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
 
 namespace DownKyi.Services.Download;
 
 internal sealed class DownloadTaskStateWriter
 {
-    private readonly DownloadTaskProjectionStore _projectionStore;
-    private readonly ILogger _logger;
+    private readonly IDownloadTaskApplicationService _tasks;
 
-    public DownloadTaskStateWriter(DownloadTaskProjectionStore projectionStore, ILogger logger)
+    public DownloadTaskStateWriter(IDownloadTaskApplicationService tasks)
     {
-        _projectionStore = projectionStore ?? throw new ArgumentNullException(nameof(projectionStore));
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
     }
 
-    public async Task UpdateAsync(
-        DownloadingItem downloading,
+    public Task<DownloadTask> StartAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.StartAsync(taskId, cancellationToken));
+
+    public Task<DownloadTask> PauseAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.PauseAsync(taskId, cancellationToken));
+
+    public Task<DownloadTask> ConfirmPausedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.ConfirmPausedAsync(taskId, cancellationToken));
+
+    public async Task<DownloadTask> ResumeAsync(
+        DownloadTaskId taskId,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(downloading);
+        var current = await FindRequiredAsync(taskId, cancellationToken).ConfigureAwait(false);
+        if (current.Phase == DownloadPhase.Queued)
+        {
+            return current;
+        }
 
-        try
+        return current.Phase == DownloadPhase.Failed
+            ? await RequireAsync(_tasks.RetryAsync(taskId, cancellationToken)).ConfigureAwait(false)
+            : await RequireAsync(_tasks.ResumeAsync(taskId, cancellationToken)).ConfigureAwait(false);
+    }
+
+    public Task<DownloadTask> RecoverInterruptedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.RecoverInterruptedAsync(taskId, cancellationToken));
+
+    public Task<DownloadTask> FailAsync(
+        DownloadTaskId taskId,
+        DownloadFailure failure,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.FailAsync(taskId, failure, cancellationToken));
+
+    public Task<DownloadTask> CompleteAsync(
+        DownloadTaskId taskId,
+        DownloadCompletion completion,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.CompleteAsync(taskId, completion, cancellationToken));
+
+    public Task<DownloadTask> RecordTransferFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        string filePath,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.RecordTransferFileAsync(taskId, key, filePath, cancellationToken));
+
+    public Task<DownloadTask> InvalidateCompletedFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.InvalidateCompletedFileAsync(taskId, key, cancellationToken));
+
+    public Task<DownloadTask> CompleteTransferFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.CompleteTransferFileAsync(taskId, key, cancellationToken));
+
+    public Task<DownloadTask> SetBackendIdentityAsync(
+        DownloadTaskId taskId,
+        string? backendIdentity,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.SetBackendIdentityAsync(taskId, backendIdentity, cancellationToken));
+
+    public Task<DownloadTask> UpdateActivityAsync(
+        DownloadTaskId taskId,
+        string? activeContent,
+        string? statusText,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.UpdateActivityAsync(
+            taskId,
+            activeContent,
+            statusText,
+            cancellationToken));
+
+    public Task<DownloadTask> UpdateProgressAsync(
+        DownloadTaskId taskId,
+        DownloadProgress progress,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.UpdateProgressAsync(taskId, progress, cancellationToken));
+
+    public Task<DownloadTask> UpdateOutputFileSizeAsync(
+        DownloadTaskId taskId,
+        string? fileSizeText,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.UpdateOutputFileSizeAsync(taskId, fileSizeText, cancellationToken));
+
+    public Task<DownloadTask> CancelAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.CancelAsync(taskId, cancellationToken));
+
+    public Task<DownloadTask> DeleteAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.DeleteAsync(taskId, cancellationToken));
+
+    private async Task<DownloadTask> FindRequiredAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        return await _tasks.FindAsync(taskId, cancellationToken).ConfigureAwait(false)
+            ?? throw new InvalidOperationException($"Download task '{taskId.Value}' was not found.");
+    }
+
+    private static async Task<DownloadTask> RequireAsync(
+        Task<OperationResult<DownloadTask>> operation)
+    {
+        var result = await operation.ConfigureAwait(false);
+        if (result.TryGetValue(out var task))
         {
-            await _projectionStore
-                .UpdateDownloadingAsync(downloading, cancellationToken)
-                .ConfigureAwait(false);
+            return task;
         }
-        catch (SqliteException e)
-        {
-            _logger.LogDebugMessage($"Persist downloading state failed: {e.Message}");
-        }
-        catch (InvalidOperationException e)
-        {
-            _logger.LogDebugMessage($"Persist downloading state conflicted: {e.Message}");
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
+
+        throw new InvalidOperationException(
+            result.Error?.Message ?? "Download state update failed.");
     }
 }

--- a/DownKyi/Services/Download/DownloadTransferRequestFactory.cs
+++ b/DownKyi/Services/Download/DownloadTransferRequestFactory.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using DownKyi.Domain.Downloads;
+
+namespace DownKyi.Services.Download;
+
+internal static class DownloadTransferRequestFactory
+{
+    public static DownloadTransferRequest Create(
+        DownloadTaskId taskId,
+        IReadOnlyList<string> urls,
+        string path,
+        string localFileName,
+        long expectedBytes,
+        DownloadTaskProjectionStore projections,
+        DownloadTaskStateWriter stateWriter,
+        Action ensureActive,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        ArgumentNullException.ThrowIfNull(projections);
+        ArgumentNullException.ThrowIfNull(stateWriter);
+        ArgumentNullException.ThrowIfNull(ensureActive);
+        var projection = projections.GetRequiredDownloadingProjection(taskId);
+        var snapshot = projections.GetRequiredSnapshot(taskId);
+        return new DownloadTransferRequest(
+            taskId,
+            snapshot.Transfer.BackendIdentity,
+            urls,
+            path,
+            localFileName,
+            expectedBytes,
+            ensureActive,
+            () => projections.GetRequiredSnapshot(taskId).Phase is
+                DownloadPhase.Pausing or DownloadPhase.Paused,
+            progress => projections.PublishLiveProgress(taskId, progress),
+            (progress, token) => stateWriter.UpdateProgressAsync(taskId, progress, token),
+            (backendIdentity, token) => stateWriter.SetBackendIdentityAsync(
+                taskId,
+                backendIdentity,
+                token),
+            service => projection.DownloadService = service,
+            cancellationToken);
+    }
+}

--- a/DownKyi/Services/Download/ITransferBackend.cs
+++ b/DownKyi/Services/Download/ITransferBackend.cs
@@ -2,18 +2,24 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
-using DownKyi.ViewModels.DownloadManager;
+using DownKyi.Domain.Downloads;
+using Downloader;
 
 namespace DownKyi.Services.Download;
 
 internal sealed record DownloadTransferRequest(
-    DownloadingItem Download,
+    DownloadTaskId TaskId,
+    string? BackendIdentity,
     IReadOnlyList<string> Urls,
     string Directory,
     string FileName,
     long ExpectedBytes,
     Action EnsureActive,
-    Func<CancellationToken, Task> PersistStateAsync,
+    Func<bool> IsPauseRequested,
+    Action<DownloadProgress> PublishProgress,
+    Func<DownloadProgress, CancellationToken, Task> PersistProgressAsync,
+    Func<string?, CancellationToken, Task> SetBackendIdentityAsync,
+    Action<DownloadService?> SetBuiltinDownloadService,
     CancellationToken CancellationToken);
 
 internal interface ITransferBackend : IDisposable

--- a/DownKyi/Services/Migration/LegacyDownloadTaskMapper.cs
+++ b/DownKyi/Services/Migration/LegacyDownloadTaskMapper.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Formats.Nrbf;
+using System.Linq;
+using DownKyi.Domain.Downloads;
+using DownKyi.Models;
+
+namespace DownKyi.Services.Migration;
+
+internal static class LegacyDownloadTaskMapper
+{
+    public static Dictionary<string, bool> ReadRequestedAssets(ClassRecord record)
+    {
+        ArgumentNullException.ThrowIfNull(record);
+        var values = record
+            .GetArrayRecord("KeyValuePairs")?
+            .GetArray(typeof(KeyValuePair<string, bool>[]));
+        var result = new Dictionary<string, bool>(StringComparer.Ordinal);
+        foreach (var item in values?.Cast<ClassRecord>() ?? [])
+        {
+            result[item.GetString("key") ?? string.Empty] = item.GetBoolean("value");
+        }
+
+        return result;
+    }
+
+    public static DownloadTask RestoreCompleted(Downloaded downloaded, DateTimeOffset migratedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(downloaded);
+        var downloadBase = downloaded.DownloadBase
+            ?? throw new ArgumentException("Legacy history is missing its base record.", nameof(downloaded));
+        var finishedAtUtc = downloaded.FinishedTimestamp > 0
+            ? DateTimeOffset.FromUnixTimeSeconds(downloaded.FinishedTimestamp)
+            : migratedAtUtc;
+        var createdAtUtc = finishedAtUtc <= migratedAtUtc ? finishedAtUtc : migratedAtUtc;
+
+        return DownloadTask.Restore(
+            new DownloadTaskId(downloadBase.Id),
+            new DownloadTaskMetadata(
+                new DownloadMediaIdentity(
+                    downloadBase.Bvid,
+                    downloadBase.Avid,
+                    downloadBase.Cid,
+                    downloadBase.EpisodeId,
+                    downloadBase.Page,
+                    downloadBase.Order),
+                downloadBase.MainTitle,
+                downloadBase.Name,
+                downloadBase.Duration,
+                downloadBase.VideoCodecName,
+                new DownloadQuality(downloadBase.Resolution.Id, downloadBase.Resolution.Name),
+                new DownloadQuality(downloadBase.AudioCodec.Id, downloadBase.AudioCodec.Name),
+                downloadBase.CoverUrl,
+                downloadBase.PageCoverUrl,
+                downloadBase.ZoneId),
+            new DownloadPlan(downloadBase.NeedDownloadContent, [], 0),
+            new DownloadOutput(downloadBase.FilePath, downloadBase.FileSize),
+            DownloadPhase.Completed,
+            DownloadProgress.None,
+            DownloadTransferState.Empty,
+            null,
+            new DownloadCompletion(
+                downloaded.FinishedTimestamp,
+                downloaded.FinishedTime,
+                downloaded.MaxSpeedDisplay),
+            0,
+            createdAtUtc,
+            migratedAtUtc);
+    }
+}

--- a/DownKyi/Services/Migration/LegacyUpgradeCoordinator.cs
+++ b/DownKyi/Services/Migration/LegacyUpgradeCoordinator.cs
@@ -7,11 +7,13 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
+using DownKyi.Application.Time;
 using DownKyi.Core.BiliApi.BiliUtils;
 using DownKyi.Core.BiliApi.Login;
 using DownKyi.Core.Logging;
 using DownKyi.Core.Storage;
 using DownKyi.Core.Storage.Database;
+using DownKyi.Domain.Downloads;
 using DownKyi.Models;
 using DownKyi.Services.Download;
 using DownKyi.ViewModels.DownloadManager;
@@ -45,14 +47,17 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
 {
     private const int BatchSize = 200;
     private readonly DownloadTaskProjectionStore _projectionStore;
+    private readonly IClock _clock;
     private readonly ILogger<LegacyUpgradeCoordinator> _logger;
 
     public LegacyUpgradeCoordinator(
         DownloadTaskProjectionStore projectionStore,
+        IClock clock,
         ILogger<LegacyUpgradeCoordinator> logger)
     {
         _projectionStore = projectionStore
             ?? throw new ArgumentNullException(nameof(projectionStore));
+        _clock = clock ?? throw new ArgumentNullException(nameof(clock));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -332,7 +337,7 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
         IProgress<LegacyUpgradeProgress> progress,
         CancellationToken cancellationToken)
     {
-        var batch = new List<Downloaded>(Math.Min(BatchSize, records.Count));
+        var batch = new List<DownloadTask>(Math.Min(BatchSize, records.Count));
         var visited = 0;
         foreach (var item in records.Values)
         {
@@ -343,7 +348,7 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
                 var downloaded = ConvertDownload(item);
                 if (downloaded != null)
                 {
-                    batch.Add(downloaded);
+                    batch.Add(LegacyDownloadTaskMapper.RestoreCompleted(downloaded, _clock.UtcNow));
                 }
             }
             catch (Exception e) when (IsLegacyRecordException(e) || e is SqliteException)
@@ -354,9 +359,7 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
 
             if (batch.Count >= BatchSize)
             {
-                await _projectionStore
-                    .AddDownloadedBatchAsync(batch, cancellationToken)
-                    .ConfigureAwait(false);
+                await PersistBatchAsync(batch, cancellationToken).ConfigureAwait(false);
                 batch.Clear();
             }
 
@@ -368,8 +371,18 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
 
         if (batch.Count > 0)
         {
+            await PersistBatchAsync(batch, cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private async Task PersistBatchAsync(
+        IEnumerable<DownloadTask> batch,
+        CancellationToken cancellationToken)
+    {
+        foreach (var task in batch)
+        {
             await _projectionStore
-                .AddDownloadedBatchAsync(batch, cancellationToken)
+                .AddMigratedCompletedAsync(task, cancellationToken)
                 .ConfigureAwait(false);
         }
     }
@@ -395,7 +408,7 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
             {
                 NeedDownloadContent = needDownloadContentRecord == null
                     ? new Dictionary<string, bool>()
-                    : ReadNeedDownloadContent(needDownloadContentRecord),
+                    : LegacyDownloadTaskMapper.ReadRequestedAssets(needDownloadContentRecord),
                 Bvid = ReadString(record, nameof(DownloadBase.Bvid)),
                 Avid = record.GetInt64($"<{nameof(DownloadBase.Avid)}>k__BackingField"),
                 Cid = record.GetInt64($"<{nameof(DownloadBase.Cid)}>k__BackingField"),
@@ -415,20 +428,6 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
                 Page = record.GetInt32($"<{nameof(DownloadBase.Page)}>k__BackingField")
             }
         };
-    }
-
-    private static Dictionary<string, bool> ReadNeedDownloadContent(ClassRecord record)
-    {
-        var values = record
-            .GetArrayRecord("KeyValuePairs")?
-            .GetArray(typeof(KeyValuePair<string, bool>[]));
-        var result = new Dictionary<string, bool>(StringComparer.Ordinal);
-        foreach (var item in values?.Cast<ClassRecord>() ?? Array.Empty<ClassRecord>())
-        {
-            result[item.GetString("key") ?? string.Empty] = item.GetBoolean("value");
-        }
-
-        return result;
     }
 
     private static Quality ReadQuality(ClassRecord? record)

--- a/DownKyi/ViewModels/DownloadManager/DownloadBaseItem.cs
+++ b/DownKyi/ViewModels/DownloadManager/DownloadBaseItem.cs
@@ -1,3 +1,4 @@
+using System;
 using Avalonia;
 using Avalonia.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -18,12 +19,22 @@ namespace DownKyi.ViewModels.DownloadManager
             get => _downloadBase;
             set
             {
+                ArgumentNullException.ThrowIfNull(value);
                 _downloadBase = value;
 
                 ZoneImage = Avalonia.Application.Current == null
                     ? null
                     : DictionaryResource.Get<DrawingImage>(
                         VideoZoneIcon.Instance().GetZoneImageKey(DownloadBase.ZoneId));
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(Order));
+                OnPropertyChanged(nameof(MainTitle));
+                OnPropertyChanged(nameof(Name));
+                OnPropertyChanged(nameof(Duration));
+                OnPropertyChanged(nameof(VideoCodecName));
+                OnPropertyChanged(nameof(Resolution));
+                OnPropertyChanged(nameof(AudioCodec));
+                OnPropertyChanged(nameof(FileSize));
             }
         }
 

--- a/DownKyi/ViewModels/DownloadManager/DownloadingItem.cs
+++ b/DownKyi/ViewModels/DownloadManager/DownloadingItem.cs
@@ -37,6 +37,12 @@ namespace DownKyi.ViewModels.DownloadManager
             {
                 ArgumentNullException.ThrowIfNull(value);
                 _downloading = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(DownloadContent));
+                OnPropertyChanged(nameof(DownloadStatusTitle));
+                OnPropertyChanged(nameof(Progress));
+                OnPropertyChanged(nameof(DownloadingFileSize));
+                OnPropertyChanged(nameof(SpeedDisplay));
                 RefreshControlPresentation(value.DownloadStatus);
             }
         }
@@ -135,27 +141,6 @@ namespace DownKyi.ViewModels.DownloadManager
         }
 
         #endregion
-
-        internal void ApplyControlStatus(DownloadStatus status)
-        {
-            Downloading.DownloadStatus = status;
-            DownloadStatusTitle = status switch
-            {
-                DownloadStatus.PauseStarted or DownloadStatus.Pause => DictionaryResource.GetString("Pausing"),
-                DownloadStatus.NotStarted or DownloadStatus.WaitForDownload => DictionaryResource.GetString("Waiting"),
-                DownloadStatus.Downloading => DictionaryResource.GetString("WhileDownloading"),
-                DownloadStatus.DownloadFailed => DictionaryResource.GetString("DownloadFailed"),
-                _ => DownloadStatusTitle
-            };
-            RefreshControlPresentation(status);
-        }
-
-        internal void RestoreControlStatus(DownloadStatus status, string? title)
-        {
-            Downloading.DownloadStatus = status;
-            DownloadStatusTitle = title;
-            RefreshControlPresentation(status);
-        }
 
         private void RefreshControlPresentation(DownloadStatus status)
         {

--- a/benchmarks/DownKyi.SystemBenchmarks/DownloadRestoreScenario.cs
+++ b/benchmarks/DownKyi.SystemBenchmarks/DownloadRestoreScenario.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using DownKyi.Application.Downloads;
 using DownKyi.Infrastructure.Downloads;
 using DownKyi.Infrastructure.Time;
 using DownKyi.Services.Download;
@@ -15,10 +16,12 @@ internal static class DownloadRestoreScenario
     {
         Directory.CreateDirectory(dataRoot);
         var databasePath = Path.Combine(dataRoot, "restore.db");
+        var clock = new SystemClock();
         var store = new SqliteDownloadTaskStore(
             new SqliteDownloadTaskStoreOptions(databasePath),
-            new SystemClock());
-        var projection = new DownloadTaskProjectionStore(store, new SystemClock());
+            clock);
+        var tasks = new DownloadTaskApplicationService(store, clock);
+        var projection = new DownloadTaskProjectionStore(tasks, clock);
         try
         {
             await store.InitializeAsync(cancellationToken).ConfigureAwait(false);
@@ -85,6 +88,7 @@ internal static class DownloadRestoreScenario
         finally
         {
             projection.Dispose();
+            tasks.Dispose();
             store.Dispose();
             SqliteConnection.ClearAllPools();
         }

--- a/benchmarks/DownKyi.SystemBenchmarks/UiProgressNotificationScenario.cs
+++ b/benchmarks/DownKyi.SystemBenchmarks/UiProgressNotificationScenario.cs
@@ -39,20 +39,27 @@ internal static class UiProgressNotificationScenario
         var publishedUpdates = 0;
         for (var sample = 0; sample < sourceSamplesPerSecond; sample++)
         {
-            if (updater.TryUpdate(
-                    item,
+            if (updater.TryCreate(
                     sample * 100d / sourceSamplesPerSecond,
                     sample,
                     sourceSamplesPerSecond,
-                    1_000_000))
+                    1_000_000,
+                    out var progress))
             {
+                DownloadTaskProjectionMapper.ApplyLiveProgress(progress, item);
                 publishedUpdates++;
             }
 
             clock.Advance(interval);
         }
 
-        updater.TryUpdate(item, 100, sourceSamplesPerSecond, sourceSamplesPerSecond, 1_000_000);
+        updater.TryCreate(
+            100,
+            sourceSamplesPerSecond,
+            sourceSamplesPerSecond,
+            1_000_000,
+            out var completed);
+        DownloadTaskProjectionMapper.ApplyLiveProgress(completed, item);
         publishedUpdates++;
         return new SystemBenchmarkResult(
             "ui_progress_notifications",

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -19,9 +19,9 @@ The target projects exist, but the target ownership model is not complete. Read 
 
 - `src/DownKyi.Desktop` currently owns only Host creation. Views, ViewModels, navigation/dialog adapters, UI projections, and lifecycle remain in the `DownKyi` executable assembly.
 - `src/DownKyi.Infrastructure` currently owns SQLite task persistence, write-behind, and clock. Bilibili HTTP, aria2, FFmpeg, filesystem paths, and logging implementation remain mainly in `DownKyi.Core` or `DownKyi`.
-- `DownKyi.Domain.DownloadTask` is not yet the runtime source of truth. Download workers still operate on `DownloadingItem`; `DownloadTaskProjectionStore` reconstructs Domain tasks from legacy mutable projections.
+- `DownKyi.Domain.DownloadTask` is the durable runtime state authority. `DownloadTaskApplicationService` loads by `DownloadTaskId`, invokes legal transitions, persists optimistic versions, and only then publishes committed snapshots. Normal runtime no longer reconstructs Domain state from mutable UI projections.
 - `DownloadOrchestrator` still scans the UI downloading collection every 500 ms before writing `DownloadingItem` values to its channel.
-- `DownloadPipeline` is still a mixed workflow/presentation/persistence owner and the HTTP compatibility layer still uses a static facade plus synchronous send/read/backoff.
+- Workers and pipeline entry points use `DownloadTaskId`, but the channel and several media stages still carry/read `DownloadingItem` as transient playback/UI context. `DownloadPipeline` remains a mixed workflow/presentation owner and the HTTP compatibility layer still uses a static facade plus synchronous send/read/backoff.
 - These facts are tracked debt, not stable contracts. The ordered migration and release blockers live in `docs/refactoring-live-plan.md`.
 - `ModuleBoundaryBaselineTests` allows every listed debt item to disappear, but rejects new owners, consumers, duplicate names, UI dependencies, synchronous HTTP debt, or oversized-file growth.
 
@@ -119,9 +119,11 @@ flowchart TD
     DownloadBootstrap["service.download-bootstrap\nDownloadBootstrapHostedService"]
     DownloadService["service.download-runtime\nFactory + Orchestrator + Pipeline"]
     DownloadDomain["core.download-domain\nimmutable task aggregate"]
+    DownloadCommands["service.download-task-application\ntyped commands + committed events"]
     StoreContract["service.application-contracts\nIDownloadTaskStore"]
     SqliteStore["core.sqlite-download-store\nSqliteDownloadTaskStore"]
-    Storage["core.storage\nProjectionStore + StorageManager"]
+    Projection["ui.download-projection\nDownloadTaskProjectionStore + mapper"]
+    Storage["core.storage\nStorageManager"]
     Aria["external.aria2\naria2c process"]
     FFmpeg["external.ffmpeg\nffmpeg process"]
     Logs["core.logging\nApplicationLogProvider + diagnostic export"]
@@ -139,6 +141,7 @@ flowchart TD
     Program -->|runs restart helper| Lifecycle
     App -->|creates| Host
     App -->|attaches Host and shell| Lifecycle
+    App -->|resolves compatible data paths| Storage
     Host -->|injects| MainWindow
     App -->|loads| UiTheme
     Host -->|registers| ApplicationLayer
@@ -147,11 +150,15 @@ flowchart TD
     Infrastructure -->|implements| ApplicationLayer
     Infrastructure -->|depends on| Domain
     Domain -->|owns| DownloadDomain
+    ApplicationLayer -->|owns| DownloadCommands
     ApplicationLayer -->|defines| StoreContract
+    DownloadCommands -->|loads and transitions| DownloadDomain
+    DownloadCommands -->|calls| StoreContract
     SqliteStore -->|implements| StoreContract
     SqliteStore -->|persists| DownloadDomain
-    Storage -->|projects legacy UI| DownloadDomain
-    Storage -->|calls| StoreContract
+    DownloadCommands -->|publishes committed snapshots| Projection
+    Projection -->|projects to UI| DownloadDomain
+    Projection -->|calls commands and queries| DownloadCommands
     SystemBenchmarks -->|measures| Host
     SystemBenchmarks -->|measures| SqliteStore
     SystemBenchmarks -->|measures| DownloadService
@@ -208,12 +215,13 @@ flowchart TD
     VideoVm -->|reads| Settings
     Settings -->|migrates old format through| LegacySettings
     VideoVm -->|calls| DownloadAdd
-    DownloadAdd -->|persists| Storage
+    DownloadAdd -->|creates queued input through| Projection
     DownloadAdd -->|queues| DownloadService
     Host -->|starts and stops| DownloadBootstrap
-    DownloadBootstrap -->|loads startup state| Storage
+    DownloadBootstrap -->|loads startup state| Projection
     DownloadBootstrap -->|starts and stops| DownloadService
-    DownloadService -->|persists| Storage
+    DownloadService -->|commands by DownloadTaskId| DownloadCommands
+    DownloadService -->|reads transient playback projection| Projection
     DownloadService -->|executes optional| Aria
     DownloadService -->|executes| FFmpeg
     DownloadService -->|writes| Logs
@@ -458,6 +466,38 @@ contracts:
   - Coalesced progress writes retain their first expected version and latest contiguous target version.
 tests:
   - test.application-lifetime
+  - test.architecture-boundaries
+```
+
+### service.download-task-application
+
+```yaml
+id: service.download-task-application
+type: service
+paths:
+  - src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+  - src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+responsibility: Owns typed download commands and queries, serializes per-task mutations, persists immutable aggregates, and publishes only committed snapshots.
+inbound:
+  - service.download-runtime
+  - ui.download-projection
+  - app.host-composition
+outbound:
+  - core.domain-contracts
+  - service.application-contracts
+contracts:
+  - Every mutation is addressed by `DownloadTaskId`; no command accepts `DownloadingItem` or another mutable UI model.
+  - A command loads the latest aggregate, invokes one legal Domain transition, writes with the expected optimistic version, and retries only a bounded store conflict.
+  - `TaskChanged` is published after the store succeeds. Invalid transitions and failed writes do not publish replacement snapshots.
+  - Start, pause, confirm-paused, resume, retry, interruption recovery, failure, completion, cancel, delete, transfer-file, GID, progress, activity, and output updates remain typed operations.
+  - Shutdown recovery preserves GID, partial-file map, completed keys, progress, output, timestamps, and monotonically increasing versions.
+hazards:
+  - The current synchronous event reaches the executable projection owner; Gate 8 must marshal projection mutation through the Desktop UI dispatcher without moving persistence into Desktop.
+  - Per-task synchronization lives for the Application service lifetime; task churn and disposal behavior must remain bounded and race-tested as queue ownership moves in Gate 5.
+tests:
+  - test.download-task-application
+  - test.download-domain
+  - test.storage-resume
   - test.architecture-boundaries
 ```
 
@@ -1531,7 +1571,8 @@ inbound:
   - viewmodel.user-space-pages
   - other viewmodels that support add-to-download
 outbound:
-  - core.storage
+  - ui.download-projection
+  - service.download-task-application
   - service.download-runtime
   - service.download-list-state
   - service.video-tag-provider
@@ -1577,9 +1618,9 @@ contracts:
   - Collection mutation is projected on the UI thread by the calling desktop boundary.
   - Headless construction must not synchronously wait on an uninitialized Avalonia dispatcher.
   - Download-manager ViewModels own only confirmation, localized feedback, binding state, and command wiring; they cannot access storage, generated files, or platform launch APIs directly.
-  - Single and bulk pause/resume transitions are persisted before the command completes; persistence failure restores the prior UI projection.
-  - Explicit deletion persists a paused state, cancels the active backend, removes media and resume sidecars, deletes the store row, and only then removes the UI projection.
-  - If generated-file cleanup reports a failure, the database row and UI projection remain so deletion can be retried; once physical deletion starts, store/list cleanup is not interrupted by shutdown cancellation.
+  - Single and bulk pause/resume commands address tasks by ID; UI state follows only committed Domain events, so a failed persistence operation cannot publish a replacement projection.
+  - Explicit deletion persists `Canceled`, cancels the active backend, removes media and resume sidecars, transitions to `Deleted`, and only then removes the UI projection.
+  - If generated-file cleanup reports a failure, the canceled database row and UI projection remain; another delete is idempotent with respect to cancellation and can retry physical cleanup.
   - File and folder probing belongs to the coordinator and returns a typed open result without exposing filesystem checks to ViewModels.
 hazards:
   - Replacing the collection object disconnects existing views and download workers.
@@ -1601,12 +1642,14 @@ id: service.legacy-upgrade
 type: migration-service
 paths:
   - DownKyi/Services/Migration/LegacyUpgradeCoordinator.cs
+  - DownKyi/Services/Migration/LegacyDownloadTaskMapper.cs
   - DownKyi/ViewModels/Dialogs/ViewUpgradingDialogViewModel.cs
 responsibility: Converts legacy NRBF login/download data into current storage while the dialog owns only progress, cancellation, result projection, and restart state.
 inbound:
   - app.application
 outbound:
   - core.storage
+  - ui.download-projection
   - service.download-list-state
 contracts:
   - Closing or disposing the dialog cancels migration; cancellation is rethrown by the coordinator and never reported as data corruption.
@@ -1614,6 +1657,7 @@ contracts:
   - A malformed legacy login payload is logged and isolated; it cannot prevent an independently present download database from migrating.
   - Each legacy SQLite connection is validated, read, and disposed before the source database is deleted, moved, or renamed.
   - Valid records are persisted in bounded batches; one malformed record is logged and skipped without discarding the rest of its batch.
+  - `LegacyDownloadTaskMapper` is the only executable-layer caller allowed to restore a Domain aggregate from NRBF data; normal runtime cannot reuse it.
   - Failed databases are preserved under a collision-resistant backup name and UI diagnostics reveal only the backup filename, never a full personal path.
   - Migration context owns typed diagnostics; the low-level SQLite helper rethrows without duplicating or printing failures.
   - The dialog cannot own NRBF, SQLite, storage lookup, worker scheduling, or dispatcher code.
@@ -1640,6 +1684,7 @@ inbound:
   - app.host-composition
 outbound:
   - core.storage
+  - ui.download-projection
   - service.download-list-state
   - service.download-runtime
 contracts:
@@ -1673,6 +1718,9 @@ paths:
   - DownKyi/Services/Download/AriaRuntimeClientRegistry.cs
   - DownKyi/Services/Download/DownloadArtifactWriter.cs
   - DownKyi/Services/Download/DownloadTaskStateWriter.cs
+  - DownKyi/Services/Download/DownloadTaskShutdownRecovery.cs
+  - DownKyi/Services/Download/DownloadTransferRequestFactory.cs
+  - DownKyi/Services/Download/DownloadOutputRecorder.cs
   - DownKyi/Services/Download/DownloadTaskFileService.cs
   - DownKyi/Services/Download/DownloadFileIntegrity.cs
   - DownKyi/Services/Download/DownloadDiagnosticLogger.cs
@@ -1682,7 +1730,8 @@ inbound:
   - service.download-bootstrap
   - service.download-add
 outbound:
-  - core.storage
+  - service.download-task-application
+  - ui.download-projection
   - service.download-list-state
   - external.aria2
   - external.ffmpeg
@@ -1696,8 +1745,9 @@ contracts:
   - Each multi-segment DURL key includes stable `DURL.Order`; BVID, codec, and runtime hash codes are not segment identities.
   - DURL merge input is sorted by Order and success requires ffprobe stream, duration, and middle/tail seek-decode validation.
   - Multi-segment DURL output is re-encoded to rebuild timestamps, keyframes, and MP4 indexes; hardware failure falls back to `libx264 + aac`.
-  - State transitions await persistence; high-rate progress uses the bounded write-behind boundary.
-  - Runtime receives `DownloadListState`, `DownloadTaskProjectionStore`, and dedicated state/artifact writers through construction; it cannot resolve dependencies through App or a global container.
+  - State transitions go through typed Application commands and await persistence; high-rate live progress is a projection signal while accepted durable samples preserve Domain resume state.
+  - `PauseAsync` persists `Pausing`; built-in and aria2 backends preserve partial state and return a paused outcome; the worker confirms `Paused` only after transfer teardown.
+  - Runtime receives `DownloadListState`, `DownloadTaskProjectionStore`, and dedicated state/artifact writers through construction; worker/pipeline command APIs use `DownloadTaskId` and cannot resolve dependencies through App or a global container.
   - Runtime factory, backends, workers, and diagnostic logger share the Host-injected `ISettingsStore`; no download service reads the global settings singleton.
   - Runtime factory captures one immutable network settings snapshot and creates a dedicated `AriaClient`; local and custom endpoints cannot overwrite process-global host, port, or token fields.
   - The same runtime client is injected into transfer, polling, server shutdown, and task cancellation. `AriaRuntimeClientRegistry` exposes only the currently active runtime client and releases it deterministically on stop or failed startup.
@@ -1705,15 +1755,15 @@ contracts:
   - Runtime factory creates a typed backend logger, and every download/file-lifecycle/maintenance owner uses the shared provider; this directory cannot call static `LogManager`.
   - Download diagnostic throttling belongs to the injected runtime logger instance; scopes contain only a SHA-256-derived short task ID and cannot retain raw task IDs in process-wide static state.
   - `DownloadTaskFileService` is an injected instance so cancellation, sidecar cleanup, retry, and permission failures use the same logger without a static owner.
-  - Shutdown cancellation while dispatch waits for capacity cannot skip fixed-worker drain or resumable-state recovery; active `Downloading` rows return to `WaitForDownload` and are persisted before exit completes.
+  - Shutdown cancellation while dispatch waits for capacity cannot skip fixed-worker drain or resumable-state recovery; active `Downloading` or `Pausing` Domain rows return to `Queued` and are persisted before exit completes.
   - Recovery persistence after cancellation explicitly ignores the canceled operation token; ordinary transfer and progress writes continue to propagate their caller token.
-  - `DownloadArtifactWriter` owns cover, subtitle, danmaku, and NFO generation; `DownloadTaskStateWriter` owns projection updates and narrow persistence error handling.
+  - `DownloadArtifactWriter` owns cover, subtitle, danmaku, and NFO generation; `DownloadTaskStateWriter` is a typed Application-command adapter and never accepts a UI task model.
   - `DownloadPipeline` cannot regain subtitle API, danmaku converter, NFO XML, direct projection-update, or SQLite exception implementation details.
   - Diagnostic logs should include downloader, split/parallel count, speed, and limit values without full local paths or sensitive URLs.
 hazards:
   - Blocking waits in download lifecycle can freeze UI or prevent process exit.
   - The bounded channel is fed by a 500 ms scan of `DownloadListState.Downloading`, so the UI projection remains a runtime input and scheduling has polling latency.
-  - Workers and stages operate on `DownloadingItem`; Domain transition rules do not yet own the runtime state machine.
+  - The channel still carries `DownloadingItem`, and media stages resolve that projection for playback metadata even though all durable transitions are Domain-authoritative.
   - Pipeline retry and backend URL fallback can multiply attempts because one typed retry budget does not yet own both decisions.
   - `DownloadPipeline` still owns UI-facing state and remains over the current 500-line architecture budget.
   - Letting an expected shutdown `OperationCanceledException` escape before state recovery leaves rows stored as active and prevents clean resume after restart.
@@ -1729,36 +1779,58 @@ tests:
   - test.durl-seekability
 ```
 
+### ui.download-projection
+
+```yaml
+id: ui.download-projection
+type: ui
+paths:
+  - DownKyi/Services/Download/DownloadTaskProjectionStore.cs
+  - DownKyi/Services/Download/DownloadTaskProjectionMapper.cs
+responsibility: Projects committed immutable tasks into existing UI models and creates only brand-new queued aggregates from add input.
+inbound:
+  - service.download-task-application
+  - service.download-bootstrap
+  - service.download-add
+  - service.download-runtime
+outbound:
+  - service.download-task-application
+contracts:
+  - The projection owner never opens SQLite or serializes storage JSON directly.
+  - Normal runtime projection is one-way Domain to UI. It may create a brand-new queued task from add input, but cannot reconstruct an existing aggregate from mutable UI state.
+  - Replacing an internal projection model raises every dependent binding notification; Gate 8 remains responsible for marshaling committed events to the UI dispatcher.
+  - Startup restores all unfinished tasks and only the newest 100 history items before loading remaining keyset pages later.
+hazards:
+  - `DownloadingItem` and `DownloadedItem` remain UI projection models, never persistence models.
+tests:
+  - test.storage-resume
+  - test.download-task-application
+  - test.architecture-boundaries
+```
+
 ### core.storage
 
 ```yaml
 id: core.storage
 type: core
 paths:
-  - DownKyi/Services/Download/DownloadTaskProjectionStore.cs
   - DownKyi.Core/Storage/StorageManager.cs
-  - src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
-  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
-responsibility: Projects immutable stored tasks into existing UI models while StorageManager owns app-data, portable-mode, cache, log, and aria paths and Infrastructure owns SQLite persistence.
+responsibility: Resolves portable and per-user application-data, cache, log, database, media, and external-process state paths.
 inbound:
+  - app.application
+  - service.legacy-upgrade
   - service.download-bootstrap
-  - service.download-add
-  - service.download-runtime
 outbound:
-  - service.application-contracts
   - external.filesystem
 contracts:
-  - Download records must survive app restarts.
-  - The projection owner never opens SQLite or serializes storage JSON directly.
-  - Startup restores all unfinished tasks and only the newest 100 history items before loading remaining keyset pages later.
-  - Legacy completion order is atomic: non-cascading remove is deferred and completion moves state through one store transaction.
-  - Storage paths used in logs must be sanitized when exported for diagnostics.
+  - Existing portable-mode and per-user path selection remains compatible across upgrades.
+  - Tests and probes use isolated roots and cannot read a developer's real settings, cookies, database, logs, or aria2 session.
+  - Storage paths used in diagnostics are redacted or reduced to safe filenames.
 hazards:
-  - `DownloadingItem` and `DownloadedItem` remain UI projection models, never persistence models.
   - Mixing user data with program files complicates updates and permissions.
 tests:
-  - test.download-store
-  - test.storage-resume
+  - test.storage-retention
+  - test.ui-smoke
 ```
 
 ### core.logging
@@ -2138,6 +2210,7 @@ sequenceDiagram
     participant Shell as MainWindow
     participant Bootstrap as DownloadBootstrapHostedService
     participant Projection as DownloadTaskProjectionStore
+    participant Tasks as DownloadTaskApplicationService
     participant Store as SqliteDownloadTaskStore
     participant Runtime as DownloadRuntime
 
@@ -2148,8 +2221,10 @@ sequenceDiagram
     App-->>Host: StartAsync after shell creation
     Host->>Bootstrap: StartAsync
     Bootstrap->>Projection: load unfinished + newest history page
-    Projection->>Store: async keyset queries
-    Store-->>Projection: immutable tasks
+    Projection->>Tasks: async task/history queries
+    Tasks->>Store: async keyset queries
+    Store-->>Tasks: immutable tasks
+    Tasks-->>Projection: immutable tasks
     Projection-->>Bootstrap: UI projections
     Bootstrap-->>Shell: project through IUiDispatcher
     Bootstrap-->>Projection: load remaining history in background
@@ -2167,7 +2242,9 @@ sequenceDiagram
     participant Parser as VideoParseCoordinator
     participant API as BiliApiRequest/WebClient
     participant Add as DownloadAddCoordinator
-    participant Storage as DownloadTaskProjectionStore
+    participant Projection as DownloadTaskProjectionStore
+    participant Tasks as DownloadTaskApplicationService
+    participant Store as SqliteDownloadTaskStore
     participant Queue as DownloadingList
 
     VM->>Resolver: classify input
@@ -2181,7 +2258,10 @@ sequenceDiagram
     alt user cancels
         Add-->>VM: return 0, no queue mutation
     else user selects directory
-        Add->>Storage: persist task
+        Add->>Projection: create new queued aggregate
+        Projection->>Tasks: AddAsync(DownloadTask)
+        Tasks->>Store: persist queued aggregate
+        Tasks-->>Projection: committed TaskChanged
         Add->>Queue: append task on UI thread
     end
 ```
@@ -2192,20 +2272,27 @@ Rule: cancel means no task, no background add, no storage write.
 
 ```mermaid
 flowchart TD
-    Queue["DownloadingList item"] --> Channel["DownloadOrchestrator bounded Channel"]
-    Channel --> Runtime["Fixed Download Workers"]
-    Runtime --> Pipeline["DownloadPipeline"]
+    Queue["DownloadingList item"] --> Poll["500 ms compatibility scan"]
+    Poll --> Channel["DownloadOrchestrator bounded Channel<DownloadingItem>"]
+    Channel --> Runtime["Worker extracts DownloadTaskId"]
+    Runtime --> Commands["DownloadTaskApplicationService"]
+    Runtime --> Pipeline["DownloadPipeline(DownloadTaskId)"]
     Pipeline --> Choice{"Downloader setting"}
     Choice --> Builtin["BuiltinTransferBackend"]
     Choice --> Aria["Aria2TransferBackend"]
     Pipeline --> Artifacts["DownloadArtifactWriter"]
-    Pipeline --> State["DownloadTaskStateWriter"]
+    Pipeline --> State["DownloadTaskStateWriter typed adapter"]
     Builtin --> Integrity["DownloadFileIntegrity"]
     Aria --> Integrity
     Integrity -->|valid| FFmpeg["FFmpeg command runner + bounded gate"]
     Integrity -->|invalid| Retry["retry or fail visibly"]
-    FFmpeg --> Complete["DownloadedList + downloaded table"]
-    State --> Projection["DownloadTaskProjectionStore"]
+    FFmpeg --> Complete["Complete Domain command"]
+    State --> Commands
+    Commands --> Store["SqliteDownloadTaskStore"]
+    Store -->|"commit succeeded"| Commands
+    Commands --> Event["TaskChanged snapshot"]
+    Event --> Projection["DownloadTaskProjectionStore"]
+    Projection --> Lists["Downloading / Downloaded UI projections"]
     Retry --> Logs["sanitized diagnostics"]
 ```
 
@@ -2671,6 +2758,17 @@ test.download-domain:
     - legal lifecycle transitions produce new immutable task versions
     - illegal pause, resume, retry, completion, and terminal updates return typed conflicts
     - timestamps and transfer/progress payloads preserve aggregate invariants
+
+test.download-task-application:
+  paths:
+    - tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+    - tests/DownKyi.Architecture.Tests/DownloadRuntimeArchitectureTests.cs
+  guards:
+    - every command persists the exact aggregate before publishing its projection event
+    - invalid transitions do not persist or publish replacement state
+    - shutdown recovery preserves resume identity, transfer files, progress, and optimistic versions
+    - runtime state APIs accept DownloadTaskId rather than mutable UI task models
+    - DownloadTask.Restore remains limited to SQLite materialization and the legacy migration mapper
 
 test.application-lifetime:
   paths:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -31,14 +31,18 @@ Current analyzer result: zero unhandled CA diagnostics. All 77 cleaned rules are
 ## Download Persistence Policy
 
 - `src/DownKyi.Domain/Downloads` owns immutable task identity, lifecycle, progress, transfer, output, failure, and completion state.
+- `IDownloadTaskApplicationService` / `DownloadTaskApplicationService` is the only normal runtime command/query owner. It loads by `DownloadTaskId`, invokes a Domain transition, persists with the current optimistic version, and publishes the committed snapshot only after a successful store operation.
 - `IDownloadTaskStore` is the only durable download contract. Infrastructure implementations must use async APIs and honor cancellation.
 - `SqliteDownloadTaskStore` is the sole owner of download SQL and storage JSON. `DownloadTaskProjectionStore` maps immutable stored tasks to existing `DownloadingItem` / `DownloadedItem` UI projections without owning SQL.
+- Runtime code must not rebuild a Domain task from a mutable UI projection. `DownloadTask.Restore` is limited to `SqliteDownloadTaskStore` materialization and `LegacyDownloadTaskMapper` migration; architecture tests enforce that allowlist.
 - Use short pooled connections, WAL, optimistic task versions, and transactions. Never restore a process-wide SQLite connection, global database lock, `Task.Run` database wrapper, or offset-based history scan.
 - Every schema migration must create a SQLite backup before DDL, execute in one transaction, update `user_version` only on success, and have a rollback test.
 - Malformed rows are quarantined individually. Diagnostics may include source table, record ID, field, and a fixed reason; never include raw JSON, full paths, cookies, or URLs.
 - Startup loads every unfinished task and the newest 100 history records after shell creation. Remaining history uses keyset pages outside the first-screen path.
-- State transitions persist immediately. High-rate progress may use `DownloadProgressWriteBehind`, whose pending task count and wake channel are bounded and whose shutdown path flushes accepted writes.
+- State transitions persist immediately and UI projection follows the committed event. High-rate live progress may be projected without a durable write for every sample; accepted persistence uses bounded/coalesced writes and shutdown recovery preserves the last durable resume state.
 - The SQLite native bundle is `SQLite3MC.PCLRaw.bundle`. Any update must pass `LegacySqlCipherCompatibilityTests` against the committed SQLCipher v4 fixture before merge.
+
+Gate 4 local result: strict `AnalysisMode=All` Release build completed with zero warnings, all 552 solution tests passed, format changed 0/750 files, `git diff --check` and the module-boundary audit passed, and NuGet reported no vulnerable or deprecated packages. Tests cover legal state transitions, optimistic conflicts, one-way projection, legacy NRBF/SQLite materialization, pause confirmation, retryable deletion, shutdown recovery, GID/partial-file/completed-key persistence, progress and output-size reopen, and the architecture allowlist for `DownloadTask.Restore`.
 
 PR 03-06 result: legacy GID, partial-file maps, completed asset keys, paused state, progress, task identity, and history survive reopen. Completion moves from active state to history in one transaction. The removed deprecated SQLCipher provider was replaced only after the current cross-platform provider opened the old encrypted fixture and rejected a wrong password. Release build, all tests, isolated App startup/close, Linux x64/arm64 and macOS x64/arm64 cross-RID builds, deprecated-package audit, and vulnerable-package audit passed locally.
 
@@ -46,8 +50,9 @@ PR 03-06 result: legacy GID, partial-file maps, completed asset keys, paused sta
 
 - Queue consumption uses a bounded Channel and fixed workers. Do not restore per-item task spawning or synchronous persistence callbacks.
 - Built-in and aria2 transfers share key, resume, integrity, and persistence behavior. Custom aria2 is a backend selection, not a copied workflow.
-- `DownloadArtifactWriter` owns cover, subtitle, danmaku, and NFO output. `DownloadTaskStateWriter` owns projection persistence and recovery writes; do not move these details back into `DownloadPipeline`.
-- Pause and process shutdown preserve partial/resume files. Explicit task deletion removes generated media and `.aria2` / `.download` sidecars.
+- `DownloadArtifactWriter` owns cover, subtitle, danmaku, and NFO output. `DownloadTaskStateWriter` adapts runtime calls to typed Application commands; it cannot accept `DownloadingItem` or persist reconstructed UI state.
+- Pause first persists `Pausing`; built-in/aria2 backends preserve partial files and return a paused outcome; the worker confirms `Paused` only after transfer teardown. Process shutdown returns active `Downloading`/`Pausing` tasks to `Queued` without dropping GID, partial-file maps, completed keys, progress, output size, or optimistic version.
+- Explicit task deletion persists `Canceled`, stops the physical backend, removes generated media and `.aria2` / `.download` sidecars, then deletes the row. A cleanup failure leaves a retryable canceled record rather than pretending deletion succeeded.
 - Multi-segment DURL identity includes `DURL.Order`, input is sorted by that order, and concat never starts with stream copy.
 - FFmpeg operations use `FfmpegProcessRunner`, bounded concurrency, cancellation, timeout, captured stderr, and process-tree cleanup. Hardware encoding is attempted when available, with CPU fallback kept for success rate.
 - A multi-segment output is complete only after ffprobe confirms a video stream, expected duration, and successful middle/tail seek decoding. Invalid partial output is deleted.

--- a/docs/operations/verification-and-rollback.md
+++ b/docs/operations/verification-and-rollback.md
@@ -31,8 +31,8 @@ dotnet build ./DownKyi.sln `
 dotnet test ./DownKyi.sln -c Release --no-restore --no-build
 dotnet format ./DownKyi.sln --no-restore --verify-no-changes
 git diff --check
-dotnet package list ./DownKyi.sln --vulnerable --include-transitive
-dotnet package list ./DownKyi.sln --deprecated
+dotnet package list --project ./DownKyi.sln --vulnerable --include-transitive
+dotnet package list --project ./DownKyi.sln --deprecated
 ```
 
 ## UI 與 runtime evidence

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -1,9 +1,9 @@
 # DownKyi Core Live Refactoring Plan
 
 Status: active
-Last updated: 2026-07-22
-Current group: Gate 3 Bilibili API contract audit
-Current branch: `audit/gate-03-bilibili-api-contracts`
+Last updated: 2026-07-26
+Current group: Gate 4 Domain download authority
+Current branch: `refactor/domain-download-authority`
 
 This file contains only unfinished or not-yet-integrated work. Completed PR 02-32 items are not restored. Design rationale belongs in `design-docs`; product acceptance belongs in `product-specs`.
 
@@ -21,47 +21,22 @@ No release tag may be created while any release blocker below remains.
 
 ## Execution Order
 
-### Gate 3: Bilibili API Inventory And Runtime Contract Audit
-
-Owner branch: `audit/gate-03-bilibili-api-contracts` from the latest integrated architecture head.
-
-Progress (2026-07-22):
-
-- Inventoried all 47 fixed Bilibili endpoints in Core with method, envelope, authentication/WBI requirement, runtime use, evidence, alternative, decision and tests.
-- Added an explicit anonymous live-probe script that records Runtime, OS, architecture and Commit SHA while refusing to load local cookies or account state.
-- Confirmed and fixed anonymous WBI bootstrap: `/x/web-interface/nav` returns `-101` with valid public WBI metadata, so only this endpoint may deserialize that code.
-- Cross-checked maintained yt-dlp, bilibili-api endpoint maps, community protocol docs and controlled live probes.
-- Migrated bangumi playback from the working legacy v1 route to current v2 and made `result.video_info` a nullable required contract.
-- Recorded retired channel APIs, the invalid unused nickname query, legacy danmaku and authenticated watch-later ambiguity without speculative remapping.
-- Full local gates are green: strict Release build `0 warning / 0 error`, all `543/543` tests, format `0/742` changed files, clean vulnerable/deprecated package audits, module-boundary inventory, anonymous live-probe `27/27` HTTP results, and `git diff --check`.
-- Remaining Gate 3 work is commit/PR publication, remote Windows/Linux/macOS CI, review, and merge into the stacked release-hardening base.
-
-Scope:
-
-- Inventory every Bilibili endpoint, method, envelope field, authentication/WBI requirement and caller.
-- Cross-check recent reliable documentation, at least one maintained open-source implementation and controlled live requests.
-- Replace an endpoint only when evidence is strong; otherwise record risk without speculative change.
-- Add fixed JSON fixtures and injectable/loopback HTTP tests for changed contracts.
-- Keep cookies, tokens, personal paths and sensitive URLs out of reports and logs.
-
-Verification:
-
-- Report lists endpoint, use, status, evidence, alternative, code change and test.
-- ordinary video, bangumi, cheese, list, favorites, publication, login and user-space paths are covered.
-- no unit test depends on production Bilibili availability.
-
-Completion:
-
-- API audit PR is green and merged.
-- Every changed endpoint has a regression fixture and typed failure behavior.
-
-Rollback:
-
-- Revert endpoint changes independently; retain audit evidence and risk notes.
-
 ### Gate 4: Make Domain DownloadTask The Runtime Authority
 
 Owner branch: `refactor/domain-download-authority`.
+
+Progress (2026-07-26):
+
+- Added `IDownloadTaskApplicationService` and `DownloadTaskApplicationService` as the authoritative typed command/query owner; commands load the aggregate, apply one legal transition, persist with optimistic versioning, then publish the committed snapshot.
+- Worker and pipeline entry points now use `DownloadTaskId`; transfer requests carry Domain progress/GID callbacks and no longer carry `DownloadingItem` as task authority.
+- Replaced normal UI-to-Domain reconstruction with one-way Domain-to-UI projection. `DownloadTask.Restore` is limited to the SQLite materializer and explicit NRBF migration mapper.
+- Preserved unfinished task IDs, GID, transfer file map, completed keys, progress, output size and versions across reopen and shutdown recovery.
+- Pause now remains `Pausing` until the transfer worker has actually stopped; built-in and aria2 pause outcomes preserve partial files before the worker confirms `Paused`.
+- Active deletion is durable and retryable: a failed physical cleanup leaves `Canceled` state, while a later delete skips duplicate cancellation and can finish file/store removal.
+- Projection changes notify all affected bindings. UI-thread dispatch of projection events remains explicit Gate 8 work; the current 500 ms UI-list queue scan remains explicit Gate 5 work.
+- Local strict Release build is green with zero warnings, all 552 solution tests pass, format changed 0/750 files, `git diff --check` passes, the module-boundary audit completes, and vulnerable/deprecated package audits are empty.
+- The .NET 10 dependency-audit command is verified with the required `dotnet package list --project <solution>` syntax; stale positional examples were removed from the Agent and rollback guides.
+- Commit/PR publication and remote matrix validation remain. Gate 4 stays in this live plan until its integration evidence is available.
 
 Scope:
 

--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -1,0 +1,341 @@
+using System.Collections.Concurrent;
+using DownKyi.Application.Time;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationService, IDisposable
+{
+    private const int MaximumUpdateAttempts = 2;
+    private readonly IDownloadTaskStore _store;
+    private readonly IClock _clock;
+    private readonly ConcurrentDictionary<DownloadTaskId, SemaphoreSlim> _taskGates = new();
+    private bool _disposed;
+
+    public DownloadTaskApplicationService(IDownloadTaskStore store, IClock clock)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(clock);
+        _store = store;
+        _clock = clock;
+    }
+
+    public event EventHandler<DownloadTaskChangedEventArgs>? TaskChanged;
+
+    public async Task<OperationResult<DownloadTask>> AddAsync(
+        DownloadTask task,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var result = await _store.AddAsync(task, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            return OperationResult.Failure<DownloadTask>(RequireError(result));
+        }
+
+        Publish(task, DownloadTaskChangeKind.Added);
+        return OperationResult.Success(task);
+    }
+
+    public Task<DownloadTask?> FindAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.FindAsync(taskId, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.GetUnfinishedAsync(cancellationToken);
+    }
+
+    public Task<DownloadHistoryPage> GetHistoryPageAsync(
+        DownloadHistoryCursor? cursor,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.GetHistoryPageAsync(cursor, pageSize, cancellationToken);
+    }
+
+    public Task<OperationResult<DownloadTask>> StartAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.Start(now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> PauseAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.Pause(now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> ConfirmPausedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.ConfirmPaused(now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> ResumeAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.Resume(now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> RetryAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.Retry(now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> RecoverInterruptedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.RecoverInterrupted(now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> FailAsync(
+        DownloadTaskId taskId,
+        DownloadFailure failure,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return MutateAsync(taskId, (task, now) => task.Fail(failure, now), cancellationToken);
+    }
+
+    public Task<OperationResult<DownloadTask>> CompleteAsync(
+        DownloadTaskId taskId,
+        DownloadCompletion completion,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(completion);
+        return MutateAsync(taskId, (task, now) => task.Complete(completion, now), cancellationToken);
+    }
+
+    public Task<OperationResult<DownloadTask>> RecordTransferFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        string filePath,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+        return MutateAsync(taskId, (task, now) =>
+        {
+            var files = task.Plan.TransferFiles.SetItem(key, filePath);
+            var plan = new DownloadPlan(task.Plan.RequestedAssets, files, task.Plan.StreamType);
+            var transfer = CopyTransfer(task.Transfer, backendIdentity: null, replaceBackendIdentity: true);
+            return task.UpdatePlan(plan, transfer, now);
+        }, cancellationToken);
+    }
+
+    public Task<OperationResult<DownloadTask>> InvalidateCompletedFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        return MutateAsync(taskId, (task, now) => task.UpdateTransferState(
+            CopyTransfer(task.Transfer, completedFileKeys: task.Transfer.CompletedFileKeys.Remove(key)),
+            now), cancellationToken);
+    }
+
+    public Task<OperationResult<DownloadTask>> CompleteTransferFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(key);
+        return MutateAsync(taskId, (task, now) =>
+        {
+            var completed = task.Transfer.CompletedFileKeys.Contains(key, StringComparer.Ordinal)
+                ? task.Transfer.CompletedFileKeys
+                : task.Transfer.CompletedFileKeys.Add(key);
+            return task.UpdateTransferState(
+                CopyTransfer(
+                    task.Transfer,
+                    backendIdentity: null,
+                    replaceBackendIdentity: true,
+                    completedFileKeys: completed),
+                now);
+        }, cancellationToken);
+    }
+
+    public Task<OperationResult<DownloadTask>> SetBackendIdentityAsync(
+        DownloadTaskId taskId,
+        string? backendIdentity,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, (task, now) => task.UpdateTransferState(
+            CopyTransfer(task.Transfer, backendIdentity, replaceBackendIdentity: true),
+            now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> UpdateActivityAsync(
+        DownloadTaskId taskId,
+        string? activeContent,
+        string? statusText,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, (task, now) => task.UpdateTransferState(
+            new DownloadTransferState(
+                task.Transfer.BackendIdentity,
+                task.Transfer.CompletedFileKeys,
+                activeContent,
+                statusText,
+                task.Transfer.MaximumBytesPerSecond),
+            now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> UpdateProgressAsync(
+        DownloadTaskId taskId,
+        DownloadProgress progress,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+        return MutateAsync(taskId, (task, now) => task.UpdateProgressAndTransfer(
+            progress,
+            CopyTransfer(
+                task.Transfer,
+                maximumBytesPerSecond: Math.Max(
+                    task.Transfer.MaximumBytesPerSecond,
+                    progress.BytesPerSecond)),
+            now), cancellationToken);
+    }
+
+    public Task<OperationResult<DownloadTask>> UpdateOutputFileSizeAsync(
+        DownloadTaskId taskId,
+        string? fileSizeText,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, (task, now) => task.UpdateOutput(
+            new DownloadOutput(task.Output.BasePath, fileSizeText),
+            now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> CancelAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.Cancel(now), cancellationToken);
+
+    public Task<OperationResult<DownloadTask>> DeleteAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        MutateAsync(taskId, static (task, now) => task.Delete(now), cancellationToken);
+
+    public async Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var result = await _store.ClearHistoryAsync(cancellationToken).ConfigureAwait(false);
+        if (result.IsSuccess)
+        {
+            TaskChanged?.Invoke(this, new DownloadTaskChangedEventArgs(
+                new DownloadTaskId("history"),
+                null,
+                DownloadTaskChangeKind.HistoryCleared));
+        }
+
+        return result;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        foreach (var gate in _taskGates.Values)
+        {
+            gate.Dispose();
+        }
+
+        _taskGates.Clear();
+        _disposed = true;
+    }
+
+    private async Task<OperationResult<DownloadTask>> MutateAsync(
+        DownloadTaskId taskId,
+        Func<DownloadTask, DateTimeOffset, OperationResult<DownloadTask>> transition,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        ArgumentNullException.ThrowIfNull(transition);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        var gate = _taskGates.GetOrAdd(taskId, static _ => new SemaphoreSlim(1, 1));
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            for (var attempt = 0; attempt < MaximumUpdateAttempts; attempt++)
+            {
+                var current = await _store.FindAsync(taskId, cancellationToken).ConfigureAwait(false);
+                if (current == null)
+                {
+                    return OperationResult.Failure<DownloadTask>(new OperationError(
+                        "download.store.not_found",
+                        $"Download task '{taskId.Value}' was not found.",
+                        OperationErrorKind.NotFound));
+                }
+
+                var now = LaterOf(_clock.UtcNow, current.UpdatedAtUtc);
+                var transitionResult = transition(current, now);
+                if (!transitionResult.TryGetValue(out var updated))
+                {
+                    return transitionResult;
+                }
+
+                var storeResult = await _store
+                    .UpdateAsync(updated, current.Version, cancellationToken)
+                    .ConfigureAwait(false);
+                if (storeResult.IsSuccess)
+                {
+                    Publish(
+                        updated,
+                        updated.Phase == DownloadPhase.Deleted
+                            ? DownloadTaskChangeKind.Deleted
+                            : DownloadTaskChangeKind.Updated);
+                    return OperationResult.Success(updated);
+                }
+
+                if (storeResult.Error?.Code != "download.store.conflict")
+                {
+                    return OperationResult.Failure<DownloadTask>(RequireError(storeResult));
+                }
+            }
+
+            return OperationResult.Failure<DownloadTask>(new OperationError(
+                "download.store.conflict",
+                $"Download task '{taskId.Value}' changed repeatedly while applying a command.",
+                OperationErrorKind.Conflict));
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+
+    private void Publish(DownloadTask task, DownloadTaskChangeKind kind)
+    {
+        TaskChanged?.Invoke(this, new DownloadTaskChangedEventArgs(task.Id, task, kind));
+    }
+
+    private static DownloadTransferState CopyTransfer(
+        DownloadTransferState source,
+        string? backendIdentity = null,
+        bool replaceBackendIdentity = false,
+        IEnumerable<string>? completedFileKeys = null,
+        long? maximumBytesPerSecond = null)
+    {
+        return new DownloadTransferState(
+            replaceBackendIdentity ? backendIdentity : source.BackendIdentity,
+            completedFileKeys ?? source.CompletedFileKeys,
+            source.ActiveContent,
+            source.StatusText,
+            maximumBytesPerSecond ?? source.MaximumBytesPerSecond);
+    }
+
+    private static OperationError RequireError(OperationResult result)
+    {
+        return result.Error ?? new OperationError(
+            "download.store.unknown",
+            "The download store rejected an operation without an error.");
+    }
+
+    private static DateTimeOffset LaterOf(DateTimeOffset first, DateTimeOffset second)
+    {
+        return first >= second ? first : second;
+    }
+}

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -1,0 +1,133 @@
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+public interface IDownloadTaskApplicationService
+{
+    event EventHandler<DownloadTaskChangedEventArgs>? TaskChanged;
+
+    Task<OperationResult<DownloadTask>> AddAsync(
+        DownloadTask task,
+        CancellationToken cancellationToken);
+
+    Task<DownloadTask?> FindAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken);
+
+    Task<DownloadHistoryPage> GetHistoryPageAsync(
+        DownloadHistoryCursor? cursor,
+        int pageSize,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> StartAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> PauseAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> ConfirmPausedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> ResumeAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> RetryAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> RecoverInterruptedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> FailAsync(
+        DownloadTaskId taskId,
+        DownloadFailure failure,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> CompleteAsync(
+        DownloadTaskId taskId,
+        DownloadCompletion completion,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> RecordTransferFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        string filePath,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> InvalidateCompletedFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> CompleteTransferFileAsync(
+        DownloadTaskId taskId,
+        string key,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> SetBackendIdentityAsync(
+        DownloadTaskId taskId,
+        string? backendIdentity,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> UpdateActivityAsync(
+        DownloadTaskId taskId,
+        string? activeContent,
+        string? statusText,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> UpdateProgressAsync(
+        DownloadTaskId taskId,
+        DownloadProgress progress,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> UpdateOutputFileSizeAsync(
+        DownloadTaskId taskId,
+        string? fileSizeText,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> CancelAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<DownloadTask>> DeleteAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken);
+}
+
+public enum DownloadTaskChangeKind
+{
+    Added,
+    Updated,
+    Deleted,
+    HistoryCleared
+}
+
+public sealed class DownloadTaskChangedEventArgs : EventArgs
+{
+    public DownloadTaskChangedEventArgs(
+        DownloadTaskId taskId,
+        DownloadTask? snapshot,
+        DownloadTaskChangeKind kind)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        TaskId = taskId;
+        Snapshot = snapshot;
+        Kind = kind;
+    }
+
+    public DownloadTaskId TaskId { get; }
+
+    public DownloadTask? Snapshot { get; }
+
+    public DownloadTaskChangeKind Kind { get; }
+}

--- a/src/DownKyi.Domain/Downloads/DownloadTask.cs
+++ b/src/DownKyi.Domain/Downloads/DownloadTask.cs
@@ -200,6 +200,92 @@ public sealed class DownloadTask
             now));
     }
 
+    public OperationResult<DownloadTask> UpdatePlan(
+        DownloadPlan plan,
+        DownloadTransferState transfer,
+        DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(plan);
+        ArgumentNullException.ThrowIfNull(transfer);
+        if (Phase is DownloadPhase.Completed or DownloadPhase.Canceled or DownloadPhase.Deleted)
+        {
+            return OperationResult.Failure<DownloadTask>(new OperationError(
+                "download.plan.terminal",
+                $"Cannot update the download plan after a download reaches {Phase}.",
+                OperationErrorKind.Conflict));
+        }
+
+        EnsureTimestampDoesNotMoveBackward(now);
+        return OperationResult.Success(new DownloadTask(
+            Id,
+            Metadata,
+            plan,
+            Output,
+            Phase,
+            Progress,
+            transfer,
+            Failure,
+            Completion,
+            checked(Version + 1),
+            CreatedAtUtc,
+            now));
+    }
+
+    public OperationResult<DownloadTask> UpdateOutput(DownloadOutput output, DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(output);
+        if (Phase is DownloadPhase.Completed or DownloadPhase.Canceled or DownloadPhase.Deleted)
+        {
+            return OperationResult.Failure<DownloadTask>(new OperationError(
+                "download.output.terminal",
+                $"Cannot update output after a download reaches {Phase}.",
+                OperationErrorKind.Conflict));
+        }
+
+        EnsureTimestampDoesNotMoveBackward(now);
+        return OperationResult.Success(new DownloadTask(
+            Id,
+            Metadata,
+            Plan,
+            output,
+            Phase,
+            Progress,
+            Transfer,
+            Failure,
+            Completion,
+            checked(Version + 1),
+            CreatedAtUtc,
+            now));
+    }
+
+    public OperationResult<DownloadTask> UpdateProgressAndTransfer(
+        DownloadProgress progress,
+        DownloadTransferState transfer,
+        DateTimeOffset now)
+    {
+        ArgumentNullException.ThrowIfNull(progress);
+        ArgumentNullException.ThrowIfNull(transfer);
+        if (Phase is not (DownloadPhase.Downloading or DownloadPhase.Pausing))
+        {
+            return InvalidTransition(Phase);
+        }
+
+        EnsureTimestampDoesNotMoveBackward(now);
+        return OperationResult.Success(new DownloadTask(
+            Id,
+            Metadata,
+            Plan,
+            Output,
+            Phase,
+            progress,
+            transfer,
+            Failure,
+            Completion,
+            checked(Version + 1),
+            CreatedAtUtc,
+            now));
+    }
+
     public OperationResult<DownloadTask> UpdateTransferState(DownloadTransferState transfer, DateTimeOffset now)
     {
         ArgumentNullException.ThrowIfNull(transfer);
@@ -225,6 +311,15 @@ public sealed class DownloadTask
             checked(Version + 1),
             CreatedAtUtc,
             now));
+    }
+
+    public OperationResult<DownloadTask> RecoverInterrupted(DateTimeOffset now)
+    {
+        return Phase switch
+        {
+            DownloadPhase.Downloading or DownloadPhase.Pausing => TransitionTo(DownloadPhase.Queued, now),
+            _ => InvalidTransition(DownloadPhase.Queued)
+        };
     }
 
     private OperationResult<DownloadTask> TransitionTo(
@@ -269,7 +364,7 @@ public sealed class DownloadTask
         {
             DownloadPhase.Queued => target is DownloadPhase.Downloading or DownloadPhase.Paused
                 or DownloadPhase.Failed or DownloadPhase.Canceled or DownloadPhase.Deleted,
-            DownloadPhase.Downloading => target is DownloadPhase.Pausing or DownloadPhase.Completed
+            DownloadPhase.Downloading => target is DownloadPhase.Queued or DownloadPhase.Pausing or DownloadPhase.Completed
                 or DownloadPhase.Failed or DownloadPhase.Canceled or DownloadPhase.Deleted,
             DownloadPhase.Pausing => target is DownloadPhase.Paused or DownloadPhase.Queued
                 or DownloadPhase.Failed or DownloadPhase.Canceled or DownloadPhase.Deleted,

--- a/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
@@ -1,0 +1,228 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Application.Time;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Tests;
+
+public sealed class DownloadTaskApplicationServiceTests
+{
+    private static readonly DateTimeOffset Epoch = new(2026, 7, 22, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public async Task CommandsPersistAggregateBeforePublishingProjectionEvent()
+    {
+        var store = new RecordingStore();
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+        var publishedVersions = new List<long>();
+        service.TaskChanged += (_, args) =>
+        {
+            if (args.Snapshot != null)
+            {
+                Assert.Same(args.Snapshot, store.Current);
+                publishedVersions.Add(args.Snapshot.Version);
+            }
+        };
+
+        var task = CreateTask();
+        Assert.True((await service.AddAsync(task, TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await service.StartAsync(task.Id, TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await service.RecordTransferFileAsync(
+            task.Id,
+            "video-1",
+            "segment.m4s",
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await service.SetBackendIdentityAsync(
+            task.Id,
+            "aria-gid",
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await service.CompleteTransferFileAsync(
+            task.Id,
+            "video-1",
+            TestContext.Current.CancellationToken)).IsSuccess);
+
+        var stored = Assert.IsType<DownloadTask>(store.Current);
+        Assert.Equal(DownloadPhase.Downloading, stored.Phase);
+        Assert.Equal("segment.m4s", stored.Plan.TransferFiles["video-1"]);
+        Assert.Null(stored.Transfer.BackendIdentity);
+        Assert.Equal("video-1", Assert.Single(stored.Transfer.CompletedFileKeys));
+        Assert.Equal([0L, 1L, 2L, 3L, 4L], publishedVersions);
+    }
+
+    [Fact]
+    public async Task ShutdownRecoveryPreservesResumeStateAndOptimisticVersion()
+    {
+        var store = new RecordingStore();
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+        var task = CreateTask();
+        await service.AddAsync(task, TestContext.Current.CancellationToken);
+        await service.StartAsync(task.Id, TestContext.Current.CancellationToken);
+        await service.RecordTransferFileAsync(
+            task.Id,
+            "video-1",
+            "segment.m4s",
+            TestContext.Current.CancellationToken);
+        await service.SetBackendIdentityAsync(
+            task.Id,
+            "aria-gid",
+            TestContext.Current.CancellationToken);
+
+        var result = await service.RecoverInterruptedAsync(
+            task.Id,
+            TestContext.Current.CancellationToken);
+
+        var recovered = result.RequireValue();
+        Assert.Equal(DownloadPhase.Queued, recovered.Phase);
+        Assert.Equal("aria-gid", recovered.Transfer.BackendIdentity);
+        Assert.Equal("segment.m4s", recovered.Plan.TransferFiles["video-1"]);
+        Assert.Equal(4, recovered.Version);
+        Assert.Equal([0L, 1L, 2L, 3L], store.ExpectedVersions);
+    }
+
+    [Fact]
+    public async Task InvalidCommandDoesNotPersistOrPublishAReplacementSnapshot()
+    {
+        var store = new RecordingStore();
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+        var task = CreateTask();
+        await service.AddAsync(task, TestContext.Current.CancellationToken);
+        var eventCount = 0;
+        service.TaskChanged += (_, _) => eventCount++;
+
+        var result = await service.CompleteAsync(
+            task.Id,
+            new DownloadCompletion(1, "finished", null),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.transition.invalid", result.Error?.Code);
+        Assert.Equal(0, eventCount);
+        Assert.Same(task, store.Current);
+    }
+
+    private static DownloadTask CreateTask()
+    {
+        return DownloadTask.Create(
+            new DownloadTaskId("task-application-01"),
+            new DownloadTaskMetadata(
+                new DownloadMediaIdentity("BV1", 1, 2, 0, 1, 1),
+                "Main",
+                "Episode",
+                "00:10",
+                "AVC",
+                new DownloadQuality(80, "1080P"),
+                new DownloadQuality(30280, "AAC"),
+                string.Empty,
+                string.Empty,
+                1),
+            new DownloadPlan(
+                new Dictionary<string, bool> { ["downloadVideo"] = true },
+                [],
+                1),
+            new DownloadOutput("episode", null),
+            Epoch);
+    }
+
+    private sealed class AdvancingClock : IClock
+    {
+        private long _ticks;
+
+        public DateTimeOffset UtcNow => Epoch.AddSeconds(Interlocked.Increment(ref _ticks));
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return Task.Delay(delay, cancellationToken);
+        }
+    }
+
+    private sealed class RecordingStore : IDownloadTaskStore
+    {
+        private readonly Lock _sync = new();
+
+        public DownloadTask? Current { get; private set; }
+
+        public List<long> ExpectedVersions { get; } = [];
+
+        public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<OperationResult> AddAsync(DownloadTask task, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                if (Current != null)
+                {
+                    return Task.FromResult(OperationResult.Failure(new OperationError(
+                        "download.store.conflict",
+                        "Task already exists.",
+                        OperationErrorKind.Conflict)));
+                }
+
+                Current = task;
+                return Task.FromResult(OperationResult.Success());
+            }
+        }
+
+        public Task<OperationResult> UpdateAsync(
+            DownloadTask task,
+            long expectedVersion,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                ExpectedVersions.Add(expectedVersion);
+                if (Current?.Version != expectedVersion)
+                {
+                    return Task.FromResult(OperationResult.Failure(new OperationError(
+                        "download.store.conflict",
+                        "Version changed.",
+                        OperationErrorKind.Conflict)));
+                }
+
+                Current = task.Phase == DownloadPhase.Deleted ? null : task;
+                return Task.FromResult(OperationResult.Success());
+            }
+        }
+
+        public Task<OperationResult> UpdateProgressAsync(
+            DownloadProgressWrite progressWrite,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(OperationResult.Success());
+
+        public Task<DownloadTask?> FindAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                return Task.FromResult(Current?.Id == taskId ? Current : null);
+            }
+        }
+
+        public Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<DownloadTask>>(Current == null ? [] : [Current]);
+
+        public Task<DownloadHistoryPage> GetHistoryPageAsync(
+            DownloadHistoryCursor? cursor,
+            int pageSize,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new DownloadHistoryPage([], null));
+
+        public Task<OperationResult> DeleteAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken)
+        {
+            Current = null;
+            return Task.FromResult(OperationResult.Success());
+        }
+
+        public Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(OperationResult.Success());
+
+        public Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<QuarantinedDownloadRecord>>([]);
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/DownloadRuntimeArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadRuntimeArchitectureTests.cs
@@ -86,6 +86,8 @@ public sealed class DownloadRuntimeArchitectureTests
 
         Assert.Contains("Channel.CreateBounded<DownloadingItem>", source, StringComparison.Ordinal);
         Assert.Contains("DownloadWorkerAsync", source, StringComparison.Ordinal);
+        Assert.Contains("_pipeline.ExecuteAsync(taskId", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("_pipeline.ExecuteAsync(downloading", source, StringComparison.Ordinal);
         Assert.DoesNotContain("void PersistDownloadingState(", source, StringComparison.Ordinal);
     }
 
@@ -93,7 +95,8 @@ public sealed class DownloadRuntimeArchitectureTests
     public void DownloadArtifactsAndTaskStateHaveDedicatedOwners()
     {
         var directory = Path.Combine(RepositoryRoot, "DownKyi", "Services", "Download");
-        var pipelineSource = File.ReadAllText(Path.Combine(directory, "DownloadPipeline.cs"));
+        var pipelineSource = File.ReadAllText(Path.Combine(directory, "DownloadPipeline.cs"))
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
         var artifactSource = File.ReadAllText(Path.Combine(directory, "DownloadArtifactWriter.cs"));
         var stateSource = File.ReadAllText(Path.Combine(directory, "DownloadTaskStateWriter.cs"));
         var factorySource = File.ReadAllText(Path.Combine(directory, "DownloadRuntimeFactory.cs"));
@@ -109,9 +112,10 @@ public sealed class DownloadRuntimeArchitectureTests
         Assert.Contains("VideoStreamApi.GetSubtitle", artifactSource, StringComparison.Ordinal);
         Assert.Contains("new BilibiliDanmakuConverter()", artifactSource, StringComparison.Ordinal);
         Assert.Contains("XmlWriter.Create", artifactSource, StringComparison.Ordinal);
-        Assert.Contains("UpdateDownloadingAsync", stateSource, StringComparison.Ordinal);
+        Assert.Contains("IDownloadTaskApplicationService _tasks", stateSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("DownloadingItem", stateSource, StringComparison.Ordinal);
         Assert.Contains("new DownloadArtifactWriter(", factorySource, StringComparison.Ordinal);
-        Assert.Contains("new DownloadTaskStateWriter(", factorySource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskStateWriter stateWriter", factorySource, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -140,6 +144,17 @@ public sealed class DownloadRuntimeArchitectureTests
         var projectionSource = File.ReadAllText(Path.Combine(
             directory,
             "DownloadTaskProjectionStore.cs"));
+        var reverseWrites = Directory.EnumerateFiles(directory, "*.cs", SearchOption.TopDirectoryOnly)
+            .Where(path =>
+            {
+                var source = File.ReadAllText(path);
+                return source.Contains(".Downloading.DownloadStatus =", StringComparison.Ordinal)
+                       || source.Contains(".Downloading.Gid =", StringComparison.Ordinal)
+                       || source.Contains(".Downloading.DownloadFiles.", StringComparison.Ordinal)
+                       || source.Contains(".Downloading.DownloadedFiles.", StringComparison.Ordinal);
+            })
+            .Select(path => Path.GetRelativePath(RepositoryRoot, path))
+            .ToArray();
         var compositionSource = File.ReadAllText(Path.Combine(
             RepositoryRoot,
             "DownKyi",
@@ -147,9 +162,11 @@ public sealed class DownloadRuntimeArchitectureTests
             "DesktopComposition.cs"));
 
         Assert.False(File.Exists(Path.Combine(directory, "DownloadStorageService.cs")));
-        Assert.Contains("IDownloadTaskStore _store", projectionSource, StringComparison.Ordinal);
+        Assert.Contains("IDownloadTaskApplicationService _tasks", projectionSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("DownloadTask.Restore", projectionSource, StringComparison.Ordinal);
         Assert.DoesNotContain("SqliteConnection", projectionSource, StringComparison.Ordinal);
         Assert.DoesNotContain("Microsoft.Data.Sqlite", projectionSource, StringComparison.Ordinal);
+        Assert.True(reverseWrites.Length == 0, string.Join(Environment.NewLine, reverseWrites));
         Assert.Contains(
             "AddSingleton<DownloadTaskProjectionStore>()",
             compositionSource,
@@ -248,7 +265,10 @@ public sealed class DownloadRuntimeArchitectureTests
         Assert.DoesNotContain("StartOrPauseCommand", itemSource, StringComparison.Ordinal);
         Assert.Contains("ToggleDownloadingCommand", viewSource, StringComparison.Ordinal);
         Assert.Contains("DownloadFileDeletionResult", taskFileSource, StringComparison.Ordinal);
-        Assert.Contains("RemoveDownloadingAsync", coordinatorSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("Downloading.DownloadStatus =", taskFileSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("Downloading.Gid =", taskFileSource, StringComparison.Ordinal);
+        Assert.Contains("_stateWriter.CancelAsync", coordinatorSource, StringComparison.Ordinal);
+        Assert.Contains("_stateWriter.DeleteAsync", coordinatorSource, StringComparison.Ordinal);
         Assert.Contains("DeleteGeneratedFilesAsync", coordinatorSource, StringComparison.Ordinal);
         Assert.Contains("AddSingleton<DownloadTaskFileService>()", compositionSource, StringComparison.Ordinal);
         Assert.Contains(
@@ -318,6 +338,46 @@ public sealed class DownloadRuntimeArchitectureTests
         Assert.Contains("await UiDispatcher.InvokeAsync", source, StringComparison.Ordinal);
         Assert.DoesNotContain("App.PropertyChange", source, StringComparison.Ordinal);
         Assert.DoesNotContain("Dispatcher.UIThread", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RuntimeApisUseTaskIdentityAndTransferCallbacksInsteadOfUiItems()
+    {
+        var directory = Path.Combine(RepositoryRoot, "DownKyi", "Services", "Download");
+        var pipelineSource = File.ReadAllText(Path.Combine(directory, "DownloadPipeline.cs"))
+            .Replace("\r\n", "\n", StringComparison.Ordinal);
+        var transferSource = File.ReadAllText(Path.Combine(directory, "ITransferBackend.cs"));
+
+        Assert.Contains("internal async Task ExecuteAsync(\n        DownloadTaskId taskId", pipelineSource, StringComparison.Ordinal);
+        Assert.Contains("internal async Task MarkFailedAsync(DownloadTaskId taskId)", pipelineSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("internal async Task ExecuteAsync(\n        DownloadingItem", pipelineSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("DownloadingItem Download", transferSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskId TaskId", transferSource, StringComparison.Ordinal);
+        Assert.Contains("Func<DownloadProgress, CancellationToken, Task> PersistProgressAsync", transferSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PauseIsAcknowledgedOnlyAfterTheTransferWorkerStops()
+    {
+        var directory = Path.Combine(RepositoryRoot, "DownKyi", "Services", "Download");
+        var stateSource = File.ReadAllText(Path.Combine(directory, "DownloadTaskStateWriter.cs"));
+        var orchestratorSource = File.ReadAllText(Path.Combine(directory, "DownloadOrchestrator.cs"));
+        var pipelineSource = File.ReadAllText(Path.Combine(directory, "DownloadPipeline.cs"));
+        var builtinSource = File.ReadAllText(Path.Combine(directory, "BuiltinTransferBackend.cs"));
+        var ariaSource = File.ReadAllText(Path.Combine(directory, "Aria2TransferBackend.cs"));
+
+        Assert.DoesNotContain("paused.Phase == DownloadPhase.Pausing", stateSource, StringComparison.Ordinal);
+        Assert.Contains("ConfirmPauseAfterWorkerStopsAsync", orchestratorSource, StringComparison.Ordinal);
+        Assert.Contains("_stateWriter.ConfirmPausedAsync", orchestratorSource, StringComparison.Ordinal);
+        Assert.Contains("outcome == DownloadTransferOutcome.Paused", pipelineSource, StringComparison.Ordinal);
+        Assert.Contains("return DownloadTransferOutcome.Paused", builtinSource, StringComparison.Ordinal);
+        Assert.Contains("return DownloadTransferOutcome.Paused", ariaSource, StringComparison.Ordinal);
+        Assert.True(
+            builtinSource.IndexOf("if (request.IsPauseRequested())", StringComparison.Ordinal) <
+            builtinSource.IndexOf("request.EnsureActive();", StringComparison.Ordinal));
+        Assert.True(
+            ariaSource.IndexOf("if (request.IsPauseRequested())", StringComparison.Ordinal) <
+            ariaSource.IndexOf("request.EnsureActive();", StringComparison.Ordinal));
     }
 
     private static string FindRepositoryRoot()

--- a/tests/DownKyi.Architecture.Tests/MediaAndHttpRuntimeArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/MediaAndHttpRuntimeArchitectureTests.cs
@@ -652,7 +652,8 @@ public sealed class MediaAndHttpRuntimeArchitectureTests
         Assert.Contains("Task.Run", coordinatorSource, StringComparison.Ordinal);
         Assert.Contains("CancellationToken", coordinatorSource, StringComparison.Ordinal);
         Assert.Contains("using var database", coordinatorSource, StringComparison.Ordinal);
-        Assert.Contains("AddDownloadedBatchAsync", coordinatorSource, StringComparison.Ordinal);
+        Assert.Contains("LegacyDownloadTaskMapper.RestoreCompleted", coordinatorSource, StringComparison.Ordinal);
+        Assert.Contains("AddMigratedCompletedAsync", coordinatorSource, StringComparison.Ordinal);
         Assert.Contains("ILogger<LegacyUpgradeCoordinator>", coordinatorSource, StringComparison.Ordinal);
         Assert.DoesNotContain("LogManager.", coordinatorSource, StringComparison.Ordinal);
         Assert.DoesNotContain("Console.", coordinatorSource, StringComparison.Ordinal);

--- a/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
@@ -263,28 +263,24 @@ public sealed class ModuleBoundaryBaselineTests
     }
 
     [Fact]
-    public void DomainToLegacyReconstructionCannotSpreadBeyondTheProjectionStore()
+    public void DomainRestoreIsRestrictedToPersistenceAndMigrationAdapters()
     {
-        var downloadRoot = Path.Combine(RepositoryRoot, "DownKyi", "Services", "Download");
-        var actual = Directory
-            .EnumerateFiles(downloadRoot, "*.cs", SearchOption.AllDirectories)
+        var actual = EnumerateProductionFiles("*.cs")
             .Where(path =>
             {
                 var source = File.ReadAllText(path);
-                return source.Contains("DomainDownloadTask.Restore", StringComparison.Ordinal) ||
-                       source.Contains("CreateUnfinishedTask", StringComparison.Ordinal) ||
-                       source.Contains("ToLegacyStatus", StringComparison.Ordinal);
+                return source.Contains("DownloadTask.Restore", StringComparison.Ordinal) ||
+                       source.Contains("DomainDownloadTask.Restore", StringComparison.Ordinal);
             })
             .Select(Relative)
             .ToArray();
 
-        AssertSubset(
-            actual,
-            new HashSet<string>(StringComparer.Ordinal)
-            {
-                "DownKyi/Services/Download/DownloadTaskProjectionStore.cs"
-            },
-            "domain-to-legacy reconstruction owner");
+        Assert.Equal(
+            [
+                "DownKyi/Services/Migration/LegacyDownloadTaskMapper.cs",
+                "src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs"
+            ],
+            actual.Order(StringComparer.Ordinal));
     }
 
     [Fact]

--- a/tests/DownKyi.Domain.Tests/DownloadTaskStateMachineTests.cs
+++ b/tests/DownKyi.Domain.Tests/DownloadTaskStateMachineTests.cs
@@ -132,6 +132,27 @@ public sealed class DownloadTaskStateMachineTests
         Assert.Equal("download.transfer.terminal", result.Error?.Code);
     }
 
+    [Fact]
+    public void InterruptedDownloadReturnsToQueueWithoutLosingResumeState()
+    {
+        var transfer = new DownloadTransferState(
+            "aria-gid",
+            ["video-segment-1"],
+            "video",
+            "Downloading",
+            4_000_000);
+        var downloading = CreateTask()
+            .Start(Epoch.AddSeconds(1)).RequireValue()
+            .UpdateTransferState(transfer, Epoch.AddSeconds(2)).RequireValue();
+
+        var recovered = downloading.RecoverInterrupted(Epoch.AddSeconds(3)).RequireValue();
+
+        Assert.Equal(DownloadPhase.Queued, recovered.Phase);
+        Assert.Same(transfer, recovered.Transfer);
+        Assert.Equal("aria-gid", recovered.Transfer.BackendIdentity);
+        Assert.Equal("video-segment-1", Assert.Single(recovered.Transfer.CompletedFileKeys));
+    }
+
     [Theory]
     [InlineData(-0.01)]
     [InlineData(100.01)]

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -16,7 +16,9 @@ public sealed class DownloadBootstrapHostedServiceTests
         using var runtime = new RecordingDownloadRuntime();
         var dispatcher = new ImmediateUiDispatcher();
         var listState = new DownloadListState();
-        using var storage = new DownloadTaskProjectionStore(new EmptyDownloadTaskStore(), new FixedClock());
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(new EmptyDownloadTaskStore(), clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
         using var service = new DownloadBootstrapHostedService(
             listState,
             storage,

--- a/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
@@ -1,4 +1,5 @@
 using DownKyi.Application.Desktop;
+using DownKyi.Application.Downloads;
 using DownKyi.Core.BiliApi.VideoStream.Models;
 using DownKyi.Domain.Downloads;
 using DownKyi.Infrastructure.Downloads;
@@ -17,19 +18,22 @@ public sealed class DownloadManagerCoordinatorTests
     public async Task PauseAndResumeAllArePersistedForNextLaunch()
     {
         using var context = new CoordinatorContext();
-        var item = context.CreateDownloadingItem("pause-resume", DownloadStatus.Downloading);
+        var item = context.CreateDownloadingItem("pause-resume", DownloadStatus.WaitForDownload);
         context.State.Downloading.Add(item);
         await context.Storage.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+        await context.StateWriter.StartAsync(
+            new DownloadTaskId(item.DownloadBase.Id),
+            TestContext.Current.CancellationToken);
 
         await context.Coordinator.PauseAllAsync(
             context.State.Downloading,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(DownloadStatus.Pause, item.Downloading.DownloadStatus);
+        Assert.Equal(DownloadStatus.PauseStarted, item.Downloading.DownloadStatus);
         var paused = await context.Store.FindAsync(
             new DownloadTaskId(item.DownloadBase.Id),
             TestContext.Current.CancellationToken);
-        Assert.Equal(DownloadPhase.Paused, Assert.IsType<DownloadTask>(paused).Phase);
+        Assert.Equal(DownloadPhase.Pausing, Assert.IsType<DownloadTask>(paused).Phase);
 
         await context.Coordinator.ResumeAllAsync(
             context.State.Downloading,
@@ -40,6 +44,28 @@ public sealed class DownloadManagerCoordinatorTests
             new DownloadTaskId(item.DownloadBase.Id),
             TestContext.Current.CancellationToken);
         Assert.Equal(DownloadPhase.Queued, Assert.IsType<DownloadTask>(resumed).Phase);
+    }
+
+    [Fact]
+    public async Task DeleteCanBeRetriedAfterAFormerFileCleanupLeftTaskCanceled()
+    {
+        using var context = new CoordinatorContext();
+        var item = context.CreateDownloadingItem("delete-retry", DownloadStatus.WaitForDownload);
+        item.Downloading.DownloadFiles["video"] = "delete-retry.mp4";
+        context.State.Downloading.Add(item);
+        await context.Storage.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+        await context.StateWriter.CancelAsync(
+            new DownloadTaskId(item.DownloadBase.Id),
+            TestContext.Current.CancellationToken);
+        var media = context.CreateFile("delete-retry.mp4", "partial media");
+
+        await context.Coordinator.DeleteAsync(item, TestContext.Current.CancellationToken);
+
+        Assert.False(File.Exists(media));
+        Assert.DoesNotContain(item, context.State.Downloading);
+        Assert.Null(await context.Store.FindAsync(
+            new DownloadTaskId(item.DownloadBase.Id),
+            TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -113,18 +139,30 @@ public sealed class DownloadManagerCoordinatorTests
             Store = new SqliteDownloadTaskStore(
                 new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
                 new SystemClock());
-            Storage = new DownloadTaskProjectionStore(Store, new SystemClock());
+            var clock = new SystemClock();
+            TaskService = new DownloadTaskApplicationService(Store, clock);
+            Storage = new DownloadTaskProjectionStore(TaskService, clock);
+            StateWriter = new DownloadTaskStateWriter(TaskService);
             State = new DownloadListState();
             Launcher = new RecordingPlatformLauncher();
             var fileService = new DownloadTaskFileService(
                 new AriaRuntimeClientRegistry(),
                 NullLogger<DownloadTaskFileService>.Instance);
-            Coordinator = new DownloadManagerCoordinator(Storage, fileService, State, Launcher);
+            Coordinator = new DownloadManagerCoordinator(
+                Storage,
+                StateWriter,
+                fileService,
+                State,
+                Launcher);
         }
 
         public SqliteDownloadTaskStore Store { get; }
 
         public DownloadTaskProjectionStore Storage { get; }
+
+        public DownloadTaskApplicationService TaskService { get; }
+
+        public DownloadTaskStateWriter StateWriter { get; }
 
         public DownloadListState State { get; }
 
@@ -175,6 +213,7 @@ public sealed class DownloadManagerCoordinatorTests
         public void Dispose()
         {
             Storage.Dispose();
+            TaskService.Dispose();
             Store.Dispose();
             SqliteConnection.ClearAllPools();
             if (Directory.Exists(_directory))

--- a/tests/DownKyi.Tests/DownloadProgressUiUpdaterTests.cs
+++ b/tests/DownKyi.Tests/DownloadProgressUiUpdaterTests.cs
@@ -1,58 +1,51 @@
-using DownKyi.Models;
 using DownKyi.Services.Download;
-using DownKyi.ViewModels.DownloadManager;
 
 namespace DownKyi.Tests;
 
 public sealed class DownloadProgressUiUpdaterTests
 {
     [Fact]
-    public void ProgressEventsAreBoundedAndCompletionIsAlwaysPublished()
+    public void ProgressSamplesAreBoundedAndCompletionIsAlwaysPublished()
     {
         var clock = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
         var updater = new DownloadProgressUiUpdater(clock, TimeSpan.FromMilliseconds(100));
-        var item = new DownloadingItem { Downloading = new Downloading() };
-        var notifications = 0;
-        item.PropertyChanged += (_, args) =>
-        {
-            if (args.PropertyName is nameof(DownloadingItem.Progress)
-                or nameof(DownloadingItem.DownloadingFileSize)
-                or nameof(DownloadingItem.SpeedDisplay))
-            {
-                notifications++;
-            }
-        };
-
-        var published = 0;
+        var published = new List<DownKyi.Domain.Downloads.DownloadProgress>();
         for (var millisecond = 0; millisecond < 1000; millisecond++)
         {
-            if (updater.TryUpdate(item, millisecond / 10d, millisecond, 1000, millisecond))
+            if (updater.TryCreate(
+                    millisecond / 10d,
+                    millisecond,
+                    1000,
+                    millisecond,
+                    out var progress))
             {
-                published++;
+                published.Add(progress);
             }
 
             clock.Advance(TimeSpan.FromMilliseconds(1));
         }
 
-        Assert.True(updater.TryUpdate(item, 100, 1000, 1000, 5000));
-        Assert.Equal(11, published + 1);
-        Assert.Equal(33, notifications);
-        Assert.Equal(100, item.Progress);
-        Assert.Equal(5000, item.Downloading.MaxSpeed);
+        Assert.True(updater.TryCreate(100, 1000, 1000, 5000, out var completed));
+        published.Add(completed);
+
+        Assert.Equal(11, published.Count);
+        Assert.Equal(100, completed.Percentage);
+        Assert.Equal(5000, completed.BytesPerSecond);
+        Assert.Equal(1000, completed.DownloadedBytes);
+        Assert.Equal(1000, completed.TotalBytes);
     }
 
     [Fact]
-    public void SuppressedUiSamplesStillTrackMaximumSpeed()
+    public void SuppressedSamplesDoNotReplaceLastPublishedDomainProgress()
     {
         var clock = new ManualTimeProvider(DateTimeOffset.UnixEpoch);
         var updater = new DownloadProgressUiUpdater(clock, TimeSpan.FromSeconds(1));
-        var item = new DownloadingItem { Downloading = new Downloading() };
 
-        Assert.True(updater.TryUpdate(item, 1, 1, 100, 100));
-        Assert.False(updater.TryUpdate(item, 2, 2, 100, 10_000));
+        Assert.True(updater.TryCreate(1, 1, 100, 100, out var first));
+        Assert.False(updater.TryCreate(2, 2, 100, 10_000, out _));
 
-        Assert.Equal(10_000, item.Downloading.MaxSpeed);
-        Assert.Equal(1, item.Progress);
+        Assert.Equal(100, first.BytesPerSecond);
+        Assert.Equal(1, first.Percentage);
     }
 
     private sealed class ManualTimeProvider(DateTimeOffset utcNow) : TimeProvider

--- a/tests/DownKyi.Tests/DownloadShutdownCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadShutdownCoordinatorTests.cs
@@ -1,4 +1,11 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Infrastructure.Downloads;
+using DownKyi.Infrastructure.Time;
+using DownKyi.Models;
 using DownKyi.Services.Download;
+using DownKyi.ViewModels.DownloadManager;
+using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Tests;
 
@@ -66,5 +73,72 @@ public sealed class DownloadShutdownCoordinatorTests
 
         Assert.Same(failure, exception);
         Assert.True(recovered);
+    }
+
+    [Fact]
+    public async Task ShutdownRecoveryQueuesActiveDomainTaskAndPreservesResumeData()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "downkyi-shutdown-recovery-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using var store = new SqliteDownloadTaskStore(
+                new SqliteDownloadTaskStoreOptions(Path.Combine(directory, "download.db")),
+                new SystemClock());
+            var clock = new SystemClock();
+            using var tasks = new DownloadTaskApplicationService(store, clock);
+            using var projections = new DownloadTaskProjectionStore(tasks, clock);
+            var stateWriter = new DownloadTaskStateWriter(tasks);
+            var lists = new DownloadListState();
+            var item = new DownloadingItem
+            {
+                DownloadBase = new DownloadBase
+                {
+                    Id = "shutdown-resume",
+                    FilePath = Path.Combine(directory, "episode")
+                },
+                Downloading = new Downloading
+                {
+                    Id = "shutdown-resume",
+                    DownloadStatus = DownloadStatus.WaitForDownload
+                }
+            };
+            await projections.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+            lists.Downloading.Add(item);
+            var taskId = new DownloadTaskId(item.DownloadBase.Id);
+            await stateWriter.StartAsync(taskId, TestContext.Current.CancellationToken);
+            await stateWriter.RecordTransferFileAsync(
+                taskId,
+                "video",
+                "video.m4s",
+                TestContext.Current.CancellationToken);
+            await stateWriter.SetBackendIdentityAsync(
+                taskId,
+                "aria-gid",
+                TestContext.Current.CancellationToken);
+            await stateWriter.UpdateProgressAsync(
+                taskId,
+                new DownloadProgress(45, 450, 1000, 2_000_000),
+                TestContext.Current.CancellationToken);
+            var recovery = new DownloadTaskShutdownRecovery(lists, projections, stateWriter);
+
+            await recovery.PersistAsync();
+
+            var restored = Assert.IsType<DownloadTask>(
+                await store.FindAsync(taskId, TestContext.Current.CancellationToken));
+            Assert.Equal(DownloadPhase.Queued, restored.Phase);
+            Assert.Equal("aria-gid", restored.Transfer.BackendIdentity);
+            Assert.Equal("video.m4s", restored.Plan.TransferFiles["video"]);
+            Assert.Equal(45, restored.Progress.Percentage);
+            Assert.Equal(450, restored.Progress.DownloadedBytes);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            Directory.Delete(directory, recursive: true);
+        }
     }
 }

--- a/tests/DownKyi.Tests/DownloadTaskProjectionStoreResumeTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskProjectionStoreResumeTests.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
 using DownKyi.Infrastructure.Downloads;
 using DownKyi.Infrastructure.Time;
 using DownKyi.Models;
@@ -27,30 +29,60 @@ public sealed class DownloadTaskProjectionStoreResumeTests : IDisposable
             Downloading = new Downloading
             {
                 Id = taskId,
-                Gid = ariaGid,
-                DownloadStatus = DownloadStatus.Pause,
-                Progress = 42.5f
+                DownloadStatus = DownloadStatus.WaitForDownload
             }
         };
-        item.Downloading.DownloadFiles["video"] = "video.m4s";
-        item.Downloading.DownloadFiles["audio"] = "audio.m4s";
-        item.Downloading.DownloadedFiles.Add("cover");
         item.DownloadBase.Id = taskId;
         item.DownloadBase.FilePath = Path.Combine(_directory, "episode-01");
 
         using (var store = new SqliteDownloadTaskStore(
                    new SqliteDownloadTaskStoreOptions(database),
                    new SystemClock()))
-        using (var storage = new DownloadTaskProjectionStore(store, new SystemClock()))
         {
+            var clock = new SystemClock();
+            using var tasks = new DownloadTaskApplicationService(store, clock);
+            using var storage = new DownloadTaskProjectionStore(tasks, clock);
+            var stateWriter = new DownloadTaskStateWriter(tasks);
             await storage.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+            var id = new DownloadTaskId(taskId);
+            await stateWriter.StartAsync(id, TestContext.Current.CancellationToken);
+            await stateWriter.RecordTransferFileAsync(
+                id,
+                "video",
+                "video.m4s",
+                TestContext.Current.CancellationToken);
+            await stateWriter.RecordTransferFileAsync(
+                id,
+                "audio",
+                "audio.m4s",
+                TestContext.Current.CancellationToken);
+            await stateWriter.CompleteTransferFileAsync(
+                id,
+                "cover",
+                TestContext.Current.CancellationToken);
+            await stateWriter.SetBackendIdentityAsync(
+                id,
+                ariaGid,
+                TestContext.Current.CancellationToken);
+            await stateWriter.UpdateProgressAsync(
+                id,
+                new DownloadProgress(42.5),
+                TestContext.Current.CancellationToken);
+            await stateWriter.UpdateOutputFileSizeAsync(
+                id,
+                "6 GB",
+                TestContext.Current.CancellationToken);
+            await stateWriter.PauseAsync(id, TestContext.Current.CancellationToken);
+            await stateWriter.ConfirmPausedAsync(id, TestContext.Current.CancellationToken);
         }
 
         using (var store = new SqliteDownloadTaskStore(
                    new SqliteDownloadTaskStoreOptions(database),
                    new SystemClock()))
-        using (var reopenedStorage = new DownloadTaskProjectionStore(store, new SystemClock()))
         {
+            var clock = new SystemClock();
+            using var tasks = new DownloadTaskApplicationService(store, clock);
+            using var reopenedStorage = new DownloadTaskProjectionStore(tasks, clock);
             var restored = Assert.Single(
                 await reopenedStorage.GetDownloadingAsync(TestContext.Current.CancellationToken));
             Assert.Equal(ariaGid, restored.Downloading.Gid);
@@ -59,6 +91,7 @@ public sealed class DownloadTaskProjectionStoreResumeTests : IDisposable
             Assert.Equal("cover", Assert.Single(restored.Downloading.DownloadedFiles));
             Assert.Equal(DownloadStatus.Pause, restored.Downloading.DownloadStatus);
             Assert.Equal(42.5f, restored.Downloading.Progress);
+            Assert.Equal("6 GB", restored.DownloadBase.FileSize);
         }
 
         using var connection = new SqliteConnection($"Data Source={database};Mode=ReadOnly");
@@ -95,43 +128,100 @@ public sealed class DownloadTaskProjectionStoreResumeTests : IDisposable
             Downloading = new Downloading
             {
                 Id = "complete-task-01",
-                DownloadStatus = DownloadStatus.Downloading,
-                Progress = 100
-            }
-        };
-        var downloadedItem = new DownloadedItem
-        {
-            DownloadBase = downloadingItem.DownloadBase,
-            Downloaded = new Downloaded
-            {
-                Id = "complete-task-01",
-                FinishedTimestamp = 1234,
-                FinishedTime = "finished",
-                MaxSpeedDisplay = "24 Mbps"
+                DownloadStatus = DownloadStatus.WaitForDownload
             }
         };
         using (var store = new SqliteDownloadTaskStore(
                    new SqliteDownloadTaskStoreOptions(database),
                    new SystemClock()))
-        using (var storage = new DownloadTaskProjectionStore(store, new SystemClock()))
         {
+            var clock = new SystemClock();
+            using var tasks = new DownloadTaskApplicationService(store, clock);
+            using var storage = new DownloadTaskProjectionStore(tasks, clock);
+            var stateWriter = new DownloadTaskStateWriter(tasks);
             await storage.AddDownloadingAsync(downloadingItem, TestContext.Current.CancellationToken);
-            await storage.RemoveDownloadingAsync(
-                downloadingItem,
-                cascadeRemove: false,
-                cancellationToken: TestContext.Current.CancellationToken);
-            await storage.AddDownloadedAsync(downloadedItem, TestContext.Current.CancellationToken);
+            var id = new DownloadTaskId(downloadingItem.DownloadBase.Id);
+            await stateWriter.StartAsync(id, TestContext.Current.CancellationToken);
+            await stateWriter.UpdateProgressAsync(
+                id,
+                new DownloadProgress(100),
+                TestContext.Current.CancellationToken);
+            await stateWriter.CompleteAsync(
+                id,
+                new DownloadCompletion(1234, "finished", "24 Mbps"),
+                TestContext.Current.CancellationToken);
         }
 
         using var reopenedStore = new SqliteDownloadTaskStore(
             new SqliteDownloadTaskStoreOptions(database),
             new SystemClock());
-        using var reopened = new DownloadTaskProjectionStore(reopenedStore, new SystemClock());
+        var reopenedClock = new SystemClock();
+        using var reopenedTasks = new DownloadTaskApplicationService(reopenedStore, reopenedClock);
+        using var reopened = new DownloadTaskProjectionStore(reopenedTasks, reopenedClock);
         Assert.Empty(await reopened.GetDownloadingAsync(TestContext.Current.CancellationToken));
         var restored = Assert.Single(
             await reopened.GetDownloadedAsync(TestContext.Current.CancellationToken));
         Assert.Equal("complete-task-01", restored.DownloadBase.Id);
         Assert.Equal(1234, restored.Downloaded.FinishedTimestamp);
+    }
+
+    [Fact]
+    public async Task PersistedDomainChangesNotifyEveryAffectedUiBinding()
+    {
+        Directory.CreateDirectory(_directory);
+        var database = Path.Combine(_directory, "projection-notifications.db");
+        var item = new DownloadingItem
+        {
+            DownloadBase = new DownloadBase
+            {
+                Id = "projection-notifications",
+                Name = "Projection",
+                FilePath = Path.Combine(_directory, "projection")
+            },
+            Downloading = new Downloading
+            {
+                Id = "projection-notifications",
+                DownloadStatus = DownloadStatus.WaitForDownload
+            }
+        };
+        using var store = new SqliteDownloadTaskStore(
+            new SqliteDownloadTaskStoreOptions(database),
+            new SystemClock());
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        var stateWriter = new DownloadTaskStateWriter(tasks);
+        await storage.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+        var notifications = new List<string?>();
+        item.PropertyChanged += (_, args) => notifications.Add(args.PropertyName);
+        var id = new DownloadTaskId(item.DownloadBase.Id);
+
+        await stateWriter.StartAsync(id, TestContext.Current.CancellationToken);
+        await stateWriter.UpdateActivityAsync(
+            id,
+            "video",
+            "downloading",
+            TestContext.Current.CancellationToken);
+        await stateWriter.UpdateProgressAsync(
+            id,
+            new DownloadProgress(50, 500, 1000, 3_000_000, "500 B/1 KB", "24 Mbps"),
+            TestContext.Current.CancellationToken);
+        await stateWriter.UpdateOutputFileSizeAsync(
+            id,
+            "1 KB",
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains(nameof(DownloadingItem.DownloadContent), notifications);
+        Assert.Contains(nameof(DownloadingItem.DownloadStatusTitle), notifications);
+        Assert.Contains(nameof(DownloadingItem.Progress), notifications);
+        Assert.Contains(nameof(DownloadingItem.DownloadingFileSize), notifications);
+        Assert.Contains(nameof(DownloadingItem.SpeedDisplay), notifications);
+        Assert.Contains(nameof(DownloadingItem.FileSize), notifications);
+        Assert.Equal("video", item.DownloadContent);
+        Assert.Equal("downloading", item.DownloadStatusTitle);
+        Assert.Equal(50, item.Progress);
+        Assert.Equal("24 Mbps", item.SpeedDisplay);
+        Assert.Equal("1 KB", item.FileSize);
     }
 
     public void Dispose()

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -224,6 +224,7 @@ public sealed class VideoTagLoadingTests : IDisposable
     private sealed class DownloadTestContext : IDisposable
     {
         private readonly DownKyi.Core.Settings.SettingsStore _settings;
+        private readonly DownloadTaskApplicationService _taskService;
         private readonly DownloadTaskProjectionStore _projectionStore;
 
         public DownloadTestContext(string settingsPath, bool generateMetadata)
@@ -240,7 +241,9 @@ public sealed class VideoTagLoadingTests : IDisposable
                 }
             });
             Store = new RecordingDownloadTaskStore();
-            _projectionStore = new DownloadTaskProjectionStore(Store, new SystemClock());
+            var clock = new SystemClock();
+            _taskService = new DownloadTaskApplicationService(Store, clock);
+            _projectionStore = new DownloadTaskProjectionStore(_taskService, clock);
             ListState = new DownloadListState();
             Logger = new RecordingLogger<AddToDownloadService>();
             var desktop = new TestDesktopInteractionContext();
@@ -287,6 +290,7 @@ public sealed class VideoTagLoadingTests : IDisposable
         public void Dispose()
         {
             _projectionStore.Dispose();
+            _taskService.Dispose();
             _settings.Dispose();
         }
     }


### PR DESCRIPTION
## Summary

- add `IDownloadTaskApplicationService` as the single typed command/query owner for durable download state
- route worker, pipeline, pause, resume, delete, progress, GID, output and shutdown recovery through `DownloadTaskId` and legal Domain transitions
- replace normal mutable UI-to-Domain reconstruction with committed Domain-to-UI projection
- preserve legacy NRBF/SQLite materialization only in explicit migration/store adapters
- keep unfinished task identity, GID, partial-file map, completed keys, progress, output size and optimistic version across reopen
- update architecture, Agent guide, live plan, maintenance and knowledge graph documentation

## Why

The previous runtime still treated `DownloadingItem` and its legacy mutable status as the effective state authority, rebuilding a Domain aggregate only near persistence. That allowed UI state, durable state and worker state to diverge. This change makes the Domain aggregate authoritative while retaining the existing UI projection and stored-data compatibility needed for the next queue and pipeline gates.

## Behavior and compatibility

- pause remains `Pausing` until the transfer worker has preserved resume state and stopped
- failed physical deletion leaves a retryable `Canceled` task instead of pretending deletion succeeded
- existing SQLite records, legacy NRBF data, unfinished tasks and resume state remain readable
- no settings, JSON, SQLite schema or external protocol format is changed

## Validation

- strict .NET 10 `AnalysisMode=All` Release build: 0 warnings, 0 errors
- full solution tests: 552 passed, 0 failed
- `dotnet format --verify-no-changes`: 0/750 files changed
- `git diff --check`: passed
- module-boundary audit: passed
- vulnerable transitive package audit: clean
- deprecated package audit: clean

## Follow-up

Gate 5 will replace the remaining 500 ms UI collection scan and `Channel<DownloadingItem>` compatibility path with event-driven `DownloadTaskId` enqueue. Gate 6/8 retain ownership of pipeline-stage extraction and UI-thread projection dispatch.