### PR TITLE
docs(api): refresh authenticated contract audit

### DIFF
--- a/docs/operations/bilibili-api-audit.md
+++ b/docs/operations/bilibili-api-audit.md
@@ -106,13 +106,14 @@ Dynamic media dependencies are not fixed API endpoints: subtitle JSON addresses 
 
 ## Authenticated Read-Only Snapshot
 
-The latest 2026-07-28 operator run completed at `2026-07-28T10:20:06Z` against commit `9f570f4bf2e4bba75b15b749b9e979567005467e`. It reloaded `BILIBILI_TEST_COOKIE` from `~/.codex/.env` inside an isolated PowerShell process. The value was never printed, persisted, hashed, copied into a fixture, or passed through command-line arguments.
+The latest 2026-07-28 operator run completed at `2026-07-28T11:54:34Z` against commit `11ee968104cfc18ccf8cd842384fd0e86a26f6fb`. It reloaded `BILIBILI_TEST_COOKIE` from `~/.codex/.env` inside an isolated PowerShell process. The value was never printed, persisted, hashed, copied into a fixture, or passed through command-line arguments.
 
 - Navigation hard gate: HTTP 200, Bilibili code 0, `data.isLogin=true`.
 - Contract probes: 14 passed, 0 failed, 0 blocked, 0 indeterminate.
 - Covered workflows: current-account envelope, history, watch later, created and collected favorites, favorite resources and IDs, followers, followings, private follows, block list, following groups and group content.
 - Persisted evidence: only API name/path, HTTP status, Bilibili code, login requirement, structure/field/drift booleans, outcome and sanitized error type.
 - Raw response bodies, request headers, query values and account values were discarded in-process.
+- Secret scan: Gitleaks inspected 939 tracked and non-ignored untracked candidate files and reported zero findings after the sanitized artifact and documentation were updated.
 
 The machine-readable artifact is [`bilibili-authenticated-api-audit.json`](bilibili-authenticated-api-audit.json). It is a sanitized evidence snapshot, not a test fixture and not an authorization token.
 

--- a/docs/operations/bilibili-authenticated-api-audit.json
+++ b/docs/operations/bilibili-authenticated-api-audit.json
@@ -1,10 +1,10 @@
 {
   "SchemaVersion": 1,
-  "CapturedAtUtc": "2026-07-28T10:20:06.6530196+00:00",
+  "CapturedAtUtc": "2026-07-28T11:54:34.7067651+00:00",
   "Runtime": "7.6.4",
   "OperatingSystem": "Microsoft Windows 10.0.26200",
   "Architecture": "X64",
-  "Commit": "9f570f4bf2e4bba75b15b749b9e979567005467e",
+  "Commit": "11ee968104cfc18ccf8cd842384fd0e86a26f6fb",
   "EnvironmentVariableLoaded": true,
   "NavigationGatePassed": true,
   "Results": [

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -2,8 +2,8 @@
 
 Status: active
 Last updated: 2026-07-28
-Current group: Gate 9 large-owner convergence
-Current branch: `refactor/my-space-viewmodel-owner`
+Current group: authenticated API contract refresh before resuming Gate 9
+Current branch: `audit/authenticated-api-refresh-20260728`
 
 This file contains only unfinished or not-yet-integrated work. Completed PR 02-32 items are not restored. Design rationale belongs in `design-docs`; product acceptance belongs in `product-specs`.
 
@@ -29,6 +29,8 @@ The previous `Status: complete` was incorrect.
 - Gate 9 Settings network/aria ownership passed Windows/Linux/macOS quality run `30351528461` and CodeQL run `30351528583`; all seven check-runs had zero annotations. PR #98 was merged into `refactor/pr-30-32-release-hardening` as merge commit `ffa5674`. The 671-line mixed partial became 319-line general network and 355-line aria runtime owners with all 44 public compatibility methods unchanged.
 - Gate 9 network-settings ViewModel ownership passed Windows/Linux/macOS quality run `30352739481` and Analyze/CodeQL run `30352739315`; all seven check-runs had zero annotations. PR #99 was merged into `refactor/pr-30-32-release-hardening` as merge commit `660d223`. The 649-line mixed owner became 384-line navigation/general-command, 275-line aria-command, and 292-line binding-state owners with XAML binding names unchanged.
 - Gate 9 video-settings ViewModel ownership passed Windows/Linux/macOS quality run `30354918725` and CodeQL run `30354918709`; all seven check-runs had zero annotations. PR #100 was merged into `refactor/pr-30-32-release-hardening` as merge commit `e663281`. The 1,020-line mixed owner became 451-line navigation/playback/transcoding, 353-line content/naming-command, and 248-line binding-state owners. The first Windows run exposed a declaration-regex timeout; line-scoped non-backtracking matching and an adversarial regression test fixed it before merge.
+- Gate 9 my-space ViewModel ownership passed Windows/Linux/macOS quality run `30356078414` and CodeQL run `30356078409`; all seven check-runs had zero annotations. PR #101 was merged into `refactor/pr-30-32-release-hardening` as merge commit `11ee968`. The 669-line owner became a 408-line navigation/profile workflow owner and a 265-line service-free binding-state owner without changing typed navigation, cancellation or XAML binding contracts.
+- The authenticated read-only API audit was repeated against `11ee968`; the isolated process reloaded the credential from `~/.codex/.env`, the `/nav` hard gate passed, and all 14 allowlisted probes passed with zero contract drift. Only the sanitized machine-readable artifact and aggregate documentation were updated; Gitleaks inspected 939 candidate files and reported zero findings.
 - `version.txt` remains `1.0.32`; v1.1.0 has not passed its release gate.
 
 No release tag may be created while any release blocker below remains.
@@ -42,7 +44,7 @@ Owner branches: separate responsibility-based large-owner PRs.
 Scope:
 
 - Split hand-written oversized owners by responsibility; do not split generated/protocol files only to satisfy LOC.
-- Current owner: separate the 669-line my-space ViewModel into navigation/profile workflow and service-free binding-state partial owners without changing command/property names, typed back navigation, cancellation, profile/stat projection, settings, or XAML bindings.
+- Next owner after the authenticated audit: separate the oversized add-to-download session coordinator from duplicate policy, draft construction and optional movie-metadata ownership without changing queue admission, settings snapshots, cancellation, completed-record policy, persisted task shape or resume behavior.
 
 Current owner progress, pending PR integration:
 


### PR DESCRIPTION
## Summary
- reload the operator-authorized authenticated cookie only inside the isolated audit process
- refresh the sanitized 14-endpoint read-only contract snapshot against `11ee968`
- record the login gate, zero drift result, and zero-finding secret scan without persisting account data

## Security
- no cookie, request headers, raw response, query values, or account identifiers are persisted
- the machine-readable artifact contains only the allowlisted sanitized schema
- Gitleaks scanned 939 tracked and non-ignored untracked candidate files with zero findings

## Validation
- `/x/web-interface/nav`: HTTP 200, Bilibili code 0, authenticated gate passed
- authenticated contract probes: 14 passed, 0 failed, 0 blocked, 0 indeterminate
- strict Release build: 0 warnings, 0 errors
- tests: 622 passed
- `dotnet format --verify-no-changes`: passed
- vulnerable packages: 0
- deprecated packages: 0
- `git diff --check`: passed