### PR TITLE
fix(ci): arm lifecycle evidence before threshold

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2386,8 +2386,8 @@ contracts:
   - Every phase exposes general failure/error type; slow-evidence error type is reserved for the diagnostic capture path.
   - Execution duration includes runner startup through OS process exit; teardown uses fixture marker timestamps, while process-exit uses the child's OS ExitTime and excludes collector overhead.
   - Marker-aware execution phases are sampled at the unchanged slow threshold; missing slow evidence is a gate failure rather than an unexplained empty array.
-  - Forensics is armed 100 ms before the unchanged classification threshold to close the monitor-poll/child-exit race; reports disclose the lead and per-phase pre-threshold capture state.
-  - The held-child forensics self-test must report `forensicsSelfTestCaptureLeadValidated=true`, proving the proactive capture path executed.
+  - Forensics is armed 1,000 ms before the unchanged classification threshold to survive hosted-runner scheduling gaps; reports disclose the lead and per-phase pre-threshold capture state.
+  - The held-child forensics self-test uses a 1.25-second synthetic threshold and must report `forensicsSelfTestCaptureLeadValidated=true`, proving the one-second proactive capture lead executed without a zero-clamped arm.
   - Lifecycle marker reads tolerate bounded writer contention and report contention/retry-exhaustion counts; only Windows sharing/lock error codes are contention, while access and other I/O errors retain a separate count/type; the final marker contract remains blocking.
   - Diagnostic capture wall time is reported separately because managed-stack collection perturbs the instrumented phase; slow execution evidence cannot be presented as post-teardown exit evidence.
   - Unexpected stdout/stderr, timeout, residual child process, missing teardown marker or failed process exit blocks the gate.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -36,8 +36,8 @@ missing. Schema 1 exit values include collector overhead and are historical
 only; do not compare them directly with schema 2.
 
 The slow classification threshold remains five seconds. Evidence collection
-is armed 100 ms before that boundary so a 25 ms monitor poll cannot observe a
-5.005-second process only after it has exited. Reports expose both the capture
+is armed 1,000 ms before that boundary so hosted-runner scheduling cannot
+observe a borderline process only after it has exited. Reports expose both the capture
 lead and whether a phase was sampled before the classification boundary;
 `capture-failed` and `process-exited-before-capture` remain fail-closed for
 phases whose final duration reaches the threshold.
@@ -95,6 +95,18 @@ therefore preserves identity and evidence on every future observation and
 dynamically self-tests the full residual-child failure path. A new Main profile
 and complete Rehearsal remain mandatory; the failed run is not replaced by a
 blind rerun.
+
+After PR #118 merged at `ad5ac64`, Main run `30461640781` proved that the
+original 100 ms capture lead was still insufficient under hosted-runner load.
+`DownKyi.Tests` execution iteration 24 exited successfully at 5007.386 ms but
+the monitor never entered the capture branch while the process was alive.
+The report failed closed with `SlowEvidenceMissing`; residual-child and
+marker-reader self-tests passed and no real residual process was observed.
+The five-second classification threshold remains unchanged. The capture arm is
+now one second early, and architecture tests prevent reducing it back to the
+demonstrably insufficient 100 ms window. The held-child self-test uses a
+1.25-second synthetic threshold so it dynamically proves capture starts after
+0.25 seconds and before classification, without relying on a zero-clamped arm.
 
 Pull requests are guarded by `.github/workflows/quality.yml`:
 

--- a/docs/product-specs/v1.1.1-corrective-release-gate.md
+++ b/docs/product-specs/v1.1.1-corrective-release-gate.md
@@ -26,7 +26,9 @@ fix is not release evidence.
   `ResidualChildProcess`, and clean the synthetic tree by PID plus creation
   time. Any real residual child remains a release blocker.
 - Slow execution evidence, teardown timing and OS process-exit timing remain
-  separate. The five-second slow threshold must not be relaxed.
+  separate. The five-second slow threshold must not be relaxed. Evidence is
+  armed one second before that boundary, and the held-child self-test must
+  prove that lead against a non-zero-clamped synthetic threshold.
 
 ## Product And Data Compatibility
 

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -199,14 +199,15 @@ history, not repeated here.
   five-second classification stays unchanged; capture now arms 1,000 ms early.
   Its held-child test uses a 1.25-second synthetic threshold, proving the full
   lead dynamically instead of passing through a zero-clamped arm.
-- The dirty-worktree local candidate passes strict `AnalysisMode=All` build
-  with zero warnings/errors, all 731 tests, format, module boundaries,
+- Clean code commit `ca8103e` passes strict `AnalysisMode=All` build with zero
+  warnings/errors, all 731 tests, format, module boundaries,
   vulnerable/deprecated dependency audits, Gitleaks and diff checks. Its
   five-iteration lifecycle run covers seven assemblies and 213 phases with
