### PR TITLE
fix: stabilize downloads and user-space URL routing

### DIFF
--- a/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.UserSpace.cs
+++ b/DownKyi.Core/BiliApi/BiliUtils/ParseEntrance.UserSpace.cs
@@ -51,7 +51,15 @@ public static partial class ParseEntrance
         }
 
         var segments = uri.AbsolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-        return segments.Length == 1
+        return IsSupportedUserSpacePath(segments)
             && long.TryParse(segments[0], NumberStyles.None, CultureInfo.InvariantCulture, out mid);
+    }
+
+    private static bool IsSupportedUserSpacePath(string[] segments)
+    {
+        return segments.Length == 1
+            || (segments.Length == 3
+                && string.Equals(segments[1], "upload", StringComparison.OrdinalIgnoreCase)
+                && string.Equals(segments[2], "video", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/DownKyi.Core/Storage/Database/SqliteDatabase.cs
+++ b/DownKyi.Core/Storage/Database/SqliteDatabase.cs
@@ -19,7 +19,7 @@ public sealed class SqliteDatabase : IDisposable
         {
             Mode = SqliteOpenMode.ReadWriteCreate,
             DataSource = dbPath,
-            Pooling = true,
+            Pooling = false,
             DefaultTimeout = 30
         }.ToString();
     }
@@ -38,7 +38,7 @@ public sealed class SqliteDatabase : IDisposable
             Mode = SqliteOpenMode.ReadWriteCreate,
             Password = secretKey,
             DataSource = legacySqlCipherUri,
-            Pooling = true,
+            Pooling = false,
             DefaultTimeout = 30
         }.ToString();
     }

--- a/DownKyi/Program.cs
+++ b/DownKyi/Program.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading.Tasks;
 using DownKyi.Desktop;
 
 namespace DownKyi;
@@ -7,8 +6,8 @@ namespace DownKyi;
 sealed class Program
 {
     [STAThread]
-    public static Task Main(string[] args)
+    public static void Main(string[] args)
     {
-        return DesktopApplication.RunAsync(args);
+        DesktopApplication.RunAsync(args).GetAwaiter().GetResult();
     }
 }

--- a/src/DownKyi.Desktop/App.axaml.cs
+++ b/src/DownKyi.Desktop/App.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -202,7 +203,20 @@ internal partial class App : Avalonia.Application, IAsyncDisposable
 
     private void OnUiUnhandledException(object? sender, DispatcherUnhandledExceptionEventArgs e)
     {
+        if (IsClipboardComInitializationFailure(e.Exception))
+        {
+            _logger?.LogWarningMessage("A clipboard operation failed because COM was not initialized.", e.Exception);
+            e.Handled = true;
+            return;
+        }
+
         _logger?.LogCriticalMessage("Unhandled UI exception.", e.Exception);
+    }
+
+    internal static bool IsClipboardComInitializationFailure(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        return exception is COMException { HResult: unchecked((int)0x800401F0) };
     }
 
     private void OnDomainUnhandledException(object? sender, UnhandledExceptionEventArgs e)

