### PR TITLE
refactor(storage): split SQLite store responsibilities

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -512,9 +512,12 @@ type: core
 paths:
   - src/DownKyi.Infrastructure/Time/SystemClock.cs
   - src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+  - src/DownKyi.Infrastructure/Downloads/DownloadTaskRecordMapper.cs
+  - src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
+  - src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlWriter.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadProgressWriteBehind.cs
-responsibility: Implements Application time and download persistence contracts using pooled SQLite connections and bounded background writes.
+responsibility: Implements Application time and download persistence contracts using a transaction coordinator, dedicated row mapper/read/write owners, pooled SQLite connections, and bounded background writes.
 inbound:
   - app.host-composition
 outbound:
@@ -524,6 +527,7 @@ contracts:
   - Infrastructure never references Desktop or Prism.
   - SystemClock returns UTC time; deterministic tests replace IClock at the composition boundary.
   - SQLite uses one short pooled connection per operation, WAL, parameterized queries, optimistic versions, and transactional state moves.
+  - `SqliteDownloadTaskStore` owns initialization, transactions, and public query coordination; record restoration, quarantine reads, and SQL write commands stay in their dedicated owners.
   - Existing databases are backed up before schema migration; failed migrations roll back and never advance `user_version`.
   - One malformed row is quarantined with record ID, field, and sanitized reason; raw JSON and personal paths are not copied into diagnostics.
   - The progress writer has a one-slot bounded wake channel, a bounded task set, contiguous coalescing, and a final shutdown flush.
@@ -2920,6 +2924,7 @@ test.download-store:
     - malformed JSON quarantines only the affected row and does not expose raw personal data
     - completed state moves atomically from downloading to keyset-paged history
     - a legacy success row left in downloading is queued for recovery instead of quarantined
+    - architecture tests prevent the store coordinator from reclaiming Domain row reconstruction or state-row upsert SQL
 
 test.progress-write-behind:
   paths:

--- a/docs/design-docs/module-boundary-naming-audit.md
+++ b/docs/design-docs/module-boundary-naming-audit.md
@@ -2,14 +2,14 @@
 
 Status: maintained verified audit
 Last verified: 2026-07-28
-Verification base: `b290b2049151f6150377425635ad46dd46a9ac8b` plus the Gate 9 naming working tree
-Verification branch: `refactor/naming-boundaries`
+Verification base: `e29ecc8ceba0ca4279187929aba7733ee2619d97` plus the Gate 9 SQLite-store working tree
+Verification branch: `refactor/sqlite-download-store`
 
 ## 結論
 
 附件報告指出的七類問題大多成立，但原始證據已被後續重構取代。以目前工作樹重新量測後，Desktop 已成為實際 UI owner、Core 已 headless、下載佇列、HTTP 與 logging 邊界也已收斂；剩餘主要缺口是 media execution context 仍讀取一個 UI projection，以及 aria2、FFmpeg 與 filesystem 的最終 Infrastructure ownership。
 
-目前仍不得宣告整體重構完成或發布 v1.1.0：Gate 9 logging 已透過 PR #94 整合，命名已在本分支收斂，但 large-owner 工作尚未完成，最終 stacked branch 也尚未進入 `main`。版本唯一來源仍是 `1.0.32`。
+目前仍不得宣告整體重構完成或發布 v1.1.0：Gate 9 logging 與 naming 已分別透過 PR #94、#95 整合；large-owner 工作仍在分支逐項收斂，最終 stacked branch 也尚未進入 `main`。版本唯一來源仍是 `1.0.32`。
 
 ## 可重現基線
 
@@ -28,7 +28,7 @@ pwsh ./script/audit-module-boundaries.ps1 `
 | `DownKyi.Core` | 271 | 18,245 |
 | `src/DownKyi.Domain` | 11 | 681 |
 | `src/DownKyi.Application` | 30 | 1,143 |
-| `src/DownKyi.Infrastructure` | 24 | 3,719 |
+| `src/DownKyi.Infrastructure` | 27 | 3,751 |
 | `src/DownKyi.Desktop` | 317 | 44,083 |
 
 `DownKyi` executable 已降為單一 14 行 bootstrap；Desktop 是最大的產品 owner。行數不能單獨證明設計品質，因此後續仍以 project references、runtime type usage 與 architecture tests 判定責任邊界。
@@ -47,7 +47,7 @@ pwsh ./script/audit-module-boundaries.ps1 `
 | resolved | service contracts 依賴 ViewModel | 0 interfaces | completed by Gate 8 |
 | resolved | custom collection contract | 0 custom collection references; standard read-only wrappers | completed by Gate 8 |
 | resolved | naming and folder taxonomy inconsistent | 4 endpoint/role-scoped duplicate groups, 0 generic names, 0 file/type mismatches | completed in Gate 9 naming branch |
-| P2 | oversized owners | 13 production files above 500 physical lines | confirmed, decreasing |
+| P2 | oversized owners | 12 production files above 500 physical lines | confirmed, decreasing |
 | resolved | logging owner too broad | contracts in Application; 268-line provider plus dedicated Infrastructure sink/buffer/retention/export owners | completed by Gate 9 PR #94 |
 | P1 | AI knowledge environment incomplete | required root/docs structure and reproducible audit scripts now exist | resolved |
 
@@ -160,12 +160,11 @@ File/type mismatch baseline 已由 4 項降為 0。Bilibili JSON DTO 與 NFO XML
 
 附件提供的「檔名必須等於第一個型別」正規表示式會誤判 partial、`.axaml.cs`、多型別 DTO 與 interface companion records。此方案不採用。
 
-## Finding 11: 巨檔與 logging owner
+## Finding 11: 巨檔 owners
 
-2026-07-28 的實際 boundary audit 有 13 個 production files 超過 500 physical lines；`DownloadPipeline`、`DownloadTaskProjectionStore`、`ViewMyFavoritesViewModel`、`ViewPublicationViewModel` 與原 715 行 `ApplicationLogProvider` 已從 allowlist 移除。其餘最優先的手寫 owners：
+2026-07-28 的實際 boundary audit 有 12 個 production files 超過 500 physical lines；`DownloadPipeline`、`DownloadTaskProjectionStore`、`ViewMyFavoritesViewModel`、`ViewPublicationViewModel`、`SqliteDownloadTaskStore` 與原 715 行 `ApplicationLogProvider` 已從 allowlist 移除。SQLite Store 從 928 行降為 447 行，交易/初始化協調、Domain row mapping、讀取/quarantine 與 SQL writes 已分成具名 owner，既有 schema/migration/resume tests 保持不變。其餘最優先的手寫 owners：
 
 - `ViewVideoViewModel.cs` 1,020
-- `SqliteDownloadTaskStore.cs` 928
 - `ViewMySpaceViewModel.cs` 669
 - `AddToDownloadService.cs` 663
 

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -2,8 +2,8 @@
 
 Status: active
 Last updated: 2026-07-28
-Current group: Gate 9 naming and large-owner convergence
-Current branch: `refactor/naming-boundaries`
+Current group: Gate 9 large-owner convergence
+Current branch: `refactor/sqlite-download-store`
 
 This file contains only unfinished or not-yet-integrated work. Completed PR 02-32 items are not restored. Design rationale belongs in `design-docs`; product acceptance belongs in `product-specs`.
 
