### PR TITLE
Unify lifecycle proof and phase error schema

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2383,6 +2383,7 @@ contracts:
   - Formal local Verification runs the ownership audit and five iterations per assembly with timeout forensics validated.
   - PR, main and release profiles run 3, 50 and 100 iterations per assembly; release evidence must never drop below 50.
   - Every report identifies runtime, OS, architecture, commit SHA, dirty-worktree state, thresholds, phase exit codes, slow-evidence status and P50/P95/P99/max durations.
+  - Every phase exposes general failure/error type; slow-evidence error type is reserved for the diagnostic capture path.
   - Execution duration includes runner startup through OS process exit; teardown uses fixture marker timestamps, while process-exit uses the child's OS ExitTime and excludes collector overhead.
   - Marker-aware execution phases are sampled at the unchanged slow threshold; missing slow evidence is a gate failure rather than an unexplained empty array.
   - Lifecycle marker reads tolerate bounded writer contention and report contention/retry-exhaustion counts; only Windows sharing/lock error codes are contention, while access and other I/O errors retain a separate count/type; the final marker contract remains blocking.
@@ -2390,6 +2391,7 @@ contracts:
   - Unexpected stdout/stderr, timeout, residual child process, missing teardown marker or failed process exit blocks the gate.
   - Slow and timed-out Windows processes preserve thread state, wait reason, process tree and a managed stack when `dotnet-stack` is available.
   - `ValidateForensics` proves both marker-aware managed-stack capture and exclusive marker-lock recovery; formal Windows profiles fail closed unless the detailed self-test reports execution, positive contention count, recovery, parsing, null error and success, and mutation checks reject inconsistent nominally-passed states.
+  - Marker self-test phase status, report summary and formal gate consume one complete proof result rather than re-expanding equivalent predicates.
   - Every scanned lifecycle mechanism maps to a declared owner with explicit start, stop and teardown behavior.
 hazards:
   - A green rerun can hide a race and does not replace owner identification or deterministic teardown.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -43,6 +43,10 @@ Formal Windows PR, Main, Rehearsal and Flaky lifecycle profiles require
 mutation checks must also pass. Missing, null, unknown or non-contending proofs
 fail closed; the top-level
 `markerReaderSelfTestPassed` value is only a summary.
+The marker self-test phase, summary and final formal contract must consume the
+single `markerReaderSelfTestComplete` result; do not re-expand the predicate.
+General lifecycle failures belong in phase `failureType` / `errorType`, while
+`slowEvidenceErrorType` is only for slow-evidence collection.
 
 Only Windows sharing/lock error codes count as marker contention.
 `UnauthorizedAccessException` and other I/O errors remain separately visible

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -132,6 +132,10 @@ history, not repeated here.
   error-bearing, zero-contention and incomplete nominally-passed states.
   Unauthorized access and non-sharing I/O now remain marker read errors instead
   of being mislabeled as contention.
+- The final consistency review removed the duplicate formal predicate: marker
+  phase, summary and gate now consume one complete proof result. Phase schema
+  now has general `failureType` / `errorType`, so marker contract failures no
+  longer masquerade as slow-evidence capture errors.
 
 ## Gate 10 Checklist
 

--- a/docs/testing/assembly-lifecycle-stability.md
+++ b/docs/testing/assembly-lifecycle-stability.md
@@ -52,6 +52,9 @@ each phase in an independent child process:
 Every phase records its exit code, duration, timeout state, stdout/stderr
 protocol state, residual child count and evidence paths. The report aggregates
 P50, P95, P99 and maximum duration per assembly and phase.
+Every phase result also has general `failureType` and `errorType` fields.
+`slowEvidenceErrorType` is reserved for failures inside slow-evidence capture
+and must not carry unrelated self-test or lifecycle contract failures.
 
 ### Measurement Definitions
 
@@ -183,7 +186,8 @@ Schema 2 records the marker-reader proof as a fail-closed object:
 The top-level `markerReaderSelfTestPassed` field is only a summary. Windows PR,
 Main, Rehearsal and Flaky profiles require `-ValidateForensics`; missing,
 skipped, unknown, non-contending or failed self-tests block the gate.
