### PR TITLE
fix(ci): preserve residual lifecycle child evidence

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2392,9 +2392,11 @@ contracts:
   - Diagnostic capture wall time is reported separately because managed-stack collection perturbs the instrumented phase; slow execution evidence cannot be presented as post-teardown exit evidence.
   - Unexpected stdout/stderr, timeout, residual child process, missing teardown marker or failed process exit blocks the gate.
   - Slow and timed-out Windows processes preserve thread state, wait reason, process tree and a managed stack when `dotnet-stack` is available.
+  - Residual children preserve PID, parent PID, process name, creation time, tree depth and a redacted command line in the phase result plus `residual-children.json`; live managed children also receive thread/tree/stack evidence.
+  - Residual evidence never changes failure into success and does not add a grace period. `ValidateForensics` creates a synthetic residual process tree and fails unless identity, manifest, `ResidualChildProcess` classification and PID-plus-creation-time cleanup all succeed.
   - `ValidateForensics` proves both marker-aware managed-stack capture and exclusive marker-lock recovery; formal Windows profiles fail closed unless the detailed self-test reports execution, positive contention count, recovery, parsing, null error and success, and mutation checks reject inconsistent nominally-passed states.
   - Marker self-test phase status, report summary and formal gate consume one complete proof result rather than re-expanding equivalent predicates.
-  - Every scanned lifecycle mechanism maps to a declared owner with explicit start, stop and teardown behavior.
+  - Every scanned lifecycle mechanism, including external process creation, maps to a declared owner with explicit start, stop and teardown behavior.
 hazards:
   - A green rerun can hide a race and does not replace owner identification or deterministic teardown.
   - Comparing timing from different runner metadata creates invalid performance conclusions.
@@ -3154,6 +3156,7 @@ test.assembly-lifecycle-architecture:
   guards:
     - every test assembly receives async fixture-owned data isolation without ModuleInitializer or ProcessExit cleanup
     - the lifecycle gate retains all six process phases, timing statistics, output-pollution checks and timeout forensics
+    - residual-child failures retain sanitized identity and evidence, stay fail-closed, and execute a deterministic observation/classification/cleanup self-test
     - PR, main and release workflows cannot drop their lifecycle profiles or managed-stack diagnostics
     - formal Verification cannot omit the ownership audit, five-iteration local gate or Rehearsal report
     - Desktop main-loop teardown awaits async App and Host disposal

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -62,6 +62,16 @@ Only Windows sharing/lock error codes count as marker contention.
 `UnauthorizedAccessException` and other I/O errors remain separately visible
 as `markerReadErrorCount` and `markerReadErrorType`.
 
+Residual-child failures are independently fail-closed. Every failed phase must
+preserve a sanitized `residualChildren` identity list plus a
+`residual-children.json` manifest; live managed children also receive thread,
+tree and managed-stack evidence. `-ValidateForensics` must prove this path by
+creating a controlled residual child, observing its identity, writing evidence,
+classifying the phase as `ResidualChildProcess` and cleaning the synthetic tree
+by PID plus creation time. It must also prove path, URL, cookie and secret
+redaction. `residualChildSelfTestPassed` is only the summary;
+the detailed `residualChildSelfTest` fields are the contract.
+
 PR #116 merged the final lifecycle proof consistency fix into `main` at
 `6a61247`. Strict PR CI `30450175286` and CodeQL `30450175415` passed. Its
 Main profile report contains 2,102 phase results across seven assemblies and
@@ -70,6 +80,21 @@ read errors. Teardown max is 7 ms and OS process-exit max is 187 ms; all 14
 slow execution phases retained evidence. This report validates the corrected
 lifecycle owner and gate, but the final versioned release commit must still
 pass its own Main profile and the 100-iteration Rehearsal profile.
+
+The first v1.1.1 Rehearsal run `30455540672` correctly blocked packaging after
+`DownKyi.Tests` assembly-info iteration 78 observed one residual child. The
+historical report retained only `residualChildCount=1`, so that runner's exact
+child identity cannot be recovered after the hosted VM was destroyed. The
+phase did not execute tests, Host, Dispatcher or application services; its
+stdout was valid xUnit metadata, stderr was empty and exit code was zero.
+Five hundred local repetitions of the same
+`dotnet DownKyi.Tests.dll -assemblyInfo` command observed no residual child,
+excluding a deterministic
+application owner but not the low-probability runner race. The corrected gate
+therefore preserves identity and evidence on every future observation and
+dynamically self-tests the full residual-child failure path. A new Main profile
+and complete Rehearsal remain mandatory; the failed run is not replaced by a
+blind rerun.
 
 Pull requests are guarded by `.github/workflows/quality.yml`:
 

--- a/docs/product-specs/v1.1.1-corrective-release-gate.md
+++ b/docs/product-specs/v1.1.1-corrective-release-gate.md
@@ -21,6 +21,10 @@ fix is not release evidence.
 - The marker-reader self-test must execute, create positive lock contention,
   recover after release, parse the marker, report no error and pass all
   mutation checks. Missing or inconsistent proof fails closed.
+- The residual-child self-test must create an actual child that outlives its
+  parent, preserve sanitized identity and a manifest, classify the phase as
+  `ResidualChildProcess`, and clean the synthetic tree by PID plus creation
+  time. Any real residual child remains a release blocker.
 - Slow execution evidence, teardown timing and OS process-exit timing remain
   separate. The five-second slow threshold must not be relaxed.
 

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -3,7 +3,7 @@
 Status: active
 Last updated: 2026-07-29
 Current group: Gate 10 Windows lifecycle blocker and corrective release
-Current branch: `release/v1.1.1-corrective`
+Current branch: `fix/lifecycle-residual-child-evidence`
 
 This file contains only unfinished or not-yet-integrated work. Completed Gate
 1-9 detail is retained in `docs/maintenance.md`, design documents and Git
@@ -160,6 +160,33 @@ history, not repeated here.
   error, teardown is at most 2 ms and OS process exit is at most 145 ms. This
   dirty-worktree report validates the candidate locally but is not release
   evidence.
