### PR TITLE
refactor(desktop): repair pager ownership and commands

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -102,6 +102,7 @@ flowchart TD
     PersonalMedia["service.personal-media\nPersonalMediaCoordinator.cs"]
     UserSpacePageVms["viewmodel.user-space-pages\nPublication/My-space ViewModels"]
     UserSpacePages["service.user-space-pages\nUserSpacePageCoordinator.cs"]
+    Pager["ui.custom-pager\nCustomPager + focused state/command/layout owners"]
     UserSpaceVm["viewmodel.user-space\nUserSpace + public favorites"]
     VideoVm["viewmodel.video-detail\nsrc/DownKyi.Desktop/ViewModels/ViewVideoDetailViewModel.cs"]
     SettingsVms["viewmodel.settings-pages\nSettings ViewModels"]
@@ -183,16 +184,20 @@ flowchart TD
     LoginVm -->|renders absolute login URI| LoginQrRenderer
     AccountSession -->|calls| BiliApi
     FriendVms -->|loads pages| FriendRelations
+    FriendVms -->|binds paging state| Pager
     FriendRelations -->|calls| BiliApi
     SeasonsSeriesVm -->|loads and queues| SeasonsSeries
+    SeasonsSeriesVm -->|binds paging state| Pager
     SeasonsSeries -->|calls| BiliApi
     FavoritesVms -->|loads snapshots| Favorites
+    FavoritesVms -->|binds paging state| Pager
     Favorites -->|calls| BiliApi
     FavoritesVms -->|queues selected media| DownloadAdd
     PersonalMediaVms -->|loads snapshots| PersonalMedia
     PersonalMedia -->|calls| BiliApi
     PersonalMediaVms -->|queues selected media| DownloadAdd
     UserSpacePageVms -->|loads snapshots| UserSpacePages
+    UserSpacePageVms -->|binds paging state| Pager
     UserSpacePages -->|calls| BiliApi
     UserSpacePageVms -->|queues publications| DownloadAdd
     UserSpaceVm -->|loads profile and public folders| BiliApi
@@ -354,6 +359,39 @@ tests:
   - test.ui-theme
   - test.ui-smoke
   - test.release-packaging
+```
+
+### ui.custom-pager
+
+```yaml
+id: ui.custom-pager
+type: ui
+paths:
+  - src/DownKyi.Desktop/CustomControl/CustomPager.axaml
+  - src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.cs
+  - src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.State.cs
+  - src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.Commands.cs
+  - src/DownKyi.Desktop/CustomControl/PagerLayout.cs
+responsibility: Presents bounded page navigation while separating change-veto workflow, XAML state, parameterless commands, and pure layout calculation.
+inbound:
+  - viewmodel.friend-relations
+  - viewmodel.seasons-series
+  - viewmodel.favorites
+  - viewmodel.user-space-pages
+outbound: []
+contracts:
+  - Constructor state honors the requested current page and clamps it into the available range without raising navigation events.
+  - A later page request publishes `ProposedCurrent` through `CurrentChanging`; a subscriber may veto before current state changes.
+  - Previous, next, first, last, and adjacent-page XAML buttons use parameterless commands because those buttons do not provide command parameters.
+  - Jump input remains parameterized, rejects invalid/zero pages, and clamps values above the final page.
+  - Layout calculation is a framework-free value operation; XAML state and commands remain separate owners below 150 lines.
+hazards:
+  - Using `RequiredParameterCommand` for a button without `CommandParameter` silently drops every click.
+  - Requiring a listener before accepting state changes makes constructor and isolated pager use ignore the requested page.
+tests:
+  - test.custom-pager
+  - test.ui-smoke
+  - test.architecture-boundaries
 ```
 
 ### service.application-lifecycle
@@ -3086,6 +3124,17 @@ test.input-parsing:
     - null input has one explicit exception contract
     - spoofed user-space hosts and malformed paths are rejected
     - parser families remain in focused partial owners below the owner budget
+
+test.custom-pager:
+  paths:
+    - tests/DownKyi.Tests/CustomPagerViewModelTests.cs
+    - tests/DownKyi.Tests/VideoSelectionStateTests.cs
+    - tests/DownKyi.Architecture.Tests/PagerArchitectureTests.cs
+  guards:
+    - constructor and listener-free page changes retain valid state
+    - parameterless XAML buttons execute and vetoed changes do not mutate current page
+    - jump and count boundaries cannot publish an invalid page
+    - state, command, and pure layout owners remain focused and below budget
 
 test.video-selection-state:
   paths:

--- a/docs/design-docs/module-boundary-naming-audit.md
+++ b/docs/design-docs/module-boundary-naming-audit.md
@@ -2,8 +2,8 @@
 
 Status: maintained verified audit
 Last verified: 2026-07-28
-Verification base: `1e265d1d3d610d0b337bc1c3d7910bab3cb5c859` plus the Gate 9 input-parser working tree
-Verification branch: `refactor/parse-entrance-owner`
+Verification base: `dd9a81a36cc3c6276f91e96f7004dbfa766b7aed` plus the Gate 9 pager working tree
+Verification branch: `refactor/custom-pager-owner`
 
 ## 結論
 
@@ -29,7 +29,7 @@ pwsh ./script/audit-module-boundaries.ps1 `
 | `src/DownKyi.Domain` | 11 | 681 |
 | `src/DownKyi.Application` | 30 | 1,143 |
 | `src/DownKyi.Infrastructure` | 27 | 3,760 |
-| `src/DownKyi.Desktop` | 327 | 44,183 |
+| `src/DownKyi.Desktop` | 330 | 43,984 |
 
 `DownKyi` executable 已降為單一 14 行 bootstrap；Desktop 是最大的產品 owner。行數不能單獨證明設計品質，因此後續仍以 project references、runtime type usage 與 architecture tests 判定責任邊界。
 