@@ -23,37 +23,35 @@ The previous `Status: complete` was incorrect.
 - Gate 7 async Bilibili Infrastructure ownership passed Windows/Linux/macOS quality run `30189537538`, protobuf run `30189537553`, and CodeQL run `30189537541`, then PR #91 was merged into `refactor/pr-30-32-release-hardening` as merge commit `55070903`.
 - Gate 8 passed Windows/Linux/macOS quality run `30191251004`, protobuf run `30191250997`, and CodeQL run `30191250992`; PR #92 was merged into `refactor/pr-30-32-release-hardening` as `f8e78c9a`. CodeQL reported no alert, but GitHub emitted one platform annotation because the single required ownership PR changed 396 files and its diff API is capped at 300 files.
 - Gate 9 logging ownership passed Windows/Linux/macOS quality run `30345373830`, protobuf run `30345371405`, and CodeQL run `30345371181`, with zero check annotations. PR #94 was merged into `refactor/pr-30-32-release-hardening` as merge commit `b290b204`.
+- Gate 9 naming convergence passed Windows/Linux/macOS quality run `30347937643` and CodeQL run `30347937639`; all seven check-runs had zero annotations. PR #95 was merged into `refactor/pr-30-32-release-hardening` as merge commit `e29ecc8`. Generic-name and file/type-mismatch baselines are zero; the four remaining duplicate-name sets are endpoint/role-scoped contracts.
 - `version.txt` remains `1.0.32`; v1.1.0 has not passed its release gate.
 
 No release tag may be created while any release blocker below remains.
 
 ## Execution Order
 
-### Gate 9: Naming And Large-Owner Convergence
+### Gate 9: Large-Owner Convergence
 
-Owner branches: separate naming and large-owner PRs.
+Owner branches: separate responsibility-based large-owner PRs.
 
 Scope:
 
-- Rename `Languanges`, QR/FFmpeg casing, duplicate SeasonsSeries owners and proven generic buckets in isolated rename PRs.
 - Split hand-written oversized owners by responsibility; do not split generated/protocol files only to satisfy LOC.
 
-Naming implementation progress, pending PR integration:
+Current owner progress, pending PR integration:
 
-- Canonical resource/runtime casing is `Languages` and `DownKyi.Core.FFmpeg`; architecture tests reject the historical spellings.
-- Seasons/series detail and user-space list owners now have distinct View/ViewModel names. Application owns the sole `VideoInputResolver`; Desktop owns only `PlayStreamTypeResolver`.
-- Generic type names fell from 5 to 0 and file/type mismatches from 4 to 0. JSON/XML DTOs were split into same-name files without changing CLR names or wire contracts.
-- Duplicate simple-name groups fell from 9 to 4. The remaining complete sets are endpoint/role-scoped `BangumiType`, `FavoritesMedia`, `Subtitle`, and `VideoPage` contracts and cannot grow.
-- Local gates: strict `AnalysisMode=All` Release build has zero warnings/errors; all 617 tests pass; format changed 0/805 files; vulnerable/deprecated package audits, `git diff --check`, 180 architecture tests, 13 Desktop smoke tests, and 931-candidate Gitleaks checks pass.
+- `SqliteDownloadTaskStore` fell from 928 to 447 lines. It retains initialization, transactions, optimistic conflict handling, and public query coordination.
+- `DownloadTaskRecordMapper`, `DownloadTaskSqlReader`, and `DownloadTaskSqlWriter` now own Domain restoration, read/quarantine SQL, and state-write SQL respectively. Schema version, table/column names, migration, backup, JSON payloads, and resume state are unchanged.
+- The oversized-file inventory fell from 13 to 12. A zero-baseline architecture test prevents row restoration or state upsert SQL from returning to the Store coordinator.
+- Local gates: strict `AnalysisMode=All` Release build has zero warnings/errors; all 618 tests pass, including 52 Infrastructure and 181 architecture tests; all 14 raw SQL literals match the pre-extraction content; format, vulnerable/deprecated package audits, `git diff --check`, and 934-candidate Gitleaks checks pass.
 
 Verification:
 
-- all XAML/resource URI and typed route smoke tests pass after rename.
-- module-boundary ratchet entries decrease and no new entries are added.
+- owner-specific contract and behavior tests pass before the full solution gate.
+- oversized-file ratchet entries decrease and no new entries are added.
 
 Completion:
 
-- remaining naming exceptions have a documented protocol/generated-code reason.
 - knowledge graph and architecture docs match final ownership.
 
 Rollback:

--- a/src/DownKyi.Infrastructure/Downloads/DownloadTaskRecordMapper.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadTaskRecordMapper.cs
@@ -1,0 +1,174 @@
+using System.Collections.Immutable;
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadTaskRecordMapper
+{
+    public static DownloadTask Read(SqliteDataReader reader)
+    {
+        try
+        {
+            return ReadCore(reader);
+        }
+        catch (DownloadRecordCorruptException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is ArgumentException or InvalidCastException or OverflowException)
+        {
+            throw new DownloadRecordCorruptException(
+                "record",
+                "Stored download violates the download task contract.",
+                exception);
+        }
+    }
+
+    private static DownloadTask ReadCore(SqliteDataReader reader)
+    {
+        var id = new DownloadTaskId(reader.GetString(reader.GetOrdinal("id")));
+        var requestedAssets = DownloadStoreJson.ReadBooleanMap(
+            reader.GetString(reader.GetOrdinal("need_download_content")),
+            "need_download_content");
+        var transferFiles = reader.IsDBNull(reader.GetOrdinal("download_files"))
+            ? ImmutableDictionary<string, string>.Empty
+            : DownloadStoreJson.ReadStringMap(reader.GetString(reader.GetOrdinal("download_files")), "download_files");
+        var completedFiles = reader.IsDBNull(reader.GetOrdinal("downloaded_files"))
+            ? ImmutableArray<string>.Empty
+            : DownloadStoreJson.ReadStringList(reader.GetString(reader.GetOrdinal("downloaded_files")), "downloaded_files");
+        var metadata = new DownloadTaskMetadata(
+            new DownloadMediaIdentity(
+                GetString(reader, "bvid"),
+                reader.GetInt64(reader.GetOrdinal("avid")),
+                reader.GetInt64(reader.GetOrdinal("cid")),
+                reader.GetInt64(reader.GetOrdinal("episode_id")),
+                reader.GetInt32(reader.GetOrdinal("page")),
+                reader.GetInt32(reader.GetOrdinal("order"))),
+            GetString(reader, "main_title"),
+            GetString(reader, "name"),
+            GetString(reader, "duration"),
+            GetString(reader, "video_codec_name"),
+            DownloadStoreJson.ReadQuality(GetNullableString(reader, "resolution"), "resolution"),
+            DownloadStoreJson.ReadQuality(GetNullableString(reader, "audio_codec"), "audio_codec"),
+            GetString(reader, "cover_url"),
+            GetString(reader, "page_cover_url"),
+            reader.GetInt32(reader.GetOrdinal("zone_id")));
+        var plan = new DownloadPlan(
+            requestedAssets,
+            transferFiles,
+            reader.IsDBNull(reader.GetOrdinal("play_stream_type"))
+                ? 0
+                : reader.GetInt32(reader.GetOrdinal("play_stream_type")));
+        var progress = new DownloadProgress(
+            reader.IsDBNull(reader.GetOrdinal("progress")) ? 0 : reader.GetDouble(reader.GetOrdinal("progress")),
+            GetNullableInt64(reader, "downloaded_bytes"),
+            GetNullableInt64(reader, "total_bytes"),
+            reader.IsDBNull(reader.GetOrdinal("bytes_per_second"))
+                ? 0
+                : reader.GetInt64(reader.GetOrdinal("bytes_per_second")),
+            GetNullableString(reader, "downloading_file_size"),
+            GetNullableString(reader, "speed_display"));
+        var transfer = new DownloadTransferState(
+            GetNullableString(reader, "gid"),
+            completedFiles,
+            GetNullableString(reader, "download_content"),
+            GetNullableString(reader, "download_status_title"),
+            reader.IsDBNull(reader.GetOrdinal("max_speed")) ? 0 : reader.GetInt64(reader.GetOrdinal("max_speed")));
+        var isCompleted = !reader.IsDBNull(reader.GetOrdinal("finished_timestamp"));
+        var phase = isCompleted ? DownloadPhase.Completed : ReadPhase(reader);
+        DownloadFailure? failure = null;
+        if (phase == DownloadPhase.Failed)
+        {
+            failure = new DownloadFailure(
+                GetNullableString(reader, "failure_code") ?? "download.legacy.failed",
+                GetNullableString(reader, "failure_message")
+                    ?? GetNullableString(reader, "download_status_title")
+                    ?? "Stored download failed.",
+                !reader.IsDBNull(reader.GetOrdinal("failure_transient"))
+                    && reader.GetBoolean(reader.GetOrdinal("failure_transient")));
+        }
+
+        DownloadCompletion? completion = null;
+        if (isCompleted)
+        {
+            completion = new DownloadCompletion(
+                reader.GetInt64(reader.GetOrdinal("finished_timestamp")),
+                GetString(reader, "finished_time"),
+                GetNullableString(reader, "max_speed_display"));
+        }
+
+        var createdAt = ReadTimestamp(reader, "created_at_utc");
+        var updatedAt = ReadTimestamp(reader, "updated_at_utc");
+        if (updatedAt < createdAt)
+        {
+            throw new DownloadRecordCorruptException("updated_at_utc", "Updated timestamp precedes creation.");
+        }
+
+        return DownloadTask.Restore(
+            id,
+            metadata,
+            plan,
+            new DownloadOutput(GetString(reader, "file_path"), GetNullableString(reader, "file_size")),
+            phase,
+            progress,
+            transfer,
+            failure,
+            completion,
+            reader.GetInt64(reader.GetOrdinal("version")),
+            createdAt,
+            updatedAt);
+    }
+
+    private static DownloadPhase ReadPhase(SqliteDataReader reader)
+    {
+        var value = reader.IsDBNull(reader.GetOrdinal("phase"))
+            ? MapLegacyStatus(reader.GetInt32(reader.GetOrdinal("download_status")))
+            : (DownloadPhase)reader.GetInt32(reader.GetOrdinal("phase"));
+        if (!Enum.IsDefined(value) || value is DownloadPhase.Completed or DownloadPhase.Deleted)
+        {
+            throw new DownloadRecordCorruptException("phase", "Stored download phase is invalid for an unfinished row.");
+        }
+
+        return value;
+    }
+
+    private static DownloadPhase MapLegacyStatus(int status)
+    {
+        return status switch
+        {
+            2 => DownloadPhase.Pausing,
+            3 => DownloadPhase.Paused,
+            4 => DownloadPhase.Downloading,
+            5 => DownloadPhase.Queued,
+            6 => DownloadPhase.Failed,
+            _ => DownloadPhase.Queued
+        };
+    }
+
+    private static string GetString(SqliteDataReader reader, string column)
+    {
+        var ordinal = reader.GetOrdinal(column);
+        return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal);
+    }
+
+    private static string? GetNullableString(SqliteDataReader reader, string column)
+    {
+        var ordinal = reader.GetOrdinal(column);
+        return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+    }
+
+    private static long? GetNullableInt64(SqliteDataReader reader, string column)
+    {
+        var ordinal = reader.GetOrdinal(column);
+        return reader.IsDBNull(ordinal) ? null : reader.GetInt64(ordinal);
+    }
+
+    private static DateTimeOffset ReadTimestamp(SqliteDataReader reader, string column)
+    {
+        var ordinal = reader.GetOrdinal(column);
+        return reader.IsDBNull(ordinal) || reader.GetInt64(ordinal) == 0
+            ? DateTimeOffset.UnixEpoch
+            : DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(ordinal));
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
@@ -1,0 +1,90 @@
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadTaskSqlReader
+{
+    public const string SelectColumns = """
+        SELECT
+            db.id, db.need_download_content, db.bvid, db.avid, db.cid, db.episode_id,
+            db.cover_url, db.page_cover_url, db.zone_id, db.[order], db.main_title,
+            db.name, db.duration, db.video_codec_name, db.resolution, db.audio_codec,
+            db.file_path, db.file_size, db.page, db.version, db.created_at_utc, db.updated_at_utc,
+            dl.gid, dl.download_files, dl.downloaded_files, dl.play_stream_type,
+            dl.download_status, dl.download_content, dl.download_status_title, dl.progress,
+            dl.downloading_file_size, dl.max_speed, dl.speed_display, dl.phase,
+            dl.failure_code, dl.failure_message, dl.failure_transient,
+            dl.downloaded_bytes, dl.total_bytes, dl.bytes_per_second,
+            d.max_speed_display, d.finished_timestamp, d.finished_time
+        FROM download_base db
+        LEFT JOIN downloading dl ON dl.id = db.id
+        LEFT JOIN downloaded d ON d.id = db.id
+        """;
+
+    public static async Task<IReadOnlyList<DownloadTask>> ReadManyAsync(
+        SqliteConnection connection,
+        SqliteCommand command,
+        string sourceTable,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var tasks = new List<DownloadTask>();
+        var corrupt = new List<(string RecordId, DownloadRecordCorruptException Error)>();
+        using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var recordId = reader.GetString(reader.GetOrdinal("id"));
+                try
+                {
+                    tasks.Add(DownloadTaskRecordMapper.Read(reader));
+                }
+                catch (DownloadRecordCorruptException exception)
+                {
+                    corrupt.Add((recordId, exception));
+                }
+            }
+        }
+
+        foreach (var item in corrupt)
+        {
+            await QuarantineAsync(
+                    connection,
+                    sourceTable,
+                    item.RecordId,
+                    item.Error,
+                    quarantinedAtUtc,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return tasks;
+    }
+
+    public static async Task QuarantineAsync(
+        SqliteConnection connection,
+        string sourceTable,
+        string recordId,
+        DownloadRecordCorruptException error,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO download_quarantine
+                (source_table, record_id, field_name, reason, quarantined_at_utc)
+            VALUES (@source_table, @record_id, @field_name, @reason, @quarantined_at_utc)
+            ON CONFLICT(source_table, record_id) DO UPDATE SET
+                field_name = excluded.field_name,
+                reason = excluded.reason,
+                quarantined_at_utc = excluded.quarantined_at_utc
+            """;
+        command.Parameters.AddWithValue("@source_table", sourceTable);
+        command.Parameters.AddWithValue("@record_id", recordId);
+        command.Parameters.AddWithValue("@field_name", error.FieldName);
+        command.Parameters.AddWithValue("@reason", error.Message);
+        command.Parameters.AddWithValue("@quarantined_at_utc", quarantinedAtUtc.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlWriter.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlWriter.cs
@@ -1,0 +1,249 @@
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadTaskSqlWriter
+{
+    public static async Task InsertBaseAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DownloadTask task,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO download_base
+                (id, need_download_content, bvid, avid, cid, episode_id, cover_url, page_cover_url,
+                 zone_id, [order], main_title, name, duration, video_codec_name, resolution,
+                 audio_codec, file_path, file_size, page, version, created_at_utc, updated_at_utc)
+            VALUES
+                (@id, @need_download_content, @bvid, @avid, @cid, @episode_id, @cover_url, @page_cover_url,
+                 @zone_id, @order, @main_title, @name, @duration, @video_codec_name, @resolution,
+                 @audio_codec, @file_path, @file_size, @page, @version, @created_at_utc, @updated_at_utc)
+            """;
+        BindBase(command, task);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<int> UpdateBaseAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DownloadTask task,
+        long expectedVersion,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            UPDATE download_base SET
+                need_download_content = @need_download_content,
+                bvid = @bvid, avid = @avid, cid = @cid, episode_id = @episode_id,
+                cover_url = @cover_url, page_cover_url = @page_cover_url,
+                zone_id = @zone_id, [order] = @order, main_title = @main_title, name = @name,
+                duration = @duration, video_codec_name = @video_codec_name, resolution = @resolution,
+                audio_codec = @audio_codec, file_path = @file_path, file_size = @file_size, page = @page,
+                version = @version, created_at_utc = @created_at_utc, updated_at_utc = @updated_at_utc
+            WHERE id = @id AND version = @expected_version
+            """;
+        BindBase(command, task);
+        command.Parameters.AddWithValue("@expected_version", expectedVersion);
+        return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task WriteStateRowAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DownloadTask task,
+        CancellationToken cancellationToken)
+    {
+        if (task.Phase == DownloadPhase.Completed)
+        {
+            await DeleteStateRowAsync(connection, transaction, false, task.Id, cancellationToken)
+                .ConfigureAwait(false);
+            await UpsertDownloadedAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        await DeleteStateRowAsync(connection, transaction, true, task.Id, cancellationToken)
+            .ConfigureAwait(false);
+        await UpsertDownloadingAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
+    }
+
+    public static void BindProgress(SqliteCommand command, DownloadProgress progress)
+    {
+        command.Parameters.AddWithValue("@progress", progress.Percentage);
+        command.Parameters.AddWithValue("@downloaded_bytes", progress.DownloadedBytes ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@total_bytes", progress.TotalBytes ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@bytes_per_second", progress.BytesPerSecond);
+        command.Parameters.AddWithValue(
+            "@downloaded_size_text",
+            progress.DownloadedSizeText ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@speed_text", progress.SpeedText ?? (object)DBNull.Value);
+    }
+
+    public static async Task DeleteBaseAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "DELETE FROM download_base WHERE id = @id";
+        command.Parameters.AddWithValue("@id", taskId.Value);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void BindBase(SqliteCommand command, DownloadTask task)
+    {
+        command.Parameters.AddWithValue("@id", task.Id.Value);
+        command.Parameters.AddWithValue(
+            "@need_download_content",
+            DownloadStoreJson.WriteBooleanMap(task.Plan.RequestedAssets));
+        command.Parameters.AddWithValue("@bvid", task.Metadata.Media.Bvid);
+        command.Parameters.AddWithValue("@avid", task.Metadata.Media.Avid);
+        command.Parameters.AddWithValue("@cid", task.Metadata.Media.Cid);
+        command.Parameters.AddWithValue("@episode_id", task.Metadata.Media.EpisodeId);
+        command.Parameters.AddWithValue("@cover_url", task.Metadata.CoverAddress);
+        command.Parameters.AddWithValue("@page_cover_url", task.Metadata.PageCoverAddress);
+        command.Parameters.AddWithValue("@zone_id", task.Metadata.ZoneId);
+        command.Parameters.AddWithValue("@order", task.Metadata.Media.Order);
+        command.Parameters.AddWithValue("@main_title", task.Metadata.MainTitle);
+        command.Parameters.AddWithValue("@name", task.Metadata.Name);
+        command.Parameters.AddWithValue("@duration", task.Metadata.DurationText);
+        command.Parameters.AddWithValue("@video_codec_name", task.Metadata.VideoCodecName);
+        command.Parameters.AddWithValue("@resolution", DownloadStoreJson.WriteQuality(task.Metadata.Resolution));
+        command.Parameters.AddWithValue("@audio_codec", DownloadStoreJson.WriteQuality(task.Metadata.AudioCodec));
+        command.Parameters.AddWithValue("@file_path", task.Output.BasePath);
+        command.Parameters.AddWithValue("@file_size", task.Output.FileSizeText ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@page", task.Metadata.Media.Page);
+        command.Parameters.AddWithValue("@version", task.Version);
+        command.Parameters.AddWithValue("@created_at_utc", task.CreatedAtUtc.ToUnixTimeMilliseconds());
+        command.Parameters.AddWithValue("@updated_at_utc", task.UpdatedAtUtc.ToUnixTimeMilliseconds());
+    }
+
+    private static async Task UpsertDownloadingAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DownloadTask task,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO downloading
+                (id, gid, download_files, downloaded_files, play_stream_type, download_status,
+                 download_content, download_status_title, progress, downloading_file_size,
+                 max_speed, speed_display, phase, failure_code, failure_message, failure_transient,
+                 downloaded_bytes, total_bytes, bytes_per_second)
+            VALUES
+                (@id, @gid, @download_files, @downloaded_files, @play_stream_type, @download_status,
+                 @download_content, @download_status_title, @progress, @downloaded_size_text,
+                 @max_speed, @speed_text, @phase, @failure_code, @failure_message, @failure_transient,
+                 @downloaded_bytes, @total_bytes, @bytes_per_second)
+            ON CONFLICT(id) DO UPDATE SET
+                gid = excluded.gid,
+                download_files = excluded.download_files,
+                downloaded_files = excluded.downloaded_files,
+                play_stream_type = excluded.play_stream_type,
+                download_status = excluded.download_status,
+                download_content = excluded.download_content,
+                download_status_title = excluded.download_status_title,
+                progress = excluded.progress,
+                downloading_file_size = excluded.downloading_file_size,
+                max_speed = excluded.max_speed,
+                speed_display = excluded.speed_display,
+                phase = excluded.phase,
+                failure_code = excluded.failure_code,
+                failure_message = excluded.failure_message,
+                failure_transient = excluded.failure_transient,
+                downloaded_bytes = excluded.downloaded_bytes,
+                total_bytes = excluded.total_bytes,
+                bytes_per_second = excluded.bytes_per_second
+            """;
+        command.Parameters.AddWithValue("@id", task.Id.Value);
+        command.Parameters.AddWithValue("@gid", task.Transfer.BackendIdentity ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@download_files", DownloadStoreJson.WriteStringMap(task.Plan.TransferFiles));
+        command.Parameters.AddWithValue(
+            "@downloaded_files",
+            DownloadStoreJson.WriteStringList(task.Transfer.CompletedFileKeys));
+        command.Parameters.AddWithValue("@play_stream_type", task.Plan.StreamType);
+        command.Parameters.AddWithValue("@download_status", ToLegacyStatus(task.Phase));
+        command.Parameters.AddWithValue("@download_content", task.Transfer.ActiveContent ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@download_status_title", task.Transfer.StatusText ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@max_speed", task.Transfer.MaximumBytesPerSecond);
+        command.Parameters.AddWithValue("@phase", (int)task.Phase);
+        command.Parameters.AddWithValue("@failure_code", task.Failure?.Code ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@failure_message", task.Failure?.Message ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue(
+            "@failure_transient",
+            task.Failure == null ? DBNull.Value : task.Failure.IsTransient ? 1 : 0);
+        BindProgress(command, task.Progress);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task UpsertDownloadedAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DownloadTask task,
+        CancellationToken cancellationToken)
+    {
+        var completion = task.Completion
+            ?? throw new InvalidOperationException("Completed download has no completion details.");
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO downloaded (id, max_speed_display, finished_timestamp, finished_time)
+            VALUES (@id, @max_speed_display, @finished_timestamp, @finished_time)
+            ON CONFLICT(id) DO UPDATE SET
+                max_speed_display = excluded.max_speed_display,
+                finished_timestamp = excluded.finished_timestamp,
+                finished_time = excluded.finished_time
+            """;
+        command.Parameters.AddWithValue("@id", task.Id.Value);
+        command.Parameters.AddWithValue("@max_speed_display", completion.MaximumSpeedText ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@finished_timestamp", completion.FinishedTimestamp);
+        command.Parameters.AddWithValue("@finished_time", completion.FinishedTimeText);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task DeleteStateRowAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        bool completed,
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        if (completed)
+        {
+            command.CommandText = "DELETE FROM downloaded WHERE id = @id";
+        }
+        else
+        {
+            command.CommandText = "DELETE FROM downloading WHERE id = @id";
+        }
+
+        command.Parameters.AddWithValue("@id", taskId.Value);
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static int ToLegacyStatus(DownloadPhase phase)
+    {
+        return phase switch
+        {
+            DownloadPhase.Queued => 1,
+            DownloadPhase.Pausing => 2,
+            DownloadPhase.Paused => 3,
+            DownloadPhase.Downloading => 4,
+            DownloadPhase.Completed => 5,
+            DownloadPhase.Failed => 6,
+            DownloadPhase.Canceled => 3,
+            DownloadPhase.Deleted => 3,
+            _ => 1
+        };
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using DownKyi.Domain.Downloads;
@@ -57,8 +56,12 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
             .ConfigureAwait(false);
         try
         {
-            await InsertBaseAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
-            await WriteStateRowAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
+            await DownloadTaskSqlWriter
+                .InsertBaseAsync(connection, transaction, task, cancellationToken)
+                .ConfigureAwait(false);
+            await DownloadTaskSqlWriter
+                .WriteStateRowAsync(connection, transaction, task, cancellationToken)
+                .ConfigureAwait(false);
             await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
             return OperationResult.Success();
         }
@@ -90,7 +93,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
             .ConfigureAwait(false);
         try
         {
-            var updated = await UpdateBaseAsync(
+            var updated = await DownloadTaskSqlWriter.UpdateBaseAsync(
                 connection,
                 transaction,
                 task,
@@ -104,11 +107,15 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
 
             if (task.Phase == DownloadPhase.Deleted)
             {
-                await DeleteBaseAsync(connection, transaction, task.Id, cancellationToken).ConfigureAwait(false);
+                await DownloadTaskSqlWriter
+                    .DeleteBaseAsync(connection, transaction, task.Id, cancellationToken)
+                    .ConfigureAwait(false);
             }
             else
             {
-                await WriteStateRowAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
+                await DownloadTaskSqlWriter
+                    .WriteStateRowAsync(connection, transaction, task, cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
@@ -164,7 +171,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
                     max_speed = MAX(max_speed, @bytes_per_second)
                 WHERE id = @id
                 """;
-            BindProgress(progressCommand, progressWrite.Progress);
+            DownloadTaskSqlWriter.BindProgress(progressCommand, progressWrite.Progress);
             progressCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
             changed = await progressCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
             if (changed == 0)
@@ -189,7 +196,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         using var command = connection.CreateCommand();
-        command.CommandText = SelectColumns + "\n" + """
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
             WHERE db.id = @id
               AND NOT EXISTS (
                   SELECT 1 FROM download_quarantine q
@@ -205,7 +212,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
 
         try
         {
-            return ReadTask(reader);
+            return DownloadTaskRecordMapper.Read(reader);
         }
         catch (DownloadRecordCorruptException exception)
         {
@@ -214,7 +221,8 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
                 .ConfigureAwait(false);
             var source = isHistory ? "downloaded" : "downloading";
             await reader.DisposeAsync().ConfigureAwait(false);
-            await QuarantineAsync(connection, source, taskId.Value, exception, _clock.UtcNow, cancellationToken)
+            await DownloadTaskSqlReader
+                .QuarantineAsync(connection, source, taskId.Value, exception, _clock.UtcNow, cancellationToken)
                 .ConfigureAwait(false);
             return null;
         }
@@ -225,14 +233,15 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         using var command = connection.CreateCommand();
-        command.CommandText = SelectColumns + "\n" + """
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
             WHERE dl.id IS NOT NULL
               AND NOT EXISTS (
                   SELECT 1 FROM download_quarantine q
                   WHERE q.source_table = 'downloading' AND q.record_id = db.id)
             ORDER BY db.main_title COLLATE NOCASE, db.[order] ASC, db.id ASC
             """;
-        return await ReadManyAsync(connection, command, "downloading", _clock.UtcNow, cancellationToken)
+        return await DownloadTaskSqlReader
+            .ReadManyAsync(connection, command, "downloading", _clock.UtcNow, cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -246,7 +255,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         using var command = connection.CreateCommand();
-        command.CommandText = SelectColumns + "\n" + """
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
             WHERE d.id IS NOT NULL
               AND (@cursor_timestamp IS NULL
                    OR d.finished_timestamp < @cursor_timestamp
@@ -260,7 +269,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         command.Parameters.AddWithValue("@cursor_timestamp", cursor?.FinishedTimestamp ?? (object)DBNull.Value);
         command.Parameters.AddWithValue("@cursor_id", cursor?.TaskId.Value ?? string.Empty);
         command.Parameters.AddWithValue("@limit", checked(pageSize + 1));
-        var items = (await ReadManyAsync(
+        var items = (await DownloadTaskSqlReader.ReadManyAsync(
                 connection,
                 command,
                 "downloaded",
@@ -419,454 +428,6 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         }
     }
 
-    private static async Task<IReadOnlyList<DownloadTask>> ReadManyAsync(
-        SqliteConnection connection,
-        SqliteCommand command,
-        string sourceTable,
-        DateTimeOffset quarantinedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        var tasks = new List<DownloadTask>();
-        var corrupt = new List<(string RecordId, DownloadRecordCorruptException Error)>();
-        using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
-        {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                var recordId = reader.GetString(reader.GetOrdinal("id"));
-                try
-                {
-                    tasks.Add(ReadTask(reader));
-                }
-                catch (DownloadRecordCorruptException exception)
-                {
-                    corrupt.Add((recordId, exception));
-                }
-            }
-        }
-
-        foreach (var item in corrupt)
-        {
-            await QuarantineAsync(
-                    connection,
-                    sourceTable,
-                    item.RecordId,
-                    item.Error,
-                    quarantinedAtUtc,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return tasks;
-    }
-
-    private static DownloadTask ReadTask(SqliteDataReader reader)
-    {
-        try
-        {
-            return ReadTaskCore(reader);
-        }
-        catch (DownloadRecordCorruptException)
-        {
-            throw;
-        }
-        catch (Exception exception) when (exception is ArgumentException or InvalidCastException or OverflowException)
-        {
-            throw new DownloadRecordCorruptException(
-                "record",
-                "Stored download violates the download task contract.",
-                exception);
-        }
-    }
-
-    private static DownloadTask ReadTaskCore(SqliteDataReader reader)
-    {
-        var id = new DownloadTaskId(reader.GetString(reader.GetOrdinal("id")));
-        var requestedAssets = DownloadStoreJson.ReadBooleanMap(
-            reader.GetString(reader.GetOrdinal("need_download_content")),
-            "need_download_content");
-        var transferFiles = reader.IsDBNull(reader.GetOrdinal("download_files"))
-            ? ImmutableDictionary<string, string>.Empty
-            : DownloadStoreJson.ReadStringMap(reader.GetString(reader.GetOrdinal("download_files")), "download_files");
-        var completedFiles = reader.IsDBNull(reader.GetOrdinal("downloaded_files"))
-            ? ImmutableArray<string>.Empty
-            : DownloadStoreJson.ReadStringList(reader.GetString(reader.GetOrdinal("downloaded_files")), "downloaded_files");
-        var metadata = new DownloadTaskMetadata(
-            new DownloadMediaIdentity(
-                GetString(reader, "bvid"),
-                reader.GetInt64(reader.GetOrdinal("avid")),
-                reader.GetInt64(reader.GetOrdinal("cid")),
-                reader.GetInt64(reader.GetOrdinal("episode_id")),
-                reader.GetInt32(reader.GetOrdinal("page")),
-                reader.GetInt32(reader.GetOrdinal("order"))),
-            GetString(reader, "main_title"),
-            GetString(reader, "name"),
-            GetString(reader, "duration"),
-            GetString(reader, "video_codec_name"),
-            DownloadStoreJson.ReadQuality(GetNullableString(reader, "resolution"), "resolution"),
-            DownloadStoreJson.ReadQuality(GetNullableString(reader, "audio_codec"), "audio_codec"),
-            GetString(reader, "cover_url"),
-            GetString(reader, "page_cover_url"),
-            reader.GetInt32(reader.GetOrdinal("zone_id")));
-        var plan = new DownloadPlan(
-            requestedAssets,
-            transferFiles,
-            reader.IsDBNull(reader.GetOrdinal("play_stream_type"))
-                ? 0
-                : reader.GetInt32(reader.GetOrdinal("play_stream_type")));
-        var progress = new DownloadProgress(
-            reader.IsDBNull(reader.GetOrdinal("progress")) ? 0 : reader.GetDouble(reader.GetOrdinal("progress")),
-            GetNullableInt64(reader, "downloaded_bytes"),
-            GetNullableInt64(reader, "total_bytes"),
-            reader.IsDBNull(reader.GetOrdinal("bytes_per_second"))
-                ? 0
-                : reader.GetInt64(reader.GetOrdinal("bytes_per_second")),
-            GetNullableString(reader, "downloading_file_size"),
-            GetNullableString(reader, "speed_display"));
-        var transfer = new DownloadTransferState(
-            GetNullableString(reader, "gid"),
-            completedFiles,
-            GetNullableString(reader, "download_content"),
-            GetNullableString(reader, "download_status_title"),
-            reader.IsDBNull(reader.GetOrdinal("max_speed")) ? 0 : reader.GetInt64(reader.GetOrdinal("max_speed")));
-        var isCompleted = !reader.IsDBNull(reader.GetOrdinal("finished_timestamp"));
-        var phase = isCompleted ? DownloadPhase.Completed : ReadPhase(reader);
-        DownloadFailure? failure = null;
-        if (phase == DownloadPhase.Failed)
-        {
-            failure = new DownloadFailure(
-                GetNullableString(reader, "failure_code") ?? "download.legacy.failed",
-                GetNullableString(reader, "failure_message")
-                    ?? GetNullableString(reader, "download_status_title")
-                    ?? "Stored download failed.",
-                !reader.IsDBNull(reader.GetOrdinal("failure_transient"))
-                    && reader.GetBoolean(reader.GetOrdinal("failure_transient")));
-        }
-
-        DownloadCompletion? completion = null;
-        if (isCompleted)
-        {
-            completion = new DownloadCompletion(
-                reader.GetInt64(reader.GetOrdinal("finished_timestamp")),
-                GetString(reader, "finished_time"),
-                GetNullableString(reader, "max_speed_display"));
-        }
-
-        var createdAt = ReadTimestamp(reader, "created_at_utc");
-        var updatedAt = ReadTimestamp(reader, "updated_at_utc");
-        if (updatedAt < createdAt)
-        {
-            throw new DownloadRecordCorruptException("updated_at_utc", "Updated timestamp precedes creation.");
-        }
-
-        return DownloadTask.Restore(
-            id,
-            metadata,
-            plan,
-            new DownloadOutput(GetString(reader, "file_path"), GetNullableString(reader, "file_size")),
-            phase,
-            progress,
-            transfer,
-            failure,
-            completion,
-            reader.GetInt64(reader.GetOrdinal("version")),
-            createdAt,
-            updatedAt);
-    }
-
-    private static DownloadPhase ReadPhase(SqliteDataReader reader)
-    {
-        var value = reader.IsDBNull(reader.GetOrdinal("phase"))
-            ? MapLegacyStatus(reader.GetInt32(reader.GetOrdinal("download_status")))
-            : (DownloadPhase)reader.GetInt32(reader.GetOrdinal("phase"));
-        if (!Enum.IsDefined(value) || value is DownloadPhase.Completed or DownloadPhase.Deleted)
-        {
-            throw new DownloadRecordCorruptException("phase", "Stored download phase is invalid for an unfinished row.");
-        }
-
-        return value;
-    }
-
-    private static DownloadPhase MapLegacyStatus(int status)
-    {
-        return status switch
-        {
-            2 => DownloadPhase.Pausing,
-            3 => DownloadPhase.Paused,
-            4 => DownloadPhase.Downloading,
-            5 => DownloadPhase.Queued,
-            6 => DownloadPhase.Failed,
-            _ => DownloadPhase.Queued
-        };
-    }
-
-    private static async Task InsertBaseAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DownloadTask task,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = """
-            INSERT INTO download_base
-                (id, need_download_content, bvid, avid, cid, episode_id, cover_url, page_cover_url,
-                 zone_id, [order], main_title, name, duration, video_codec_name, resolution,
-                 audio_codec, file_path, file_size, page, version, created_at_utc, updated_at_utc)
-            VALUES
-                (@id, @need_download_content, @bvid, @avid, @cid, @episode_id, @cover_url, @page_cover_url,
-                 @zone_id, @order, @main_title, @name, @duration, @video_codec_name, @resolution,
-                 @audio_codec, @file_path, @file_size, @page, @version, @created_at_utc, @updated_at_utc)
-            """;
-        BindBase(command, task);
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task<int> UpdateBaseAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DownloadTask task,
-        long expectedVersion,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = """
-            UPDATE download_base SET
-                need_download_content = @need_download_content,
-                bvid = @bvid, avid = @avid, cid = @cid, episode_id = @episode_id,
-                cover_url = @cover_url, page_cover_url = @page_cover_url,
-                zone_id = @zone_id, [order] = @order, main_title = @main_title, name = @name,
-                duration = @duration, video_codec_name = @video_codec_name, resolution = @resolution,
-                audio_codec = @audio_codec, file_path = @file_path, file_size = @file_size, page = @page,
-                version = @version, created_at_utc = @created_at_utc, updated_at_utc = @updated_at_utc
-            WHERE id = @id AND version = @expected_version
-            """;
-        BindBase(command, task);
-        command.Parameters.AddWithValue("@expected_version", expectedVersion);
-        return await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static void BindBase(SqliteCommand command, DownloadTask task)
-    {
-        command.Parameters.AddWithValue("@id", task.Id.Value);
-        command.Parameters.AddWithValue(
-            "@need_download_content",
-            DownloadStoreJson.WriteBooleanMap(task.Plan.RequestedAssets));
-        command.Parameters.AddWithValue("@bvid", task.Metadata.Media.Bvid);
-        command.Parameters.AddWithValue("@avid", task.Metadata.Media.Avid);
-        command.Parameters.AddWithValue("@cid", task.Metadata.Media.Cid);
-        command.Parameters.AddWithValue("@episode_id", task.Metadata.Media.EpisodeId);
-        command.Parameters.AddWithValue("@cover_url", task.Metadata.CoverAddress);
-        command.Parameters.AddWithValue("@page_cover_url", task.Metadata.PageCoverAddress);
-        command.Parameters.AddWithValue("@zone_id", task.Metadata.ZoneId);
-        command.Parameters.AddWithValue("@order", task.Metadata.Media.Order);
-        command.Parameters.AddWithValue("@main_title", task.Metadata.MainTitle);
-        command.Parameters.AddWithValue("@name", task.Metadata.Name);
-        command.Parameters.AddWithValue("@duration", task.Metadata.DurationText);
-        command.Parameters.AddWithValue("@video_codec_name", task.Metadata.VideoCodecName);
-        command.Parameters.AddWithValue("@resolution", DownloadStoreJson.WriteQuality(task.Metadata.Resolution));
-        command.Parameters.AddWithValue("@audio_codec", DownloadStoreJson.WriteQuality(task.Metadata.AudioCodec));
-        command.Parameters.AddWithValue("@file_path", task.Output.BasePath);
-        command.Parameters.AddWithValue("@file_size", task.Output.FileSizeText ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@page", task.Metadata.Media.Page);
-        command.Parameters.AddWithValue("@version", task.Version);
-        command.Parameters.AddWithValue("@created_at_utc", task.CreatedAtUtc.ToUnixTimeMilliseconds());
-        command.Parameters.AddWithValue("@updated_at_utc", task.UpdatedAtUtc.ToUnixTimeMilliseconds());
-    }
-
-    private static async Task WriteStateRowAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DownloadTask task,
-        CancellationToken cancellationToken)
-    {
-        if (task.Phase == DownloadPhase.Completed)
-        {
-            await DeleteStateRowAsync(connection, transaction, false, task.Id, cancellationToken)
-                .ConfigureAwait(false);
-            await UpsertDownloadedAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
-            return;
-        }
-
-        await DeleteStateRowAsync(connection, transaction, true, task.Id, cancellationToken)
-            .ConfigureAwait(false);
-        await UpsertDownloadingAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task UpsertDownloadingAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DownloadTask task,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = """
-            INSERT INTO downloading
-                (id, gid, download_files, downloaded_files, play_stream_type, download_status,
-                 download_content, download_status_title, progress, downloading_file_size,
-                 max_speed, speed_display, phase, failure_code, failure_message, failure_transient,
-                 downloaded_bytes, total_bytes, bytes_per_second)
-            VALUES
-                (@id, @gid, @download_files, @downloaded_files, @play_stream_type, @download_status,
-                 @download_content, @download_status_title, @progress, @downloaded_size_text,
-                 @max_speed, @speed_text, @phase, @failure_code, @failure_message, @failure_transient,
-                 @downloaded_bytes, @total_bytes, @bytes_per_second)
-            ON CONFLICT(id) DO UPDATE SET
-                gid = excluded.gid,
-                download_files = excluded.download_files,
-                downloaded_files = excluded.downloaded_files,
-                play_stream_type = excluded.play_stream_type,
-                download_status = excluded.download_status,
-                download_content = excluded.download_content,
-                download_status_title = excluded.download_status_title,
-                progress = excluded.progress,
-                downloading_file_size = excluded.downloading_file_size,
-                max_speed = excluded.max_speed,
-                speed_display = excluded.speed_display,
-                phase = excluded.phase,
-                failure_code = excluded.failure_code,
-                failure_message = excluded.failure_message,
-                failure_transient = excluded.failure_transient,
-                downloaded_bytes = excluded.downloaded_bytes,
-                total_bytes = excluded.total_bytes,
-                bytes_per_second = excluded.bytes_per_second
-            """;
-        command.Parameters.AddWithValue("@id", task.Id.Value);
-        command.Parameters.AddWithValue("@gid", task.Transfer.BackendIdentity ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@download_files", DownloadStoreJson.WriteStringMap(task.Plan.TransferFiles));
-        command.Parameters.AddWithValue(
-            "@downloaded_files",
-            DownloadStoreJson.WriteStringList(task.Transfer.CompletedFileKeys));
-        command.Parameters.AddWithValue("@play_stream_type", task.Plan.StreamType);
-        command.Parameters.AddWithValue("@download_status", ToLegacyStatus(task.Phase));
-        command.Parameters.AddWithValue("@download_content", task.Transfer.ActiveContent ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@download_status_title", task.Transfer.StatusText ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@max_speed", task.Transfer.MaximumBytesPerSecond);
-        command.Parameters.AddWithValue("@phase", (int)task.Phase);
-        command.Parameters.AddWithValue("@failure_code", task.Failure?.Code ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@failure_message", task.Failure?.Message ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue(
-            "@failure_transient",
-            task.Failure == null ? DBNull.Value : task.Failure.IsTransient ? 1 : 0);
-        BindProgress(command, task.Progress);
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static void BindProgress(SqliteCommand command, DownloadProgress progress)
-    {
-        command.Parameters.AddWithValue("@progress", progress.Percentage);
-        command.Parameters.AddWithValue("@downloaded_bytes", progress.DownloadedBytes ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@total_bytes", progress.TotalBytes ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@bytes_per_second", progress.BytesPerSecond);
-        command.Parameters.AddWithValue(
-            "@downloaded_size_text",
-            progress.DownloadedSizeText ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@speed_text", progress.SpeedText ?? (object)DBNull.Value);
-    }
-
-    private static async Task UpsertDownloadedAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DownloadTask task,
-        CancellationToken cancellationToken)
-    {
-        var completion = task.Completion
-            ?? throw new InvalidOperationException("Completed download has no completion details.");
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = """
-            INSERT INTO downloaded (id, max_speed_display, finished_timestamp, finished_time)
-            VALUES (@id, @max_speed_display, @finished_timestamp, @finished_time)
-            ON CONFLICT(id) DO UPDATE SET
-                max_speed_display = excluded.max_speed_display,
-                finished_timestamp = excluded.finished_timestamp,
-                finished_time = excluded.finished_time
-            """;
-        command.Parameters.AddWithValue("@id", task.Id.Value);
-        command.Parameters.AddWithValue("@max_speed_display", completion.MaximumSpeedText ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@finished_timestamp", completion.FinishedTimestamp);
-        command.Parameters.AddWithValue("@finished_time", completion.FinishedTimeText);
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task DeleteStateRowAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        bool completed,
-        DownloadTaskId taskId,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        if (completed)
-        {
-            command.CommandText = "DELETE FROM downloaded WHERE id = @id";
-        }
-        else
-        {
-            command.CommandText = "DELETE FROM downloading WHERE id = @id";
-        }
-
-        command.Parameters.AddWithValue("@id", taskId.Value);
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task DeleteBaseAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DownloadTaskId taskId,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = "DELETE FROM download_base WHERE id = @id";
-        command.Parameters.AddWithValue("@id", taskId.Value);
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task QuarantineAsync(
-        SqliteConnection connection,
-        string sourceTable,
-        string recordId,
-        DownloadRecordCorruptException error,
-        DateTimeOffset quarantinedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO download_quarantine
-                (source_table, record_id, field_name, reason, quarantined_at_utc)
-            VALUES (@source_table, @record_id, @field_name, @reason, @quarantined_at_utc)
-            ON CONFLICT(source_table, record_id) DO UPDATE SET
-                field_name = excluded.field_name,
-                reason = excluded.reason,
-                quarantined_at_utc = excluded.quarantined_at_utc
-            """;
-        command.Parameters.AddWithValue("@source_table", sourceTable);
-        command.Parameters.AddWithValue("@record_id", recordId);
-        command.Parameters.AddWithValue("@field_name", error.FieldName);
-        command.Parameters.AddWithValue("@reason", error.Message);
-        command.Parameters.AddWithValue("@quarantined_at_utc", quarantinedAtUtc.ToUnixTimeMilliseconds());
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static int ToLegacyStatus(DownloadPhase phase)
-    {
-        return phase switch
-        {
-            DownloadPhase.Queued => 1,
-            DownloadPhase.Pausing => 2,
-            DownloadPhase.Paused => 3,
-            DownloadPhase.Downloading => 4,
-            DownloadPhase.Completed => 5,
-            DownloadPhase.Failed => 6,
-            DownloadPhase.Canceled => 3,
-            DownloadPhase.Deleted => 3,
-            _ => 1
-        };
-    }
-
     private static OperationResult Conflict(DownloadTaskId taskId, string reason)
     {
         return OperationResult.Failure(new OperationError(
@@ -883,46 +444,4 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
             OperationErrorKind.NotFound));
     }
 
-    private static string GetString(SqliteDataReader reader, string column)
-    {
-        var ordinal = reader.GetOrdinal(column);
-        return reader.IsDBNull(ordinal) ? string.Empty : reader.GetString(ordinal);
-    }
-
-    private static string? GetNullableString(SqliteDataReader reader, string column)
-    {
-        var ordinal = reader.GetOrdinal(column);
-        return reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
-    }
-
-    private static long? GetNullableInt64(SqliteDataReader reader, string column)
-    {
-        var ordinal = reader.GetOrdinal(column);
-        return reader.IsDBNull(ordinal) ? null : reader.GetInt64(ordinal);
-    }
-
-    private static DateTimeOffset ReadTimestamp(SqliteDataReader reader, string column)
-    {
-        var ordinal = reader.GetOrdinal(column);
-        return reader.IsDBNull(ordinal) || reader.GetInt64(ordinal) == 0
-            ? DateTimeOffset.UnixEpoch
-            : DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(ordinal));
-    }
-
-    private const string SelectColumns = """
-        SELECT
-            db.id, db.need_download_content, db.bvid, db.avid, db.cid, db.episode_id,
-            db.cover_url, db.page_cover_url, db.zone_id, db.[order], db.main_title,
-            db.name, db.duration, db.video_codec_name, db.resolution, db.audio_codec,
-            db.file_path, db.file_size, db.page, db.version, db.created_at_utc, db.updated_at_utc,
-            dl.gid, dl.download_files, dl.downloaded_files, dl.play_stream_type,
-            dl.download_status, dl.download_content, dl.download_status_title, dl.progress,
-            dl.downloading_file_size, dl.max_speed, dl.speed_display, dl.phase,
-            dl.failure_code, dl.failure_message, dl.failure_transient,
-            dl.downloaded_bytes, dl.total_bytes, dl.bytes_per_second,
-            d.max_speed_display, d.finished_timestamp, d.finished_time
-        FROM download_base db
-        LEFT JOIN downloading dl ON dl.id = db.id
-        LEFT JOIN downloaded d ON d.id = db.id
-        """;
 }

--- a/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
@@ -51,8 +51,7 @@ public sealed class ModuleBoundaryBaselineTests
         ["src/DownKyi.Desktop/ViewModels/ViewMySpaceViewModel.cs"] = 669,
         ["src/DownKyi.Desktop/ViewModels/ViewUserSpaceViewModel.cs"] = 569,
         ["src/DownKyi.Desktop/Views/Settings/ViewNetwork.axaml"] = 608,
-        ["src/DownKyi.Desktop/Views/ViewVideoDetail.axaml"] = 565,
-        ["src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs"] = 928
+        ["src/DownKyi.Desktop/Views/ViewVideoDetail.axaml"] = 565
     };
 
     [Fact]
@@ -250,9 +249,29 @@ public sealed class ModuleBoundaryBaselineTests
         Assert.Equal(
             [
                 "src/DownKyi.Desktop/Services/Migration/LegacyDownloadTaskMapper.cs",
-                "src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs"
+                "src/DownKyi.Infrastructure/Downloads/DownloadTaskRecordMapper.cs"
             ],
             actual.Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void SqliteDownloadStoreCoordinatesDedicatedRecordAndCommandOwners()
+    {
+        var downloadRoot = Path.Combine(RepositoryRoot, "src", "DownKyi.Infrastructure", "Downloads");
+        var storeSource = File.ReadAllText(Path.Combine(downloadRoot, "SqliteDownloadTaskStore.cs"));
+        var mapperSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskRecordMapper.cs"));
+        var readerSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskSqlReader.cs"));
+        var writerSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskSqlWriter.cs"));
+
+        Assert.Contains("DownloadTaskRecordMapper.Read", storeSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlReader.ReadManyAsync", storeSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlWriter", storeSource, StringComparison.Ordinal);
+        Assert.Contains("WriteStateRowAsync", storeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("DownloadTask.Restore", storeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("INSERT INTO downloading", storeSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTask.Restore", mapperSource, StringComparison.Ordinal);
+        Assert.Contains("INSERT INTO download_quarantine", readerSource, StringComparison.Ordinal);
+        Assert.Contains("INSERT INTO downloading", writerSource, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- reduce `SqliteDownloadTaskStore` from 928 to 447 lines
- move Domain row restoration into `DownloadTaskRecordMapper`
- move read/quarantine SQL into `DownloadTaskSqlReader`
- move base/state write SQL and parameter binding into `DownloadTaskSqlWriter`
- retain the Store as the initialization, transaction, conflict, and public query coordinator
- update architecture ratchets, the AI knowledge graph, the maintained audit, and the live plan

## Stable contracts

- no SQLite schema version, table name, column name, index, migration, backup, or transaction behavior change
- no JSON payload, task ID, optimistic version, GID, partial-file map, completed-file set, progress, history cursor, or resume-state change
- all 14 raw SQL literals are byte-content equivalent after line-ending normalization to their pre-extraction versions
- no settings or user-data path change

## Evidence

- strict .NET 10 Release build with `AnalysisMode=All` and warnings as errors: 0 warnings, 0 errors
- full solution tests: 618 passed
- Infrastructure tests: 52 passed
- architecture tests: 181 passed
- oversized production files: 13 -> 12
- `SqliteDownloadTaskStore`: 928 -> 447 lines
- `dotnet format --verify-no-changes`: passed
- vulnerable packages: 0
- deprecated packages: 0
- Gitleaks: 934 candidate files, 0 findings
- `git diff --check`: passed

## Rollback

Revert commit `707cca1`. The extraction changes only source ownership; no data migration or user-data rollback is required.