+- PR #117 merged the v1.1.1 corrective candidate into `main` at `c251a4f`.
+  Strict PR CI `30453512364`, CodeQL `30453517140` and the exact-commit Main
+  lifecycle run `30453933568` passed. The Main report contains 2,102 phases,
+  zero failures, four captured slow phases, zero missing evidence, teardown at
+  no more than 3 ms and OS process exit at no more than 24 ms.
+- The first v1.1.1 Rehearsal `30455540672` correctly stopped before packaging.
+  `DownKyi.Tests` assembly-info iteration 78 exited zero with valid xUnit JSON
+  and empty stderr, but the post-exit scan observed one residual child. Schema 2
+  stored only the count, so the hosted runner's exact child identity is
+  unrecoverable. No test, Host, Dispatcher or application service executes in
+  this phase.
+- The same assembly-info command completed 500 isolated local repetitions with
+  zero residual children. This excludes a deterministic application owner but
+  does not erase the low-probability runner race. The corrective gate now
+  preserves sanitized child identity and a residual evidence manifest, captures
+  live managed children, and dynamically proves observation, classification and
+  PID-plus-creation-time cleanup with a synthetic residual process tree.
+- The residual-evidence candidate passes strict `AnalysisMode=All` build with
+  zero warnings/errors and all 731 tests. Formal local lifecycle Verification
+  covers 213 phases with zero failures, zero real residual children, five slow
+  phases with five captures and zero missing evidence. Residual-child,
+  redaction, capture-lead and marker-reader self-tests all pass; teardown is at
+  most 3 ms and OS process exit at most 14 ms. Ownership now includes external
+  process creation with 452 matches and zero violations. Format, module
+  boundaries, vulnerable/deprecated dependency audits, Gitleaks and diff checks
+  pass. This dirty-worktree result is candidate evidence, not Main or release
+  evidence.
 
 ## Gate 10 Checklist
 
@@ -204,6 +231,13 @@ history, not repeated here.
 - [x] Repeat Windows assembly-info and Desktop/full-solution tests enough to
       make the original race observable if it remains.
 - [x] Pass a new strict PR quality run on the corrected lifecycle commit.
+- [x] Merge v1.1.1 PR #117 and pass its exact-commit Main 50 lifecycle profile.
+- [x] Preserve the failed Rehearsal evidence and classify the remaining gap as
+      missing residual-child identity, not a passing rerun.
+- [x] Repeat the exact failing assembly-info command 500 times without observing
+      a deterministic residual owner.
+- [ ] Merge the residual-child identity, evidence and dynamic self-test fix.
+- [ ] Pass a new exact-commit Main 50 lifecycle profile after that fix.
 - [ ] Pass the complete manual release rehearsal on the final versioned
       candidate commit.
 - [ ] Keep `v1.1.0` immutable. Document the withdrawn draft and publish a

