### PR TITLE
docs(api): refresh authenticated contract audit

### DIFF
--- a/docs/operations/bilibili-api-audit.md
+++ b/docs/operations/bilibili-api-audit.md
@@ -106,7 +106,7 @@ Dynamic media dependencies are not fixed API endpoints: subtitle JSON addresses 
 
 ## Authenticated Read-Only Snapshot
 
-The 2026-07-28 operator run reloaded `BILIBILI_TEST_COOKIE` from `~/.codex/.env` inside an isolated PowerShell process. The value was never printed, persisted, hashed, copied into a fixture, or passed through command-line arguments.
+The latest 2026-07-28 operator run completed at `2026-07-28T10:20:06Z` against commit `9f570f4bf2e4bba75b15b749b9e979567005467e`. It reloaded `BILIBILI_TEST_COOKIE` from `~/.codex/.env` inside an isolated PowerShell process. The value was never printed, persisted, hashed, copied into a fixture, or passed through command-line arguments.
 
 - Navigation hard gate: HTTP 200, Bilibili code 0, `data.isLogin=true`.
 - Contract probes: 14 passed, 0 failed, 0 blocked, 0 indeterminate.

--- a/docs/operations/bilibili-authenticated-api-audit.json
+++ b/docs/operations/bilibili-authenticated-api-audit.json
@@ -1,10 +1,10 @@
 {
   "SchemaVersion": 1,
-  "CapturedAtUtc": "2026-07-28T07:53:15.1255118+00:00",
+  "CapturedAtUtc": "2026-07-28T10:20:06.6530196+00:00",
   "Runtime": "7.6.4",
   "OperatingSystem": "Microsoft Windows 10.0.26200",
   "Architecture": "X64",
-  "Commit": "1a603697df8578d86545fa70614706475b85bc33",
+  "Commit": "9f570f4bf2e4bba75b15b749b9e979567005467e",
   "EnvironmentVariableLoaded": true,
   "NavigationGatePassed": true,
   "Results": [


### PR DESCRIPTION
## Summary
- reload `BILIBILI_TEST_COOKIE` only inside the isolated audit process
- require `/x/web-interface/nav` code 0 and `data.isLogin=true` before probing
- refresh the sanitized authenticated API contract snapshot against commit `9f570f4bf2e4bba75b15b749b9e979567005467e`
- persist only allowlisted contract metadata; no headers, response bodies, query values, cookies, or account identifiers

## Results
- 14 passed, 0 failed, 0 blocked, 0 indeterminate
- 0 contract drift
- `BilibiliApiInventoryArchitectureTests`: 5/5 passed
- Gitleaks 8.30.1: 934 candidate files, 0 findings
- `git diff --check`: passed