-The self-test phase and final report use the same complete proof predicate,
+The self-test phase, top-level summary and final report use the same
+`markerReaderSelfTestComplete` result,
 including `contentionCount > 0` and `errorType == null`. Mutation checks prove
 that a nominal `passed = true` cannot override an error, zero contention or an
 incomplete proof.

--- a/script/test-assembly-lifecycle.ps1
+++ b/script/test-assembly-lifecycle.ps1
@@ -705,12 +705,32 @@ function New-ProcessPhaseResult {
         $stderrClean -and
         $slowEvidenceComplete -and
         $unexpectedText.Count -eq 0
+    $failureType = if ($success) {
+        $null
+    }
+    elseif ($ProcessResult.timedOut) {
+        "Timeout"
+    }
+    elseif (-not $slowEvidenceComplete) {
+        "SlowEvidenceMissing"
+    }
+    elseif ($ProcessResult.residualChildren.Count -gt 0) {
+        "ResidualChildProcess"
+    }
+    elseif (-not $protocolValid -or -not $stderrClean -or $unexpectedText.Count -gt 0) {
+        "OutputContractViolation"
+    }
+    else {
+        "ProcessPhaseFailed"
+    }
     return [pscustomobject]@{
         assembly = $ProcessResult.assembly
         iteration = $ProcessResult.iteration
         phase = $ProcessResult.phase
         processId = $ProcessResult.processId
         success = $success
+        failureType = $failureType
+        errorType = $ProcessResult.slowEvidenceErrorType
         exitCode = $ProcessResult.exitCode
         durationMs = $ProcessResult.durationMs
         timedOut = $ProcessResult.timedOut
@@ -887,6 +907,8 @@ if ($ValidateForensics) {
         phase = "forensics-self-test"
         processId = $selfTest.processId
         success = $forensicsValid
+        failureType = if ($forensicsValid) { $null } else { "ForensicsSelfTestFailed" }
+        errorType = $selfTestPhase.errorType
         exitCode = if ($forensicsValid) { 0 } else { 1 }
         durationMs = $selfTest.durationMs
         timedOut = $selfTest.timedOut
@@ -1046,6 +1068,13 @@ if ($ValidateForensics) {
             phase = "marker-reader-self-test"
             processId = $PID
             success = $markerReaderSelfTestComplete
+            failureType = if ($markerReaderSelfTestComplete) {
+                $null
+            }
+            else {
+                "MarkerReaderSelfTestFailed"
+            }
+            errorType = $markerReaderSelfTestFailureType
             exitCode = if ($markerReaderSelfTestComplete) { 0 } else { 1 }
             durationMs = [Math]::Round(
                 $markerReaderSelfTestStopwatch.Elapsed.TotalMilliseconds,
@@ -1064,7 +1093,7 @@ if ($ValidateForensics) {
             diagnosticCaptureDurationMs = 0.0
             slowThresholdExceeded = $false
             slowEvidenceStatus = "not-applicable"
-            slowEvidenceErrorType = $markerReaderSelfTestFailureType
+            slowEvidenceErrorType = $null
         }
 
         $script:markerReadContentionCount = 0
@@ -1163,6 +1192,16 @@ foreach ($testProject in $testProjects) {
             iteration = $iteration
             phase = "assembly-teardown"
             success = $markerValid -and $testRootRemoved
+            failureType = if ($markerValid -and $testRootRemoved) {
+                $null
+            }
+            elseif (-not $markerValid) {
+                "TeardownMarkerInvalid"
+            }
+            else {
+                "TestDataCleanupFailed"
+            }
+            errorType = $null
             exitCode = if ($markerValid -and $testRootRemoved) { 0 } else { 1 }
             durationMs = $teardownDuration
             timedOut = $false
@@ -1190,6 +1229,8 @@ foreach ($testProject in $testProjects) {
             iteration = $iteration
             phase = "process-exit"
             success = $exitSucceeded
+            failureType = if ($exitSucceeded) { $null } else { "ProcessExitFailed" }
+            errorType = $null
             exitCode = if ($exitSucceeded) { 0 } else { 1 }
             durationMs = [Math]::Round($exitDuration, 3)
             timedOut = $execution.timedOut
@@ -1221,15 +1262,7 @@ $slowEvidenceCapturedCount = @(
 $slowEvidenceMissingCount = $slowResults.Count - $slowEvidenceCapturedCount
 $markerReaderSelfTestContractPassed =
     -not $markerReaderSelfTest.required -or
-    ($markerReaderSelfTest.executed -and
-        $markerReaderSelfTest.passed -and
-        $markerReaderSelfTest.contentionObserved -and
-        $markerReaderSelfTest.contentionCount -gt 0 -and
-        $markerReaderSelfTest.recoveredAfterLockRelease -and
-        $markerReaderSelfTest.markerParsedAfterRecovery -and
-        $null -eq $markerReaderSelfTest.errorType -and
-        $markerReaderSelfTest.contractChecks.executed -and
-        $markerReaderSelfTest.contractChecks.passed)
+    $markerReaderSelfTestComplete
 $diagnosticCaptureTotalMs = [Math]::Round(
     [double](
         $phaseResults |
@@ -1365,6 +1398,7 @@ else {
             "timeout=$($failure.timedOut), stdoutPolluted=$($failure.stdoutPolluted), " +
             "stderrPolluted=$($failure.stderrPolluted), " +
             "residualChildren=$($failure.residualChildCount), " +
+            "failureType=$($failure.failureType), errorType=$($failure.errorType), " +
             "slowEvidence=$($failure.slowEvidenceStatus)")
     }
 }

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -50,6 +50,8 @@ public sealed class AssemblyLifecycleArchitectureTests
             "stdoutPolluted",
             "stderrPolluted",
             "residualChildCount",
+            "failureType",
+            "errorType",
             "workingTreeDirty",
             "slowEvidenceStatus",
             "slowEvidenceComplete",
@@ -94,9 +96,10 @@ public sealed class AssemblyLifecycleArchitectureTests
             "markerParsedAfterRecovery = $false",
             "errorType = $null",
             "$markerReaderSelfTestContractPassed",
-            "$markerReaderSelfTest.contentionCount -gt 0",
-            "$null -eq $markerReaderSelfTest.errorType",
+            "$SelfTest.contentionCount -gt 0",
+            "$null -eq $SelfTest.errorType",
             "success = $markerReaderSelfTestComplete",
+            "errorType = $markerReaderSelfTestFailureType",
             "validProofAccepted",
             "errorTypeRejected",
             "zeroContentionRejected",
@@ -111,6 +114,18 @@ public sealed class AssemblyLifecycleArchitectureTests
         {
             Assert.Contains(token, source, StringComparison.Ordinal);
         }
+
+        Assert.Contains(
+            "-not $markerReaderSelfTest.required -or",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "($markerReaderSelfTest.executed -and",
+            source,
+            StringComparison.Ordinal);
+        Assert.True(
+            source.Split("failureType =", StringSplitOptions.None).Length - 1 >= 5,
+            "Every synthetic and process phase family must expose failureType.");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- make the formal marker contract consume the same `markerReaderSelfTestComplete` result as the self-test phase and top-level summary
- keep the detailed field requirements in the single `Test-MarkerReaderSelfTestProof` predicate
- add general `failureType` and `errorType` fields to every process and synthetic lifecycle phase
- reserve `slowEvidenceErrorType` for failures in slow-evidence capture
- report marker-reader contract failures as ordinary phase failures instead of slow-evidence failures
- update architecture constraints, lifecycle testing policy, maintenance guidance, live plan, and AI knowledge graph

## Why

The previous behavior was correct, but the final formal contract re-expanded the same conditions already represented by `markerReaderSelfTestComplete`. That left a future drift path despite the PR description promising one complete result. The marker self-test also stored its ordinary contract failure under `slowEvidenceErrorType`, which gave the field the wrong meaning.

## Verification

- strict targeted Release build with all analyzers/warnings as errors: 0 warnings, 0 errors
- complete solution tests: 729 passed
- all seven assemblies x five Main-profile iterations: 212 phase results, 0 failures, 0 slow phases, 0 missing evidence
- every phase result contains `failureType` and `errorType`
- marker self-test phase/summary/formal gate all consume `markerReaderSelfTestComplete`
- marker self-test `slowEvidenceErrorType` is null on success
- marker proof and mutation checks remain true
- runtime marker errors and retry exhaustion: 0
- format and `git diff --check`: passed