-  zero failures, eight slow phases, eight evidence captures, zero missing
-  evidence and zero real residual processes. Both dynamic self-tests pass.
-  Diagnostic collection consumed 20,859.884 ms in total and remains separately
-  disclosed; exact-commit PR and Main evidence are still required.
+  zero failures, seven slow phases, seven evidence captures, zero missing
+  evidence and zero real residual processes. Both dynamic self-tests pass;
+  teardown is at most 7 ms and OS process exit is at most 75 ms. Diagnostic
+  collection consumed 19,765.952 ms in total and remains separately disclosed;
+  exact-commit PR and Main evidence are still required.
 
 ## Gate 10 Checklist
 

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -3,7 +3,7 @@
 Status: active
 Last updated: 2026-07-29
 Current group: Gate 10 Windows lifecycle blocker and corrective release
-Current branch: `fix/lifecycle-residual-child-evidence`
+Current branch: `fix/lifecycle-slow-evidence-arm-window`
 
 This file contains only unfinished or not-yet-integrated work. Completed Gate
 1-9 detail is retained in `docs/maintenance.md`, design documents and Git
@@ -187,6 +187,26 @@ history, not repeated here.
   boundaries, vulnerable/deprecated dependency audits, Gitleaks and diff checks
   pass. This dirty-worktree result is candidate evidence, not Main or release
   evidence.
+- PR #118 merged the residual-child evidence fix at `ad5ac64`. Strict PR CI
+  `30461103180` and CodeQL `30461103401` passed; its PR lifecycle report has
+  129 phases, zero failures, complete residual identity/evidence/classification/
+  cleanup/redaction proof and zero real residual children.
+- The exact-commit Main 50 run `30461640781` failed closed on one different
+  boundary race: `DownKyi.Tests` execution iteration 24 ended normally at
+  5007.386 ms, but the 100 ms pre-threshold arm was still skipped under runner
+  scheduling. The report contains 2,103 phases, one `SlowEvidenceMissing`,
+  zero real residual processes, and passing residual/marker self-tests. The
+  five-second classification stays unchanged; capture now arms 1,000 ms early.
+  Its held-child test uses a 1.25-second synthetic threshold, proving the full
+  lead dynamically instead of passing through a zero-clamped arm.
+- The dirty-worktree local candidate passes strict `AnalysisMode=All` build
+  with zero warnings/errors, all 731 tests, format, module boundaries,
+  vulnerable/deprecated dependency audits, Gitleaks and diff checks. Its
+  five-iteration lifecycle run covers seven assemblies and 213 phases with
+  zero failures, eight slow phases, eight evidence captures, zero missing
+  evidence and zero real residual processes. Both dynamic self-tests pass.
+  Diagnostic collection consumed 20,859.884 ms in total and remains separately
+  disclosed; exact-commit PR and Main evidence are still required.
 
 ## Gate 10 Checklist
 
@@ -236,7 +256,10 @@ history, not repeated here.
       missing residual-child identity, not a passing rerun.
 - [x] Repeat the exact failing assembly-info command 500 times without observing
       a deterministic residual owner.
-- [ ] Merge the residual-child identity, evidence and dynamic self-test fix.
+- [x] Merge the residual-child identity, evidence and dynamic self-test fix.
+- [x] Preserve the failed post-merge Main report showing the 100 ms arm window
+      is insufficient; do not replace it with a blind rerun.
+- [ ] Merge the one-second pre-threshold capture-arm correction.
 - [ ] Pass a new exact-commit Main 50 lifecycle profile after that fix.
 - [ ] Pass the complete manual release rehearsal on the final versioned
       candidate commit.

--- a/docs/testing/assembly-lifecycle-stability.md
+++ b/docs/testing/assembly-lifecycle-stability.md
@@ -72,18 +72,20 @@ and must not carry unrelated self-test or lifecycle contract failures.
   child's OS `Process.ExitTime`. Report serialization, stdout/stderr copying and
   process-tree inspection are not part of this metric.
 - The slow classification remains exactly
-  `duration >= slowPhaseThresholdSeconds`. To prevent a 25 ms monitor poll
-  from crossing directly from just below the threshold to an already-exited
-  child, evidence capture is armed 100 ms early. The report records this as
+  `duration >= slowPhaseThresholdSeconds`. To prevent runner scheduling from
+  crossing directly from just below the threshold to an already-exited child,
+  evidence capture is armed 1,000 ms early. The report records this as
   `slowEvidenceCaptureLeadMilliseconds` and per phase as
   `slowEvidenceTriggeredBeforeThreshold`; it does not lower the slow
   threshold. `slowEvidenceStatus` is `captured`, `capture-failed`, or
   `process-exited-before-capture`; the latter two still fail a slow phase
   instead of leaving an unexplained empty evidence array.
 - `-ValidateForensics` uses its held child to prove the capture lead actually