@@ -47,7 +47,7 @@ pwsh ./script/audit-module-boundaries.ps1 `
 | resolved | service contracts 依賴 ViewModel | 0 interfaces | completed by Gate 8 |
 | resolved | custom collection contract | 0 custom collection references; standard read-only wrappers | completed by Gate 8 |
 | resolved | naming and folder taxonomy inconsistent | 4 endpoint/role-scoped duplicate groups, 0 generic names, 0 file/type mismatches | completed in Gate 9 naming branch |
-| P2 | oversized owners | 4 production files above 500 physical lines | confirmed, decreasing |
+| P2 | oversized owners | 3 production files above 500 physical lines | confirmed, decreasing |
 | resolved | logging owner too broad | contracts in Application; 268-line provider plus dedicated Infrastructure sink/buffer/retention/export owners | completed by Gate 9 PR #94 |
 | P1 | AI knowledge environment incomplete | required root/docs structure and reproducible audit scripts now exist | resolved |
 
@@ -162,7 +162,7 @@ File/type mismatch baseline 已由 4 項降為 0。Bilibili JSON DTO 與 NFO XML
 
 ## Finding 11: 巨檔 owners
 
-2026-07-28 的實際 boundary audit 有 4 個 production files 超過 500 physical lines；`DownloadPipeline`、`DownloadTaskProjectionStore`、`AddToDownloadService`、`ViewMyFavoritesViewModel`、`ViewPublicationViewModel`、`SqliteDownloadTaskStore`、`SettingsManager.Network`、`ViewNetworkViewModel`、`ViewVideoViewModel`、`ViewMySpaceViewModel`、`ViewUserSpaceViewModel`、`ViewMyBangumiFollowViewModel`、`ParseEntrance` 與原 715 行 `ApplicationLogProvider` 已從 allowlist 移除。SQLite Store 從 928 行降為 447 行，交易/初始化協調、Domain row mapping、讀取/quarantine 與 SQL writes 已分成具名 owner，既有 schema/migration/resume tests 保持不變。Settings 的一般 network/downloader/proxy owner 為 319 行，aria RPC/runtime owner 為 355 行；44 個既有 public compatibility methods 的方法級內容相同，且仍讀寫同一個 `ApplicationSettings.Network` schema。Network settings ViewModel 現分為 384 行 navigation/general-command owner、275 行 aria-command owner 與 292 行 binding-state owner；28 個方法與 25 個 command properties 保持等價，XAML binding 名稱未變。Video settings ViewModel 現分為 451 行 navigation/playback/transcoding owner、353 行 directory/content/filename-command owner 與 248 行 binding-state owner；27 個方法、54 個 public members 與 56 個 private fields 保持等價，XAML binding 名稱與同一個 injected `ISettingsStore` ownership 未變。My-space ViewModel 現分為 408 行 navigation/profile workflow owner 與 265 行 service-free binding-state owner；12 個方法、36 個 public members 與 41 個 private fields 保持等價，typed back navigation、cancellation、settings 與 XAML bindings 未變。Add-to-download 現為 275 行 session coordinator、114 行 duplicate policy、206 行 stateless draft factory與 85 行 optional metadata builder；16 個 owner/tag/cancellation tests 固定完成紀錄、設定 snapshot、檔名、內容旗標與 queue admission 契約。User-space ViewModel 現為 412 行 typed-navigation/load/projection workflow owner、161 行 service-free binding-state owner與既有 27 行 favorite-folder owner；20 個 XAML properties 的名稱與生命週期責任由 architecture test 固定。Bangumi-follow ViewModel 現為 435 行 pager/navigation/load/download workflow owner與 103 行 service-free binding-state owner；12 個 XAML properties、pager event ownership、typed back navigation、cancellation、batch projection 與 download coordinator 邊界由 architecture test 固定。輸入解析現由 8 個責任 partial 擁有，所有檔案低於 120 行；確定性矩陣固定 AV/BV、番劇、課程、收藏夾、使用者空間與投稿清單契約，並拒絕偽造 `space.bilibili.com` host。
+2026-07-28 的實際 boundary audit 有 3 個 production files 超過 500 physical lines；`DownloadPipeline`、`DownloadTaskProjectionStore`、`AddToDownloadService`、`ViewMyFavoritesViewModel`、`ViewPublicationViewModel`、`SqliteDownloadTaskStore`、`SettingsManager.Network`、`ViewNetworkViewModel`、`ViewVideoViewModel`、`ViewMySpaceViewModel`、`ViewUserSpaceViewModel`、`ViewMyBangumiFollowViewModel`、`ParseEntrance`、`CustomPagerViewModel` 與原 715 行 `ApplicationLogProvider` 已從 allowlist 移除。SQLite Store 從 928 行降為 447 行，交易/初始化協調、Domain row mapping、讀取/quarantine 與 SQL writes 已分成具名 owner，既有 schema/migration/resume tests 保持不變。Settings 的一般 network/downloader/proxy owner 為 319 行，aria RPC/runtime owner 為 355 行；44 個既有 public compatibility methods 的方法級內容相同，且仍讀寫同一個 `ApplicationSettings.Network` schema。Network settings ViewModel 現分為 384 行 navigation/general-command owner、275 行 aria-command owner 與 292 行 binding-state owner；28 個方法與 25 個 command properties 保持等價，XAML binding 名稱未變。Video settings ViewModel 現分為 451 行 navigation/playback/transcoding owner、353 行 directory/content/filename-command owner 與 248 行 binding-state owner；27 個方法、54 個 public members 與 56 個 private fields 保持等價，XAML binding 名稱與同一個 injected `ISettingsStore` ownership 未變。My-space ViewModel 現分為 408 行 navigation/profile workflow owner 與 265 行 service-free binding-state owner；12 個方法、36 個 public members 與 41 個 private fields 保持等價，typed back navigation、cancellation、settings 與 XAML bindings 未變。Add-to-download 現為 275 行 session coordinator、114 行 duplicate policy、206 行 stateless draft factory與 85 行 optional metadata builder；16 個 owner/tag/cancellation tests 固定完成紀錄、設定 snapshot、檔名、內容旗標與 queue admission 契約。User-space ViewModel 現為 412 行 typed-navigation/load/projection workflow owner、161 行 service-free binding-state owner與既有 27 行 favorite-folder owner；20 個 XAML properties 的名稱與生命週期責任由 architecture test 固定。Bangumi-follow ViewModel 現為 435 行 pager/navigation/load/download workflow owner與 103 行 service-free binding-state owner；12 個 XAML properties、pager event ownership、typed back navigation、cancellation、batch projection 與 download coordinator 邊界由 architecture test 固定。輸入解析現由 8 個責任 partial 擁有，所有檔案低於 120 行；確定性矩陣固定 AV/BV、番劇、課程、收藏夾、使用者空間與投稿清單契約，並拒絕偽造 `space.bilibili.com` host。Pager 現為 103 行 change-veto owner、110 行 XAML state、51 行 command owner與 41 行純 layout value owner；無參數按鈕不再被 `RequiredParameterCommand` 靜默丟棄，建構子也會保留要求的目前頁。
 
 `AriaClient.cs` 1,119 行屬 RPC client 類型，應先確認生成/同步來源，不可只為行數拆分。
 

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -3,7 +3,7 @@
 Status: active
 Last updated: 2026-07-28
 Current group: Gate 9 large-owner convergence
-Current branch: `refactor/search-service-composition`
+Current branch: `refactor/custom-pager-owner`
 
 This file contains only unfinished or not-yet-integrated work. Completed PR 02-32 items are not restored. Design rationale belongs in `design-docs`; product acceptance belongs in `product-specs`.
 
@@ -35,6 +35,7 @@ The previous `Status: complete` was incorrect.
 - Gate 9 user-space ViewModel ownership passed Windows/Linux/macOS quality run `30360515743` and CodeQL run `30360513188`; all seven check-runs had zero annotations. PR #104 was merged into `refactor/pr-30-32-release-hardening` as merge commit `a946242`. The 569-line mixed owner became a 412-line typed-navigation/load/projection workflow owner, a 161-line service-free binding-state owner and the unchanged 27-line favorite-folder owner.
 - Gate 9 bangumi-follow ViewModel ownership passed Windows/Linux/macOS quality run `30364267364` and CodeQL run `30364266723`; all seven check-runs had zero annotations and every platform retained seven assembly-named TRX artifacts. PR #105 was merged into `refactor/pr-30-32-release-hardening` as merge commit `1e265d1`. The 531-line mixed owner became a 435-line pager/navigation/load/download workflow owner and a 103-line service-free binding-state owner. CI also exposed and fixed NLog target-batch rotation overshoot plus solution-level xUnit host/TRX contention before merge.
 - Gate 9 input-parser ownership passed Windows/Linux/macOS quality run `30366101959` and CodeQL run `30366101939`; all seven check-runs had zero annotations and every platform retained seven assembly-named TRX artifacts. PR #106 was merged into `refactor/pr-30-32-release-hardening` as merge commit `152e4a4`. The 586-line mixed parser became eight responsibility partials below 120 lines, with deterministic canonical, sentinel, null and exact-host contracts.
+- Gate 9 search composition passed Windows/Linux/macOS quality run `30367302324` and CodeQL run `30367302508`; all seven check-runs had zero annotations and every platform retained seven assembly-named TRX artifacts. PR #107 was merged into `refactor/pr-30-32-release-hardening` as merge commit `dd9a81a`. MainWindow and Index now share the Host-owned `SearchService`, and an architecture ratchet rejects direct ViewModel construction.
 - `version.txt` remains `1.0.32`; v1.1.0 has not passed its release gate.
 
 No release tag may be created while any release blocker below remains.
@@ -48,12 +49,13 @@ Owner branches: separate responsibility-based large-owner PRs.
 Scope:
 
 - Split hand-written oversized owners by responsibility; do not split generated/protocol files only to satisfy LOC.
-- Current owner: converge both search callers on the Host-owned `SearchService` instead of constructing a second service inside `ViewIndexViewModel`.
+- Current owner: separate the oversized custom pager into change-veto, XAML state, parameterless command and pure layout owners while fixing ignored button clicks and constructor state.
 
 Current owner progress, pending PR integration:
 
-- Host composition registers one singleton and both MainWindow and Index now receive it through constructor injection. The architecture ratchet rejects `new SearchService` inside the Index ViewModel.
-- Strict `AnalysisMode=All` Release build has zero warnings/errors; all 693 tests pass, including Host/XAML smoke. Format, vulnerable/deprecated package audits, boundary audit, `git diff --check`, and 955-candidate Gitleaks checks pass. Remote gates remain before integration.
+- The 506-line owner is now 103-line change-veto coordination, 110-line binding state, 51-line commands and a 41-line framework-free layout value owner.
+- Previous/next/first/last buttons now use parameterless commands matching their XAML; constructor state honors its requested page, listener-free changes work, veto remains effective, and the unused `CountChanged` event plus six empty handlers are removed.
+- Strict `AnalysisMode=All` Release build has zero warnings/errors; all 702 tests pass, including six deterministic pager behaviors, three pager architecture checks, and Host/XAML smoke. Format, vulnerable/deprecated package audits, boundary audit, `git diff --check`, and 960-candidate Gitleaks checks pass. Remote gates remain before integration.
 
 Verification:
 

--- a/src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.Commands.cs
+++ b/src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.Commands.cs
@@ -1,0 +1,51 @@
+using CommunityToolkit.Mvvm.Input;
+
+namespace DownKyi.CustomControl;
+
+internal sealed partial class CustomPagerViewModel
+{
+    private RelayCommand? _previousCommand;
+    private RelayCommand? _firstCommand;
+    private RelayCommand? _previousSecondCommand;
+    private RelayCommand? _previousFirstCommand;
+    private RelayCommand? _nextFirstCommand;
+    private RelayCommand? _nextSecondCommand;
+    private RelayCommand? _lastCommand;
+    private RelayCommand? _nextCommand;
+    private RelayCommand<object>? _jumpCommand;
+
+    public RelayCommand PreviousCommand =>
+        _previousCommand ??= new RelayCommand(() => Current -= 1);
+
+    public RelayCommand FirstCommand =>
+        _firstCommand ??= new RelayCommand(() => Current = 1);
+
+    public RelayCommand PreviousSecondCommand =>
+        _previousSecondCommand ??= new RelayCommand(() => Current -= 2);
+
+    public RelayCommand PreviousFirstCommand =>
+        _previousFirstCommand ??= new RelayCommand(() => Current -= 1);
+
+    public RelayCommand NextFirstCommand =>
+        _nextFirstCommand ??= new RelayCommand(() => Current += 1);
+
+    public RelayCommand NextSecondCommand =>
+        _nextSecondCommand ??= new RelayCommand(() => Current += 2);
+
+    public RelayCommand LastCommand =>
+        _lastCommand ??= new RelayCommand(() => Current = Count);
+
+    public RelayCommand NextCommand =>
+        _nextCommand ??= new RelayCommand(() => Current += 1);
+
+    public RelayCommand<object> JumpCommand =>
+        _jumpCommand ??= RequiredParameterCommand.Create<object>(ExecuteJump);
+
+    private void ExecuteJump(object parameter)
+    {
+        if (parameter is string text && int.TryParse(text, out var page))
+        {
+            Current = page >= _count ? _count : page;
+        }
+    }
+}

--- a/src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.State.cs
+++ b/src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.State.cs
@@ -1,0 +1,110 @@
+namespace DownKyi.CustomControl;
+
+internal sealed partial class CustomPagerViewModel
+{
+    private int _first;
+    private int _previousSecond;
+    private int _previousFirst;
+    private int _nextFirst;
+    private int _nextSecond;
+    private bool _previousVisibility;
+    private bool _firstVisibility;
+    private bool _leftJumpVisibility;
+    private bool _previousSecondVisibility;
+    private bool _previousFirstVisibility;
+    private bool _nextFirstVisibility;
+    private bool _nextSecondVisibility;
+    private bool _rightJumpVisibility;
+    private bool _lastVisibility;
+    private bool _nextVisibility;
+
+    public int First
+    {
+        get => _first;
+        set => SetProperty(ref _first, value);
+    }
+
+    public int PreviousSecond
+    {
+        get => _previousSecond;
+        set => SetProperty(ref _previousSecond, value);
+    }
+
+    public int PreviousFirst
+    {
+        get => _previousFirst;
+        set => SetProperty(ref _previousFirst, value);
+    }
+
+    public int NextFirst
+    {
+        get => _nextFirst;
+        set => SetProperty(ref _nextFirst, value);
+    }
+
+    public int NextSecond
+    {
+        get => _nextSecond;
+        set => SetProperty(ref _nextSecond, value);
+    }
+
+    public bool PreviousVisibility
+    {
+        get => _previousVisibility;
+        set => SetProperty(ref _previousVisibility, value);
+    }
+
+    public bool FirstVisibility
+    {
+        get => _firstVisibility;
+        set => SetProperty(ref _firstVisibility, value);
+    }
+
+    public bool LeftJumpVisibility
+    {
+        get => _leftJumpVisibility;
+        set => SetProperty(ref _leftJumpVisibility, value);
+    }
+
+    public bool PreviousSecondVisibility
+    {
+        get => _previousSecondVisibility;
+        set => SetProperty(ref _previousSecondVisibility, value);
+    }
+
+    public bool PreviousFirstVisibility
+    {
+        get => _previousFirstVisibility;
+        set => SetProperty(ref _previousFirstVisibility, value);
+    }
+
+    public bool NextFirstVisibility
+    {
+        get => _nextFirstVisibility;
+        set => SetProperty(ref _nextFirstVisibility, value);
+    }
+
+    public bool NextSecondVisibility
+    {
+        get => _nextSecondVisibility;
+        set => SetProperty(ref _nextSecondVisibility, value);
+    }
+
+    public bool RightJumpVisibility
+    {
+        get => _rightJumpVisibility;
+        set => SetProperty(ref _rightJumpVisibility, value);
+    }
+
+    public bool LastVisibility
+    {
+        get => _lastVisibility;
+        set => SetProperty(ref _lastVisibility, value);
+    }
+
+    public bool NextVisibility
+    {
+        get => _nextVisibility;
+        set => SetProperty(ref _nextVisibility, value);
+    }
+}

--- a/src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.cs
+++ b/src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.cs
@@ -1,63 +1,34 @@
 using System;
 using System.ComponentModel;
-using Avalonia.Controls;
-using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace DownKyi.CustomControl;
 
-internal class CustomPagerViewModel : INotifyPropertyChanged
+internal sealed partial class CustomPagerViewModel : ObservableObject
 {
+    private int _count;
+    private int _current;
+    private bool? _visibility;
+
     public CustomPagerViewModel(int current, int count)
     {
-        Current = current;
-        Count = count;
-
-        SetView();
+        _count = Math.Max(0, count);
+        _current = _count == 0
+            ? 1
+            : Math.Clamp(current, 1, _count);
+        _visibility = _count > 1;
+        ApplyLayout();
     }
 
-    public event PropertyChangedEventHandler? PropertyChanged;
-
-    // Current修改的回调
     public event EventHandler<CancelEventArgs>? CurrentChanging;
 
     public int ProposedCurrent { get; private set; }
 
-    private bool RequestCurrentChange(int current)
-    {
-        if (CurrentChanging == null)
-        {
-            return false;
-        }
-
-        ProposedCurrent = current;
-        var eventArgs = new CancelEventArgs();
-        CurrentChanging.Invoke(this, eventArgs);
-        return !eventArgs.Cancel;
-    }
-
-    // Count修改的回调
-    public event EventHandler? CountChanged;
-
-    protected virtual void OnCountChanged(int count)
-    {
-        CountChanged?.Invoke(this, EventArgs.Empty);
-    }
-
-    #region 绑定属性
-
-    private bool? _visibility;
-
     public bool? Visibility
     {
         get => _visibility;
-        set
-        {
-            _visibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Visibility)));
-        }
+        set => SetProperty(ref _visibility, value);
     }
-
-    private int _count;
 
     public int Count
     {
@@ -67,440 +38,63 @@ internal class CustomPagerViewModel : INotifyPropertyChanged
             if (value < Current || value < 0)
             {
                 Visibility = false;
-                //throw new Exception("数值不在允许的范围内。");
+                return;
             }
-            else
-            {
-                _count = value;
 
-                Visibility = _count > 1;
-
-                OnCountChanged(_count);
-
-                SetView();
-
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Count)));
-            }
+            _count = value;
+            Visibility = _count > 1;
+            ApplyLayout();
+            OnPropertyChanged();
         }
     }
-
-
-
-
-    private int _current;
 
     public int Current
     {
-        get
+        get => _current;
+        set
         {
-            if (_current < 1)
+            if ((_count > 0 && (value > _count || value < 1))
+                || !RequestCurrentChange(value))
             {
-                _current = 1;
+                return;
             }
 
-            return _current;
-        }
-        set
-        {
-            if (Count > 0 && (value > Count || value < 1))
-            {
-                //throw new Exception("数值不在允许的范围内。");
-            }
-            else
-            {
-                var isSuccess = RequestCurrentChange(value);
-                if (isSuccess)
-                {
-                    _current = value;
-
-                    SetView();
-
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Current)));
-                }
-            }
+            _current = value;
+            ApplyLayout();
+            OnPropertyChanged();
         }
     }
 
-    private int _first;
-
-    public int First
+    private bool RequestCurrentChange(int current)
     {
-        get => _first;
-        set
+        ProposedCurrent = current;
+        if (CurrentChanging == null)
         {
-            _first = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(First)));
+            return true;
         }
+
+        var eventArgs = new CancelEventArgs();
+        CurrentChanging.Invoke(this, eventArgs);
+        return !eventArgs.Cancel;
     }
 
-    private int _previousSecond;
-
-    public int PreviousSecond
+    private void ApplyLayout()
     {
-        get => _previousSecond;
-        set
-        {
-            _previousSecond = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PreviousSecond)));
-        }
-    }
-
-    private int _previousFirst;
-
-    public int PreviousFirst
-    {
-        get => _previousFirst;
-        set
-        {
-            _previousFirst = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PreviousFirst)));
-        }
-    }
-
-    private int _nextFirst;
-
-    public int NextFirst
-    {
-        get => _nextFirst;
-        set
-        {
-            _nextFirst = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NextFirst)));
-        }
-    }
-
-    private int _nextSecond;
-
-    public int NextSecond
-    {
-        get => _nextSecond;
-        set
-        {
-            _nextSecond = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NextSecond)));
-        }
-    }
-
-    // 控制Current左边的控件
-    private bool _previousVisibility;
-
-    public bool PreviousVisibility
-    {
-        get => _previousVisibility;
-        set
-        {
-            _previousVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PreviousVisibility)));
-        }
-    }
-
-    private bool _firstVisibility;
-
-    public bool FirstVisibility
-    {
-        get => _firstVisibility;
-        set
-        {
-            _firstVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(FirstVisibility)));
-        }
-    }
-
-    private bool _leftJumpVisibility;
-
-    public bool LeftJumpVisibility
-    {
-        get => _leftJumpVisibility;
-        set
-        {
-            _leftJumpVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LeftJumpVisibility)));
-        }
-    }
-
-    private bool _previousSecondVisibility;
-
-    public bool PreviousSecondVisibility
-    {
-        get => _previousSecondVisibility;
-        set
-        {
-            _previousSecondVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PreviousSecondVisibility)));
-        }
-    }
-
-    private bool _previousFirstVisibility;
-
-    public bool PreviousFirstVisibility
-    {
-        get => _previousFirstVisibility;
-        set
-        {
-            _previousFirstVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(PreviousFirstVisibility)));
-        }
-    }
-
-    // 控制Current右边的控件
-    private bool _nextFirstVisibility;
-
-    public bool NextFirstVisibility
-    {
-        get => _nextFirstVisibility;
-        set
-        {
-            _nextFirstVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NextFirstVisibility)));
-        }
-    }
-
-    private bool _nextSecondVisibility;
-
-    public bool NextSecondVisibility
-    {
-        get => _nextSecondVisibility;
-        set
-        {
-            _nextSecondVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NextSecondVisibility)));
-        }
-    }
-
-    private bool _rightJumpVisibility;
-
-    public bool RightJumpVisibility
-    {
-        get => _rightJumpVisibility;
-        set
-        {
-            _rightJumpVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(RightJumpVisibility)));
-        }
-    }
-
-    private bool _lastVisibility;
-
-    public bool LastVisibility
-    {
-        get => _lastVisibility;
-        set
-        {
-            _lastVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(LastVisibility)));
-        }
-    }
-
-    private bool _nextVisibility;
-
-    public bool NextVisibility
-    {
-        get => _nextVisibility;
-        set
-        {
-            _nextVisibility = value;
-            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(NextVisibility)));
-        }
-    }
-
-    #endregion
-
-
-    private RelayCommand<object>? _previousCommand;
-
-    public RelayCommand<object> PreviousCommand => _previousCommand ??= RequiredParameterCommand.Create<object>(PreviousExecuted);
-
-    private void PreviousExecuted(object obj)
-    {
-        Current -= 1;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _firstCommand;
-
-    public RelayCommand<object> FirstCommand => _firstCommand ??= RequiredParameterCommand.Create<object>(FirstExecuted);
-
-    private void FirstExecuted(object obj)
-    {
-        Current = 1;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _previousSecondCommand;
-
-    public RelayCommand<object> PreviousSecondCommand => _previousSecondCommand ??= RequiredParameterCommand.Create<object>(
-        PreviousSecondExecuted);
-
-    private void PreviousSecondExecuted(object obj)
-    {
-        Current -= 2;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _previousFirstCommand;
-
-    public RelayCommand<object> PreviousFirstCommand => _previousFirstCommand ??= RequiredParameterCommand.Create<object>(PreviousFirstExecuted);
-
-    private void PreviousFirstExecuted(object obj)
-    {
-        Current -= 1;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _nextFirstCommand;
-
-    public RelayCommand<object> NextFirstCommand => _nextFirstCommand ??= RequiredParameterCommand.Create<object>(NextFirstExecuted);
-
-    private void NextFirstExecuted(object obj)
-    {
-        Current += 1;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _nextSecondCommand;
-
-    public RelayCommand<object> NextSecondCommand => _nextSecondCommand ??= RequiredParameterCommand.Create<object>(NextSecondExecuted);
-
-    private void NextSecondExecuted(object obj)
-    {
-        Current += 2;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _lastCommand;
-
-    public RelayCommand<object> LastCommand => _lastCommand ??= RequiredParameterCommand.Create<object>(LastExecuted);
-
-    private void LastExecuted(object obj)
-    {
-        Current = Count;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _nextCommand;
-
-    public RelayCommand<object> NextCommand => _nextCommand ??= RequiredParameterCommand.Create<object>(NextExecuted);
-
-    private void NextExecuted(object obj)
-    {
-        Current += 1;
-
-        SetView();
-    }
-
-    private RelayCommand<object>? _jumpCommand;
-
-    public RelayCommand<object> JumpCommand => _jumpCommand ??= RequiredParameterCommand.Create<object>(JumpExecuted);
-
-    private void JumpExecuted(object obj)
-    {
-        if (obj is string s && int.TryParse(s, out var i))
-        {
-            Current = (i >= _count) ? _count : i;
-            SetView();
-        }
-    }
-
-    /// <summary>
-    /// 控制显示，暴力实现，以后重构
-    /// </summary>
-    private void SetView()
-    {
-        First = 1;
-        PreviousSecond = Current - 2;
-        PreviousFirst = Current - 1;
-        NextFirst = Current + 1;
-        NextSecond = Current + 2;
-
-        // 控制Current左边的控件
-        if (Current == 1)
-        {
-            PreviousVisibility = false;
-            FirstVisibility = false;
-            LeftJumpVisibility = false;
-            PreviousSecondVisibility = false;
-            PreviousFirstVisibility = false;
-        }
-        else if (Current == 2)
-        {
-            PreviousVisibility = true;
-            FirstVisibility = false;
-            LeftJumpVisibility = false;
-            PreviousSecondVisibility = false;
-            PreviousFirstVisibility = true;
-        }
-        else if (Current == 3)
-        {
-            PreviousVisibility = true;
-            FirstVisibility = false;
-            LeftJumpVisibility = false;
-            PreviousSecondVisibility = true;
-            PreviousFirstVisibility = true;
-        }
-        else if (Current == 4)
-        {
-            PreviousVisibility = true;
-            FirstVisibility = true;
-            LeftJumpVisibility = false;
-            PreviousSecondVisibility = true;
-            PreviousFirstVisibility = true;
-        }
-        else
-        {
-            PreviousVisibility = true;
-            FirstVisibility = true;
-            LeftJumpVisibility = true;
-            PreviousSecondVisibility = true;
-            PreviousFirstVisibility = true;
-        }
-
-        // 控制Current右边的控件
-        if (Current == Count)
-        {
-            NextFirstVisibility = false;
-            NextSecondVisibility = false;
-            RightJumpVisibility = false;
-            LastVisibility = false;
-            NextVisibility = false;
-        }
-        else if (Current == Count - 1)
-        {
-            NextFirstVisibility = true;
-            NextSecondVisibility = false;
-            RightJumpVisibility = false;
-            LastVisibility = false;
-            NextVisibility = true;
-        }
-        else if (Current == Count - 2)
-        {
-            NextFirstVisibility = true;
-            NextSecondVisibility = true;
-            RightJumpVisibility = false;
-            LastVisibility = false;
-            NextVisibility = true;
-        }
-        else if (Current == Count - 3)
-        {
-            NextFirstVisibility = true;
-            NextSecondVisibility = true;
-            RightJumpVisibility = false;
-            LastVisibility = true;
-            NextVisibility = true;
-        }
-        else
-        {
-            NextFirstVisibility = true;
-            NextSecondVisibility = true;
-            RightJumpVisibility = true;
-            LastVisibility = true;
-            NextVisibility = true;
-        }
+        var layout = PagerLayout.Create(_current, _count);
+        First = layout.First;
+        PreviousSecond = layout.PreviousSecond;
+        PreviousFirst = layout.PreviousFirst;
+        NextFirst = layout.NextFirst;
+        NextSecond = layout.NextSecond;
+        PreviousVisibility = layout.PreviousVisibility;
+        FirstVisibility = layout.FirstVisibility;
+        LeftJumpVisibility = layout.LeftJumpVisibility;
+        PreviousSecondVisibility = layout.PreviousSecondVisibility;
+        PreviousFirstVisibility = layout.PreviousFirstVisibility;
+        NextFirstVisibility = layout.NextFirstVisibility;
+        NextSecondVisibility = layout.NextSecondVisibility;
+        RightJumpVisibility = layout.RightJumpVisibility;
+        LastVisibility = layout.LastVisibility;
+        NextVisibility = layout.NextVisibility;
     }
 }

--- a/src/DownKyi.Desktop/CustomControl/PagerLayout.cs
+++ b/src/DownKyi.Desktop/CustomControl/PagerLayout.cs
@@ -1,0 +1,41 @@
+namespace DownKyi.CustomControl;
+
+internal readonly record struct PagerLayout(
+    int First,
+    int PreviousSecond,
+    int PreviousFirst,
+    int NextFirst,
+    int NextSecond,
+    bool PreviousVisibility,
+    bool FirstVisibility,
+    bool LeftJumpVisibility,
+    bool PreviousSecondVisibility,
+    bool PreviousFirstVisibility,
+    bool NextFirstVisibility,
+    bool NextSecondVisibility,
+    bool RightJumpVisibility,
+    bool LastVisibility,
+    bool NextVisibility)
+{
+    public static PagerLayout Create(int current, int count)
+    {
+        var hasPrevious = current > 1;
+        var hasNext = current < count;
+        return new PagerLayout(
+            First: 1,
+            PreviousSecond: current - 2,
+            PreviousFirst: current - 1,
+            NextFirst: current + 1,
+            NextSecond: current + 2,
+            PreviousVisibility: hasPrevious,
+            FirstVisibility: current >= 4,
+            LeftJumpVisibility: current >= 5,
+            PreviousSecondVisibility: current >= 3,
+            PreviousFirstVisibility: hasPrevious,
+            NextFirstVisibility: hasNext,
+            NextSecondVisibility: current <= count - 2,
+            RightJumpVisibility: current <= count - 4,
+            LastVisibility: current <= count - 3,
+            NextVisibility: hasNext);
+    }
+}

--- a/src/DownKyi.Desktop/ViewModels/Friends/ViewFollowerViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Friends/ViewFollowerViewModel.cs
@@ -201,21 +201,15 @@ internal class ViewFollowerViewModel : ViewModelBase
         }
     }
 
-    private void OnCountChangedPager(object? sender, EventArgs e)
-    {
-    }
-
     private void ReplacePager(CustomPagerViewModel pager)
     {
         if (Pager != null)
         {
             Pager.CurrentChanging -= OnCurrentChangedPager;
-            Pager.CountChanged -= OnCountChangedPager;
         }
 
         Pager = pager;
         Pager.CurrentChanging += OnCurrentChangedPager;
-        Pager.CountChanged += OnCountChangedPager;
     }
 
     private void OnCurrentChangedPager(object? sender, CancelEventArgs e)
@@ -290,7 +284,6 @@ internal class ViewFollowerViewModel : ViewModelBase
             if (Pager != null)
             {
                 Pager.CurrentChanging -= OnCurrentChangedPager;
-                Pager.CountChanged -= OnCountChangedPager;
             }
         }
 

--- a/src/DownKyi.Desktop/ViewModels/Friends/ViewFollowingViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Friends/ViewFollowingViewModel.cs
@@ -391,21 +391,15 @@ internal class ViewFollowingViewModel : ViewModelBase
         }
     }
 
-    private void OnCountChangedPager(object? sender, EventArgs e)
-    {
-    }
-
     private void ReplacePager(CustomPagerViewModel pager)
     {
         if (Pager != null)
         {
             Pager.CurrentChanging -= OnCurrentChangedPager;
-            Pager.CountChanged -= OnCountChangedPager;
         }
 
         Pager = pager;
         Pager.CurrentChanging += OnCurrentChangedPager;
-        Pager.CountChanged += OnCountChangedPager;
     }
 
     private void OnCurrentChangedPager(object? sender, CancelEventArgs e)
@@ -464,7 +458,6 @@ internal class ViewFollowingViewModel : ViewModelBase
             if (Pager != null)
             {
                 Pager.CurrentChanging -= OnCurrentChangedPager;
-                Pager.CountChanged -= OnCountChangedPager;
             }
         }
 

--- a/src/DownKyi.Desktop/ViewModels/ViewMyBangumiFollowViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyBangumiFollowViewModel.cs
@@ -56,13 +56,11 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
             if (_pager != null)
             {
                 _pager.CurrentChanging -= OnCurrentChangedPager;
-                _pager.CountChanged -= OnCountChangedPager;
             }
 
             _pager = value;
             OnPropertyChanged(nameof(Pager));
             _pager.CurrentChanging += OnCurrentChangedPager;
-            _pager.CountChanged += OnCountChangedPager;
         }
     }
 
@@ -288,10 +286,6 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
         }
     }
 
-    private void OnCountChangedPager(object? sender, EventArgs e)
-    {
-    }
-
     private void OnCurrentChangedPager(object? sender, CancelEventArgs e)
     {
         if (!IsEnabled)
@@ -426,7 +420,6 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
             if (_pager != null)
             {
                 _pager.CurrentChanging -= OnCurrentChangedPager;
-                _pager.CountChanged -= OnCountChangedPager;
             }
         }
 

--- a/src/DownKyi.Desktop/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyFavoritesViewModel.cs
@@ -166,13 +166,11 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
             if (_pager != null)
             {
                 _pager.CurrentChanging -= OnCurrentChangedPager;
-                _pager.CountChanged -= OnCountChangedPager;
             }
 
             _pager = value;
             OnPropertyChanged(nameof(Pager));
             value.CurrentChanging += OnCurrentChangedPager;
-            value.CountChanged += OnCountChangedPager;
         }
     }
 
@@ -387,10 +385,6 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
         }
     }
 
-    private void OnCountChangedPager(object? sender, EventArgs e)
-    {
-    }
-
     private void OnCurrentChangedPager(object? sender, CancelEventArgs e)
     {
         if (!IsEnabled)
@@ -424,7 +418,6 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
             if (_pager != null)
             {
                 _pager.CurrentChanging -= OnCurrentChangedPager;
-                _pager.CountChanged -= OnCountChangedPager;
             }
         }
 

--- a/src/DownKyi.Desktop/ViewModels/ViewPublicationViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewPublicationViewModel.cs
@@ -124,11 +124,9 @@ namespace DownKyi.ViewModels
                 }
 
                 _pager.CurrentChanging -= OnCurrentChangedPager;
-                _pager.CountChanged -= OnCountChangedPager;
                 _pager = value;
                 OnPropertyChanged(nameof(Pager));
                 _pager.CurrentChanging += OnCurrentChangedPager;
-                _pager.CountChanged += OnCountChangedPager;
             }
         }
 
@@ -180,7 +178,6 @@ namespace DownKyi.ViewModels
             _medias = new RangeObservableCollection<PublicationMedia>();
             _pager = new CustomPagerViewModel(1, 1);
             _pager.CurrentChanging += OnCurrentChangedPager;
-            _pager.CountChanged += OnCountChangedPager;
 
             #endregion
         }
@@ -351,10 +348,6 @@ namespace DownKyi.ViewModels
             }
         }
 
-        private void OnCountChangedPager(object? sender, EventArgs e)
-        {
-        }
-
         private void OnCurrentChangedPager(object? sender, CancelEventArgs e)
         {
             if (!IsEnabled)
@@ -394,7 +387,6 @@ namespace DownKyi.ViewModels
             {
                 CancelOperations();
                 _pager.CurrentChanging -= OnCurrentChangedPager;
-                _pager.CountChanged -= OnCountChangedPager;
             }
 
             base.Dispose(disposing);

--- a/src/DownKyi.Desktop/ViewModels/ViewSeasonsSeriesDetailViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewSeasonsSeriesDetailViewModel.cs
@@ -323,10 +323,6 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
         };
     }
 
-    private void OnCountChangedPager(object? sender, EventArgs e)
-    {
-    }
-
     private void OnCurrentChangedPager(object? sender, CancelEventArgs e)
     {
         if (!IsEnabled)
@@ -346,12 +342,10 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
         if (Pager != null)
         {
             Pager.CurrentChanging -= OnCurrentChangedPager;
-            Pager.CountChanged -= OnCountChangedPager;
         }
 
         Pager = pager;
         Pager.CurrentChanging += OnCurrentChangedPager;
-        Pager.CountChanged += OnCountChangedPager;
     }
 
     public override void OnNavigatedTo(AppNavigationContext navigationContext)
@@ -409,7 +403,6 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
             if (Pager != null)
             {
                 Pager.CurrentChanging -= OnCurrentChangedPager;
-                Pager.CountChanged -= OnCountChangedPager;
             }
         }
 

--- a/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
@@ -52,7 +52,6 @@ public sealed class ModuleBoundaryBaselineTests
     private static readonly Dictionary<string, int> KnownOversizedFiles = new(StringComparer.Ordinal)
     {
         ["DownKyi.Core/Aria2cNet/Client/AriaClient.cs"] = 1137,
-        ["src/DownKyi.Desktop/CustomControl/CustomPagerViewModel.cs"] = 506,
         ["src/DownKyi.Desktop/Views/Settings/ViewNetwork.axaml"] = 608,
         ["src/DownKyi.Desktop/Views/ViewVideoDetail.axaml"] = 565
     };

--- a/tests/DownKyi.Architecture.Tests/PagerArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/PagerArchitectureTests.cs
@@ -1,0 +1,81 @@
+namespace DownKyi.Architecture.Tests;
+
+public sealed class PagerArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string PagerRoot = Path.Combine(
+        RepositoryRoot,
+        "src",
+        "DownKyi.Desktop",
+        "CustomControl");
+
+    [Fact]
+    public void PagerOwnersRemainFocusedAndBelowBudget()
+    {
+        var ownerNames = new[]
+        {
+            "CustomPagerViewModel.cs",
+            "CustomPagerViewModel.State.cs",
+            "CustomPagerViewModel.Commands.cs",
+            "PagerLayout.cs"
+        };
+
+        Assert.All(ownerNames, name =>
+        {
+            var path = Path.Combine(PagerRoot, name);
+            Assert.True(File.Exists(path), $"{name} is missing.");
+            Assert.True(
+                File.ReadAllLines(path).Length <= 150,
+                $"{name} exceeded the 150-line pager-owner budget.");
+        });
+    }
+
+    [Fact]
+    public void ParameterlessPagerButtonsUseParameterlessCommands()
+    {
+        var commandSource = Read("CustomPagerViewModel.Commands.cs");
+        var xamlSource = Read("CustomPager.axaml");
+
+        Assert.Contains("RelayCommand PreviousCommand", commandSource, StringComparison.Ordinal);
+        Assert.Contains("RelayCommand FirstCommand", commandSource, StringComparison.Ordinal);
+        Assert.Contains("RelayCommand NextCommand", commandSource, StringComparison.Ordinal);
+        Assert.Contains("RelayCommand LastCommand", commandSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("RelayCommand<object> PreviousCommand", commandSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("RelayCommand<object> NextCommand", commandSource, StringComparison.Ordinal);
+        Assert.Contains("Command=\"{Binding PreviousCommand}\"", xamlSource, StringComparison.Ordinal);
+        Assert.Contains("Command=\"{Binding NextCommand}\"", xamlSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PagerLayoutRemainsPureAndFrameworkFree()
+    {
+        var source = Read("PagerLayout.cs");
+
+        Assert.Contains("record struct PagerLayout", source, StringComparison.Ordinal);
+        Assert.Contains("PagerLayout Create", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Avalonia", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CommunityToolkit", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("ICommand", source, StringComparison.Ordinal);
+    }
+
+    private static string Read(string fileName)
+    {
+        return File.ReadAllText(Path.Combine(PagerRoot, fileName));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the DownKyi repository root.");
+    }
+}

--- a/tests/DownKyi.Tests/CustomPagerViewModelTests.cs
+++ b/tests/DownKyi.Tests/CustomPagerViewModelTests.cs
@@ -1,0 +1,93 @@
+using System.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using DownKyi.CustomControl;
+
+namespace DownKyi.Tests;
+
+public sealed class CustomPagerViewModelTests
+{
+    [Fact]
+    public void ConstructorHonorsCurrentPageAndBuildsItsLayout()
+    {
+        var pager = new CustomPagerViewModel(5, 10);
+
+        Assert.Equal(5, pager.Current);
+        Assert.Equal(3, pager.PreviousSecond);
+        Assert.Equal(4, pager.PreviousFirst);
+        Assert.Equal(6, pager.NextFirst);
+        Assert.Equal(7, pager.NextSecond);
+        Assert.True(pager.LeftJumpVisibility);
+        Assert.True(pager.RightJumpVisibility);
+    }
+
+    [Fact]
+    public void CurrentCanChangeBeforeAListenerIsAttached()
+    {
+        var pager = new CustomPagerViewModel(1, 3);
+
+        pager.Current = 2;
+
+        Assert.Equal(2, pager.Current);
+        Assert.Equal(2, pager.ProposedCurrent);
+    }
+
+    [Fact]
+    public void NavigationButtonsExecuteWithoutCommandParameters()
+    {
+        var pager = new CustomPagerViewModel(3, 10);
+
+        Execute(pager.PreviousCommand);
+        Assert.Equal(2, pager.Current);
+
+        Execute(pager.FirstCommand);
+        Assert.Equal(1, pager.Current);
+
+        Execute(pager.NextCommand);
+        Execute(pager.NextSecondCommand);
+        Assert.Equal(4, pager.Current);
+
+        Execute(pager.LastCommand);
+        Assert.Equal(10, pager.Current);
+    }
+
+    [Fact]
+    public void CurrentChangingCanVetoACommand()
+    {
+        var pager = new CustomPagerViewModel(2, 4);
+        pager.CurrentChanging += (_, args) => args.Cancel = true;
+
+        Execute(pager.NextCommand);
+
+        Assert.Equal(2, pager.Current);
+        Assert.Equal(3, pager.ProposedCurrent);
+    }
+
+    [Fact]
+    public void JumpClampsToTheLastPageAndRejectsZero()
+    {
+        var pager = new CustomPagerViewModel(2, 6);
+
+        pager.JumpCommand.Execute("99");
+        Assert.Equal(6, pager.Current);
+
+        pager.JumpCommand.Execute("0");
+        Assert.Equal(6, pager.Current);
+    }
+
+    [Fact]
+    public void CountBelowCurrentHidesPagerWithoutPublishingAnInvalidRange()
+    {
+        var pager = new CustomPagerViewModel(3, 5);
+
+        pager.Count = 2;
+
+        Assert.Equal(5, pager.Count);
+        Assert.Equal(3, pager.Current);
+        Assert.False(pager.Visibility);
+    }
+
+    private static void Execute(RelayCommand command)
+    {
+        command.Execute(null);
+    }
+}

--- a/tests/DownKyi.Tests/VideoSelectionStateTests.cs
+++ b/tests/DownKyi.Tests/VideoSelectionStateTests.cs
@@ -9,27 +9,23 @@ namespace DownKyi.Tests;
 public sealed class VideoSelectionStateTests
 {
     [Fact]
-    public void PagerEventsPreserveVetoAndCountSemantics()
+    public void PagerEventPreservesVetoSemantics()
     {
         var pager = new CustomPagerViewModel(1, 3);
         CancelEventArgs? changing = null;
-        var countChanged = false;
 
         pager.CurrentChanging += (_, e) =>
         {
             changing = e;
             e.Cancel = true;
         };
-        pager.CountChanged += (_, _) => countChanged = true;
 
         pager.Current = 2;
-        pager.Count = 4;
 
         Assert.NotNull(changing);
         Assert.True(changing.Cancel);
         Assert.Equal(2, pager.ProposedCurrent);
         Assert.Equal(1, pager.Current);
-        Assert.True(countChanged);
     }
 
     [Fact]


### PR DESCRIPTION
## Goal
Split the oversized pager owner and fix page controls whose commands were silently ignored.

## Scope
- separate change-veto coordination, XAML state, parameterless commands, and pure layout calculation
- use parameterless commands for buttons that provide no XAML command parameter
- honor the constructor current page and allow valid state changes before listeners attach
- retain `CurrentChanging` veto behavior and remove the unused `CountChanged` event plus six empty handlers
- remove the 506-line owner from the oversized baseline
- update the module audit, live plan, and AI knowledge graph

## Stable contracts
- XAML binding property names are unchanged
- valid page changes still publish `ProposedCurrent` before mutation and can be vetoed
- jump input remains parameterized and bounded
- no persistence, settings, download, API, or user-data changes

## Local verification
- strict `AnalysisMode=All` Release build: 0 warnings, 0 errors
- 7 test projects / 702 tests passed, including Host/XAML smoke
- format, vulnerable/deprecated package audits, boundary audit, Gitleaks, and `git diff --check` passed
- oversized production inventory decreased from 4 files to 3

## Rollback
Revert commit `e358b93`; no durable data migration is involved.