--- a/src/DownKyi.Desktop/DesktopApplication.cs
+++ b/src/DownKyi.Desktop/DesktopApplication.cs
@@ -16,7 +16,10 @@ public static class DesktopApplication
         var appBuilder = BuildAvaloniaApp();
         try
         {
-            appBuilder.StartWithClassicDesktopLifetime(args);
+            using (WindowsOleApartment.Enter())
+            {
+                appBuilder.StartWithClassicDesktopLifetime(args);
+            }
         }
         finally
         {

--- a/src/DownKyi.Desktop/DownKyi.Desktop.csproj
+++ b/src/DownKyi.Desktop/DownKyi.Desktop.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <BuiltInComInteropSupport>true</BuiltInComInteropSupport>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <SatelliteResourceLanguages>zh-Hans</SatelliteResourceLanguages>

--- a/src/DownKyi.Desktop/Platform/WindowsOleApartment.cs
+++ b/src/DownKyi.Desktop/Platform/WindowsOleApartment.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace DownKyi.Platform;
+
+internal sealed partial class WindowsOleApartment : IDisposable
+{
+    private const int Success = 0;
+    private const int AlreadyInitialized = 1;
+    private readonly bool _requiresUninitialize;
+
+    private WindowsOleApartment(bool requiresUninitialize)
+    {
+        _requiresUninitialize = requiresUninitialize;
+    }
+
+    public static WindowsOleApartment Enter()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return new WindowsOleApartment(false);
+        }
+
+        var result = OleInitialize(IntPtr.Zero);
+        if (result is not (Success or AlreadyInitialized))
+        {
+            Marshal.ThrowExceptionForHR(result);
+        }
+
+        return new WindowsOleApartment(true);
+    }
+
+    public void Dispose()
+    {
+        if (_requiresUninitialize)
+        {
+            OleUninitialize();
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    [LibraryImport("ole32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial int OleInitialize(IntPtr reserved);
+
+    [LibraryImport("ole32.dll")]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static partial void OleUninitialize();
+}

--- a/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
@@ -380,14 +380,9 @@ internal sealed class Aria2TransferBackend : ITransferBackend
             _logger.LogErrorMessage("Aria server shutdown failed.", e);
         }
 
-        if (!await _ariaServer.CloseServerAsync(
-                _ariaClient,
-                TimeSpan.FromSeconds(3)).ConfigureAwait(true))
-        {
-            await _ariaServer.ForceCloseServerAsync(
-                _ariaClient,
-                TimeSpan.FromSeconds(2)).ConfigureAwait(true);
-        }
+        await _ariaServer.CloseServerAsync(
+            _ariaClient,
+            TimeSpan.FromSeconds(3)).ConfigureAwait(true);
     }
 
     private DownloadProgress? CreateProgress(string activeGid, AriaProgressEventArgs eventArgs)

--- a/src/DownKyi.Desktop/Services/Download/CompletedMediaOutput.cs
+++ b/src/DownKyi.Desktop/Services/Download/CompletedMediaOutput.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using DownKyi.Models;
+
+namespace DownKyi.Services.Download;
+
+internal static class CompletedMediaOutput
+{
+    private static readonly string[] VideoExtensions = [".mp4", ".flv"];
+    private static readonly string[] AudioExtensions = [".aac", ".mp3", ".flac"];
+    private static readonly string[] CoverExtensions = [".jpg", ".jpeg", ".png", ".webp", ".avif", ".gif"];
+
+    public static bool Exists(DownloadBase downloadBase)
+    {
+        ArgumentNullException.ThrowIfNull(downloadBase);
+        if (string.IsNullOrWhiteSpace(downloadBase.FilePath))
+        {
+            return false;
+        }
+
+        if (IsRequested(downloadBase, "downloadVideo"))
+        {
+            return HasNonEmptyFile(downloadBase.FilePath, VideoExtensions);
+        }
+
+        if (IsRequested(downloadBase, "downloadAudio"))
+        {
+            return HasNonEmptyFile(downloadBase.FilePath, AudioExtensions);
+        }
+
+        return (IsRequested(downloadBase, "downloadDanmaku")
+                && HasNonEmptyFile(downloadBase.FilePath, [".ass"]))
+            || (IsRequested(downloadBase, "downloadSubtitle")
+                && HasSubtitle(downloadBase.FilePath))
+            || (IsRequested(downloadBase, "downloadCover")
+                && HasCover(downloadBase.FilePath));
+    }
+
+    private static bool IsRequested(DownloadBase downloadBase, string contentName)
+    {
+        return downloadBase.NeedDownloadContent.TryGetValue(contentName, out var requested) && requested;
+    }
+
+    private static bool HasSubtitle(string basePath)
+    {
+        if (HasNonEmptyFile(basePath, [".srt"]))
+        {
+            return true;
+        }
+
+        var directory = Path.GetDirectoryName(basePath);
+        var name = Path.GetFileName(basePath);
+        if (string.IsNullOrWhiteSpace(directory)
+            || string.IsNullOrWhiteSpace(name)
+            || !Directory.Exists(directory))
+        {
+            return false;
+        }
+
+        try
+        {
+            foreach (var path in Directory.EnumerateFiles(directory, $"{name}_*.srt", SearchOption.TopDirectoryOnly))
+            {
+                if (HasNonEmptyFile(path))
+                {
+                    return true;
+                }
+            }
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+
+        return false;
+    }
+
+    private static bool HasCover(string basePath)
+    {
+        foreach (var extension in CoverExtensions)
+        {
+            if (HasNonEmptyFile(basePath + extension)
+                || HasNonEmptyFile(basePath + ".Cover" + extension))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasNonEmptyFile(string basePath, IReadOnlyList<string> extensions)
+    {
+        foreach (var extension in extensions)
+        {
+            if (HasNonEmptyFile(basePath + extension))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool HasNonEmptyFile(string path)
+    {
+        try
+        {
+            return File.Exists(path) && new FileInfo(path).Length > 0;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/DownloadDuplicatePolicy.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadDuplicatePolicy.cs
@@ -60,10 +60,11 @@ internal sealed class DownloadDuplicatePolicy
 
             return strategy switch
             {
+                RepeatDownloadStrategy.JumpOver => true,
+                RepeatDownloadStrategy.ReDownload => false,
+                RepeatDownloadStrategy.Ask when !CompletedMediaOutput.Exists(item.DownloadBase) => false,
                 RepeatDownloadStrategy.Ask => await ResolveAskAsync(item, cancellationToken)
                     .ConfigureAwait(true),
-                RepeatDownloadStrategy.ReDownload => false,
-                RepeatDownloadStrategy.JumpOver => true,
                 _ => true
             };
         }

--- a/src/DownKyi.Desktop/Services/Download/DownloadDuplicatePolicy.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadDuplicatePolicy.cs
@@ -39,7 +39,7 @@ internal sealed class DownloadDuplicatePolicy
         ArgumentNullException.ThrowIfNull(videoQuality);
         cancellationToken.ThrowIfCancellationRequested();
 
-        foreach (var item in _downloadLists.Downloading)
+        foreach (var item in _downloadLists.GetDownloadingSnapshot())
         {
             if (!IsSameVideo(item, page, videoQuality))
             {
@@ -51,7 +51,7 @@ internal sealed class DownloadDuplicatePolicy
             return true;
         }
 
-        foreach (var item in _downloadLists.Downloaded)
+        foreach (var item in _downloadLists.GetDownloadedSnapshot())
         {
             if (!IsSameVideo(item, page, videoQuality))
             {

--- a/src/DownKyi.Desktop/Services/Download/DownloadListState.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadListState.cs
@@ -10,6 +10,7 @@ namespace DownKyi.Services.Download;
 
 internal sealed class DownloadListState
 {
+    private readonly object _sync = new();
     private readonly RangeObservableCollection<DownloadingItem> _downloading = new();
     private readonly RangeObservableCollection<DownloadedItem> _downloaded = new();
 
@@ -26,61 +27,104 @@ internal sealed class DownloadListState
     public void AddDownloading(DownloadingItem item)
     {
         ArgumentNullException.ThrowIfNull(item);
-        _downloading.Add(item);
+        lock (_sync)
+        {
+            _downloading.Add(item);
+        }
     }
 
     public void AddDownloadingRange(IEnumerable<DownloadingItem> items)
     {
         ArgumentNullException.ThrowIfNull(items);
-        _downloading.AddRange(items);
+        lock (_sync)
+        {
+            _downloading.AddRange(items);
+        }
     }
 
     public bool RemoveDownloading(DownloadingItem item)
     {
         ArgumentNullException.ThrowIfNull(item);
-        return _downloading.Remove(item);
+        lock (_sync)
+        {
+            return _downloading.Remove(item);
+        }
     }
 
     public void AddDownloaded(DownloadedItem item)
     {
         ArgumentNullException.ThrowIfNull(item);
-        _downloaded.Add(item);
+        lock (_sync)
+        {
+            _downloaded.Add(item);
+        }
     }
 
     public void AddDownloadedRange(IEnumerable<DownloadedItem> items)
     {
         ArgumentNullException.ThrowIfNull(items);
-        _downloaded.AddRange(items);
+        lock (_sync)
+        {
+            _downloaded.AddRange(items);
+        }
     }
 
     public bool RemoveDownloaded(DownloadedItem item)
     {
         ArgumentNullException.ThrowIfNull(item);
-        return _downloaded.Remove(item);
+        lock (_sync)
+        {
+            return _downloaded.Remove(item);
+        }
     }
 
     public void ClearDownloaded()
     {
-        _downloaded.Clear();
+        lock (_sync)
+        {
+            _downloaded.Clear();
+        }
     }
 
     public void ReplaceDownloaded(IEnumerable<DownloadedItem> items)
     {
         ArgumentNullException.ThrowIfNull(items);
-        ReplaceDownloadedCore(items.ToList());
+        lock (_sync)
+        {
+            ReplaceDownloadedCore(items.ToList());
+        }
     }
 
     public void SortDownloaded(DownloadFinishedSort finishedSort)
     {
-        var items = Downloaded.ToList();
-        items.Sort(finishedSort switch
+        lock (_sync)
         {
-            DownloadFinishedSort.DownloadAsc => CompareFinishedAscending,
-            DownloadFinishedSort.DownloadDesc => CompareFinishedDescending,
-            DownloadFinishedSort.Number => CompareTitleAndOrder,
-            _ => static (_, _) => 0
-        });
-        ReplaceDownloadedCore(items);
+            var items = _downloaded.ToList();
+            items.Sort(finishedSort switch
+            {
+                DownloadFinishedSort.DownloadAsc => CompareFinishedAscending,
+                DownloadFinishedSort.DownloadDesc => CompareFinishedDescending,
+                DownloadFinishedSort.Number => CompareTitleAndOrder,
+                _ => static (_, _) => 0
+            });
+            ReplaceDownloadedCore(items);
+        }
+    }
+
+    public IReadOnlyList<DownloadingItem> GetDownloadingSnapshot()
+    {
+        lock (_sync)
+        {
+            return _downloading.ToArray();
+        }
+    }
+
+    public IReadOnlyList<DownloadedItem> GetDownloadedSnapshot()
+    {
+        lock (_sync)
+        {
+            return _downloaded.ToArray();
+        }
     }
 
     private static int CompareFinishedAscending(DownloadedItem left, DownloadedItem right)

--- a/src/DownKyi.Desktop/Services/Migration/LegacyUpgradeCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Migration/LegacyUpgradeCoordinator.cs
@@ -233,8 +233,9 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
                     progress.Report(new LegacyUpgradeProgress("尝试备用连接方式"));
                 }
 
-                ValidateLegacyDatabase(database);
-                return ReadLegacyRecords(database, progress, cancellationToken);
+                return HasLegacyDownloadSchema(database)
+                    ? ReadLegacyRecords(database, progress, cancellationToken)
+                    : new Dictionary<string, DownloadedWithData>(StringComparer.Ordinal);
             }
             catch (Exception e) when (e is SqliteException or IOException or UnauthorizedAccessException
                 or InvalidOperationException or ArgumentException)
@@ -248,7 +249,7 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
         return null;
     }
 
-    private static void ValidateLegacyDatabase(SqliteDatabase database)
+    internal static bool HasLegacyDownloadSchema(SqliteDatabase database)
     {
         var tableCount = 0;
         database.ExecuteQuery(
@@ -260,6 +261,11 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
                     tableCount++;
                 }
             });
+        if (tableCount == 0)
+        {
+            return false;
+        }
+
         if (tableCount < 2)
         {
             throw new SqliteException("数据库表不存在或结构不完整", 1);
@@ -283,6 +289,8 @@ internal sealed class LegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
         {
             throw new SqliteException("缺少必要的数据库表", 1);
         }
+
+        return true;
     }
 
     private Dictionary<string, DownloadedWithData> ReadLegacyRecords(

--- a/src/DownKyi.Desktop/Services/SearchService.cs
+++ b/src/DownKyi.Desktop/Services/SearchService.cs
@@ -39,7 +39,7 @@ internal class SearchService
         ArgumentNullException.ThrowIfNull(input);
 
         // 移除剪贴板id
-        var justId = input.Replace(AppConstant.ClipboardId, "", StringComparison.Ordinal);
+        var justId = NormalizeInput(input);
 
         // 视频
         if (ParseEntrance.IsAvId(justId))
@@ -130,6 +130,23 @@ internal class SearchService
         }
 
         return true;
+    }
+
+    internal static string NormalizeInput(string input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        var normalized = input
+            .Replace(AppConstant.ClipboardId, string.Empty, StringComparison.Ordinal)
+            .Trim();
+        if (!normalized.StartsWith('【'))
+        {
+            return normalized;
+        }
+
+        var titleEnd = normalized.IndexOf('】', StringComparison.Ordinal);
+        return titleEnd < 0
+            ? normalized
+            : normalized[(titleEnd + 1)..].Trim();
     }
 
     /// <summary>

--- a/src/DownKyi.Desktop/ViewModels/ViewIndexViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewIndexViewModel.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
@@ -230,7 +229,6 @@ internal class ViewIndexViewModel : ViewModelBase
         }
 
         _logger.LogDebugMessage("Processing search input.");
-        InputText = Regex.Replace(InputText, @"[【]*[^【]*[^】]*[】 ]", "");
         var isSupport = _searchService.BiliInput(InputText, AppRoute.Index);
         if (!isSupport)
         {

--- a/src/DownKyi.Desktop/ViewModels/ViewMyBangumiFollowViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyBangumiFollowViewModel.cs
@@ -31,7 +31,6 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
     private readonly ILogger<ViewMyBangumiFollowViewModel> _logger;
     private readonly IUserSpacePageCoordinator _userSpaceCoordinator;
     private CancellationTokenSource? _loadCancellation;
-    private CancellationTokenSource? _downloadCancellation;
 
     private long _mid = -1;
 
@@ -251,7 +250,7 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
     /// <param name="isOnlySelected"></param>
     private async Task AddToDownloadAsync(bool isOnlySelected)
     {
-        var cancellationToken = ReplaceCancellationSource(ref _downloadCancellation);
+        var cancellationToken = CancellationToken.None;
         var items = Medias
             .Select(media => new ContentDownloadItem(
                 $"{ParseEntrance.BangumiMediaUrl}md{media.MediaId}",
@@ -409,7 +408,6 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
     private void CancelOperations()
     {
         CancelAndDispose(ref _loadCancellation);
-        CancelAndDispose(ref _downloadCancellation);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyFavoritesViewModel.cs
@@ -29,7 +29,6 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
     private readonly ILogger<ViewMyFavoritesViewModel> _logger;
     private CancellationTokenSource? _folderLoadCancellation;
     private CancellationTokenSource? _mediaLoadCancellation;
-    private CancellationTokenSource? _downloadCancellation;
 
     private long _mid = -1;
 
@@ -355,7 +354,7 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
     /// <param name="isOnlySelected"></param>
     private async Task AddToDownloadAsync(bool isOnlySelected)
     {
-        var cancellationToken = ReplaceCancellationSource(ref _downloadCancellation);
+        var cancellationToken = CancellationToken.None;
         var items = FavoritesSelectionPolicy.CreateDownloadItems(Medias);
         try
         {
@@ -407,7 +406,6 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
     {
         CancelAndDispose(ref _folderLoadCancellation);
         CancelAndDispose(ref _mediaLoadCancellation);
-        CancelAndDispose(ref _downloadCancellation);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.cs
@@ -29,7 +29,6 @@ internal class ViewMyHistoryViewModel : ViewModelBase
     // 每页视频数量，暂时在此写死，以后在设置中增加选项
     private const int VideoNumberInPage = 30;
     private CancellationTokenSource? _loadCancellation;
-    private CancellationTokenSource? _downloadCancellation;
     private bool _isLoadingPage;
     private bool _hasMoreHistory = true;
     private int _loadVersion;
@@ -280,7 +279,7 @@ internal class ViewMyHistoryViewModel : ViewModelBase
     /// <param name="isOnlySelected"></param>
     private async Task AddToDownloadAsync(bool isOnlySelected)
     {
-        var cancellationToken = ReplaceCancellationSource(ref _downloadCancellation);
+        var cancellationToken = CancellationToken.None;
         var items = Medias
             .Where(media => media.Business is "archive" or "pgc")
             .Select(media => new ContentDownloadItem(
@@ -456,7 +455,6 @@ internal class ViewMyHistoryViewModel : ViewModelBase
     {
         Interlocked.Increment(ref _loadVersion);
         CancelAndDispose(ref _loadCancellation);
-        CancelAndDispose(ref _downloadCancellation);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/ViewModels/ViewMyToViewVideoViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyToViewVideoViewModel.cs
@@ -26,7 +26,6 @@ internal class ViewMyToViewVideoViewModel : ViewModelBase
     private readonly ILogger<ViewMyToViewVideoViewModel> _logger;
     private readonly IPersonalMediaCoordinator _personalMediaCoordinator;
     private CancellationTokenSource? _loadCancellation;
-    private CancellationTokenSource? _downloadCancellation;
 
     #region 页面属性申明
 
@@ -248,7 +247,7 @@ internal class ViewMyToViewVideoViewModel : ViewModelBase
     /// <param name="isOnlySelected"></param>
     private async Task AddToDownloadAsync(bool isOnlySelected)
     {
-        var cancellationToken = ReplaceCancellationSource(ref _downloadCancellation);
+        var cancellationToken = CancellationToken.None;
         var items = Medias
             .Select(media => new ContentDownloadItem(media.Bvid, DownloadInfoKind.Video, media.IsSelected))
             .ToArray();
@@ -379,7 +378,6 @@ internal class ViewMyToViewVideoViewModel : ViewModelBase
     private void CancelOperations()
     {
         CancelAndDispose(ref _loadCancellation);
-        CancelAndDispose(ref _downloadCancellation);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/ViewModels/ViewPublicFavoritesViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewPublicFavoritesViewModel.cs
@@ -30,7 +30,6 @@ internal class ViewPublicFavoritesViewModel : ViewModelBase
     private readonly ILogger<ViewPublicFavoritesViewModel> _logger;
     private readonly ISettingsStore _settingsStore;
     private CancellationTokenSource? _loadCancellation;
-    private CancellationTokenSource? _downloadCancellation;
 
     #region 页面属性申明
 
@@ -263,7 +262,7 @@ internal class ViewPublicFavoritesViewModel : ViewModelBase
 
     private async Task AddToDownloadAsync(bool isOnlySelected)
     {
-        var cancellationToken = ReplaceCancellationSource(ref _downloadCancellation);
+        var cancellationToken = CancellationToken.None;
         var items = FavoritesSelectionPolicy.CreateDownloadItems(FavoritesMedias);
         try
         {
@@ -385,7 +384,6 @@ internal class ViewPublicFavoritesViewModel : ViewModelBase
     private void CancelOperations()
     {
         CancelAndDispose(ref _loadCancellation);
-        CancelAndDispose(ref _downloadCancellation);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/ViewModels/ViewPublicationViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewPublicationViewModel.cs
@@ -29,7 +29,6 @@ namespace DownKyi.ViewModels
         private readonly ILogger<ViewPublicationViewModel> _logger;
         private readonly IUserSpacePageCoordinator _userSpaceCoordinator;
         private CancellationTokenSource? _loadCancellation;
-        private CancellationTokenSource? _downloadCancellation;
 
         private long _mid = -1;
 
@@ -316,7 +315,7 @@ namespace DownKyi.ViewModels
         /// <param name="isOnlySelected"></param>
         private async Task AddToDownloadAsync(bool isOnlySelected)
         {
-            var cancellationToken = ReplaceCancellationSource(ref _downloadCancellation);
+            var cancellationToken = CancellationToken.None;
             var items = Medias
                 .Select(media => new ContentDownloadItem(media.Bvid, DownloadInfoKind.Video, media.IsSelected))
                 .ToArray();
@@ -378,7 +377,6 @@ namespace DownKyi.ViewModels
         private void CancelOperations()
         {
             CancelAndDispose(ref _loadCancellation);
-            CancelAndDispose(ref _downloadCancellation);
         }
 
         protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/ViewModels/ViewSeasonsSeriesDetailViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewSeasonsSeriesDetailViewModel.cs
@@ -34,7 +34,6 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
     private readonly ISeasonsSeriesCoordinator _coordinator;
     private readonly ILogger<ViewSeasonsSeriesDetailViewModel> _logger;
     private CancellationTokenSource? _loadCancellation;
-    private CancellationTokenSource? _downloadCancellation;
     private long _mid = -1;
     private long _id = -1;
     private SeasonsSeriesKind _kind;
@@ -210,7 +209,7 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
 
     private async Task AddToDownloadAsync(bool onlySelected)
     {
-        var cancellationToken = ReplaceCancellationSource(ref _downloadCancellation);
+        var cancellationToken = CancellationToken.None;
         var items = Medias
             .Select(media => new SeasonsSeriesDownloadItem(media.Bvid, media.IsSelected))
             .ToArray();
@@ -392,7 +391,6 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
     private void CancelOperations()
     {
         CancelAndDispose(ref _loadCancellation);
-        CancelAndDispose(ref _downloadCancellation);
     }
 
     protected override void Dispose(bool disposing)

--- a/src/DownKyi.Desktop/Views/MainWindow.axaml.cs
+++ b/src/DownKyi.Desktop/Views/MainWindow.axaml.cs
@@ -75,6 +75,7 @@ internal partial class MainWindow : Window
 
         _closeInProgress = true;
         SaveWindowSettings();
+        Hide();
         ObserveCloseCompletion(CompleteCloseAsync());
     }
 

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -251,6 +251,7 @@ public sealed class AssemblyLifecycleArchitectureTests
         const string legacyExitSubscription = "Exit += OnExit";
 
         Assert.Contains("finally", desktopApplication, StringComparison.Ordinal);
+        Assert.Contains("WindowsOleApartment.Enter()", desktopApplication, StringComparison.Ordinal);
         Assert.Contains("await application.DisposeAsync()", desktopApplication, StringComparison.Ordinal);
         Assert.Contains("IAsyncDisposable", app, StringComparison.Ordinal);
         Assert.Contains("RequestShutdownAsync(CancellationToken.None)", app, StringComparison.Ordinal);

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -245,11 +245,14 @@ public sealed class AssemblyLifecycleArchitectureTests
     [Fact]
     public void DesktopMainLoopAwaitsApplicationAndHostTeardown()
     {
+        var program = Read("DownKyi/Program.cs");
         var desktopApplication = Read("src/DownKyi.Desktop/DesktopApplication.cs");
         var app = Read("src/DownKyi.Desktop/App.axaml.cs");
         const string desktopPrefix = "desktop.";
         const string legacyExitSubscription = "Exit += OnExit";
 
+        Assert.Contains("public static void Main", program, StringComparison.Ordinal);
+        Assert.Contains("RunAsync(args).GetAwaiter().GetResult()", program, StringComparison.Ordinal);
         Assert.Contains("finally", desktopApplication, StringComparison.Ordinal);
         Assert.Contains("WindowsOleApartment.Enter()", desktopApplication, StringComparison.Ordinal);
         Assert.Contains("await application.DisposeAsync()", desktopApplication, StringComparison.Ordinal);

--- a/tests/DownKyi.Architecture.Tests/DownloadRuntimeArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadRuntimeArchitectureTests.cs
@@ -363,6 +363,11 @@ public sealed class DownloadRuntimeArchitectureTests
             "src", "DownKyi.Desktop",
             "Platform",
             "AvaloniaApplicationLifecycle.cs"));
+        var transferBackendSource = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "src", "DownKyi.Desktop",
+            "Services", "Download",
+            "Aria2TransferBackend.cs"));
 
         Assert.True(violations.Length == 0, string.Join(Environment.NewLine, violations));
         Assert.Contains("sealed class AriaServer", serverSource, StringComparison.Ordinal);
@@ -371,6 +376,7 @@ public sealed class DownloadRuntimeArchitectureTests
         Assert.Contains("AddSingleton<AriaServer>()", compositionSource, StringComparison.Ordinal);
         Assert.Contains("GetService<AriaServer>()", lifecycleSource, StringComparison.Ordinal);
         Assert.DoesNotContain("AriaServer.KillTrackedServer", lifecycleSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("ForceCloseServerAsync(", transferBackendSource, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/DownKyi.Architecture.Tests/InputParsingArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/InputParsingArchitectureTests.cs
@@ -84,7 +84,7 @@ public sealed class InputParsingArchitectureTests
     }
 
     [Fact]
-    public void UserSpaceParsingRequiresAnExactHostAndNumericPath()
+    public void UserSpaceParsingRequiresAnExactHostAndSupportedPath()
     {
         var source = Read("ParseEntrance.UserSpace.cs");
 
@@ -93,7 +93,9 @@ public sealed class InputParsingArchitectureTests
             "string.Equals(uri.Host, \"space.bilibili.com\", StringComparison.OrdinalIgnoreCase)",
             source,
             StringComparison.Ordinal);
-        Assert.Contains("segments.Length == 1", source, StringComparison.Ordinal);
+        Assert.Contains("IsSupportedUserSpacePath(segments)", source, StringComparison.Ordinal);
+        Assert.Contains("string.Equals(segments[1], \"upload\"", source, StringComparison.Ordinal);
+        Assert.Contains("string.Equals(segments[2], \"video\"", source, StringComparison.Ordinal);
         Assert.DoesNotContain(".Contains(\"space.bilibili.com\"", source, StringComparison.Ordinal);
     }
 

--- a/tests/DownKyi.Core.Tests/ParseEntranceContractTests.cs
+++ b/tests/DownKyi.Core.Tests/ParseEntranceContractTests.cs
@@ -139,6 +139,15 @@ public sealed class ParseEntranceContractTests
     }
 
     [Theory]
+    [InlineData("https://space.bilibili.com/3707029862484836/upload/video", 3707029862484836)]
+    [InlineData("https://space.bilibili.com/928123/UPLOAD/VIDEO/?spm_id_from=333.337.0.0", 928123)]
+    public void UserUploadVideoUrlsResolveToUserSpace(string input, long expected)
+    {
+        Assert.True(ParseEntrance.IsUserUrl(input));
+        Assert.Equal(expected, ParseEntrance.GetUserId(input));
+    }
+
+    [Theory]
     [InlineData("https://space.bilibili.com.evil/928123")]
     [InlineData("https://evil.example/space.bilibili.com/928123")]
     [InlineData("https://space.bilibili.com/user928123")]

--- a/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
+++ b/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
@@ -477,6 +477,57 @@ public sealed class UiSmokeTests
         }).ConfigureAwait(true);
     }
 
+    [AvaloniaFact]
+    public async Task MainWindowHidesWhileShutdownCleanupIsStillRunning()
+    {
+        await AvaloniaTestDispatcher.RunAsync(async () =>
+        {
+            var testDirectory = Path.Combine(Path.GetTempPath(), $"downkyi-close-hide-{Guid.NewGuid():N}");
+            var settingsStore = new SettingsStore(Path.Combine(testDirectory, "settings.json"));
+            var logProvider = new ApplicationLogProvider(
+                new ApplicationLogOptions(Path.Combine(testDirectory, "logs")));
+            var loggerFactory = LoggerFactory.Create(builder => builder.AddProvider(logProvider));
+            var lifecycle = new BlockingApplicationLifecycle();
+
+            try
+            {
+                using var host = DownKyiHost.Create(services =>
+                {
+                    services.AddDownKyiDesktop(loggerFactory, logProvider);
+                    services.Replace(ServiceDescriptor.Singleton<ISettingsStore>(settingsStore));
+                    services.Replace(ServiceDescriptor.Singleton<IApplicationLifecycle>(lifecycle));
+                    services.Replace(ServiceDescriptor.Singleton(
+                        new SqliteDownloadTaskStoreOptions(Path.Combine(testDirectory, "downkyi.db"))));
+                });
+                var window = host.Services.GetRequiredService<MainWindow>();
+                var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                window.Closed += (_, _) => closed.TrySetResult();
+
+                window.Show();
+                window.Close();
+
+                Assert.False(window.IsVisible);
+                Assert.False(closed.Task.IsCompleted);
+                Assert.Equal(1, lifecycle.ShutdownRequestCount);
+
+                lifecycle.CompleteShutdown();
+                await closed.Task
+                    .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken)
+                    .ConfigureAwait(true);
+            }
+            finally
+            {
+                loggerFactory.Dispose();
+                await logProvider.DisposeAsync().ConfigureAwait(true);
+                await settingsStore.DisposeAsync().ConfigureAwait(true);
+                if (Directory.Exists(testDirectory))
+                {
+                    Directory.Delete(testDirectory, recursive: true);
+                }
+            }
+        }).ConfigureAwait(true);
+    }
+
     [Fact]
     public void CreatingHostDoesNotRedirectExistingUserDataPaths()
     {
@@ -688,6 +739,38 @@ public sealed class UiSmokeTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(false);
+        }
+    }
+
+    private sealed class BlockingApplicationLifecycle : IApplicationLifecycle
+    {
+        private readonly TaskCompletionSource _shutdown = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int ShutdownRequestCount { get; private set; }
+
+        public Task RequestShutdownAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            ShutdownRequestCount++;
+            return _shutdown.Task;
+        }
+
+        public Task ExitAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> RestartAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(false);
+        }
+
+        public void CompleteShutdown()
+        {
+            _shutdown.TrySetResult();
         }
     }
 

--- a/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
+++ b/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
@@ -85,6 +85,52 @@ public sealed class UiSmokeTests
     }
 
     [AvaloniaFact]
+    public async Task PublicationBatchDownloadContinuesAfterNavigationAway()
+    {
+        await AvaloniaTestDispatcher.RunAsync(async () =>
+        {
+            EnsureProductThemeResources();
+            ViewPublicationViewModel? publication = null;
+            using var navigation = new AvaloniaNavigationService(
+                route => route switch
+                {
+                    AppRoute.Publication => publication!,
+                    AppRoute.VideoDetail => new NavigationProbe(route),
+                    _ => throw new InvalidOperationException($"Unexpected route {route}.")
+                },
+                static action => action());
+            var downloadCoordinator = new BlockingContentDownloadCoordinator();
+            publication = new ViewPublicationViewModel(
+                new DesktopInteractionContextStub(navigation),
+                downloadCoordinator,
+                new PublicationPageCoordinatorStub(navigation),
+                NullLogger<ViewPublicationViewModel>.Instance);
+
+            navigation.Navigate(new AppNavigationRequest(
+                AppRoute.Publication,
+                AppRoute.Index,
+                PublicationNavigationPayload.All(42)));
+            Assert.Single(publication.Medias);
+
+            publication.AddAllToDownloadCommand.Execute(null);
+            var cancellationToken = await downloadCoordinator.Started
+                .WaitAsync(TimeSpan.FromSeconds(5))
+                .ConfigureAwait(true);
+
+            navigation.Navigate(new AppNavigationRequest(
+                AppRoute.VideoDetail,
+                AppRoute.Publication,
+                "video"));
+
+            Assert.False(cancellationToken.CanBeCanceled);
+            Assert.False(cancellationToken.IsCancellationRequested);
+
+            downloadCoordinator.Complete(1);
+            await Task.Yield();
+        }).ConfigureAwait(true);
+    }
+
+    [AvaloniaFact]
     public async Task FavoritesSearchPageAndSnapshotSurviveTypedBackNavigation()
     {
         await AvaloniaTestDispatcher.RunAsync(async () =>
@@ -827,6 +873,30 @@ public sealed class UiSmokeTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult<int?>(0);
+        }
+    }
+
+    private sealed class BlockingContentDownloadCoordinator : IContentDownloadCoordinator
+    {
+        private readonly TaskCompletionSource<CancellationToken> _started =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<int?> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<CancellationToken> Started => _started.Task;
+
+        public Task<int?> AddAsync(
+            IReadOnlyList<ContentDownloadItem> items,
+            bool onlySelected,
+            CancellationToken cancellationToken)
+        {
+            _started.TrySetResult(cancellationToken);
+            return _completion.Task;
+        }
+
+        public void Complete(int addedCount)
+        {
+            _completion.TrySetResult(addedCount);
         }
     }
 

--- a/tests/DownKyi.Tests/CompletedMediaOutputTests.cs
+++ b/tests/DownKyi.Tests/CompletedMediaOutputTests.cs
@@ -1,0 +1,61 @@
+using DownKyi.Models;
+using DownKyi.Services.Download;
+
+namespace DownKyi.Tests;
+
+public sealed class CompletedMediaOutputTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "downkyi-completed-media-output-tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData("downloadDanmaku", ".ass")]
+    [InlineData("downloadSubtitle", ".srt")]
+    [InlineData("downloadCover", ".Cover.jpg")]
+    public void RequestedAuxiliaryOutputMustExist(string contentName, string extension)
+    {
+        Directory.CreateDirectory(_directory);
+        var downloadBase = CreateDownloadBase(contentName);
+
+        Assert.False(CompletedMediaOutput.Exists(downloadBase));
+
+        File.WriteAllText(downloadBase.FilePath + extension, "content");
+
+        Assert.True(CompletedMediaOutput.Exists(downloadBase));
+    }
+
+    [Fact]
+    public void LanguageSpecificSubtitleSatisfiesRequestedOutput()
+    {
+        Directory.CreateDirectory(_directory);
+        var downloadBase = CreateDownloadBase("downloadSubtitle");
+        File.WriteAllText(downloadBase.FilePath + "_zh-CN.srt", "subtitle");
+
+        Assert.True(CompletedMediaOutput.Exists(downloadBase));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private DownloadBase CreateDownloadBase(string contentName)
+    {
+        var downloadBase = new DownloadBase
+        {
+            FilePath = Path.Combine(_directory, "completed-output")
+        };
+        foreach (var key in downloadBase.NeedDownloadContent.Keys.ToArray())
+        {
+            downloadBase.NeedDownloadContent[key] = false;
+        }
+
+        downloadBase.NeedDownloadContent[contentName] = true;
+        return downloadBase;
+    }
+}

--- a/tests/DownKyi.Tests/DesktopInteractionServiceTests.cs
+++ b/tests/DownKyi.Tests/DesktopInteractionServiceTests.cs
@@ -90,6 +90,36 @@ public sealed class DesktopInteractionServiceTests
         Assert.Equal(3707029862484836L, request.Parameter);
     }
 
+    [Theory]
+    [InlineData("https://space.bilibili.com/301479902")]
+    [InlineData(" https://space.bilibili.com/301479902\r\n")]
+    [InlineData("【UP主个人空间】 https://space.bilibili.com/301479902 ")]
+    [InlineData("https://space.bilibili.com/301479902\r\n" + AppConstant.ClipboardId)]
+    public void CopiedUserSpaceUrlNavigatesToUserSpaceHome(string input)
+    {
+        using var settings = new TestSettingsStore();
+        var navigation = new RecordingNavigationService();
+        var search = new SearchService(settings.Store, navigation);
+
+        Assert.True(search.BiliInput(input, AppRoute.Index));
+
+        var request = Assert.Single(navigation.Requests);
+        Assert.Equal(AppRoute.UserSpace, request.Route);
+        Assert.Equal(AppRoute.Index, request.Parent);
+        Assert.Equal(301479902L, request.Parameter);
+    }
+
+    [Fact]
+    public void ClipboardComInitializationFailureIsRecoverable()
+    {
+        var exception = System.Runtime.InteropServices.Marshal.GetExceptionForHR(
+            unchecked((int)0x800401F0));
+
+        Assert.NotNull(exception);
+        Assert.True(App.IsClipboardComInitializationFailure(exception));
+        Assert.False(App.IsClipboardComInitializationFailure(new InvalidOperationException()));
+    }
+
     [Fact]
     public void UnsupportedSearchInputDoesNotNavigate()
     {

--- a/tests/DownKyi.Tests/DesktopInteractionServiceTests.cs
+++ b/tests/DownKyi.Tests/DesktopInteractionServiceTests.cs
@@ -74,6 +74,23 @@ public sealed class DesktopInteractionServiceTests
     }
 
     [Fact]
+    public void UserUploadVideoUrlNavigatesToUserSpaceHome()
+    {
+        using var settings = new TestSettingsStore();
+        var navigation = new RecordingNavigationService();
+        var search = new SearchService(settings.Store, navigation);
+
+        Assert.True(search.BiliInput(
+            "https://space.bilibili.com/3707029862484836/upload/video",
+            AppRoute.Index));
+
+        var request = Assert.Single(navigation.Requests);
+        Assert.Equal(AppRoute.UserSpace, request.Route);
+        Assert.Equal(AppRoute.Index, request.Parent);
+        Assert.Equal(3707029862484836L, request.Parameter);
+    }
+
+    [Fact]
     public void UnsupportedSearchInputDoesNotNavigate()
     {
         using var settings = new TestSettingsStore();

--- a/tests/DownKyi.Tests/DownloadAddOwnerTests.cs
+++ b/tests/DownKyi.Tests/DownloadAddOwnerTests.cs
@@ -35,7 +35,7 @@ public sealed class DownloadAddOwnerTests : IDisposable
     }
 
     [Fact]
-    public async Task CompletedDuplicateJumpOverPreservesHistory()
+    public async Task CompletedDuplicateJumpOverPreservesHistoryWhenOutputWasMoved()
     {
         using var context = DuplicatePolicyContext.WithCompleted(AppDialogOutcome.Accepted);
 
@@ -71,7 +71,7 @@ public sealed class DownloadAddOwnerTests : IDisposable
     [Fact]
     public async Task RejectedDuplicateConfirmationPreservesCompletedRecord()
     {
-        using var context = DuplicatePolicyContext.WithCompleted(AppDialogOutcome.Canceled);
+        using var context = DuplicatePolicyContext.WithCompleted(_directory, AppDialogOutcome.Canceled);
 
         var shouldSkip = await context.Policy.ShouldSkipAsync(
             CreatePage(),
@@ -88,7 +88,7 @@ public sealed class DownloadAddOwnerTests : IDisposable
     [Fact]
     public async Task AcceptedDuplicateConfirmationDeletesPersistedRecordBeforeAllowingTask()
     {
-        using var context = DuplicatePolicyContext.WithCompleted(AppDialogOutcome.Accepted);
+        using var context = DuplicatePolicyContext.WithCompleted(_directory, AppDialogOutcome.Accepted);
 
         var shouldSkip = await context.Policy.ShouldSkipAsync(
             CreatePage(),
@@ -101,6 +101,23 @@ public sealed class DownloadAddOwnerTests : IDisposable
         Assert.Equal(1, context.Store.UpdateCount);
         Assert.Equal(DownloadPhase.Deleted, context.Store.Current?.Phase);
         Assert.Equal(1, context.Dialogs.ShowCount);
+    }
+
+    [Fact]
+    public async Task MissingCompletedOutputAllowsDownloadWithoutPromptWhenStrategyAsks()
+    {
+        using var context = DuplicatePolicyContext.WithCompleted(AppDialogOutcome.Accepted);
+
+        var shouldSkip = await context.Policy.ShouldSkipAsync(
+            CreatePage(),
+            CreateVideoQuality(),
+            DownKyi.Core.Settings.RepeatDownloadStrategy.Ask,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(shouldSkip);
+        Assert.Single(context.ListState.Downloaded);
+        Assert.Equal(0, context.Store.UpdateCount);
+        Assert.Equal(0, context.Dialogs.ShowCount);
     }
 
     [Fact]
@@ -326,8 +343,23 @@ public sealed class DownloadAddOwnerTests : IDisposable
 
         public static DuplicatePolicyContext WithCompleted(AppDialogOutcome outcome)
         {
+            return WithCompleted(outputDirectory: null, outcome);
+        }
+
+        public static DuplicatePolicyContext WithCompleted(
+            string? outputDirectory,
+            AppDialogOutcome outcome)
+        {
+            var downloadingItem = CreateDownloadingItem();
+            if (!string.IsNullOrWhiteSpace(outputDirectory))
+            {
+                Directory.CreateDirectory(outputDirectory);
+                downloadingItem.DownloadBase.FilePath = Path.Combine(outputDirectory, "completed-output");
+                File.WriteAllText(downloadingItem.DownloadBase.FilePath + ".mp4", "media");
+            }
+
             var queued = DownloadTaskProjectionMapper.CreateNewTask(
-                CreateDownloadingItem(),
+                downloadingItem,
                 DateTimeOffset.UnixEpoch);
             Assert.True(queued.Start(DateTimeOffset.UnixEpoch.AddSeconds(1))
                 .TryGetValue(out var started));

--- a/tests/DownKyi.Tests/DownloadListStateTests.cs
+++ b/tests/DownKyi.Tests/DownloadListStateTests.cs
@@ -59,6 +59,54 @@ public sealed class DownloadListStateTests
             ((ICollection<DownloadedItem>)state.Downloaded).Add(item));
     }
 
+    [Fact]
+    public void DownloadedSnapshotRemainsStableWhenSourceChanges()
+    {
+        var state = new DownloadListState();
+        var first = CreateDownloadedItem("A", order: 1, finishedTimestamp: 10);
+        var second = CreateDownloadedItem("B", order: 2, finishedTimestamp: 20);
+        state.AddDownloaded(first);
+
+        var snapshot = state.GetDownloadedSnapshot();
+        state.AddDownloaded(second);
+        state.RemoveDownloaded(first);
+
+        Assert.Equal([first], snapshot);
+        Assert.Equal([second], state.Downloaded);
+    }
+
+    [Fact]
+    public async Task DownloadedSnapshotsCanBeEnumeratedWhileCollectionChanges()
+    {
+        var state = new DownloadListState();
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var items = Enumerable.Range(0, 20)
+            .Select(index => CreateDownloadedItem($"Item {index}", index, index))
+            .ToArray();
+
+        var writer = Task.Run(() =>
+        {
+            for (var index = 0; index < 2_000; index++)
+            {
+                var item = items[index % items.Length];
+                state.AddDownloaded(item);
+                state.RemoveDownloaded(item);
+            }
+        }, cancellationToken);
+        var reader = Task.Run(() =>
+        {
+            for (var index = 0; index < 2_000; index++)
+            {
+                foreach (var item in state.GetDownloadedSnapshot())
+                {
+                    Assert.NotNull(item);
+                }
+            }
+        }, cancellationToken);
+
+        await Task.WhenAll(writer, reader);
+    }
+
     private static DownloadedItem CreateDownloadedItem(
         string title,
         int order,

--- a/tests/DownKyi.Tests/LegacySqliteDatabaseTests.cs
+++ b/tests/DownKyi.Tests/LegacySqliteDatabaseTests.cs
@@ -1,0 +1,103 @@
+using DownKyi.Core.Storage.Database;
+using DownKyi.Services.Migration;
+
+namespace DownKyi.Tests;
+
+public sealed class LegacySqliteDatabaseTests
+{
+    [Fact]
+    public void QueryCompletionReleasesDatabaseFileForBackup()
+    {
+        using var directory = new TemporaryDirectory();
+        var databasePath = Path.Combine(directory.Path, "Download.db");
+        var backupPath = Path.Combine(directory.Path, "Download_failed.db");
+
+        using (var database = new SqliteDatabase(databasePath))
+        {
+            database.ExecuteQuery(
+                command => command.CommandText = "SELECT name FROM sqlite_master",
+                reader =>
+                {
+                    while (reader.Read())
+                    {
+                    }
+                });
+        }
+
+        File.Move(databasePath, backupPath);
+
+        Assert.False(File.Exists(databasePath));
+        Assert.True(File.Exists(backupPath));
+    }
+
+    [Fact]
+    public void EmptyDatabaseDoesNotRequireLegacyMigration()
+    {
+        using var directory = new TemporaryDirectory();
+        var databasePath = Path.Combine(directory.Path, "Download.db");
+
+        using var database = new SqliteDatabase(databasePath);
+
+        Assert.False(LegacyUpgradeCoordinator.HasLegacyDownloadSchema(database));
+    }
+
+    [Fact]
+    public void EncryptedEmptyDatabaseIsReleasedAfterSchemaCheck()
+    {
+        using var directory = new TemporaryDirectory();
+        var databasePath = Path.Combine(directory.Path, "Download.db");
+        var backupPath = Path.Combine(directory.Path, "Download_failed.db");
+
+        using (var database = new SqliteDatabase(
+                   databasePath,
+                   "bdb8eb69-3698-4af9-b722-9312d0fba623"))
+        {
+            Assert.False(LegacyUpgradeCoordinator.HasLegacyDownloadSchema(database));
+        }
+
+        File.Move(databasePath, backupPath);
+
+        Assert.True(File.Exists(backupPath));
+    }
+
+    [Fact]
+    public void DownloadTablesAreRecognizedAsLegacySchema()
+    {
+        using var directory = new TemporaryDirectory();
+        var databasePath = Path.Combine(directory.Path, "Download.db");
+
+        using var database = new SqliteDatabase(databasePath);
+        database.ExecuteQuery(
+            command => command.CommandText = """
+                CREATE TABLE downloaded (id TEXT PRIMARY KEY, data BLOB NOT NULL);
+                CREATE TABLE download_base (id TEXT PRIMARY KEY, data BLOB NOT NULL);
+                SELECT 1;
+                """,
+            reader =>
+            {
+                while (reader.Read())
+                {
+                }
+            });
+
+        Assert.True(LegacyUpgradeCoordinator.HasLegacyDownloadSchema(database));
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                $"DownKyi.Tests.{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
+        }
+    }
+}


### PR DESCRIPTION
# Title

fix: improve download stability, startup behavior, and user-space URL handling

# Description

## Summary

This PR fixes several stability issues related to batch downloads, duplicate detection, Bilibili user-space links, database migration, application shutdown, and Windows clipboard initialization.

The main goal is to prevent downloads from stopping unexpectedly and reduce application crashes during normal use.

## Main fixes

### Batch downloads continue after leaving the page

Previously, starting a batch download from a user-space or publication page and then navigating away could cancel the remaining download tasks.

Batch download operations are now separated from the page loading lifecycle, so they continue even after the user leaves the page.

### Prevent download-list collection crashes

The download and completed-download collections could be modified while another operation was reading them, causing:

```text
InvalidOperationException:
Collection was modified; enumeration operation may not execute.
```

Download-list updates are now synchronized, and read operations use snapshots instead of directly enumerating a collection that may be changing.

### Improve duplicate download detection

The previous duplicate-download check relied mainly on download history.

This could incorrectly treat a video as already downloaded even when the actual output file had been moved, deleted, or was empty.

The application now checks whether the expected video, audio, subtitle, danmaku, or cover file actually exists before deciding how to handle the duplicate.

The configured duplicate-download strategy is still respected:

* `JumpOver`: skip the existing history entry
* `ReDownload`: download it again
* `Ask`: ask only when a valid output file still exists

### Support more Bilibili user-space URLs

The following user-space URL formats are now supported:

```text
https://space.bilibili.com/{UID}
https://space.bilibili.com/{UID}/upload/video
```

Copied URLs are also normalized before parsing. This includes links containing:

* Leading or trailing spaces
* Line breaks
* Bilibili clipboard markers
* Bilibili title prefixes such as `【Title】`

## Additional fixes

### Legacy database migration

* Disabled SQLite connection pooling for legacy database access so failed databases can be moved to `Storage/Backup` immediately.
* A valid but empty legacy database is now treated as having no records to migrate instead of being reported as damaged.
* Added regression tests for plain, encrypted, empty, and valid legacy databases.

### Application shutdown

* The main window now hides immediately after the user closes the application.
* Settings, download state, and logs continue to finish saving in the background.
* Removed a redundant aria2 force-shutdown request after the tracked aria2 process has already terminated.
* This reduces the observed shutdown delay while making the application appear to close immediately.

### Windows clipboard and application startup

* The Windows UI thread now initializes OLE before Avalonia starts.
* The executable now uses a synchronous `[STAThread] void Main` entry point to ensure Avalonia and OLE remain on the correct STA startup thread.
* Clipboard COM initialization failures are treated as recoverable instead of terminating the application.
* This fixes crashes involving:

```text
CO_E_NOTINITIALIZED (0x800401F0)
RPC_E_CHANGED_MODE (0x80010106)
```

## Verification

Added regression coverage for:

* Batch downloads continuing after page navigation
* Concurrent download-list modifications
* Duplicate downloads when output files were moved or deleted
* `/UID/upload/video` user-space URLs
* Copied Bilibili URLs with titles, whitespace, and clipboard markers
* Legacy database migration and file release
* Windows OLE and STA startup lifecycle
* Recoverable clipboard initialization failures
* Application shutdown behavior

Latest verification results:

* Full Release test suite: 751 passed
* Existing FFmpeg integration test: 1 skipped
* Failed tests: 0
* Release `win-x64` self-contained publish completed successfully
* Published `DownKyi.exe` reports version `1.1.1.0`
* Packaged application launched successfully and remained responsive without a new .NET crash event