-  ran before the synthetic 250 ms threshold. The machine report exposes
-  `forensicsSelfTestCaptureLeadValidated`; the forensics self-test fails when
-  that value is false, even if a later stack capture would otherwise exist.
+  ran before a synthetic 1.25-second threshold. The one-second lead therefore
+  arms at 0.25 seconds instead of relying on a zero-clamped threshold. The
+  machine report exposes `forensicsSelfTestCaptureLeadValidated`; the forensics
+  self-test fails when that value is false, even if a later stack capture would
+  otherwise exist.
 - Managed-stack collection can pause or otherwise perturb the observed child.
   `durationMs` remains the honest instrumented wall-clock value, while
   `diagnosticCaptureDurationMs` records collector wall time separately. These

--- a/script/test-assembly-lifecycle.ps1
+++ b/script/test-assembly-lifecycle.ps1
@@ -47,7 +47,7 @@ $script:markerReadContentionCount = 0
 $script:markerReadRetriesExhaustedCount = 0
 $script:markerReadErrorCount = 0
 $script:markerReadErrorType = $null
-$slowEvidenceCaptureLeadMilliseconds = 100
+$slowEvidenceCaptureLeadMilliseconds = 1000
 $forensicsSelfTestCaptureLeadValidated = $false
 $markerReaderSelfTestRequired = $IsWindows -and
     @("PR", "Main", "Rehearsal", "Flaky").Contains($Profile)
@@ -1158,7 +1158,7 @@ if ($ValidateForensics) {
             "5000"
         ) `
         -LifecycleMarkerPath $selfTestMarker `
-        -EvidenceThresholdSeconds 0.25
+        -EvidenceThresholdSeconds 1.25
     $selfTestPhase = New-ProcessPhaseResult -ProcessResult $selfTest
     $evidenceReports = @(
         foreach ($relativeEvidence in $selfTest.evidence) {

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -89,11 +89,15 @@ public sealed class AssemblyLifecycleArchitectureTests
             source,
             StringComparison.Ordinal);
         Assert.Contains(
-            "$slowEvidenceCaptureLeadMilliseconds = 100",
+            "$slowEvidenceCaptureLeadMilliseconds = 1000",
             source,
             StringComparison.Ordinal);
         Assert.Contains(
             "$EvidenceThresholdSeconds - ($slowEvidenceCaptureLeadMilliseconds / 1000)",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "-EvidenceThresholdSeconds 1.25",
             source,
             StringComparison.Ordinal);
         Assert.Contains(


### PR DESCRIPTION
## Summary

- arm lifecycle slow-evidence capture 1,000 ms before the unchanged five-second classification threshold
- strengthen the held-child forensics self-test with a 1.25-second synthetic threshold so it proves the full one-second lead without a zero-clamped arm
- ratchet the timing contract in architecture tests and update the lifecycle, maintenance, release-gate, live-plan, and AI knowledge documents

## Root cause

Main lifecycle run `30461640781` failed closed when `DownKyi.Tests` execution iteration 24 exited normally at 5007.386 ms. The original 100 ms capture lead was skipped under hosted-runner scheduling load, leaving `slowEvidenceStatus=process-exited-before-capture`. The report contained zero real residual processes and both residual-child and marker-reader self-tests passed, so this is a gate-side evidence-arm race rather than a production thread owner.

The five-second threshold is unchanged. This PR moves only the evidence arm and keeps missing/capture-failed evidence fail-closed.

## Validation

- strict Release build with `AnalysisMode=All` and warnings as errors: 0 warnings, 0 errors
- full solution tests: 731 passed
- `dotnet format --verify-no-changes`: passed, 0/863 files changed
- clean commit five-iteration lifecycle gate: 7 assemblies, 213 phases, 0 failures
- lifecycle evidence: 7 slow phases, 7 captures, 0 missing, 0 real residual processes
- dynamic forensics, residual-child, and marker-reader self-tests: passed
- lifecycle ownership audit: 452 matches, 0 violations
- teardown max 7 ms; OS process-exit max 75 ms
- module-boundary audit: passed
- vulnerable packages: 0
- deprecated packages: 0
- Gitleaks: 1,000 candidate files, 0 findings
- `git diff --check`: passed

## Release impact

This is a corrective release-gate fix for v1.1.1. It changes no application runtime behavior, user data, settings, SQLite records, download state, resume state, API contracts, or package contents. A fresh exact-commit Main 50 profile and full 100-iteration release rehearsal remain mandatory after merge; a green rerun of the failed commit is not accepted as evidence.