--- a/docs/testing/assembly-lifecycle-owners.json
+++ b/docs/testing/assembly-lifecycle-owners.json
@@ -44,6 +44,7 @@
       "teardown": "Assembly fixture cleanup completes before the process is allowed to exit.",
       "allowedMechanisms": [
         "static_initialization",
+        "external_process",
         "task_run",
         "dispatcher",
         "timer",
@@ -79,6 +80,7 @@
       "teardown": "No process-wide event handler may substitute for fixture cleanup.",
       "allowedMechanisms": [
         "static_initialization",
+        "external_process",
         "task_run",
         "dispatcher",
         "timer",
@@ -140,6 +142,7 @@
       "teardown": "Long-running work must accept cancellation and be awaited by its owner.",
       "allowedMechanisms": [
         "static_initialization",
+        "external_process",
         "task_run",
         "dispatcher",
         "timer",
@@ -193,6 +196,7 @@
       "teardown": "Cancellation and bounded process termination prevent orphaned aria2 children.",
       "allowedMechanisms": [
         "static_initialization",
+        "external_process",
         "task_run",
         "timer",
         "host_lifecycle",
@@ -210,6 +214,7 @@
       "teardown": "External process, stream and file owners must expose deterministic cleanup.",
       "allowedMechanisms": [
         "static_initialization",
+        "external_process",
         "task_run",
         "timer",
         "host_lifecycle",
@@ -265,11 +270,12 @@
         "tools/DownKyi.AssemblyLifecycleProbe/**"
       ],
       "owner": "Assembly lifecycle gate child process",
-      "start": "The probe creates one collectible AssemblyLoadContext.",
-      "stop": "The probe unloads it and performs bounded garbage collection checks.",
-      "teardown": "A retained context fails the load phase.",
+      "start": "The probe creates one collectible AssemblyLoadContext or, only for the forensics self-test, one bounded residual child.",
+      "stop": "The probe unloads the context; the lifecycle gate identifies and stops the synthetic residual tree.",
+      "teardown": "A retained context fails the load phase. Residual-child self-test cleanup matches PID and creation time, kills the synthetic tree and performs a bounded wait.",
       "allowedMechanisms": [
         "static_initialization",
+        "external_process",
         "bounded_sleep"
       ]
     }

--- a/docs/testing/assembly-lifecycle-stability.md
+++ b/docs/testing/assembly-lifecycle-stability.md
@@ -50,8 +50,11 @@ each phase in an independent child process:
    deadline without residual children or runner-protocol pollution.
 
 Every phase records its exit code, duration, timeout state, stdout/stderr
-protocol state, residual child count and evidence paths. The report aggregates
-P50, P95, P99 and maximum duration per assembly and phase.
+protocol state, residual child count, sanitized child identity and evidence
+paths. Residual identity includes PID, parent PID, process name, creation time,
+tree depth and a command line with repository, user-profile, temporary, URL and
+credential values redacted. The report aggregates P50, P95, P99 and maximum
+duration per assembly and phase.
 Every phase result also has general `failureType` and `errorType` fields.
 `slowEvidenceErrorType` is reserved for failures inside slow-evidence capture
 and must not carry unrelated self-test or lifecycle contract failures.
@@ -112,6 +115,7 @@ tool sources for:
 
 - module initializers and process-exit handlers;
 - static constructors and static field initialization;
+- external process creation;
 - explicit threads, `Task.Run`, dispatchers and timers;
 - global event registration;
 - Generic Host startup and shutdown;
@@ -158,12 +162,28 @@ On Windows, a slow phase or slow post-teardown exit automatically captures:
 - a sanitized process tree containing PID, parent PID and process name;
 - `dotnet-stack report --process-id` output when the tool is available.
 
+Residual children use a separate evidence path. The first observation is always
+written to `residual-children.json`, even when a process exits before deeper
+collection begins. A still-live managed child receives the normal thread,
+process-tree and managed-stack capture; native descendants retain identity and
+thread/process evidence without waiting on an inapplicable managed collector.
+Any observed residual child remains a blocking `ResidualChildProcess`; evidence
+capture never converts it to success and no grace period weakens the contract.
+
 CI installs the pinned Microsoft `dotnet-stack` tool and runs
 `-ValidateForensics`. That self-test deliberately holds a marker-aware
 `execution` probe beyond the slow threshold. It fails unless the same code path
 used by test execution produces evidence and a non-empty managed stack.
 On Windows it also opens a valid marker with exclusive sharing and proves that
 the reader tolerates the temporary lock, then parses the marker after release.
+It additionally launches a deterministic residual `dotnet` child, requires the
+gate to preserve its identity and evidence manifest, requires
+`ResidualChildProcess` classification, and terminates the synthetic process tree
+by matching both PID and creation time. The same self-test proves that private
+paths, URLs, cookies and command-line secrets are redacted. Schema 2 exposes the detailed
+`residualChildSelfTest` object and top-level `residualChildSelfTestPassed`
+summary. Missing execution, identity, evidence, failure classification or
+cleanup fails closed.
 Timeout evidence is saved before the process tree is terminated.
 
 Schema 2 records the marker-reader proof as a fail-closed object:

--- a/script/audit-lifecycle-ownership.ps1
+++ b/script/audit-lifecycle-ownership.ps1
@@ -19,6 +19,7 @@ $rules = [ordered]@{
     module_initializer = '\[ModuleInitializer\]'
     process_exit = '\bProcessExit\b'
     static_initialization = '(?:^\s*static\s+[A-Za-z_][A-Za-z0-9_]*\s*\(|^\s*(?:(?:public|internal|private|protected)\s+)?static\s+(?:readonly\s+)?[^();]+\s+[A-Za-z_][A-Za-z0-9_]*\s*(?:=|;))'
+    external_process = '\b(?:Process\.Start\s*\(|new\s+Process\s*(?:\(\s*\)|\{))'
     new_thread = '\bnew\s+Thread\s*\('
     task_run = '\bTask\.Run\s*\('
     dispatcher = '\bDispatcher(?:\.UIThread|Timer)?\b'

--- a/script/test-assembly-lifecycle.ps1
+++ b/script/test-assembly-lifecycle.ps1
@@ -52,6 +52,20 @@ $forensicsSelfTestCaptureLeadValidated = $false
 $markerReaderSelfTestRequired = $IsWindows -and
     @("PR", "Main", "Rehearsal", "Flaky").Contains($Profile)
 $markerReaderSelfTestComplete = $false
+$residualChildSelfTestComplete = $false
+$residualChildSelfTest = [ordered]@{
+    required = $IsWindows -and $ValidateForensics
+    executed = $false
+    passed = $false
+    childObserved = $false
+    identityCaptured = $false
+    evidenceManifestWritten = $false
+    failureClassified = $false
+    cleanupCompleted = $false
+    redactionValidated = $false
+    observedChildCount = 0
+    errorType = $null
+}
 $markerReaderSelfTest = [ordered]@{
     required = $markerReaderSelfTestRequired
     executed = $false
@@ -110,6 +124,52 @@ function Resolve-DiagnosticsTool {
     return $command.Source
 }
 
+function Protect-ProcessDiagnosticText {
+    param(
+        [AllowNull()]
+        [string]$Value
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return $null
+    }
+
+    $protected = $Value
+    $pathAliases = @(
+        [pscustomobject]@{ path = $repositoryRoot; alias = "<repository>" }
+        [pscustomobject]@{
+            path = [Environment]::GetFolderPath(
+                [Environment+SpecialFolder]::UserProfile)
+            alias = "<user-profile>"
+        }
+        [pscustomobject]@{
+            path = [System.IO.Path]::GetTempPath().TrimEnd(
+                [System.IO.Path]::DirectorySeparatorChar,
+                [System.IO.Path]::AltDirectorySeparatorChar)
+            alias = "<temp>"
+        }
+    )
+    foreach ($pathAlias in $pathAliases) {
+        if (-not [string]::IsNullOrWhiteSpace($pathAlias.path)) {
+            $protected = $protected.Replace(
+                $pathAlias.path,
+                $pathAlias.alias,
+                [StringComparison]::OrdinalIgnoreCase)
+        }
+    }
+
+    $protected = $protected -replace '(?i)https?://\S+', '<url>'
+    $protected = $protected -replace (
+        '(?i)(SESSDATA|bili_jct|DedeUserID|cookie|token|secret)' +
+        '\s*[:=]\s*(?:"[^"]*"|''[^'']*''|[^\s;]+)'),
+        '$1=<redacted>'
+    $protected = $protected -replace (
+        '(?i)(--(?:rpc-)?secret|--?cookie|--?token|SESSDATA|bili_jct|' +
+        'DedeUserID)\s+(?:"[^"]*"|''[^'']*''|\S+)'),
+        '$1 <redacted>'
+    return $protected
+}
+
 function Get-ProcessTree {
     param(
         [Parameter(Mandatory)]
@@ -118,15 +178,23 @@ function Get-ProcessTree {
     )
 
     if ($IsWindows) {
-        $pending = [System.Collections.Generic.Queue[int]]::new()
-        $pending.Enqueue($RootProcessId)
+        $pending = [System.Collections.Generic.Queue[object]]::new()
+        $pending.Enqueue([pscustomobject]@{
+            processId = $RootProcessId
+            depth = 0
+        })
+        $visited = [System.Collections.Generic.HashSet[int]]::new()
         $result = @()
         while ($pending.Count -gt 0) {
             $parent = $pending.Dequeue()
+            if (-not $visited.Add([int]$parent.processId)) {
+                continue
+            }
+
             $children = @(
                 Get-CimInstance `
                     -ClassName Win32_Process `
-                    -Filter "ParentProcessId = $parent" `
+                    -Filter "ParentProcessId = $($parent.processId)" `
                     -ErrorAction SilentlyContinue
             )
             foreach ($child in $children) {
@@ -140,8 +208,22 @@ function Get-ProcessTree {
                     parentProcessId = [int]$child.ParentProcessId
                     name = [string]$child.Name
                     createdAtUtc = $creationTime.ToUniversalTime().ToString("O")
+                    depth = [int]$parent.depth + 1
+                    executableName = if (
+                        [string]::IsNullOrWhiteSpace([string]$child.ExecutablePath)
+                    ) {
+                        $null
+                    }
+                    else {
+                        [System.IO.Path]::GetFileName([string]$child.ExecutablePath)
+                    }
+                    commandLine = Protect-ProcessDiagnosticText `
+                        -Value ([string]$child.CommandLine)
                 }
-                $pending.Enqueue([int]$child.ProcessId)
+                $pending.Enqueue([pscustomobject]@{
+                    processId = [int]$child.ProcessId
+                    depth = [int]$parent.depth + 1
+                })
             }
         }
 
@@ -152,10 +234,32 @@ function Get-ProcessTree {
     $processes = @(
         foreach ($row in $rows) {
             if ($row -match '^\s*(\d+)\s+(\d+)\s+(.+?)\s*$') {
+                $observedProcess = Get-Process `
+                    -Id ([int]$Matches[1]) `
+                    -ErrorAction SilentlyContinue
+                $createdAtUtc = $null
+                if ($null -ne $observedProcess) {
+                    try {
+                        $createdAtUtc = (
+                            [DateTimeOffset]$observedProcess.StartTime.ToUniversalTime()
+                        ).ToString("O")
+                    }
+                    catch [System.InvalidOperationException] {
+                        $createdAtUtc = $null
+                    }
+                    finally {
+                        $observedProcess.Dispose()
+                    }
+                }
+
                 [pscustomobject]@{
                     processId = [int]$Matches[1]
                     parentProcessId = [int]$Matches[2]
                     name = $Matches[3]
+                    createdAtUtc = $createdAtUtc
+                    depth = 0
+                    executableName = $Matches[3]
+                    commandLine = $null
                 }
             }
         }
@@ -249,7 +353,8 @@ function Save-ProcessEvidence {
         [Parameter(Mandatory)]
         [string]$Phase,
         [Parameter(Mandatory)]
-        [string]$Reason
+        [string]$Reason,
+        [switch]$SkipManagedStack
     )
 
     $safeReason = $Reason -replace '[^A-Za-z0-9_.-]', '-'
@@ -286,7 +391,7 @@ function Save-ProcessEvidence {
     }
 
     $processTree = @(Get-ProcessTree -RootProcessId $Process.Id)
-    $stackResult = if ($Process.HasExited) {
+    $stackResult = if ($Process.HasExited -or $SkipManagedStack) {
         [pscustomobject]@{
             available = $false
             captured = $false
@@ -314,6 +419,119 @@ function Save-ProcessEvidence {
         Set-Content -LiteralPath (Join-Path $directory "process-evidence.json") -Encoding utf8
     return [System.IO.Path]::GetRelativePath($runRoot, $directory).
         Replace([System.IO.Path]::DirectorySeparatorChar, '/')
+}
+
+function Save-ResidualChildEvidence {
+    param(
+        [Parameter(Mandatory)]
+        [object[]]$Children,
+        [Parameter(Mandatory)]
+        [string]$AssemblyName,
+        [Parameter(Mandatory)]
+        [int]$Iteration,
+        [Parameter(Mandatory)]
+        [string]$Phase
+    )
+
+    $directory = Join-Path $evidenceRoot (
+        "$AssemblyName/iteration-{0:D4}/{1}-residual-children" -f $Iteration, $Phase)
+    New-Item -ItemType Directory -Force -Path $directory | Out-Null
+    $childEvidence = @()
+    $captureErrors = @()
+    foreach ($child in $Children) {
+        $captureState = "exited-before-capture"
+        $processEvidencePath = $null
+        $captureErrorType = $null
+        $childProcess = $null
+        try {
+            $childProcess = Get-Process `
+                -Id $child.processId `
+                -ErrorAction SilentlyContinue
+            if ($null -eq $childProcess) {
+                $captureState = "exited-before-capture"
+            }
+            else {
+                $actualStart = [DateTimeOffset]$childProcess.StartTime.ToUniversalTime()
+                $expectedStart = if (
+                    [string]::IsNullOrWhiteSpace([string]$child.createdAtUtc)
+                ) {
+                    $actualStart
+                }
+                else {
+                    [DateTimeOffset]::Parse(
+                        $child.createdAtUtc,
+                        [System.Globalization.CultureInfo]::InvariantCulture)
+                }
+                if ([Math]::Abs(($actualStart - $expectedStart).TotalSeconds) -gt 1) {
+                    $captureState = "process-identity-changed"
+                    $captureErrorType = "ProcessIdentityChanged"
+                }
+                else {
+                    $processEvidencePath = Save-ProcessEvidence `
+                        -Process $childProcess `
+                        -AssemblyName $AssemblyName `
+                        -Iteration $Iteration `
+                        -Phase $Phase `
+                        -Reason "residual-child-$($child.processId)" `
+                        -SkipManagedStack:(
+                            [string]$child.name -notmatch
+                                '^(?:dotnet|pwsh|testhost|xunit|DownKyi).*\.exe$')
+                    $captureState = "captured"
+                }
+            }
+        }
+        catch [System.InvalidOperationException] {
+            $captureState = "exited-before-capture"
+        }
+        catch {
+            $captureState = "capture-failed"
+            $captureErrorType = $_.Exception.GetType().Name
+        }
+        finally {
+            if ($null -ne $childProcess) {
+                $childProcess.Dispose()
+            }
+        }
+
+        if ($null -ne $captureErrorType) {
+            $captureErrors += $captureErrorType
+        }
+        $childEvidence += [pscustomobject]@{
+            processId = $child.processId
+            createdAtUtc = $child.createdAtUtc
+            captureState = $captureState
+            processEvidencePath = $processEvidencePath
+            errorType = $captureErrorType
+        }
+    }
+
+    $manifest = [ordered]@{
+        capturedAtUtc = [DateTimeOffset]::UtcNow.ToString("O")
+        reason = "residual-child-process"
+        observedChildren = $Children
+        childEvidence = $childEvidence
+        captureErrors = @($captureErrors | Select-Object -Unique)
+    }
+    $manifestPath = Join-Path $directory "residual-children.json"
+    $manifest |
+        ConvertTo-Json -Depth 10 |
+        Set-Content -LiteralPath $manifestPath -Encoding utf8
+    return [pscustomobject]@{
+        evidencePath = [System.IO.Path]::GetRelativePath($runRoot, $directory).
+            Replace([System.IO.Path]::DirectorySeparatorChar, '/')
+        capturedChildCount = @(
+            $childEvidence | Where-Object captureState -eq "captured"
+        ).Count
+        exitedBeforeCaptureCount = @(
+            $childEvidence | Where-Object captureState -eq "exited-before-capture"
+        ).Count
+        errorType = if ($captureErrors.Count -eq 0) {
+            $null
+        }
+        else {
+            [string]$captureErrors[0]
+        }
+    }
 }
 
 function Get-LifecycleMarkerReadFailureCategory {
@@ -477,6 +695,7 @@ function Invoke-IsolatedProcess {
     $slowEvidence = @()
     $exitEvidence = @()
     $timeoutEvidence = @()
+    $residualChildEvidence = @()
     $diagnosticCaptureDurationMs = 0.0
     $slowThresholdExceeded = $false
     $slowEvidenceAttempted = $false
@@ -484,6 +703,8 @@ function Invoke-IsolatedProcess {
     $slowEvidenceStatus = "not-triggered"
     $slowEvidenceErrorType = $null
     $slowEvidenceTriggeredBeforeThreshold = $false
+    $residualChildEvidenceStatus = "not-triggered"
+    $residualChildEvidenceErrorType = $null
     $exitEvidenceCaptured = $false
     $teardownObservedAt = $null
     $evidenceCaptureThresholdSeconds = [Math]::Max(
@@ -604,6 +825,28 @@ function Invoke-IsolatedProcess {
                 -RootProcessId $processId `
                 -NotBeforeUtc $processStartedAt
         )
+        if ($residualChildren.Count -gt 0) {
+            $captureStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+            try {
+                $residualCapture = Save-ResidualChildEvidence `
+                    -Children $residualChildren `
+                    -AssemblyName $AssemblyName `
+                    -Iteration $Iteration `
+                    -Phase $Phase
+                $residualChildEvidence += $residualCapture.evidencePath
+                $evidence += $residualCapture.evidencePath
+                $residualChildEvidenceStatus = "captured"
+                $residualChildEvidenceErrorType = $residualCapture.errorType
+            }
+            catch {
+                $residualChildEvidenceStatus = "capture-failed"
+                $residualChildEvidenceErrorType = $_.Exception.GetType().Name
+            }
+            finally {
+                $captureStopwatch.Stop()
+                $diagnosticCaptureDurationMs += $captureStopwatch.Elapsed.TotalMilliseconds
+            }
+        }
         return [pscustomobject]@{
             assembly = $AssemblyName
             iteration = $Iteration
@@ -619,6 +862,9 @@ function Invoke-IsolatedProcess {
             stderrPath = [System.IO.Path]::GetRelativePath($runRoot, $stderrPath).
                 Replace([System.IO.Path]::DirectorySeparatorChar, '/')
             residualChildren = $residualChildren
+            residualChildEvidence = @($residualChildEvidence)
+            residualChildEvidenceStatus = $residualChildEvidenceStatus
+            residualChildEvidenceErrorType = $residualChildEvidenceErrorType
             evidence = $evidence
             slowEvidence = $slowEvidence
             exitEvidence = $exitEvidence
@@ -732,6 +978,15 @@ function New-ProcessPhaseResult {
     else {
         "ProcessPhaseFailed"
     }
+    $errorType = if ($failureType -eq "SlowEvidenceMissing") {
+        $ProcessResult.slowEvidenceErrorType
+    }
+    elseif ($failureType -eq "ResidualChildProcess") {
+        $ProcessResult.residualChildEvidenceErrorType
+    }
+    else {
+        $null
+    }
     return [pscustomobject]@{
         assembly = $ProcessResult.assembly
         iteration = $ProcessResult.iteration
@@ -739,7 +994,7 @@ function New-ProcessPhaseResult {
         processId = $ProcessResult.processId
         success = $success
         failureType = $failureType
-        errorType = $ProcessResult.slowEvidenceErrorType
+        errorType = $errorType
         exitCode = $ProcessResult.exitCode
         durationMs = $ProcessResult.durationMs
         timedOut = $ProcessResult.timedOut
@@ -747,6 +1002,10 @@ function New-ProcessPhaseResult {
         stderrPolluted = -not $stderrClean
         unexpectedOutput = $unexpectedText
         residualChildCount = $ProcessResult.residualChildren.Count
+        residualChildren = @($ProcessResult.residualChildren)
+        residualChildEvidence = @($ProcessResult.residualChildEvidence)
+        residualChildEvidenceStatus = $ProcessResult.residualChildEvidenceStatus
+        residualChildEvidenceErrorType = $ProcessResult.residualChildEvidenceErrorType
         stdoutPath = $ProcessResult.stdoutPath
         stderrPath = $ProcessResult.stderrPath
         evidence = $ProcessResult.evidence
@@ -930,6 +1189,10 @@ if ($ValidateForensics) {
         stderrPolluted = $selfTestPhase.stderrPolluted
         unexpectedOutput = $selfTestPhase.unexpectedOutput
         residualChildCount = $selfTestPhase.residualChildCount
+        residualChildren = @($selfTestPhase.residualChildren)
+        residualChildEvidence = @($selfTestPhase.residualChildEvidence)
+        residualChildEvidenceStatus = $selfTestPhase.residualChildEvidenceStatus
+        residualChildEvidenceErrorType = $selfTestPhase.residualChildEvidenceErrorType
         stdoutPath = $selfTest.stdoutPath
         stderrPath = $selfTest.stderrPath
         evidence = $selfTest.evidence
@@ -945,6 +1208,212 @@ if ($ValidateForensics) {
     }
 
     if ($IsWindows) {
+        $residualChildSelfTestStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
+        $residualChildSelfTest.executed = $true
+        $residualProbe = $null
+        $residualProbePhase = $null
+        $observedResidualChildren = @()
+        try {
+            $residualProbe = Invoke-IsolatedProcess `
+                -AssemblyName "Gate.ResidualChild" `
+                -Iteration 1 `
+                -Phase "residual-child-probe" `
+                -FileName "dotnet" `
+                -Arguments @(
+                    $probeAssembly,
+                    "--spawn-residual-child-ms",
+                    "20000"
+                )
+            $residualProbePhase = New-ProcessPhaseResult -ProcessResult $residualProbe
+            $residualPayload = $residualProbe.stdout | ConvertFrom-Json -ErrorAction Stop
+            $expectedChildProcessId = [int]$residualPayload.ChildProcessId
+            $observedResidualChildren = @($residualProbe.residualChildren)
+            $matchingChild = @(
+                $observedResidualChildren |
+                    Where-Object processId -eq $expectedChildProcessId
+            )
+            $residualChildSelfTest.observedChildCount =
+                $observedResidualChildren.Count
+            $residualChildSelfTest.childObserved = $matchingChild.Count -eq 1
+            $residualChildSelfTest.identityCaptured =
+                $matchingChild.Count -eq 1 -and
+                -not [string]::IsNullOrWhiteSpace($matchingChild[0].name) -and
+                -not [string]::IsNullOrWhiteSpace($matchingChild[0].createdAtUtc)
+            $residualChildSelfTest.evidenceManifestWritten =
+                $residualProbe.residualChildEvidenceStatus -eq "captured" -and
+                @(
+                    foreach ($relativePath in $residualProbe.residualChildEvidence) {
+                        $manifestPath = Join-Path $runRoot $relativePath (
+                            "residual-children.json")
+                        if (Test-Path -LiteralPath $manifestPath -PathType Leaf) {
+                            $manifestPath
+                        }
+                    }
+                ).Count -gt 0
+            $residualChildSelfTest.failureClassified =
+                -not $residualProbePhase.success -and
+                $residualProbePhase.failureType -eq "ResidualChildProcess"
+            $redactionSample = (
+                "$repositoryRoot https://example.invalid/private " +
+                "SESSDATA=example-cookie-value " +
+                "--rpc-secret `"example secret value`"")
+            $redactedSample = Protect-ProcessDiagnosticText -Value $redactionSample
+            $residualChildSelfTest.redactionValidated =
+                $redactedSample.Contains(
+                    "<repository>",
+                    [StringComparison]::Ordinal) -and
+                $redactedSample.Contains("<url>", [StringComparison]::Ordinal) -and
+                $redactedSample.Contains(
+                    "SESSDATA=<redacted>",
+                    [StringComparison]::Ordinal) -and
+                $redactedSample.Contains(
+                    "--rpc-secret <redacted>",
+                    [StringComparison]::Ordinal) -and
+                -not $redactedSample.Contains(
+                    "example-cookie-value",
+                    [StringComparison]::Ordinal) -and
+                -not $redactedSample.Contains(
+                    "example secret value",
+                    [StringComparison]::Ordinal)
+        }
+        catch {
+            $residualChildSelfTest.errorType = $_.Exception.GetType().Name
+        }
+        finally {
+            $cleanupCompleted = $true
+            foreach ($child in $observedResidualChildren) {
+                $childProcess = $null
+                try {
+                    $childProcess = Get-Process `
+                        -Id $child.processId `
+                        -ErrorAction SilentlyContinue
+                    if ($null -eq $childProcess) {
+                        continue
+                    }
+
+                    $actualStart = [DateTimeOffset]$childProcess.StartTime.ToUniversalTime()
+                    $expectedStart = [DateTimeOffset]::Parse(
+                        $child.createdAtUtc,
+                        [System.Globalization.CultureInfo]::InvariantCulture)
+                    if ([Math]::Abs(($actualStart - $expectedStart).TotalSeconds) -gt 1) {
+                        $cleanupCompleted = $false
+                        continue
+                    }
+
+                    $childProcess.Kill($true)
+                    if (-not $childProcess.WaitForExit(5000)) {
+                        $cleanupCompleted = $false
+                    }
+                }
+                catch {
+                    $cleanupCompleted = $false
+                    if ($null -eq $residualChildSelfTest.errorType) {
+                        $residualChildSelfTest.errorType =
+                            $_.Exception.GetType().Name
+                    }
+                }
+                finally {
+                    if ($null -ne $childProcess) {
+                        $childProcess.Dispose()
+                    }
+                }
+            }
+
+            $residualChildSelfTest.cleanupCompleted = $cleanupCompleted
+            $residualChildSelfTestStopwatch.Stop()
+        }
+
+        $residualChildSelfTest.passed =
+            $residualChildSelfTest.childObserved -and
+            $residualChildSelfTest.identityCaptured -and
+            $residualChildSelfTest.evidenceManifestWritten -and
+            $residualChildSelfTest.failureClassified -and
+            $residualChildSelfTest.cleanupCompleted -and
+            $residualChildSelfTest.redactionValidated -and
+            $null -eq $residualChildSelfTest.errorType
+        $residualChildSelfTestComplete = $residualChildSelfTest.passed
+        if (-not $residualChildSelfTestComplete -and
+            $null -eq $residualChildSelfTest.errorType) {
+            $residualChildSelfTest.errorType = "ContractNotSatisfied"
+        }
+
+        $phaseResults += [pscustomobject]@{
+            assembly = "Gate.ResidualChild"
+            iteration = 1
+            phase = "residual-child-self-test"
+            processId = if ($null -eq $residualProbe) {
+                $PID
+            }
+            else {
+                $residualProbe.processId
+            }
+            success = $residualChildSelfTestComplete
+            failureType = if ($residualChildSelfTestComplete) {
+                $null
+            }
+            else {
+                "ResidualChildSelfTestFailed"
+            }
+            errorType = $residualChildSelfTest.errorType
+            exitCode = if ($residualChildSelfTestComplete) { 0 } else { 1 }
+            durationMs = [Math]::Round(
+                $residualChildSelfTestStopwatch.Elapsed.TotalMilliseconds,
+                3)
+            timedOut = $false
+            stdoutPolluted = $false
+            stderrPolluted = $false
+            unexpectedOutput = @()
+            residualChildCount = 0
+            residualChildren = @()
+            residualChildEvidence = @(
+                if ($null -ne $residualProbe) {
+                    $residualProbe.residualChildEvidence
+                }
+            )
+            residualChildEvidenceStatus = if ($null -eq $residualProbe) {
+                "not-triggered"
+            }
+            else {
+                $residualProbe.residualChildEvidenceStatus
+            }
+            residualChildEvidenceErrorType = if ($null -eq $residualProbe) {
+                $null
+            }
+            else {
+                $residualProbe.residualChildEvidenceErrorType
+            }
+            stdoutPath = if ($null -eq $residualProbe) {
+                $null
+            }
+            else {
+                $residualProbe.stdoutPath
+            }
+            stderrPath = if ($null -eq $residualProbe) {
+                $null
+            }
+            else {
+                $residualProbe.stderrPath
+            }
+            evidence = @(
+                if ($null -ne $residualProbe) {
+                    $residualProbe.evidence
+                }
+            )
+            slowEvidence = @()
+            exitEvidence = @()
+            timeoutEvidence = @()
+            diagnosticCaptureDurationMs = if ($null -eq $residualProbe) {
+                0.0
+            }
+            else {
+                $residualProbe.diagnosticCaptureDurationMs
+            }
+            slowThresholdExceeded = $false
+            slowEvidenceStatus = "not-applicable"
+            slowEvidenceErrorType = $null
+            slowEvidenceTriggeredBeforeThreshold = $false
+        }
+
         $markerReaderSelfTestStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
         $markerReaderSelfTest.executed = $true
         $markerReaderTestPath = Join-Path $rawRoot "Gate.MarkerReader/read-race.lifecycle"
@@ -1100,6 +1569,10 @@ if ($ValidateForensics) {
             stderrPolluted = $false
             unexpectedOutput = @()
             residualChildCount = 0
+            residualChildren = @()
+            residualChildEvidence = @()
+            residualChildEvidenceStatus = "not-triggered"
+            residualChildEvidenceErrorType = $null
             stdoutPath = $null
             stderrPath = $null
             evidence = @()
@@ -1226,6 +1699,10 @@ foreach ($testProject in $testProjects) {
             stderrPolluted = $false
             unexpectedOutput = @()
             residualChildCount = 0
+            residualChildren = @()
+            residualChildEvidence = @()
+            residualChildEvidenceStatus = "not-triggered"
+            residualChildEvidenceErrorType = $null
             stdoutPath = $null
             stderrPath = $null
             evidence = @()
@@ -1256,6 +1733,10 @@ foreach ($testProject in $testProjects) {
             stderrPolluted = $false
             unexpectedOutput = @()
             residualChildCount = $execution.residualChildren.Count
+            residualChildren = @($execution.residualChildren)
+            residualChildEvidence = @($execution.residualChildEvidence)
+            residualChildEvidenceStatus = $execution.residualChildEvidenceStatus
+            residualChildEvidenceErrorType = $execution.residualChildEvidenceErrorType
             stdoutPath = $execution.stdoutPath
             stderrPath = $execution.stderrPath
             evidence = $execution.exitEvidence
@@ -1279,9 +1760,25 @@ $slowEvidenceCapturedCount = @(
         Where-Object slowEvidenceStatus -eq "captured"
 ).Count
 $slowEvidenceMissingCount = $slowResults.Count - $slowEvidenceCapturedCount
+$residualChildResults = @(
+    $phaseResults | Where-Object residualChildCount -gt 0
+)
+$residualChildObservedCount = [int](
+    $residualChildResults |
+        Measure-Object -Property residualChildCount -Sum
+).Sum
+$residualChildEvidenceCapturedCount = @(
+    $residualChildResults |
+        Where-Object residualChildEvidenceStatus -eq "captured"
+).Count
+$residualChildEvidenceMissingCount =
+    $residualChildResults.Count - $residualChildEvidenceCapturedCount
 $markerReaderSelfTestContractPassed =
     -not $markerReaderSelfTest.required -or
     $markerReaderSelfTestComplete
+$residualChildSelfTestContractPassed =
+    -not $residualChildSelfTest.required -or
+    $residualChildSelfTestComplete
 $diagnosticCaptureTotalMs = [Math]::Round(
     [double](
         $phaseResults |
@@ -1318,11 +1815,16 @@ $report = [ordered]@{
     ownershipAuditErrorType = $ownershipError
     successful = $ownershipPassed -and
         $failedResults.Count -eq 0 -and
-        $markerReaderSelfTestContractPassed
+        $markerReaderSelfTestContractPassed -and
+        $residualChildSelfTestContractPassed
     failedPhaseCount = $failedResults.Count
     slowPhaseCount = $slowResults.Count
     slowEvidenceCapturedCount = $slowEvidenceCapturedCount
     slowEvidenceMissingCount = $slowEvidenceMissingCount
+    residualChildPhaseCount = $residualChildResults.Count
+    residualChildObservedCount = $residualChildObservedCount
+    residualChildEvidenceCapturedCount = $residualChildEvidenceCapturedCount
+    residualChildEvidenceMissingCount = $residualChildEvidenceMissingCount
     diagnosticCaptureTotalMs = $diagnosticCaptureTotalMs
     markerReadContentionCount = $script:markerReadContentionCount
     markerReadRetriesExhaustedCount = $script:markerReadRetriesExhaustedCount
@@ -1335,6 +1837,13 @@ $report = [ordered]@{
         $null
     }
     markerReaderSelfTest = $markerReaderSelfTest
+    residualChildSelfTestPassed = if ($residualChildSelfTest.executed) {
+        $residualChildSelfTestComplete
+    }
+    else {
+        $null
+    }
+    residualChildSelfTest = $residualChildSelfTest
     statistics = $statistics
     results = $phaseResults
 }
@@ -1359,6 +1868,11 @@ $markdown.Add("- Slow phases: $($slowResults.Count)")
 $markdown.Add(
     "- Slow phase evidence: $slowEvidenceCapturedCount captured, " +
     "$slowEvidenceMissingCount missing")
+$markdown.Add(
+    "- Residual children: $residualChildObservedCount observed across " +
+    "$($residualChildResults.Count) phase(s); " +
+    "$residualChildEvidenceCapturedCount evidence manifest(s), " +
+    "$residualChildEvidenceMissingCount missing")
 $markdown.Add("- Diagnostic capture wall time: $diagnosticCaptureTotalMs ms")
 $markdown.Add(
     "- Forensics pre-threshold capture self-test: " +
@@ -1377,6 +1891,16 @@ $markdown.Add(
     "parsed=$($markerReaderSelfTest.markerParsedAfterRecovery), " +
     "error=$($markerReaderSelfTest.errorType), " +
     "contractChecks=$($markerReaderSelfTest.contractChecks.passed)")
+$markdown.Add(
+    "- Residual child self-test: executed=$($residualChildSelfTest.executed), " +
+    "passed=$($residualChildSelfTest.passed), " +
+    "observed=$($residualChildSelfTest.childObserved), " +
+    "identity=$($residualChildSelfTest.identityCaptured), " +
+    "evidence=$($residualChildSelfTest.evidenceManifestWritten), " +
+    "classified=$($residualChildSelfTest.failureClassified), " +
+    "cleanup=$($residualChildSelfTest.cleanupCompleted), " +
+    "redaction=$($residualChildSelfTest.redactionValidated), " +
+    "error=$($residualChildSelfTest.errorType)")
 $markdown.Add("")
 $markdown.Add("| Assembly | Phase | Pass / Runs | Slow / captured | Success | P50 ms | P95 ms | P99 ms | Max ms |")
 $markdown.Add("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |")
@@ -1424,7 +1948,17 @@ else {
             "stderrPolluted=$($failure.stderrPolluted), " +
             "residualChildren=$($failure.residualChildCount), " +
             "failureType=$($failure.failureType), errorType=$($failure.errorType), " +
-            "slowEvidence=$($failure.slowEvidenceStatus)")
+            "slowEvidence=$($failure.slowEvidenceStatus), " +
+            "residualEvidence=$($failure.residualChildEvidenceStatus)")
+        foreach ($child in @($failure.residualChildren)) {
+            $markdown.Add(
+                "  - child pid=$($child.processId), parent=$($child.parentProcessId), " +
+                "name=``$($child.name)``, created=$($child.createdAtUtc), " +
+                "command=``$($child.commandLine)``")
+        }
+        foreach ($evidencePath in @($failure.residualChildEvidence)) {
+            $markdown.Add("  - residual evidence: ``$evidencePath``")
+        }
     }
 }
 $markdown | Set-Content -LiteralPath $markdownPath -Encoding utf8

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -50,6 +50,12 @@ public sealed class AssemblyLifecycleArchitectureTests
             "stdoutPolluted",
             "stderrPolluted",
             "residualChildCount",
+            "residualChildren",
+            "residualChildEvidence",
+            "residualChildEvidenceStatus",
+            "residualChildEvidenceErrorType",
+            "residualChildEvidenceCapturedCount",
+            "residualChildEvidenceMissingCount",
             "failureType",
             "errorType",
             "workingTreeDirty",
@@ -97,6 +103,50 @@ public sealed class AssemblyLifecycleArchitectureTests
         Assert.Contains(
             "$forensicsSelfTestCaptureLeadValidated =",
             source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResidualChildForensicsPreserveIdentityAndFailClosed()
+    {
+        var gate = Read("script/test-assembly-lifecycle.ps1");
+        var probe = Read("tools/DownKyi.AssemblyLifecycleProbe/Program.cs");
+        string[] requiredGateContract =
+        [
+            "Protect-ProcessDiagnosticText",
+            "Save-ResidualChildEvidence",
+            "residual-children.json",
+            "failureType -eq \"ResidualChildProcess\"",
+            "residualChildSelfTestPassed",
+            "residualChildSelfTest",
+            "childObserved",
+            "identityCaptured",
+            "evidenceManifestWritten",
+            "failureClassified",
+            "cleanupCompleted",
+            "redactionValidated",
+            "$residualChildSelfTestContractPassed",
+            "$residualChildSelfTestComplete",
+            "\"--spawn-residual-child-ms\"",
+            "$childProcess.Kill($true)",
+            "$childProcess.WaitForExit(5000)"
+        ];
+
+        foreach (var token in requiredGateContract)
+        {
+            Assert.Contains(token, gate, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("--spawn-residual-child-ms", probe, StringComparison.Ordinal);
+        Assert.Contains("--child-hold-ms", probe, StringComparison.Ordinal);
+        Assert.Contains("UseShellExecute = true", probe, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "residualChildCount -eq 0 -or",
+            gate,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "residualChildEvidenceStatus -eq \"captured\" -or",
+            gate,
             StringComparison.Ordinal);
     }
 

--- a/tools/DownKyi.AssemblyLifecycleProbe/Program.cs
+++ b/tools/DownKyi.AssemblyLifecycleProbe/Program.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.Loader;
@@ -10,9 +11,20 @@ internal static class Program
 {
     public static int Main(string[] args)
     {
+        if (TryReadChildHoldArguments(args, out var childHoldMilliseconds))
+        {
+            Thread.Sleep(childHoldMilliseconds);
+            return 0;
+        }
+
+        if (TryReadResidualChildArguments(args, out var residualChildHoldMilliseconds))
+        {
+            return RunResidualChildProbe(residualChildHoldMilliseconds);
+        }
+
         if (!TryReadArguments(args, out var assemblyPath, out var holdAfterUnloadMilliseconds))
         {
-            WriteResult(new ProbeResult(false, null, null, false, "invalid_arguments"));
+            WriteResult(new ProbeResult(false, null, null, false, "invalid_arguments", null));
             return 2;
         }
 
@@ -29,8 +41,53 @@ internal static class Program
             loaded.AssemblyName,
             loaded.AssemblyVersion,
             unloaded,
-            unloaded ? null : "assembly_context_retained"));
+            unloaded ? null : "assembly_context_retained",
+            null));
         return unloaded ? 0 : 1;
+    }
+
+    private static int RunResidualChildProbe(int holdMilliseconds)
+    {
+        var processPath = Environment.ProcessPath;
+        if (string.IsNullOrWhiteSpace(processPath))
+        {
+            WriteResult(new ProbeResult(
+                false,
+                null,
+                null,
+                false,
+                "process_path_unavailable",
+                null));
+            return 1;
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = processPath,
+            UseShellExecute = true,
+            WindowStyle = ProcessWindowStyle.Hidden
+        };
+        startInfo.ArgumentList.Add(typeof(Program).Assembly.Location);
+        startInfo.ArgumentList.Add("--child-hold-ms");
+        startInfo.ArgumentList.Add(
+            holdMilliseconds.ToString(
+                System.Globalization.CultureInfo.InvariantCulture));
+
+        using var child = Process.Start(startInfo);
+        if (child is null)
+        {
+            WriteResult(new ProbeResult(
+                false,
+                null,
+                null,
+                false,
+                "residual_child_start_failed",
+                null));
+            return 1;
+        }
+
+        WriteResult(new ProbeResult(true, null, null, true, null, child.Id));
+        return 0;
     }
 
     private static bool TryReadArguments(
@@ -65,6 +122,42 @@ internal static class Program
                 System.Globalization.CultureInfo.InvariantCulture,
                 out holdAfterUnloadMilliseconds) &&
             holdAfterUnloadMilliseconds is >= 0 and <= 30_000;
+    }
+
+    private static bool TryReadChildHoldArguments(
+        string[] args,
+        out int holdMilliseconds)
+    {
+        return TryReadBoundedMillisecondsArgument(
+            args,
+            "--child-hold-ms",
+            out holdMilliseconds);
+    }
+
+    private static bool TryReadResidualChildArguments(
+        string[] args,
+        out int holdMilliseconds)
+    {
+        return TryReadBoundedMillisecondsArgument(
+            args,
+            "--spawn-residual-child-ms",
+            out holdMilliseconds);
+    }
+
+    private static bool TryReadBoundedMillisecondsArgument(
+        string[] args,
+        string option,
+        out int milliseconds)
+    {
+        milliseconds = 0;
+        return args.Length == 2 &&
+            string.Equals(args[0], option, StringComparison.Ordinal) &&
+            int.TryParse(
+                args[1],
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out milliseconds) &&
+            milliseconds is >= 1_000 and <= 30_000;
     }
 
     [MethodImpl(MethodImplOptions.NoInlining)]
@@ -130,7 +223,8 @@ internal static class Program
         string? AssemblyName,
         string? AssemblyVersion,
         bool Unloaded,
-        string? ErrorType);
+        string? ErrorType,
+        int? ChildProcessId);
 }
 
 [JsonSerializable(typeof(Program.ProbeResult))]


### PR DESCRIPTION
## Summary

- preserve sanitized residual-child identity and a dedicated `residual-children.json` manifest for every lifecycle phase that observes an outliving child
- capture thread/process-tree evidence and managed stacks for live managed children without applying managed diagnostics to native descendants
- add a deterministic Windows residual-child self-test that proves observation, `ResidualChildProcess` classification, evidence creation, redaction, and bounded PID-plus-creation-time cleanup
- expand lifecycle ownership auditing to include external process creation
- update the lifecycle policy, v1.1.1 release gate, live plan, maintenance guide, and AI knowledge graph

## Root cause

The first v1.1.1 release rehearsal (`30455540672`) correctly failed when `DownKyi.Tests` assembly-info iteration 78 observed one residual child. The phase exited with code 0, valid xUnit metadata, and empty stderr, but schema 2 flattened the observation to `residualChildCount=1` and did not trigger evidence capture. The hosted VM was then destroyed, so the historical child's exact identity cannot be recovered.

The failing assembly-info phase does not execute tests, Host, Dispatcher, or application services. Repeating the exact command 500 times locally produced zero residual children, so there is no deterministic application owner to fix. This PR closes the observation gap without weakening the fail-closed policy: any future occurrence retains enough evidence to identify the actual process owner.

## Validation

- strict .NET 10 `AnalysisMode=All` Release build: 0 warnings, 0 errors
- all 7 test projects: 731 passed
- clean-commit local lifecycle gate: 7 assemblies, 5 iterations, 213 phases, 0 failures
- real residual phases: 0; missing residual evidence: 0
- residual-child, redaction, capture-lead, and marker-reader self-tests: passed
- slow phases: 5 captured, 0 missing
- teardown max: 3 ms; process-exit max: 18 ms
- lifecycle ownership audit: 452 matches, 0 violations
- `dotnet format --verify-no-changes`: passed
- module-boundary audit: passed
- vulnerable/deprecated package audits: no findings
- Gitleaks: 1,000 candidate files, 0 findings
- `git diff --check`: passed

This PR must pass PR CI, then a fresh Main 50 lifecycle profile and a complete Rehearsal 100 before v1.1.1 packaging or publication resumes.