### PR TITLE
feat(personal): add history auto refresh and dynamic feed

### DIFF
--- a/DownKyi.Core/BiliApi/Dynamic/DynamicFeedApi.cs
+++ b/DownKyi.Core/BiliApi/Dynamic/DynamicFeedApi.cs
@@ -1,0 +1,36 @@
+using DownKyi.Application.Bilibili;
+using DownKyi.Core.BiliApi.Dynamic.Models;
+using Newtonsoft.Json;
+
+namespace DownKyi.Core.BiliApi.Dynamic;
+
+public static class DynamicFeedApi
+{
+    private const string FeedUrl =
+        "https://api.bilibili.com/x/polymer/web-dynamic/v1/feed/all?type=all&platform=web";
+
+    public static async Task<DynamicFeedData> GetDynamicFeedAsync(
+        this IBilibiliApiClient client,
+        string? offset = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        var url = string.IsNullOrWhiteSpace(offset)
+            ? FeedUrl
+            : $"{FeedUrl}&offset={Uri.EscapeDataString(offset)}";
+        var origin = await BiliApiRequest.RequestJsonAsync<DynamicFeedOrigin>(
+            client,
+            url,
+            "https://t.bilibili.com/",
+            nameof(GetDynamicFeedAsync),
+            nameof(DynamicFeedApi),
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return BiliApiRequest.RequirePayload(origin.Data);
+    }
+
+    internal static DynamicFeedData? ParseResponse(string response)
+    {
+        var origin = JsonConvert.DeserializeObject<DynamicFeedOrigin>(response);
+        return origin is { Code: 0 } ? origin.Data : null;
+    }
+}

--- a/DownKyi.Core/BiliApi/Dynamic/Models/DynamicFeedOrigin.cs
+++ b/DownKyi.Core/BiliApi/Dynamic/Models/DynamicFeedOrigin.cs
@@ -1,0 +1,244 @@
+using DownKyi.Core.BiliApi.Models;
+using Newtonsoft.Json;
+
+namespace DownKyi.Core.BiliApi.Dynamic.Models;
+
+public sealed class DynamicFeedOrigin : BaseModel
+{
+    [JsonProperty("code")]
+    public int Code { get; set; }
+
+    [JsonProperty("message")]
+    public string Message { get; set; } = string.Empty;
+
+    [JsonProperty("data")]
+    public DynamicFeedData? Data { get; set; }
+}
+
+public sealed class DynamicFeedData : BaseModel
+{
+    [JsonProperty("has_more")]
+    public bool HasMore { get; set; }
+
+    [JsonProperty("offset")]
+    public string Offset { get; set; } = string.Empty;
+
+    [JsonProperty("items")]
+    public IReadOnlyList<DynamicFeedItem> Items { get; set; } = Array.Empty<DynamicFeedItem>();
+}
+
+public sealed class DynamicFeedItem : BaseModel
+{
+    [JsonProperty("id_str")]
+    public string Id { get; set; } = string.Empty;
+
+    [JsonProperty("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonProperty("visible")]
+    public bool Visible { get; set; } = true;
+
+    [JsonProperty("modules")]
+    public DynamicModules Modules { get; set; } = new();
+
+    [JsonProperty("orig")]
+    public DynamicFeedItem? Original { get; set; }
+}
+
+public sealed class DynamicModules : BaseModel
+{
+    [JsonProperty("module_author")]
+    public DynamicAuthor Author { get; set; } = new();
+
+    [JsonProperty("module_dynamic")]
+    public DynamicContent Content { get; set; } = new();
+
+    [JsonProperty("module_stat")]
+    public DynamicStats Stats { get; set; } = new();
+}
+
+public sealed class DynamicAuthor : BaseModel
+{
+    [JsonProperty("mid")]
+    public long Mid { get; set; }
+
+    [JsonProperty("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonProperty("face")]
+    public string Face { get; set; } = string.Empty;
+
+    [JsonProperty("pub_action")]
+    public string PublishAction { get; set; } = string.Empty;
+
+    [JsonProperty("pub_time")]
+    public string PublishTime { get; set; } = string.Empty;
+
+    [JsonProperty("pub_ts")]
+    public long PublishTimestamp { get; set; }
+}
+
+public sealed class DynamicContent : BaseModel
+{
+    [JsonProperty("desc")]
+    public DynamicText? Description { get; set; }
+
+    [JsonProperty("major")]
+    public DynamicMajor? Major { get; set; }
+}
+
+public sealed class DynamicText : BaseModel
+{
+    [JsonProperty("text")]
+    public string Text { get; set; } = string.Empty;
+}
+
+public sealed class DynamicMajor : BaseModel
+{
+    [JsonProperty("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonProperty("archive")]
+    public DynamicArchive? Archive { get; set; }
+
+    [JsonProperty("draw")]
+    public DynamicDraw? Draw { get; set; }
+
+    [JsonProperty("opus")]
+    public DynamicOpus? Opus { get; set; }
+
+    [JsonProperty("article")]
+    public DynamicArticle? Article { get; set; }
+
+    [JsonProperty("pgc")]
+    public DynamicCommonCard? Pgc { get; set; }
+
+    [JsonProperty("common")]
+    public DynamicCommonCard? Common { get; set; }
+
+    [JsonProperty("live")]
+    public DynamicCommonCard? Live { get; set; }
+
+    [JsonProperty("none")]
+    public DynamicUnavailable? Unavailable { get; set; }
+}
+
+public sealed class DynamicArchive : BaseModel
+{
+    [JsonProperty("bvid")]
+    public string Bvid { get; set; } = string.Empty;
+
+    [JsonProperty("cover")]
+    public string Cover { get; set; } = string.Empty;
+
+    [JsonProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonProperty("desc")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonProperty("duration_text")]
+    public string Duration { get; set; } = string.Empty;
+
+    [JsonProperty("jump_url")]
+    public string JumpAddress { get; set; } = string.Empty;
+}
+
+public sealed class DynamicDraw : BaseModel
+{
+    [JsonProperty("items")]
+    public IReadOnlyList<DynamicPicture> Items { get; set; } = Array.Empty<DynamicPicture>();
+}
+
+public sealed class DynamicOpus : BaseModel
+{
+    [JsonProperty("jump_url")]
+    public string JumpAddress { get; set; } = string.Empty;
+
+    [JsonProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonProperty("summary")]
+    public DynamicText? Summary { get; set; }
+
+    [JsonProperty("pics")]
+    public IReadOnlyList<DynamicPicture> Pictures { get; set; } = Array.Empty<DynamicPicture>();
+}
+
+public sealed class DynamicPicture : BaseModel
+{
+    [JsonProperty("src")]
+    public string Source { get; set; } = string.Empty;
+
+    [JsonProperty("url")]
+    private string AlternateSource
+    {
+        set
+        {
+            if (string.IsNullOrEmpty(Source))
+            {
+                Source = value;
+            }
+        }
+    }
+
+    [JsonProperty("width")]
+    public int Width { get; set; }
+
+    [JsonProperty("height")]
+    public int Height { get; set; }
+}
+
+public sealed class DynamicArticle : BaseModel
+{
+    [JsonProperty("covers")]
+    public IReadOnlyList<string> Covers { get; set; } = Array.Empty<string>();
+
+    [JsonProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonProperty("desc")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonProperty("jump_url")]
+    public string JumpAddress { get; set; } = string.Empty;
+}
+
+public sealed class DynamicCommonCard : BaseModel
+{
+    [JsonProperty("cover")]
+    public string Cover { get; set; } = string.Empty;
+
+    [JsonProperty("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonProperty("desc")]
+    public string Description { get; set; } = string.Empty;
+
+    [JsonProperty("jump_url")]
+    public string JumpAddress { get; set; } = string.Empty;
+}
+
+public sealed class DynamicUnavailable : BaseModel
+{
+    [JsonProperty("tips")]
+    public string Tips { get; set; } = string.Empty;
+}
+
+public sealed class DynamicStats : BaseModel
+{
+    [JsonProperty("forward")]
+    public DynamicStat Forward { get; set; } = new();
+
+    [JsonProperty("comment")]
+    public DynamicStat Comment { get; set; } = new();
+
+    [JsonProperty("like")]
+    public DynamicStat Like { get; set; } = new();
+}
+
+public sealed class DynamicStat : BaseModel
+{
+    [JsonProperty("count")]
+    public long Count { get; set; }
+}

--- a/DownKyi.Core/Settings/ApplicationSettings.cs
+++ b/DownKyi.Core/Settings/ApplicationSettings.cs
@@ -6,6 +6,8 @@ namespace DownKyi.Core.Settings;
 
 public static class ApplicationSettingsDefaults
 {
+    public const decimal MinimumHistoryAutoRefreshIntervalSeconds = 10m;
+    public const decimal DefaultHistoryAutoRefreshIntervalSeconds = 30m;
     public const int HighSpeedBuiltInSplit = 16;
     public const int HighSpeedAriaSplit = 16;
     public const int HighSpeedAriaMaxConnectionPerServer = 16;
@@ -34,6 +36,7 @@ public sealed record ApplicationSettings(
     VideoApplicationSettings Video,
     DanmakuApplicationSettings Danmaku,
     AboutApplicationSettings About,
+    HistoryApplicationSettings History,
     UserApplicationSettings User,
     WindowApplicationSettings Window);
 
@@ -116,6 +119,10 @@ public sealed record AboutApplicationSettings(
     AllowStatus IsReceiveBetaVersion,
     AllowStatus AutoUpdateWhenLaunch,
     string SkipVersionOnLaunch);
+
+public sealed record HistoryApplicationSettings(
+    bool IsAutoRefreshEnabled,
+    decimal AutoRefreshIntervalSeconds);
 
 public sealed record UserApplicationSettings(
     long Mid,
@@ -232,6 +239,26 @@ internal static class ApplicationSettingsValidator
                 ? settings.About.SkipVersionOnLaunch
                 : string.Empty
         };
+        var historyInterval = settings.History.AutoRefreshIntervalSeconds <= 0
+            ? Corrected(
+                "History.AutoRefreshIntervalSeconds",
+                ApplicationSettingsDefaults.DefaultHistoryAutoRefreshIntervalSeconds,
+                corrections)
+            : Math.Max(
+                ApplicationSettingsDefaults.MinimumHistoryAutoRefreshIntervalSeconds,
+                Math.Round(
+                    settings.History.AutoRefreshIntervalSeconds,
+                    2,
+                    MidpointRounding.AwayFromZero));
+        if (historyInterval != settings.History.AutoRefreshIntervalSeconds
+            && settings.History.AutoRefreshIntervalSeconds > 0)
+        {
+            corrections.Add("History.AutoRefreshIntervalSeconds");
+        }
+        var history = settings.History with
+        {
+            AutoRefreshIntervalSeconds = historyInterval
+        };
         var user = settings.User with
         {
             Mid = settings.User.Mid < -1 ? Corrected("User.Mid", -1L, corrections) : settings.User.Mid,
@@ -259,6 +286,7 @@ internal static class ApplicationSettingsValidator
                 Video = video,
                 Danmaku = danmaku,
                 About = about,
+                History = history,
                 User = user,
                 Window = window
             },

--- a/DownKyi.Core/Settings/Models/AppSettings.cs
+++ b/DownKyi.Core/Settings/Models/AppSettings.cs
@@ -8,6 +8,7 @@ public class AppSettings
     public VideoSettings Video { get; set; } = new();
     public DanmakuSettings Danmaku { get; set; } = new();
     public AboutSettings About { get; set; } = new();
+    public HistorySettings History { get; set; } = new();
     public UserInfoSettings UserInfo { get; set; } = new();
     public WindowSettings WindowSettings { get; set; } = new();
 }

--- a/DownKyi.Core/Settings/Models/HistorySettings.cs
+++ b/DownKyi.Core/Settings/Models/HistorySettings.cs
@@ -1,0 +1,8 @@
+namespace DownKyi.Core.Settings.Models;
+
+public sealed class HistorySettings
+{
+    public bool IsAutoRefreshEnabled { get; set; }
+    public decimal AutoRefreshIntervalSeconds { get; set; } =
+        ApplicationSettingsDefaults.DefaultHistoryAutoRefreshIntervalSeconds;
+}

--- a/DownKyi.Core/Settings/SettingsManager.History.cs
+++ b/DownKyi.Core/Settings/SettingsManager.History.cs
@@ -1,0 +1,50 @@
+namespace DownKyi.Core.Settings;
+
+public partial class SettingsManager
+{
+    public bool IsHistoryAutoRefreshEnabled()
+    {
+        return _appSettings.History.IsAutoRefreshEnabled;
+    }
+
+    public bool SetHistoryAutoRefreshEnabled(bool isEnabled)
+    {
+        return SetProperty(
+            _appSettings.History.IsAutoRefreshEnabled,
+            isEnabled,
+            value => _appSettings.History.IsAutoRefreshEnabled = value);
+    }
+
+    public decimal GetHistoryAutoRefreshIntervalSeconds()
+    {
+        var interval = NormalizeHistoryAutoRefreshInterval(
+            _appSettings.History.AutoRefreshIntervalSeconds);
+        if (interval != _appSettings.History.AutoRefreshIntervalSeconds)
+        {
+            SetHistoryAutoRefreshIntervalSeconds(interval);
+        }
+
+        return interval;
+    }
+
+    public bool SetHistoryAutoRefreshIntervalSeconds(decimal seconds)
+    {
+        var interval = NormalizeHistoryAutoRefreshInterval(seconds);
+        return SetProperty(
+            _appSettings.History.AutoRefreshIntervalSeconds,
+            interval,
+            value => _appSettings.History.AutoRefreshIntervalSeconds = value);
+    }
+
+    private static decimal NormalizeHistoryAutoRefreshInterval(decimal seconds)
+    {
+        if (seconds <= 0)
+        {
+            return ApplicationSettingsDefaults.DefaultHistoryAutoRefreshIntervalSeconds;
+        }
+
+        return Math.Max(
+            ApplicationSettingsDefaults.MinimumHistoryAutoRefreshIntervalSeconds,
+            Math.Round(seconds, 2, MidpointRounding.AwayFromZero));
+    }
+}

--- a/DownKyi.Core/Settings/SettingsManager.Snapshot.cs
+++ b/DownKyi.Core/Settings/SettingsManager.Snapshot.cs
@@ -116,6 +116,9 @@ public partial class SettingsManager
                 GetIsReceiveBetaVersion(),
                 GetAutoUpdateWhenLaunch(),
                 GetSkipVersionOnLaunch()),
+            new HistoryApplicationSettings(
+                IsHistoryAutoRefreshEnabled(),
+                GetHistoryAutoRefreshIntervalSeconds()),
             new UserApplicationSettings(
                 user.Mid,
                 user.Name,
@@ -217,6 +220,8 @@ public partial class SettingsManager
                     _appSettings.About.SkipVersionOnLaunch,
                     validated.About.SkipVersionOnLaunch,
                     value => _appSettings.About.SkipVersionOnLaunch = value);
+                SetHistoryAutoRefreshEnabled(validated.History.IsAutoRefreshEnabled);
+                SetHistoryAutoRefreshIntervalSeconds(validated.History.AutoRefreshIntervalSeconds);
                 SetUserInfo(new UserInfoSettings
                 {
                     Mid = validated.User.Mid,

--- a/DownKyi.Core/Settings/SettingsManager.cs
+++ b/DownKyi.Core/Settings/SettingsManager.cs
@@ -8,6 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
 
 namespace DownKyi.Core.Settings;
+
 public sealed partial class SettingsManager : IDisposable, IAsyncDisposable
 {
     private static readonly TimeSpan FlushDelay = TimeSpan.FromMilliseconds(750);

--- a/DownKyi.Core/Settings/SettingsManager.cs
+++ b/DownKyi.Core/Settings/SettingsManager.cs
@@ -432,8 +432,7 @@ public sealed partial class SettingsManager : IDisposable, IAsyncDisposable
                     .ConfigureAwait(false);
                 if (document.RootElement.ValueKind != System.Text.Json.JsonValueKind.Object)
                 {
-                    throw new JsonSerializationException(
-                        "The temporary settings payload must contain one JSON object.");
+                    throw new JsonSerializationException("The temporary settings payload must contain one JSON object.");
                 }
             }
         }

--- a/DownKyi.Core/Settings/SettingsManager.cs
+++ b/DownKyi.Core/Settings/SettingsManager.cs
@@ -8,7 +8,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
 
 namespace DownKyi.Core.Settings;
-
 public sealed partial class SettingsManager : IDisposable, IAsyncDisposable
 {
     private static readonly TimeSpan FlushDelay = TimeSpan.FromMilliseconds(750);
@@ -202,6 +201,7 @@ public sealed partial class SettingsManager : IDisposable, IAsyncDisposable
         settings.Video ??= new VideoSettings();
         settings.Danmaku ??= new DanmakuSettings();
         settings.About ??= new AboutSettings();
+        settings.History ??= new HistorySettings();
         settings.UserInfo ??= new UserInfoSettings();
         settings.WindowSettings ??= new WindowSettings();
     }

--- a/docs/operations/bilibili-api-audit.md
+++ b/docs/operations/bilibili-api-audit.md
@@ -74,6 +74,7 @@ Dynamic media dependencies are not fixed API endpoints: subtitle JSON addresses 
 | `api.bilibili.com/x/v3/fav/resource/ids` | `FavoritesResource.GetFavoritesMediaId`; resource identities | GET, `data[]` | `current`; AUTH-LIVE, NEMO and YT agree | Keep. Required payload semantics apply. |
 | `api.bilibili.com/x/web-interface/history/cursor` | `HistoryApi.GetHistory`; watch history | GET, `data.cursor/list`, Cookie required | `current`; AUTH-LIVE returned HTTP 200/code 0 with both required fields; anonymous LIVE returned `-101`; NEMO and DOC agree | Keep. Cancellation and typed API errors are preserved. |
 | `api.bilibili.com/x/v2/history/toview` | `ToView.GetToView`; watch later | GET, `data.count/list`, Cookie required | `current`; AUTH-LIVE returned HTTP 200/code 0 with both required fields; DOC and maintained UI implementations still use it | Keep `/x/v2/history/toview`. The `/web` alternative has no demonstrated contract advantage. |
+| `api.bilibili.com/x/polymer/web-dynamic/v1/feed/all` | `DynamicFeedApi.GetDynamicFeedAsync`; authenticated dynamic feed | GET, `data.items/offset/has_more`, Cookie required | `current`; maintained web UI uses this endpoint and typed fixtures cover archive/draw cards and cursor fields | Keep with cancellation, typed payload validation, duplicate filtering, and cursor pagination. |
 
 ## User Space, Collections And Relations
 

--- a/src/DownKyi.Application/Desktop/IAppNavigationService.cs
+++ b/src/DownKyi.Application/Desktop/IAppNavigationService.cs
@@ -43,7 +43,8 @@ public enum AppRoute
     Archive = 28,
     UserSpaceChannel = 29,
     UserSpaceSeasonsSeries = 30,
-    UserSpaceFavorites = 31
+    UserSpaceFavorites = 31,
+    MyDynamic = 32
 }
 
 public sealed record AppNavigationRequest(

--- a/src/DownKyi.Desktop/App.axaml
+++ b/src/DownKyi.Desktop/App.axaml
@@ -45,6 +45,7 @@
         <DataTemplate DataType="vm:ViewMyBangumiFollowViewModel"><views:ViewMyBangumiFollow /></DataTemplate>
         <DataTemplate DataType="vm:ViewMyToViewVideoViewModel"><views:ViewMyToViewVideo /></DataTemplate>
         <DataTemplate DataType="vm:ViewMyHistoryViewModel"><views:ViewMyHistory /></DataTemplate>
+        <DataTemplate DataType="vm:ViewMyDynamicViewModel"><views:ViewMyDynamic /></DataTemplate>
         <DataTemplate DataType="downloadVm:ViewDownloadingViewModel"><downloadViews:ViewDownloading /></DataTemplate>
         <DataTemplate DataType="downloadVm:ViewDownloadFinishedViewModel"><downloadViews:ViewDownloadFinished /></DataTemplate>
         <DataTemplate DataType="friendsVm:ViewFollowingViewModel"><friendsViews:ViewFollowing /></DataTemplate>

--- a/src/DownKyi.Desktop/Composition/DesktopComposition.cs
+++ b/src/DownKyi.Desktop/Composition/DesktopComposition.cs
@@ -112,6 +112,7 @@ internal static class DesktopComposition
         services.AddSingleton<IContentDownloadCoordinator, ContentDownloadCoordinator>();
         services.AddSingleton<IContentInfoServiceFactory, ContentInfoServiceFactory>();
         services.AddSingleton<IPersonalMediaCoordinator, PersonalMediaCoordinator>();
+        services.AddSingleton<IDynamicFeedCoordinator, DynamicFeedCoordinator>();
         services.AddSingleton<ILegacyUpgradeCoordinator, LegacyUpgradeCoordinator>();
         services.AddSingleton<IFavoritesService, FavoritesService>();
         services.AddSingleton<IFavoritesCoordinator, FavoritesCoordinator>();
@@ -174,6 +175,7 @@ internal static class DesktopComposition
         services.AddTransient<ViewMyBangumiFollowViewModel>();
         services.AddTransient<ViewMyToViewVideoViewModel>();
         services.AddTransient<ViewMyHistoryViewModel>();
+        services.AddTransient<ViewMyDynamicViewModel>();
         services.AddTransient<ViewDownloadingViewModel>();
         services.AddTransient<ViewDownloadFinishedViewModel>();
         services.AddTransient<ViewFollowingViewModel>();

--- a/src/DownKyi.Desktop/Images/NormalIcon.cs
+++ b/src/DownKyi.Desktop/Images/NormalIcon.cs
@@ -224,6 +224,15 @@ internal class NormalIcon
             Fill = "#FF000000"
         };
 
+        Dynamic = new VectorImage
+        {
+            Height = 24,
+            Width = 24,
+            Data = @"M512 42 L632 392 L982 512 L632 632 L512 982 L392 632 L42 512 L392 392 Z
+                     M512 330 L452 452 L330 512 L452 572 L512 694 L572 572 L694 512 L572 452 Z",
+            Fill = "#FF000000"
+        };
+
         ToView = new VectorImage
         {
             Height = 24,
@@ -408,6 +417,7 @@ internal class NormalIcon
 
     public VectorImage FavoriteOutline { get; private set; }
     public VectorImage Subscription { get; private set; }
+    public VectorImage Dynamic { get; private set; }
     public VectorImage ToView { get; private set; }
     public VectorImage History { get; private set; }
 

--- a/src/DownKyi.Desktop/Languanges/Default.axaml
+++ b/src/DownKyi.Desktop/Languanges/Default.axaml
@@ -80,6 +80,19 @@
     
     <!--  MyHistory  -->
     <system:String x:Key="MyHistory">历史记录</system:String>
+    <system:String x:Key="HistoryAutoRefresh">自动刷新</system:String>
+    <system:String x:Key="HistoryRefreshInterval">间隔</system:String>
+    <system:String x:Key="HistoryRefreshSeconds">秒</system:String>
+    <system:String x:Key="HistoryRefreshIntervalTip">最少 10 秒；每次刷新会在设置时间上随机增加或减少 0.00 至 1.00 秒</system:String>
+    <system:String x:Key="HistoryNextRefresh">下次刷新：{0:F2} 秒</system:String>
+    <system:String x:Key="Dynamic">动态</system:String>
+    <system:String x:Key="MyDynamic">我的动态</system:String>
+    <system:String x:Key="DynamicRefresh">刷新</system:String>
+    <system:String x:Key="DynamicForward">转发</system:String>
+    <system:String x:Key="DynamicComment">评论</system:String>
+    <system:String x:Key="DynamicLike">点赞</system:String>
+    <system:String x:Key="DynamicForwardedFrom">转发自</system:String>
+    <system:String x:Key="DynamicNoData">暂无动态，或当前登录状态已失效</system:String>
     <system:String x:Key="HistoryFinished">已看完</system:String>
     <system:String x:Key="HistoryStarted">刚开始</system:String>
     <system:String x:Key="HistoryWatch">看到</system:String>

--- a/src/DownKyi.Desktop/Platform/AvaloniaNavigationService.cs
+++ b/src/DownKyi.Desktop/Platform/AvaloniaNavigationService.cs
@@ -282,6 +282,7 @@ internal sealed class AvaloniaNavigationService : IAppNavigationService, IDispos
             AppRoute.MyBangumiFollow => typeof(ViewMyBangumiFollowViewModel),
             AppRoute.MyToViewVideo => typeof(ViewMyToViewVideoViewModel),
             AppRoute.MyHistory => typeof(ViewMyHistoryViewModel),
+            AppRoute.MyDynamic => typeof(ViewMyDynamicViewModel),
             AppRoute.Downloading => typeof(ViewDownloadingViewModel),
             AppRoute.DownloadFinished => typeof(ViewDownloadFinishedViewModel),
             AppRoute.Following => typeof(ViewFollowingViewModel),

--- a/src/DownKyi.Desktop/Presentation/DynamicCard.cs
+++ b/src/DownKyi.Desktop/Presentation/DynamicCard.cs
@@ -1,0 +1,77 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DownKyi.Application.Desktop;
+using DownKyi.Core.BiliApi.BiliUtils;
+
+namespace DownKyi.Presentation;
+
+internal sealed class DynamicCard : ObservableObject
+{
+    private readonly IAppNavigationService _navigationService;
+    private readonly IPlatformLauncher _platformLauncher;
+
+    public DynamicCard(
+        IAppNavigationService navigationService,
+        IPlatformLauncher platformLauncher)
+    {
+        _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
+        _platformLauncher = platformLauncher ?? throw new ArgumentNullException(nameof(platformLauncher));
+    }
+
+    public string Id { get; set; } = string.Empty;
+    public long AuthorMid { get; set; }
+    public string AuthorName { get; set; } = string.Empty;
+    public string AuthorFace { get; set; } = string.Empty;
+    public string PublishText { get; set; } = string.Empty;
+    public string Description { get; set; } = string.Empty;
+    public string CardTitle { get; set; } = string.Empty;
+    public string CardDescription { get; set; } = string.Empty;
+    public string Cover { get; set; } = string.Empty;
+    public string Bvid { get; set; } = string.Empty;
+    public string ContentUrl { get; set; } = string.Empty;
+    public string ForwardText { get; set; } = string.Empty;
+    public string CommentText { get; set; } = string.Empty;
+    public string LikeText { get; set; } = string.Empty;
+    public bool HasDescription { get; set; }
+    public bool HasCard { get; set; }
+    public bool HasCover { get; set; }
+    public bool HasPictures { get; set; }
+    public IReadOnlyList<DynamicPictureView> Pictures { get; set; } = Array.Empty<DynamicPictureView>();
+
+    private RelayCommand? _authorCommand;
+
+    public RelayCommand AuthorCommand => _authorCommand ??= new RelayCommand(
+        () => _navigationService.Navigate(new AppNavigationRequest(
+            AppRoute.UserSpace,
+            AppRoute.MyDynamic,
+            AuthorMid)),
+        () => AuthorMid > 0);
+
+    private AsyncRelayCommand? _openContentCommand;
+
+    public AsyncRelayCommand OpenContentCommand => _openContentCommand ??= new AsyncRelayCommand(
+        OpenContentAsync,
+        () => !string.IsNullOrWhiteSpace(Bvid) || !string.IsNullOrWhiteSpace(ContentUrl));
+
+    private async Task OpenContentAsync()
+    {
+        if (!string.IsNullOrWhiteSpace(Bvid))
+        {
+            _navigationService.Navigate(new AppNavigationRequest(
+                AppRoute.VideoDetail,
+                AppRoute.MyDynamic,
+                $"{ParseEntrance.VideoUrl}{Bvid}"));
+            return;
+        }
+
+        if (Uri.TryCreate(ContentUrl, UriKind.Absolute, out var uri))
+        {
+            _ = await _platformLauncher.OpenUriAsync(uri).ConfigureAwait(true);
+        }
+    }
+}
+
+internal sealed class DynamicPictureView
+{
+    public string Source { get; init; } = string.Empty;
+}

--- a/src/DownKyi.Desktop/Services/Media/DynamicFeedCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Media/DynamicFeedCoordinator.cs
@@ -1,0 +1,27 @@
+using DownKyi.Application.Bilibili;
+using DownKyi.Core.BiliApi.Dynamic;
+using DownKyi.Core.BiliApi.Dynamic.Models;
+
+namespace DownKyi.Services.Media;
+
+internal interface IDynamicFeedCoordinator
+{
+    Task<DynamicFeedData> LoadPageAsync(string? offset, CancellationToken cancellationToken);
+}
+
+internal sealed class DynamicFeedCoordinator : IDynamicFeedCoordinator
+{
+    private readonly IBilibiliApiClient _client;
+
+    public DynamicFeedCoordinator(IBilibiliApiClient client)
+    {
+        _client = client ?? throw new ArgumentNullException(nameof(client));
+    }
+
+    public Task<DynamicFeedData> LoadPageAsync(
+        string? offset,
+        CancellationToken cancellationToken)
+    {
+        return _client.GetDynamicFeedAsync(offset, cancellationToken);
+    }
+}

--- a/src/DownKyi.Desktop/ViewModels/ViewMyDynamicViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyDynamicViewModel.cs
@@ -1,0 +1,398 @@
+using System.Globalization;
+using System.Net.Http;
+using CommunityToolkit.Mvvm.Input;
+using DownKyi.Application.Desktop;
+using DownKyi.Commands;
+using DownKyi.Core.BiliApi.Dynamic.Models;
+using DownKyi.Core.Logging;
+using DownKyi.Images;
+using DownKyi.Presentation;
+using DownKyi.Services.Media;
+using DownKyi.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace DownKyi.ViewModels;
+
+internal sealed class ViewMyDynamicViewModel : ViewModelBase
+{
+    public const string Tag = "PageMyDynamic";
+
+    private readonly HashSet<string> _loadedIds = new(StringComparer.Ordinal);
+    private readonly IDynamicFeedCoordinator _feedCoordinator;
+    private readonly IPlatformLauncher _platformLauncher;
+    private readonly ILogger<ViewMyDynamicViewModel> _logger;
+    private readonly DynamicLabels _labels;
+    private CancellationTokenSource? _loadCancellation;
+    private string _offset = string.Empty;
+    private bool _hasMore = true;
+    private int _loadGate;
+
+    public ViewMyDynamicViewModel(
+        IDesktopInteractionContext desktopInteractions,
+        IDynamicFeedCoordinator feedCoordinator,
+        IPlatformLauncher platformLauncher,
+        ILogger<ViewMyDynamicViewModel> logger) : base(desktopInteractions)
+    {
+        _feedCoordinator = feedCoordinator ?? throw new ArgumentNullException(nameof(feedCoordinator));
+        _platformLauncher = platformLauncher ?? throw new ArgumentNullException(nameof(platformLauncher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArrowBack = NavigationIcon.CreateArrowBack();
+        ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
+        _labels = new DynamicLabels(
+            DictionaryResource.GetString("DynamicForward"),
+            DictionaryResource.GetString("DynamicComment"),
+            DictionaryResource.GetString("DynamicLike"),
+            DictionaryResource.GetString("DynamicForwardedFrom"));
+    }
+
+    public VectorImage ArrowBack { get; }
+
+    private RangeObservableCollection<DynamicCard> _items = new();
+
+    public RangeObservableCollection<DynamicCard> Items
+    {
+        get => _items;
+        private set => SetProperty(ref _items, value);
+    }
+
+    private bool _contentVisibility;
+
+    public bool ContentVisibility
+    {
+        get => _contentVisibility;
+        private set => SetProperty(ref _contentVisibility, value);
+    }
+
+    private bool _loadingVisibility;
+
+    public bool LoadingVisibility
+    {
+        get => _loadingVisibility;
+        private set => SetProperty(ref _loadingVisibility, value);
+    }
+
+    private bool _noDataVisibility;
+
+    public bool NoDataVisibility
+    {
+        get => _noDataVisibility;
+        private set => SetProperty(ref _noDataVisibility, value);
+    }
+
+    private RelayCommand? _backSpaceCommand;
+
+    public RelayCommand BackSpaceCommand => _backSpaceCommand ??= new RelayCommand(ExecuteBackSpace);
+
+    protected internal override void ExecuteBackSpace()
+    {
+        CancelAndDispose(ref _loadCancellation);
+        if (!TryNavigateBack())
+        {
+            NavigateToParent();
+        }
+    }
+
+    private DownKyiAsyncDelegateCommand? _refreshCommand;
+
+    public DownKyiAsyncDelegateCommand RefreshCommand =>
+        _refreshCommand ??= new DownKyiAsyncDelegateCommand(RefreshAsync, _logger);
+
+    private DownKyiAsyncDelegateCommand? _loadMoreCommand;
+
+    public DownKyiAsyncDelegateCommand LoadMoreCommand =>
+        _loadMoreCommand ??= new DownKyiAsyncDelegateCommand(LoadMoreAsync, _logger);
+
+    private async Task RefreshAsync()
+    {
+        var cancellationToken = ReplaceCancellationSource(ref _loadCancellation);
+        _offset = string.Empty;
+        _hasMore = true;
+        _loadedIds.Clear();
+        await LoadPageAsync(reset: true, waitForTurn: true, cancellationToken).ConfigureAwait(true);
+    }
+
+    private async Task LoadMoreAsync()
+    {
+        if (!_hasMore || NoDataVisibility)
+        {
+            return;
+        }
+
+        var cancellationToken = _loadCancellation?.Token
+                                ?? ReplaceCancellationSource(ref _loadCancellation);
+        await LoadPageAsync(reset: false, waitForTurn: false, cancellationToken).ConfigureAwait(true);
+    }
+
+    private async Task LoadPageAsync(
+        bool reset,
+        bool waitForTurn,
+        CancellationToken cancellationToken)
+    {
+        var entered = false;
+        try
+        {
+            if (waitForTurn)
+            {
+                while (Interlocked.CompareExchange(ref _loadGate, 1, 0) != 0)
+                {
+                    await Task.Delay(25, cancellationToken).ConfigureAwait(true);
+                }
+
+                entered = true;
+            }
+            else
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                entered = Interlocked.CompareExchange(ref _loadGate, 1, 0) == 0;
+                if (!entered)
+                {
+                    return;
+                }
+            }
+
+            LoadingVisibility = reset && Items.Count == 0;
+            NoDataVisibility = false;
+            var data = await _feedCoordinator.LoadPageAsync(
+                reset ? null : _offset,
+                cancellationToken).ConfigureAwait(true);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var cards = data.Items
+                .Where(item => item.Visible)
+                .Where(item => !string.IsNullOrWhiteSpace(item.Id) && _loadedIds.Add(item.Id))
+                .Select(item => Convert(item, Navigation, _platformLauncher, _labels))
+                .Where(card => card != null)
+                .Cast<DynamicCard>()
+                .ToArray();
+            if (reset)
+            {
+                Items.ReplaceRange(cards);
+            }
+            else
+            {
+                Items.AddRange(cards);
+            }
+
+            _offset = data.Offset;
+            _hasMore = data.HasMore && !string.IsNullOrWhiteSpace(_offset);
+            ContentVisibility = Items.Count > 0;
+            NoDataVisibility = Items.Count == 0;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception e) when (e is HttpRequestException or InvalidOperationException
+            or ArgumentException or FormatException or Newtonsoft.Json.JsonException)
+        {
+            _logger.LogErrorMessage("Dynamic feed loading failed.", e);
+            ContentVisibility = Items.Count > 0;
+            NoDataVisibility = Items.Count == 0;
+        }
+        finally
+        {
+            LoadingVisibility = false;
+            if (entered)
+            {
+                Volatile.Write(ref _loadGate, 0);
+            }
+        }
+    }
+
+    internal static DynamicCard? Convert(
+        DynamicFeedItem item,
+        IAppNavigationService navigationService,
+        IPlatformLauncher platformLauncher)
+    {
+        return Convert(
+            item,
+            navigationService,
+            platformLauncher,
+            new DynamicLabels("转发", "评论", "点赞", "转发自"));
+    }
+
+    private static DynamicCard? Convert(
+        DynamicFeedItem item,
+        IAppNavigationService navigationService,
+        IPlatformLauncher platformLauncher,
+        DynamicLabels labels)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(navigationService);
+        ArgumentNullException.ThrowIfNull(platformLauncher);
+        if (string.IsNullOrWhiteSpace(item.Id))
+        {
+            return null;
+        }
+
+        var majorOwner = item.Modules.Content.Major != null ? item : item.Original ?? item;
+        var major = majorOwner.Modules.Content.Major;
+        var description = BuildDescription(item, labels.ForwardedFrom);
+        var pictures = GetPictures(major)
+            .Select(picture => new DynamicPictureView { Source = NormalizeUrl(picture.Source) })
+            .Where(picture => !string.IsNullOrWhiteSpace(picture.Source))
+            .Take(9)
+            .ToArray();
+        var cardTitle = GetCardTitle(major);
+        var cover = NormalizeUrl(GetCover(major));
+        var author = item.Modules.Author;
+
+        return new DynamicCard(navigationService, platformLauncher)
+        {
+            Id = item.Id,
+            AuthorMid = author.Mid,
+            AuthorName = author.Name,
+            AuthorFace = NormalizeUrl(author.Face),
+            PublishText = BuildPublishText(author),
+            Description = description,
+            CardTitle = cardTitle,
+            CardDescription = GetCardDescription(major),
+            Cover = cover,
+            Bvid = major?.Archive?.Bvid ?? string.Empty,
+            ContentUrl = NormalizeContentUrl(GetContentUrl(major), item.Id),
+            ForwardText = $"{labels.Forward} {item.Modules.Stats.Forward.Count}",
+            CommentText = $"{labels.Comment} {item.Modules.Stats.Comment.Count}",
+            LikeText = $"{labels.Like} {item.Modules.Stats.Like.Count}",
+            HasDescription = !string.IsNullOrWhiteSpace(description),
+            HasCard = !string.IsNullOrWhiteSpace(cardTitle) || !string.IsNullOrWhiteSpace(cover),
+            HasCover = !string.IsNullOrWhiteSpace(cover),
+            HasPictures = pictures.Length > 0,
+            Pictures = pictures
+        };
+    }
+
+    private static string BuildDescription(DynamicFeedItem item, string forwardedFromLabel)
+    {
+        var text = item.Modules.Content.Description?.Text
+                   ?? item.Modules.Content.Major?.Opus?.Summary?.Text
+                   ?? string.Empty;
+        if (item.Original == null)
+        {
+            return text;
+        }
+
+        var originalText = item.Original.Modules.Content.Description?.Text
+                           ?? item.Original.Modules.Content.Major?.Opus?.Summary?.Text
+                           ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(originalText))
+        {
+            return text;
+        }
+
+        var originalAuthor = item.Original.Modules.Author.Name;
+        var prefix = string.IsNullOrWhiteSpace(originalAuthor)
+            ? forwardedFromLabel
+            : $"{forwardedFromLabel} @{originalAuthor}";
+        return string.IsNullOrWhiteSpace(text)
+            ? $"{prefix}：{originalText}"
+            : $"{text}{Environment.NewLine}{prefix}：{originalText}";
+    }
+
+    private static string BuildPublishText(DynamicAuthor author)
+    {
+        var publishTime = author.PublishTime;
+        if (string.IsNullOrWhiteSpace(publishTime) && author.PublishTimestamp > 0)
+        {
+            publishTime = DateTimeOffset.FromUnixTimeSeconds(author.PublishTimestamp)
+                .ToLocalTime()
+                .ToString("yyyy-MM-dd HH:mm", CultureInfo.CurrentCulture);
+        }
+
+        return string.IsNullOrWhiteSpace(author.PublishAction)
+            ? publishTime
+            : $"{publishTime} · {author.PublishAction}".TrimStart(' ', '·');
+    }
+
+    private static IReadOnlyList<DynamicPicture> GetPictures(DynamicMajor? major) =>
+        major?.Draw?.Items ?? major?.Opus?.Pictures ?? Array.Empty<DynamicPicture>();
+
+    private static string GetCardTitle(DynamicMajor? major) =>
+        major?.Archive?.Title ?? major?.Article?.Title ?? major?.Opus?.Title
+        ?? major?.Pgc?.Title ?? major?.Common?.Title ?? major?.Live?.Title
+        ?? major?.Unavailable?.Tips ?? string.Empty;
+
+    private static string GetCardDescription(DynamicMajor? major) =>
+        major?.Archive?.Description ?? major?.Article?.Description
+        ?? major?.Pgc?.Description ?? major?.Common?.Description
+        ?? major?.Live?.Description ?? string.Empty;
+
+    private static string GetCover(DynamicMajor? major)
+    {
+        var articleCovers = major?.Article?.Covers;
+        return major?.Archive?.Cover
+               ?? (articleCovers is { Count: > 0 } ? articleCovers[0] : null)
+               ?? major?.Pgc?.Cover ?? major?.Common?.Cover ?? major?.Live?.Cover
+               ?? string.Empty;
+    }
+
+    private static string GetContentUrl(DynamicMajor? major) =>
+        major?.Archive?.JumpAddress ?? major?.Article?.JumpAddress
+        ?? major?.Opus?.JumpAddress ?? major?.Pgc?.JumpAddress
+        ?? major?.Common?.JumpAddress ?? major?.Live?.JumpAddress ?? string.Empty;
+
+    private static string NormalizeUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        return url.StartsWith("//", StringComparison.Ordinal) ? $"https:{url}" : url;
+    }
+
+    private static string NormalizeContentUrl(string? url, string dynamicId)
+    {
+        var normalized = NormalizeUrl(url);
+        return string.IsNullOrWhiteSpace(normalized)
+            ? $"https://t.bilibili.com/{dynamicId}"
+            : normalized;
+    }
+
+    private void InitView()
+    {
+        Items.Clear();
+        _loadedIds.Clear();
+        _offset = string.Empty;
+        _hasMore = true;
+        ContentVisibility = false;
+        LoadingVisibility = false;
+        NoDataVisibility = false;
+    }
+
+    public override void OnNavigatedTo(AppNavigationContext navigationContext)
+    {
+        ArgumentNullException.ThrowIfNull(navigationContext);
+        base.OnNavigatedTo(navigationContext);
+        ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
+        ReplaceCancellationSource(ref _loadCancellation);
+        if (Items.Count > 0)
+        {
+            return;
+        }
+
+        InitView();
+        RunFireAndForget(RefreshAsync(), nameof(RefreshAsync), _logger);
+    }
+
+    public override void OnNavigatedFrom(AppNavigationContext navigationContext)
+    {
+        CancelAndDispose(ref _loadCancellation);
+        base.OnNavigatedFrom(navigationContext);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !IsDisposed)
+        {
+            CancelAndDispose(ref _loadCancellation);
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private readonly record struct DynamicLabels(
+        string Forward,
+        string Comment,
+        string Like,
+        string ForwardedFrom);
+}

--- a/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.AutoRefresh.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.AutoRefresh.cs
@@ -1,0 +1,125 @@
+using System.Globalization;
+using System.Security.Cryptography;
+using System.Text;
+using DownKyi.Core.Settings;
+using DownKyi.Utils;
+
+namespace DownKyi.ViewModels;
+
+internal partial class ViewMyHistoryViewModel
+{
+    private readonly ISettingsStore _settingsStore;
+    private readonly CompositeFormat _nextRefreshFormat;
+    private CancellationTokenSource? _autoRefreshCancellation;
+    private bool _isPageActive;
+
+    private bool _isHistoryAutoRefreshEnabled;
+
+    public bool IsHistoryAutoRefreshEnabled
+    {
+        get => _isHistoryAutoRefreshEnabled;
+        set
+        {
+            if (!SetProperty(ref _isHistoryAutoRefreshEnabled, value))
+            {
+                return;
+            }
+
+            _settingsStore.Update(settings => settings with
+            {
+                History = settings.History with { IsAutoRefreshEnabled = value }
+            });
+            RestartAutoRefresh();
+        }
+    }
+
+    private decimal _historyAutoRefreshIntervalSeconds;
+
+    public decimal HistoryAutoRefreshIntervalSeconds
+    {
+        get => _historyAutoRefreshIntervalSeconds;
+        set
+        {
+            var normalized = NormalizeAutoRefreshInterval(value);
+            if (!SetProperty(ref _historyAutoRefreshIntervalSeconds, normalized))
+            {
+                return;
+            }
+
+            _settingsStore.Update(settings => settings with
+            {
+                History = settings.History with { AutoRefreshIntervalSeconds = normalized }
+            });
+            RestartAutoRefresh();
+        }
+    }
+
+    private string _nextAutoRefreshText = string.Empty;
+
+    public string NextAutoRefreshText
+    {
+        get => _nextAutoRefreshText;
+        private set => SetProperty(ref _nextAutoRefreshText, value);
+    }
+
+    private void RestartAutoRefresh()
+    {
+        CancelAndDispose(ref _autoRefreshCancellation);
+        NextAutoRefreshText = string.Empty;
+        if (!_isPageActive || !IsHistoryAutoRefreshEnabled || IsDisposed)
+        {
+            return;
+        }
+
+        var cancellationToken = ReplaceCancellationSource(ref _autoRefreshCancellation);
+        RunFireAndForget(RunAutoRefreshAsync(cancellationToken), nameof(RunAutoRefreshAsync), _logger);
+    }
+
+    private async Task RunAutoRefreshAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var delay = CreateAutoRefreshDelay(
+                    HistoryAutoRefreshIntervalSeconds,
+                    RandomNumberGenerator.GetInt32(-100, 101));
+                NextAutoRefreshText = string.Format(
+                    CultureInfo.CurrentCulture,
+                    _nextRefreshFormat,
+                    delay.TotalSeconds);
+
+                await Task.Delay(delay, cancellationToken).ConfigureAwait(true);
+                cancellationToken.ThrowIfCancellationRequested();
+                await UpdateHistoryMediaListAsync().ConfigureAwait(true);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+    }
+
+    internal static decimal NormalizeAutoRefreshInterval(decimal seconds)
+    {
+        if (seconds <= 0)
+        {
+            return ApplicationSettingsDefaults.DefaultHistoryAutoRefreshIntervalSeconds;
+        }
+
+        return Math.Max(
+            ApplicationSettingsDefaults.MinimumHistoryAutoRefreshIntervalSeconds,
+            Math.Round(seconds, 2, MidpointRounding.AwayFromZero));
+    }
+
+    internal static TimeSpan CreateAutoRefreshDelay(decimal seconds, int jitterHundredths)
+    {
+        if (jitterHundredths is < -100 or > 100)
+        {
+            throw new ArgumentOutOfRangeException(nameof(jitterHundredths));
+        }
+
+        var actualSeconds = NormalizeAutoRefreshInterval(seconds) + jitterHundredths / 100m;
+        return TimeSpan.FromMilliseconds((double)(actualSeconds * 1000m));
+    }
+}

--- a/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.cs
@@ -3,12 +3,14 @@ using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using DownKyi.Application.Desktop;
 using DownKyi.Commands;
 using DownKyi.Core.Logging;
+using DownKyi.Core.Settings;
 using DownKyi.Images;
 using DownKyi.Presentation;
 using DownKyi.Services;
@@ -19,7 +21,7 @@ using Microsoft.Extensions.Logging;
 
 namespace DownKyi.ViewModels;
 
-internal class ViewMyHistoryViewModel : ViewModelBase
+internal partial class ViewMyHistoryViewModel : ViewModelBase
 {
     public const string Tag = "PageMyHistory";
     private readonly IContentDownloadCoordinator _downloadCoordinator;
@@ -114,12 +116,15 @@ internal class ViewMyHistoryViewModel : ViewModelBase
         IDesktopInteractionContext desktopInteractions,
         IContentDownloadCoordinator downloadCoordinator,
         IPersonalMediaCoordinator personalMediaCoordinator,
+        ISettingsStore settingsStore,
         ILogger<ViewMyHistoryViewModel> logger) : base(desktopInteractions)
     {
         _downloadCoordinator = downloadCoordinator ?? throw new ArgumentNullException(nameof(downloadCoordinator));
         _personalMediaCoordinator = personalMediaCoordinator
             ?? throw new ArgumentNullException(nameof(personalMediaCoordinator));
+        _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _nextRefreshFormat = CompositeFormat.Parse(DictionaryResource.GetString("HistoryNextRefresh"));
 
         #region 属性初始化
 
@@ -138,6 +143,9 @@ internal class ViewMyHistoryViewModel : ViewModelBase
         DownloadManage.Fill = DictionaryResource.GetColor("ColorPrimary");
 
         Medias = new RangeObservableCollection<HistoryMedia>();
+        _isHistoryAutoRefreshEnabled = _settingsStore.Current.History.IsAutoRefreshEnabled;
+        _historyAutoRefreshIntervalSeconds =
+            _settingsStore.Current.History.AutoRefreshIntervalSeconds;
 
         #endregion
     }
@@ -418,6 +426,7 @@ internal class ViewMyHistoryViewModel : ViewModelBase
     {
         ArgumentNullException.ThrowIfNull(navigationContext);
         base.OnNavigatedTo(navigationContext);
+        _isPageActive = true;
 
         ArrowBack.Fill = DictionaryResource.GetColor("ColorTextDark");
 
@@ -436,16 +445,19 @@ internal class ViewMyHistoryViewModel : ViewModelBase
                 media.IsSelected = false;
             }
 
+            RestartAutoRefresh();
             return;
         }
 
         InitView();
 
         RunFireAndForget(UpdateHistoryMediaListAsync(), nameof(UpdateHistoryMediaListAsync), _logger);
+        RestartAutoRefresh();
     }
 
     public override void OnNavigatedFrom(AppNavigationContext navigationContext)
     {
+        _isPageActive = false;
         CancelOperations();
         LoadingVisibility = false;
         _isLoadingPage = false;
@@ -457,6 +469,8 @@ internal class ViewMyHistoryViewModel : ViewModelBase
         Interlocked.Increment(ref _loadVersion);
         CancelAndDispose(ref _loadCancellation);
         CancelAndDispose(ref _downloadCancellation);
+        CancelAndDispose(ref _autoRefreshCancellation);
+        NextAutoRefreshText = string.Empty;
     }
 
     protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/ViewModels/ViewMySpaceViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMySpaceViewModel.cs
@@ -431,34 +431,18 @@ internal class ViewMySpaceViewModel : ViewModelBase
             return;
         }
 
-        switch (SelectedPackage)
+        var route = SelectedPackage switch
         {
-            case 0:
-                Navigation.Navigate(new AppNavigationRequest(
-                    AppRoute.MyFavorites,
-                    AppRoute.MySpace,
-                    _mid));
-                break;
-            case 1:
-                Navigation.Navigate(new AppNavigationRequest(
-                    AppRoute.MyBangumiFollow,
-                    AppRoute.MySpace,
-                    _mid));
-                break;
-            case 2:
-                Navigation.Navigate(new AppNavigationRequest(
-                    AppRoute.MyToViewVideo,
-                    AppRoute.MySpace,
-                    _mid));
-                break;
-            case 3:
-                Navigation.Navigate(new AppNavigationRequest(
-                    AppRoute.MyHistory,
-                    AppRoute.MySpace,
-                    _mid));
-                break;
-            default:
-                break;
+            0 => AppRoute.MyFavorites,
+            1 => AppRoute.MyBangumiFollow,
+            2 => AppRoute.MyToViewVideo,
+            3 => AppRoute.MyHistory,
+            4 => AppRoute.MyDynamic,
+            _ => (AppRoute?)null
+        };
+        if (route is { } selectedRoute)
+        {
+            Navigation.Navigate(new AppNavigationRequest(selectedRoute, AppRoute.MySpace, _mid));
         }
 
         SelectedPackage = -1;
@@ -523,10 +507,17 @@ internal class ViewMySpaceViewModel : ViewModelBase
             Image = NormalIcon.Instance().History,
             Title = DictionaryResource.GetString("History")
         });
+        PackageList.Add(new SpaceItem
+        {
+            IsEnabled = true,
+            Image = NormalIcon.Instance().Dynamic,
+            Title = DictionaryResource.GetString("Dynamic")
+        });
         NormalIcon.Instance().FavoriteOutline.Fill = DictionaryResource.GetColor("ColorPrimary");
         NormalIcon.Instance().Subscription.Fill = DictionaryResource.GetColor("ColorPrimary");
         NormalIcon.Instance().ToView.Fill = DictionaryResource.GetColor("ColorPrimary");
         NormalIcon.Instance().History.Fill = DictionaryResource.GetColor("ColorPrimary");
+        NormalIcon.Instance().Dynamic.Fill = DictionaryResource.GetColor("ColorPrimary");
 
         SelectedStatus = -1;
         SelectedPackage = -1;

--- a/src/DownKyi.Desktop/Views/ViewMyDynamic.axaml
+++ b/src/DownKyi.Desktop/Views/ViewMyDynamic.axaml
@@ -1,0 +1,273 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:DownKyi.ViewModels"
+             xmlns:vmp="clr-namespace:DownKyi.Presentation"
+             xmlns:custom="clr-namespace:DownKyi.CustomControl"
+             xmlns:customAction="clr-namespace:DownKyi.CustomAction"
+             xmlns:asyncImageLoader="clr-namespace:DownKyi.CustomControl.AsyncImageLoader"
+             x:Class="DownKyi.Views.ViewMyDynamic"
+             x:DataType="vm:ViewMyDynamicViewModel"
+             d:DesignWidth="840"
+             d:DesignHeight="620"
+             mc:Ignorable="d">
+    <Grid RowDefinitions="50,1,*">
+        <Grid Grid.Row="0" ColumnDefinitions="140,*,140">
+            <Button
+                Grid.Column="0"
+                Margin="10,5,0,5"
+                HorizontalAlignment="Left"
+                VerticalAlignment="Center"
+                Command="{Binding BackSpaceCommand}"
+                Theme="{StaticResource ImageBtnStyle}">
+                <StackPanel Orientation="Horizontal">
+                    <ContentControl Width="24" Height="24">
+                        <Path
+                            Width="{Binding ArrowBack.Width}"
+                            Height="{Binding ArrowBack.Height}"
+                            Data="{Binding ArrowBack.Data}"
+                            Fill="{Binding ArrowBack.Fill}"
+                            Stretch="None" />
+                    </ContentControl>
+                    <TextBlock
+                        VerticalAlignment="Center"
+                        FontSize="16"
+                        Foreground="{DynamicResource BrushTextDark}"
+                        Text="{DynamicResource MyDynamic}" />
+                </StackPanel>
+            </Button>
+
+            <Button
+                Grid.Column="2"
+                MinWidth="64"
+                Height="30"
+                Margin="0,0,12,0"
+                HorizontalAlignment="Right"
+                VerticalAlignment="Center"
+                Command="{Binding RefreshCommand}"
+                Content="{DynamicResource DynamicRefresh}"
+                FontSize="12"
+                Foreground="{DynamicResource BrushText}"
+                Theme="{StaticResource BtnStyle}" />
+        </Grid>
+
+        <Border Grid.Row="1" Background="{DynamicResource BrushBorder}" />
+
+        <ListBox
+            Grid.Row="2"
+            Margin="0,4,0,0"
+            Background="Transparent"
+            BorderThickness="0"
+            IsVisible="{Binding ContentVisibility}"
+            ItemsSource="{Binding Items}"
+            SelectionMode="Single">
+            <Interaction.Behaviors>
+                <customAction:InfiniteScrollBehavior LoadMoreCommand="{Binding LoadMoreCommand}" />
+            </Interaction.Behaviors>
+            <ListBox.ItemsPanel>
+                <ItemsPanelTemplate>
+                    <VirtualizingStackPanel />
+                </ItemsPanelTemplate>
+            </ListBox.ItemsPanel>
+            <ListBox.ItemContainerTheme>
+                <ControlTheme TargetType="ListBoxItem">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="Template">
+                        <ControlTemplate TargetType="{x:Type ListBoxItem}">
+                            <ContentPresenter
+                                HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                Content="{TemplateBinding Content}"
+                                ContentTemplate="{TemplateBinding ContentTemplate}" />
+                        </ControlTemplate>
+                    </Setter>
+                </ControlTheme>
+            </ListBox.ItemContainerTheme>
+            <ListBox.ItemTemplate>
+                <DataTemplate x:DataType="vmp:DynamicCard">
+                    <Border
+                        MaxWidth="740"
+                        Margin="20,10"
+                        Padding="16"
+                        HorizontalAlignment="Stretch"
+                        Background="{DynamicResource BrushBackground}"
+                        BorderBrush="{DynamicResource BrushBorderTranslucent}"
+                        BorderThickness="1"
+                        CornerRadius="8">
+                        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto">
+                            <Grid Grid.Row="0" ColumnDefinitions="42,*,Auto">
+                                <Border
+                                    Grid.Column="0"
+                                    Width="36"
+                                    Height="36"
+                                    HorizontalAlignment="Left"
+                                    VerticalAlignment="Top"
+                                    CornerRadius="18"
+                                    Cursor="Hand">
+                                    <Interaction.Behaviors>
+                                        <EventTriggerBehavior EventName="PointerReleased">
+                                            <InvokeCommandAction Command="{Binding AuthorCommand}" />
+                                        </EventTriggerBehavior>
+                                    </Interaction.Behaviors>
+                                    <Border.Background>
+                                        <ImageBrush
+                                            asyncImageLoader:ImageBrushLoader.Source="{Binding AuthorFace}"
+                                            asyncImageLoader:ImageBrushLoader.Width="36"
+                                            asyncImageLoader:ImageBrushLoader.Height="36"
+                                            Stretch="UniformToFill" />
+                                    </Border.Background>
+                                </Border>
+                                <StackPanel Grid.Column="1" VerticalAlignment="Center">
+                                    <TextBlock
+                                        Cursor="Hand"
+                                        FontSize="14"
+                                        FontWeight="Bold"
+                                        Foreground="{DynamicResource BrushTextDark}"
+                                        Text="{Binding AuthorName}">
+                                        <Interaction.Behaviors>
+                                            <EventTriggerBehavior EventName="PointerReleased">
+                                                <InvokeCommandAction Command="{Binding AuthorCommand}" />
+                                            </EventTriggerBehavior>
+                                        </Interaction.Behaviors>
+                                    </TextBlock>
+                                    <TextBlock
+                                        Margin="0,3,0,0"
+                                        FontSize="11"
+                                        Foreground="{DynamicResource BrushTextGrey}"
+                                        Text="{Binding PublishText}" />
+                                </StackPanel>
+                            </Grid>
+
+                            <TextBlock
+                                Grid.Row="1"
+                                Margin="42,12,0,0"
+                                FontSize="13"
+                                Foreground="{DynamicResource BrushTextDark}"
+                                IsVisible="{Binding HasDescription}"
+                                MaxLines="8"
+                                Text="{Binding Description}"
+                                TextTrimming="CharacterEllipsis"
+                                TextWrapping="Wrap" />
+
+                            <ItemsControl
+                                Grid.Row="2"
+                                Margin="42,12,0,0"
+                                IsVisible="{Binding HasPictures}"
+                                ItemsSource="{Binding Pictures}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <WrapPanel />
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate x:DataType="vmp:DynamicPictureView">
+                                        <Border
+                                            Width="150"
+                                            Height="100"
+                                            Margin="0,0,8,8"
+                                            CornerRadius="6">
+                                            <Border.Background>
+                                                <ImageBrush
+                                                    asyncImageLoader:ImageBrushLoader.Source="{Binding Source}"
+                                                    asyncImageLoader:ImageBrushLoader.Width="150"
+                                                    asyncImageLoader:ImageBrushLoader.Height="100"
+                                                    Stretch="UniformToFill" />
+                                            </Border.Background>
+                                        </Border>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+
+                            <Border
+                                Grid.Row="3"
+                                Margin="42,12,0,0"
+                                Padding="10"
+                                Background="{DynamicResource BrushPrimaryTranslucent3}"
+                                CornerRadius="8"
+                                Cursor="Hand"
+                                IsVisible="{Binding HasCard}">
+                                <Interaction.Behaviors>
+                                    <EventTriggerBehavior EventName="PointerReleased">
+                                        <InvokeCommandAction Command="{Binding OpenContentCommand}" />
+                                    </EventTriggerBehavior>
+                                </Interaction.Behaviors>
+                                <Grid ColumnDefinitions="Auto,*">
+                                    <Border
+                                        Grid.Column="0"
+                                        Width="150"
+                                        Height="94"
+                                        CornerRadius="6"
+                                        IsVisible="{Binding HasCover}">
+                                        <Border.Background>
+                                            <ImageBrush
+                                                asyncImageLoader:ImageBrushLoader.Source="{Binding Cover}"
+                                                asyncImageLoader:ImageBrushLoader.Width="150"
+                                                asyncImageLoader:ImageBrushLoader.Height="94"
+                                                Stretch="UniformToFill" />
+                                        </Border.Background>
+                                    </Border>
+                                    <StackPanel Grid.Column="1" Margin="12,0,0,0" VerticalAlignment="Center">
+                                        <TextBlock
+                                            FontSize="14"
+                                            FontWeight="Bold"
+                                            Foreground="{DynamicResource BrushTextDark}"
+                                            MaxLines="2"
+                                            Text="{Binding CardTitle}"
+                                            TextTrimming="CharacterEllipsis"
+                                            TextWrapping="Wrap" />
+                                        <TextBlock
+                                            Margin="0,6,0,0"
+                                            FontSize="12"
+                                            Foreground="{DynamicResource BrushTextGrey2}"
+                                            MaxLines="2"
+                                            Text="{Binding CardDescription}"
+                                            TextTrimming="CharacterEllipsis"
+                                            TextWrapping="Wrap" />
+                                    </StackPanel>
+                                </Grid>
+                            </Border>
+
+                            <StackPanel
+                                Grid.Row="4"
+                                Margin="42,12,0,0"
+                                HorizontalAlignment="Right"
+                                Orientation="Horizontal"
+                                Spacing="22">
+                                <TextBlock FontSize="12" Foreground="{DynamicResource BrushTextGrey}" Text="{Binding ForwardText}" />
+                                <TextBlock FontSize="12" Foreground="{DynamicResource BrushTextGrey}" Text="{Binding CommentText}" />
+                                <TextBlock FontSize="12" Foreground="{DynamicResource BrushTextGrey}" Text="{Binding LikeText}" />
+                            </StackPanel>
+                        </Grid>
+                    </Border>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+
+        <StackPanel
+            Grid.Row="2"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            IsVisible="{Binding LoadingVisibility}">
+            <custom:Loading Width="40" Height="40" Foreground="Gray" IsActive="True" />
+            <TextBlock
+                Margin="0,10,0,0"
+                FontSize="14"
+                Foreground="{DynamicResource BrushTextDark}"
+                Text="{DynamicResource MySpaceWait}" />
+        </StackPanel>
+
+        <StackPanel
+            Grid.Row="2"
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            IsVisible="{Binding NoDataVisibility}">
+            <Image Width="220" Height="220" Source="/Resources/no-data.png" />
+            <TextBlock
+                Margin="0,8,0,0"
+                HorizontalAlignment="Center"
+                FontSize="13"
+                Foreground="{DynamicResource BrushTextGrey}"
+                Text="{DynamicResource DynamicNoData}" />
+        </StackPanel>
+    </Grid>
+</UserControl>

--- a/src/DownKyi.Desktop/Views/ViewMyDynamic.axaml.cs
+++ b/src/DownKyi.Desktop/Views/ViewMyDynamic.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DownKyi.Views;
+
+internal partial class ViewMyDynamic : UserControl
+{
+    public ViewMyDynamic()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DownKyi.Desktop/Views/ViewMyHistory.axaml
+++ b/src/DownKyi.Desktop/Views/ViewMyHistory.axaml
@@ -226,6 +226,88 @@
                 </StackPanel>
             </Button>
 
+            <Grid
+                Grid.Column="1"
+                Width="500"
+                Height="36"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Center">
+                <Grid.Styles>
+                    <Style Selector="Border.autoRefreshBorder">
+                        <Setter Property="Background" Value="{DynamicResource BrushBackground}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushBorderTranslucent}" />
+                    </Style>
+                    <Style Selector="Grid:pointerover Border.autoRefreshBorder">
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushPrimaryTranslucent2}" />
+                    </Style>
+                    <Style Selector="Grid:focus-within Border.autoRefreshBorder">
+                        <Setter Property="Background" Value="{DynamicResource BrushPrimaryTranslucent3}" />
+                        <Setter Property="BorderBrush" Value="{DynamicResource BrushPrimary}" />
+                    </Style>
+                </Grid.Styles>
+                <Border
+                    Classes="autoRefreshBorder"
+                    BorderThickness="1"
+                    CornerRadius="18">
+                    <Grid
+                        Margin="14,0"
+                        ColumnDefinitions="Auto,Auto,Auto,72,Auto,*">
+                        <CheckBox
+                            Grid.Column="0"
+                            VerticalAlignment="Center"
+                            Content="{DynamicResource HistoryAutoRefresh}"
+                            FontSize="13"
+                            Foreground="{DynamicResource BrushTextDark}"
+                            IsChecked="{Binding IsHistoryAutoRefreshEnabled, Mode=TwoWay}" />
+                        <Border
+                            Grid.Column="1"
+                            Width="1"
+                            Height="18"
+                            Margin="12,0"
+                            VerticalAlignment="Center"
+                            Background="{DynamicResource BrushBorderTranslucent}" />
+                        <TextBlock
+                            Grid.Column="2"
+                            VerticalAlignment="Center"
+                            FontSize="13"
+                            Foreground="{DynamicResource BrushTextDark}"
+                            Text="{DynamicResource HistoryRefreshInterval}" />
+                        <NumericUpDown
+                            Grid.Column="3"
+                            Height="30"
+                            VerticalContentAlignment="Center"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            FontSize="13"
+                            Foreground="{DynamicResource BrushPrimary}"
+                            FormatString="0.##"
+                            Increment="1"
+                            Maximum="86400"
+                            Minimum="10"
+                            Padding="4,0"
+                            ShowButtonSpinner="False"
+                            TextAlignment="Center"
+                            ToolTip.Tip="{DynamicResource HistoryRefreshIntervalTip}"
+                            Value="{Binding HistoryAutoRefreshIntervalSeconds, Mode=TwoWay}" />
+                        <TextBlock
+                            Grid.Column="4"
+                            VerticalAlignment="Center"
+                            FontSize="13"
+                            Foreground="{DynamicResource BrushTextDark}"
+                            Text="{DynamicResource HistoryRefreshSeconds}" />
+                        <TextBlock
+                            Grid.Column="5"
+                            MinWidth="142"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Center"
+                            FontSize="12"
+                            Foreground="{DynamicResource BrushPrimary}"
+                            IsVisible="{Binding IsHistoryAutoRefreshEnabled}"
+                            Text="{Binding NextAutoRefreshText}" />
+                    </Grid>
+                </Border>
+            </Grid>
+
             <Button
                 Grid.Column="2"
                 Width="24"

--- a/tests/DownKyi.Core.Tests/DynamicApiTests.cs
+++ b/tests/DownKyi.Core.Tests/DynamicApiTests.cs
@@ -1,0 +1,97 @@
+using DownKyi.Core.BiliApi.Dynamic;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class DynamicApiTests
+{
+    [Fact]
+    public void ParseResponseReadsArchiveDrawAndPaginationFields()
+    {
+        const string json = """
+            {
+              "code": 0,
+              "message": "0",
+              "data": {
+                "has_more": true,
+                "offset": "next-offset",
+                "items": [
+                  {
+                    "id_str": "1001",
+                    "type": "DYNAMIC_TYPE_AV",
+                    "visible": true,
+                    "modules": {
+                      "module_author": {
+                        "mid": 42,
+                        "name": "Uploader",
+                        "face": "https://example.test/avatar.jpg",
+                        "pub_action": "投稿了视频",
+                        "pub_time": "1分钟前",
+                        "pub_ts": 1700000000
+                      },
+                      "module_dynamic": {
+                        "desc": { "text": "video text" },
+                        "major": {
+                          "type": "MAJOR_TYPE_ARCHIVE",
+                          "archive": {
+                            "bvid": "BV1test",
+                            "cover": "https://example.test/cover.jpg",
+                            "title": "Video title",
+                            "desc": "Video description",
+                            "duration_text": "03:21",
+                            "jump_url": "//www.bilibili.com/video/BV1test"
+                          }
+                        }
+                      },
+                      "module_stat": {
+                        "forward": { "count": 1 },
+                        "comment": { "count": 2 },
+                        "like": { "count": 3 }
+                      }
+                    }
+                  },
+                  {
+                    "id_str": "1002",
+                    "type": "DYNAMIC_TYPE_DRAW",
+                    "modules": {
+                      "module_dynamic": {
+                        "major": {
+                          "type": "MAJOR_TYPE_DRAW",
+                          "draw": {
+                            "items": [
+                              { "src": "https://example.test/image.jpg", "width": 1920, "height": 1080 }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+
+        var data = DynamicFeedApi.ParseResponse(json);
+
+        Assert.NotNull(data);
+        Assert.True(data.HasMore);
+        Assert.Equal("next-offset", data.Offset);
+        Assert.Equal(2, data.Items.Count);
+        Assert.Equal("BV1test", data.Items[0].Modules.Content.Major?.Archive?.Bvid);
+        Assert.Equal(3, data.Items[0].Modules.Stats.Like.Count);
+        Assert.Equal(
+            "https://example.test/image.jpg",
+            data.Items[1].Modules.Content.Major?.Draw?.Items[0].Source);
+    }
+
+    [Theory]
+    [InlineData(-101)]
+    [InlineData(-352)]
+    public void ParseResponseRejectsApiFailures(int code)
+    {
+        var data = DynamicFeedApi.ParseResponse($$"""
+            { "code": {{code}}, "message": "failed", "data": null }
+            """);
+
+        Assert.Null(data);
+    }
+}

--- a/tests/DownKyi.Core.Tests/HistorySettingsTests.cs
+++ b/tests/DownKyi.Core.Tests/HistorySettingsTests.cs
@@ -1,0 +1,42 @@
+using DownKyi.Core.Settings;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class HistorySettingsTests
+{
+    [Fact]
+    public async Task HistoryAutoRefreshSettingsAreNormalizedAndPersisted()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "downkyi-history-settings", Guid.NewGuid().ToString("N"));
+        var settingsPath = Path.Combine(directory, "settings.json");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using (var store = new SettingsStore(settingsPath))
+            {
+                var updated = store.Update(settings => settings with
+                {
+                    History = settings.History with
+                    {
+                        IsAutoRefreshEnabled = true,
+                        AutoRefreshIntervalSeconds = 9.999m
+                    }
+                });
+                Assert.True(updated.History.IsAutoRefreshEnabled);
+                Assert.Equal(10m, updated.History.AutoRefreshIntervalSeconds);
+                await store.FlushAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+            }
+
+            using var reopened = new SettingsStore(settingsPath);
+            Assert.True(reopened.Current.History.IsAutoRefreshEnabled);
+            Assert.Equal(10m, reopened.Current.History.AutoRefreshIntervalSeconds);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/DownKyi.Desktop.Tests/DownKyi.Desktop.Tests.csproj
+++ b/tests/DownKyi.Desktop.Tests/DownKyi.Desktop.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Avalonia.Headless" />
+    <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="coverlet.collector" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />

--- a/tests/DownKyi.Desktop.Tests/DynamicFeedViewModelTests.cs
+++ b/tests/DownKyi.Desktop.Tests/DynamicFeedViewModelTests.cs
@@ -1,0 +1,127 @@
+using DownKyi.Application.Desktop;
+using DownKyi.Core.BiliApi.Dynamic.Models;
+using DownKyi.ViewModels;
+
+namespace DownKyi.Desktop.Tests;
+
+public sealed class DynamicFeedViewModelTests
+{
+    [Fact]
+    public void ArchiveDynamicConvertsToNavigableVideoCard()
+    {
+        var item = new DynamicFeedItem
+        {
+            Id = "1001",
+            Modules = new DynamicModules
+            {
+                Author = new DynamicAuthor
+                {
+                    Mid = 42,
+                    Name = "Uploader",
+                    Face = "//example.test/avatar.jpg",
+                    PublishTime = "1分钟前",
+                    PublishAction = "投稿了视频"
+                },
+                Content = new DynamicContent
+                {
+                    Description = new DynamicText { Text = "dynamic text" },
+                    Major = new DynamicMajor
+                    {
+                        Archive = new DynamicArchive
+                        {
+                            Bvid = "BV1test",
+                            Cover = "//example.test/cover.jpg",
+                            Title = "Video title",
+                            Description = "Video description"
+                        }
+                    }
+                },
+                Stats = new DynamicStats
+                {
+                    Like = new DynamicStat { Count = 12 }
+                }
+            }
+        };
+
+        var card = ViewMyDynamicViewModel.Convert(
+            item,
+            new StubNavigationService(),
+            new StubPlatformLauncher());
+
+        Assert.NotNull(card);
+        Assert.Equal("BV1test", card.Bvid);
+        Assert.Equal("Video title", card.CardTitle);
+        Assert.Equal("https://example.test/cover.jpg", card.Cover);
+        Assert.Equal("https://example.test/avatar.jpg", card.AuthorFace);
+        Assert.Equal("点赞 12", card.LikeText);
+        Assert.True(card.HasCard);
+    }
+
+    [Fact]
+    public void ForwardDynamicUsesOriginalPicturesAndText()
+    {
+        var item = new DynamicFeedItem
+        {
+            Id = "1002",
+            Modules = new DynamicModules
+            {
+                Author = new DynamicAuthor { Name = "Forwarder" },
+                Content = new DynamicContent
+                {
+                    Description = new DynamicText { Text = "forward comment" }
+                }
+            },
+            Original = new DynamicFeedItem
+            {
+                Modules = new DynamicModules
+                {
+                    Author = new DynamicAuthor { Name = "OriginalUploader" },
+                    Content = new DynamicContent
+                    {
+                        Description = new DynamicText { Text = "original text" },
+                        Major = new DynamicMajor
+                        {
+                            Draw = new DynamicDraw
+                            {
+                                Items = [new DynamicPicture { Source = "//example.test/image.jpg" }]
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        var card = ViewMyDynamicViewModel.Convert(
+            item,
+            new StubNavigationService(),
+            new StubPlatformLauncher());
+
+        Assert.NotNull(card);
+        Assert.Contains("forward comment", card.Description, StringComparison.Ordinal);
+        Assert.Contains("转发自 @OriginalUploader：original text", card.Description, StringComparison.Ordinal);
+        Assert.True(card.HasPictures);
+        Assert.Equal("https://example.test/image.jpg", card.Pictures[0].Source);
+    }
+
+    private sealed class StubNavigationService : IAppNavigationService
+    {
+        public event EventHandler<AppNavigationChangedEventArgs>? NavigationChanged
+        {
+            add { }
+            remove { }
+        }
+        public void Navigate(AppNavigationRequest request) { }
+        public void NavigateRegion(AppNavigationRegion region, AppRoute route, IReadOnlyDictionary<string, object?>? parameters = null) { }
+        public void ClearRegion(AppNavigationRegion region) { }
+        public object? GetActiveView(AppNavigationRegion region) => null;
+        public bool CanGoBack(AppNavigationRegion region) => false;
+        public void GoBack(AppNavigationRegion region) { }
+    }
+
+    private sealed class StubPlatformLauncher : IPlatformLauncher
+    {
+        public Task<bool> OpenFileAsync(string path, CancellationToken cancellationToken = default) => Task.FromResult(true);
+        public Task<bool> OpenFolderAsync(string path, CancellationToken cancellationToken = default) => Task.FromResult(true);
+        public Task<bool> OpenUriAsync(Uri uri, CancellationToken cancellationToken = default) => Task.FromResult(true);
+    }
+}

--- a/tests/DownKyi.Desktop.Tests/HistoryAutoRefreshTests.cs
+++ b/tests/DownKyi.Desktop.Tests/HistoryAutoRefreshTests.cs
@@ -1,0 +1,40 @@
+using DownKyi.ViewModels;
+
+namespace DownKyi.Desktop.Tests;
+
+public sealed class HistoryAutoRefreshTests
+{
+    [Theory]
+    [InlineData(-1, 30)]
+    [InlineData(0, 30)]
+    [InlineData(9.99, 10)]
+    [InlineData(10, 10)]
+    [InlineData(30.126, 30.13)]
+    public void ConfiguredIntervalIsNormalized(decimal value, decimal expected)
+    {
+        Assert.Equal(expected, ViewMyHistoryViewModel.NormalizeAutoRefreshInterval(value));
+    }
+
+    [Theory]
+    [InlineData(-100, 9.00)]
+    [InlineData(-1, 9.99)]
+    [InlineData(0, 10.00)]
+    [InlineData(1, 10.01)]
+    [InlineData(100, 11.00)]
+    public void RefreshDelayUsesInclusiveHundredthSecondJitter(int jitter, decimal expectedSeconds)
+    {
+        var delay = ViewMyHistoryViewModel.CreateAutoRefreshDelay(10m, jitter);
+
+        Assert.Equal(expectedSeconds, (decimal)delay.TotalSeconds);
+        Assert.Equal(0, delay.TotalMilliseconds % 10);
+    }
+
+    [Theory]
+    [InlineData(-101)]
+    [InlineData(101)]
+    public void RefreshDelayRejectsJitterOutsideOneSecond(int jitter)
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ViewMyHistoryViewModel.CreateAutoRefreshDelay(10m, jitter));
+    }
+}


### PR DESCRIPTION
## Why

The upstream desktop refactor does not yet include two personal-space workflows that are useful for regular account activity:

- History can only be refreshed manually, which makes long-running history monitoring cumbersome.
- Personal space has no entry for the authenticated user's dynamic feed.

These features need to use the current async Bilibili client, settings snapshot, dependency injection, and navigation architecture instead of restoring the former singleton and Prism-based implementations.

## What Changed

- Added configurable history auto-refresh. It is disabled by default, uses a minimum interval of 10 seconds, persists through `ISettingsStore`, and applies a new random `-1.00` to `+1.00` second offset at hundredth-second precision for every cycle. Navigation away cancels the timer and active history loading.
- Added an authenticated personal dynamic-feed page with cursor pagination, refresh, duplicate filtering, cancellation, and a virtualized list.
- Added cards for archive, picture, opus/article, PGC, live, common, unavailable, and forwarded dynamics, including author/video navigation and external URL launching.
- Registered the dynamic endpoint in the Bilibili API audit and added the route, DI composition, personal-space entry, resources, and data template.
- Added focused contract, settings persistence, conversion, timing, and jitter tests.

## Verification

- `HistoryAutoRefreshTests` covers the 10-second minimum and inclusive hundredth-second jitter range.
- `HistorySettingsTests` verifies normalization and persistence after reopening the settings store.
- `DynamicApiTests` verifies archive, picture, statistics, and cursor response fields.
- `DynamicFeedViewModelTests` verifies archive and forwarded-card conversion.
- Full solution test run: 627 passed, 1 environment-dependent FFmpeg seek test skipped, 0 failed.
