### PR TITLE
security: enforce aria2 TLS and secure redirects

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -132,7 +132,14 @@ jobs:
         run: bash ./script/aria2.sh '${{ matrix.asset-argument }}'
       - name: Restore
         run: dotnet restore ${{ env.SOLUTION_FILE }}
+      - name: Install ARM64 protobuf compiler
+        if: matrix.rid == 'linux-arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes protobuf-compiler
       - name: Build TLS integration tests with all warnings as errors
+        env:
+          PROTOBUF_PROTOC: ${{ matrix.rid == 'linux-arm64' && '/usr/bin/protoc' || '' }}
         run: >
           dotnet build ./tests/DownKyi.Tests/DownKyi.Tests.csproj
           -c Release

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Fetch and verify Unix aria2 asset
         if: ${{ !startsWith(matrix.rid, 'win-') }}
         shell: bash
-        run: ./script/aria2.sh '${{ matrix.asset-argument }}'
+        run: bash ./script/aria2.sh '${{ matrix.asset-argument }}'
       - name: Restore
         run: dotnet restore ${{ env.SOLUTION_FILE }}
       - name: Build TLS integration tests with all warnings as errors

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -83,6 +83,86 @@ jobs:
           path: TestResults/*.trx
           if-no-files-found: ignore
 
+  aria2-tls-security:
+    name: aria2 TLS security (${{ matrix.rid }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - rid: win-x86
+            runner: windows-latest
+            asset-argument: x86
+            binary: DownKyi.Core/Binary/win-x86/aria2/aria2c.exe
+          - rid: win-x64
+            runner: windows-latest
+            asset-argument: x64
+            binary: DownKyi.Core/Binary/win-x64/aria2/aria2c.exe
+          - rid: linux-x64
+            runner: ubuntu-24.04
+            asset-argument: linux-x64
+            binary: DownKyi.Core/Binary/linux-x64/aria2/aria2c
+          - rid: linux-arm64
+            runner: ubuntu-24.04-arm
+            asset-argument: linux-arm64
+            binary: DownKyi.Core/Binary/linux-arm64/aria2/aria2c
+          - rid: osx-x64
+            runner: macos-15-intel
+            asset-argument: osx-x64
+            binary: DownKyi.Core/Binary/osx-x64/aria2/aria2c
+          - rid: osx-arm64
+            runner: macos-15
+            asset-argument: osx-arm64
+            binary: DownKyi.Core/Binary/osx-arm64/aria2/aria2c
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - name: Fetch and verify Windows aria2 asset
+        if: startsWith(matrix.rid, 'win-')
+        shell: pwsh
+        run: ./script/aria2.ps1 '${{ matrix.asset-argument }}'
+      - name: Fetch and verify Unix aria2 asset
+        if: ${{ !startsWith(matrix.rid, 'win-') }}
+        shell: bash
+        run: ./script/aria2.sh '${{ matrix.asset-argument }}'
+      - name: Restore
+        run: dotnet restore ${{ env.SOLUTION_FILE }}
+      - name: Build TLS integration tests with all warnings as errors
+        run: >
+          dotnet build ./tests/DownKyi.Tests/DownKyi.Tests.csproj
+          -c Release
+          --no-restore
+          --no-incremental
+          -p:TreatWarningsAsErrors=true
+          -p:CodeAnalysisTreatWarningsAsErrors=true
+          -p:EnableNETAnalyzers=true
+          -p:AnalysisMode=All
+          -p:EnforceCodeStyleInBuild=true
+          -p:UseSharedCompilation=false
+      - name: Verify packaged aria2 TLS behavior
+        env:
+          DOWNKYI_ARIA2_BINARY: ${{ github.workspace }}/${{ matrix.binary }}
+          DOWNKYI_ARIA2_RID: ${{ matrix.rid }}
+          DOWNKYI_ARIA2_TLS_REPORT: ${{ github.workspace }}/artifacts/aria2-tls/${{ matrix.rid }}.json
+        run: >
+          dotnet test ./tests/DownKyi.Tests/DownKyi.Tests.csproj
+          -c Release
+          --no-restore
+          --no-build
+          --filter Category=Aria2TlsIntegration
+      - name: Upload sanitized aria2 TLS report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: aria2-tls-${{ matrix.rid }}
+          path: artifacts/aria2-tls/${{ matrix.rid }}.json
+          if-no-files-found: warn
+
   assembly-lifecycle:
     name: Assembly lifecycle stability
     runs-on: windows-latest

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -207,6 +207,36 @@ DownloadMediaStage
 
 `AriaClient` 是專案內維護的 JSON-RPC compatibility adapter，不是生成檔。核心 partial 只擁有 immutable endpoint/token、序列化、response decoding 與單次 HTTP transport；下載控制、狀態/URI、選項、生命週期與 `system.*` methods 各自由責任 partial 擁有。所有 `aria2.*` method 的 token 位置與 RPC method name 由全公開方法合約測試固定。來源證據、owner 表和變更流程位於 `docs/design-docs/aria2-rpc-client-ownership.md`。
 
+## aria2 安全邊界
+
+```mermaid
+flowchart LR
+    Factory["DownloadRuntimeFactory"] --> Endpoint["random loopback port + secret"]
+    Endpoint --> Client["immutable AriaClient"]
+    Endpoint --> Config["temporary restricted config"]
+    Config --> Child["tracked packaged aria2 child"]
+    Client --> Child
+    Request["single-address transfer request"] --> Headers["host-scoped task headers"]
+    Headers --> Client
+    Child --> TLS["platform TLS trust + hostname validation"]
+```
+
+Packaged aria2 is process-local: each runtime creates an ephemeral loopback port
+and high-entropy secret, passes the secret through a temporary restricted config,
+and accepts RPC readiness only while the supervised child is alive. Process
+arguments cannot contain Cookie, RPC secret or caller-provided combined argument
+text. Custom remote aria2 remains externally owned; HTTP is allowed only for a
+loopback endpoint and every non-loopback endpoint requires HTTPS without RPC
+redirects.
+
+Transfer credentials are task-level rather than process-global. Cookie is
+eligible only for an exact HTTPS `bilibili.com` host or subdomain and disables
+redirects for that task; other hosts cannot receive it. aria2 uses normal
+platform certificate/hostname validation, and TLS failure is a typed terminal
+address failure rather than a reason to downgrade. The six-RID real-binary gate,
+legacy `UseSsl` migration and third-party binary evidence are documented in
+`docs/operations/aria2-security.md`.
+
 ## 邊界規則
 
 ### Domain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [1.1.1] - 2026-07-29
 
+### Security
+
+- 恢复 aria2 HTTPS 凭证与主机名称验证，移除旧 `UseSsl` 下载降级能力；
+  旧设置字段仅用于一次性相容读取并在下一次保存时移除。
+- 内建 aria2 使用随机 loopback port、高强度 RPC secret 与受限临时设置
+  档，Cookie 和 secret 不再进入程序命令列。
+- Cookie 改为符合 HTTPS Bilibili host 范围的任务级 header，携带凭证
+  时禁止重新导向；远端自订 aria2 RPC 强制 HTTPS 且不跟随重新导向。
+- 新增六 RID 真实 aria2 TLS 合约闸门，以及来源 tag、commit、SHA-256
+  与尚缺可重现建置/SBOM/provenance 的明确审计记录。
+
 ### Reliability
 
 - 修复 Windows 测试宿主偶发残留前台执行绪的问题：测试资料清理由同步 `ProcessExit` handler 改为可等待的 assembly fixture，Avalonia 测试改用 assembly-scoped headless session，正式 Host、Dispatcher、SQLite 与应用关闭路径均有确定性 teardown。

--- a/DownKyi.Core/Aria2cNet/Client/AriaClient.Lifecycle.cs
+++ b/DownKyi.Core/Aria2cNet/Client/AriaClient.Lifecycle.cs
@@ -74,7 +74,8 @@ public sealed partial class AriaClient
     /// The response is a struct and contains following keys.
     /// </summary>
     /// <returns></returns>
-    public async Task<AriaVersion> GetAriaVersionAsync()
+    public async Task<AriaVersion> GetAriaVersionAsync(
+        CancellationToken cancellationToken = default)
     {
         List<object> ariaParams = new List<object>
         {
@@ -87,7 +88,8 @@ public sealed partial class AriaClient
             Method = "aria2.getVersion",
             Params = ariaParams
         };
-        return await GetRpcResponseAsync<AriaVersion>(ariaSend).ConfigureAwait(false);
+        return await GetRpcResponseAsync<AriaVersion>(ariaSend, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>

--- a/DownKyi.Core/Aria2cNet/Client/AriaClient.cs
+++ b/DownKyi.Core/Aria2cNet/Client/AriaClient.cs
@@ -14,7 +14,7 @@ public sealed partial class AriaClient
     {
         AllowAutoRedirect = false
     });
-    private readonly Func<Uri, string, Task<string?>> _requestAsync;
+    private readonly Func<Uri, string, CancellationToken, Task<string?>> _requestAsync;
     private readonly Uri _rpcUri;
     private readonly string _token;
 
@@ -22,7 +22,12 @@ public sealed partial class AriaClient
         string host,
         int listenPort,
         string token)
-        : this(host, listenPort, token, static (url, parameters) => RequestAsync(url, parameters))
+        : this(
+            host,
+            listenPort,
+            token,
+            static (url, parameters, cancellationToken) =>
+                RequestAsync(url, parameters, cancellationToken))
     {
     }
 
@@ -31,6 +36,20 @@ public sealed partial class AriaClient
         int listenPort,
         string token,
         Func<Uri, string, Task<string?>> requestAsync)
+        : this(
+            host,
+            listenPort,
+            token,
+            (url, parameters, _) => requestAsync(url, parameters))
+    {
+        ArgumentNullException.ThrowIfNull(requestAsync);
+    }
+
+    internal AriaClient(
+        string host,
+        int listenPort,
+        string token,
+        Func<Uri, string, CancellationToken, Task<string?>> requestAsync)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(host);
         ArgumentOutOfRangeException.ThrowIfLessThan(listenPort, 1);
@@ -64,7 +83,21 @@ public sealed partial class AriaClient
             Query = string.Empty,
             Fragment = string.Empty
         }.Uri;
-        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+        ArgumentNullException.ThrowIfNull(token);
+        if (token.Length > 0 && string.IsNullOrWhiteSpace(token))
+        {
+            throw new ArgumentException(
+                "The aria2 RPC secret must be empty or contain a non-whitespace value.",
+                nameof(token));
+        }
+
+        if (token.Any(char.IsControl))
+        {
+            throw new ArgumentException(
+                "The aria2 RPC secret contains a control character.",
+                nameof(token));
+        }
+
         _token = token;
         _requestAsync = requestAsync ?? throw new ArgumentNullException(nameof(requestAsync));
     }
@@ -75,15 +108,29 @@ public sealed partial class AriaClient
     /// <typeparam name="T"></typeparam>
     /// <param name="ariaSend"></param>
     /// <returns></returns>
-    private async Task<T> GetRpcResponseAsync<T>(AriaSendData ariaSend)
+    private async Task<T> GetRpcResponseAsync<T>(
+        AriaSendData ariaSend,
+        CancellationToken cancellationToken = default)
         where T : class
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_token.Length == 0
+            && ariaSend.Params.Count > 0
+            && ariaSend.Params[0] is string firstParameter
+            && string.Equals(firstParameter, "token:", StringComparison.Ordinal))
+        {
+            ariaSend.Params = ariaSend.Params.Skip(1).ToArray();
+        }
+
         // 去掉null
         var jsonSetting = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
         // 转换为json字符串
         string sendJson = JsonConvert.SerializeObject(ariaSend, Formatting.Indented, jsonSetting);
         // 向服务器请求数据
-        var result = await _requestAsync(_rpcUri, sendJson).ConfigureAwait(false);
+        var result = await _requestAsync(
+            _rpcUri,
+            sendJson,
+            cancellationToken).ConfigureAwait(false);
         if (result == null)
         {
             throw new HttpRequestException("aria2 RPC retry attempts were exhausted.");
@@ -107,7 +154,10 @@ public sealed partial class AriaClient
     /// <param name="parameters"></param>
     /// <param name="retry"></param>
     /// <returns></returns>
-    private static async Task<string?> RequestAsync(Uri url, string parameters)
+    private static async Task<string?> RequestAsync(
+        Uri url,
+        string parameters,
+        CancellationToken cancellationToken)
     {
         using var request = new HttpRequestMessage(HttpMethod.Post, url)
         {
@@ -115,9 +165,12 @@ public sealed partial class AriaClient
         };
         using var response = await HttpClient.SendAsync(
             request,
-            HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+            HttpCompletionOption.ResponseHeadersRead,
+            cancellationToken).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
-        return await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+        return await response.Content
+            .ReadAsStringAsync(cancellationToken)
+            .ConfigureAwait(false);
     }
 
 }

--- a/DownKyi.Core/Aria2cNet/Client/AriaClient.cs
+++ b/DownKyi.Core/Aria2cNet/Client/AriaClient.cs
@@ -10,18 +10,18 @@ namespace DownKyi.Core.Aria2cNet.Client;
 public sealed partial class AriaClient
 {
     private const string JSONRPC = "2.0";
-    private const string LOCAL_HOST = "http://localhost";
-    private const string TOKEN = "downkyi";
-    private const int LISTEN_PORT = 35076;
-    private static readonly HttpClient HttpClient = new();
+    private static readonly HttpClient HttpClient = new(new SocketsHttpHandler
+    {
+        AllowAutoRedirect = false
+    });
     private readonly Func<Uri, string, Task<string?>> _requestAsync;
     private readonly Uri _rpcUri;
     private readonly string _token;
 
     public AriaClient(
-        string host = LOCAL_HOST,
-        int listenPort = LISTEN_PORT,
-        string token = TOKEN)
+        string host,
+        int listenPort,
+        string token)
         : this(host, listenPort, token, static (url, parameters) => RequestAsync(url, parameters))
     {
     }
@@ -42,6 +42,21 @@ public sealed partial class AriaClient
             throw new ArgumentException("The aria2 RPC host must be an absolute HTTP or HTTPS URI.", nameof(host));
         }
 
+        if (string.Equals(hostUri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+            && !hostUri.IsLoopback)
+        {
+            throw new ArgumentException(
+                "Remote aria2 RPC endpoints must use HTTPS.",
+                nameof(host));
+        }
+
+        if (!string.IsNullOrEmpty(hostUri.UserInfo))
+        {
+            throw new ArgumentException(
+                "The aria2 RPC host must not contain user information.",
+                nameof(host));
+        }
+
         _rpcUri = new UriBuilder(hostUri)
         {
             Port = listenPort,
@@ -49,7 +64,8 @@ public sealed partial class AriaClient
             Query = string.Empty,
             Fragment = string.Empty
         }.Uri;
-        _token = token ?? string.Empty;
+        ArgumentException.ThrowIfNullOrWhiteSpace(token);
+        _token = token;
         _requestAsync = requestAsync ?? throw new ArgumentNullException(nameof(requestAsync));
     }
 

--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaOption.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaOption.cs
@@ -5,9 +5,6 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     [JsonObject]
     public class AriaOption
     {
-        [JsonProperty("all-proxy")]
-        public string AllProxy { get; set; } = string.Empty;
-
         [JsonProperty("allow-overwrite")]
         public string AllowOverwrite { get; set; } = string.Empty;
 

--- a/DownKyi.Core/Aria2cNet/Client/Entity/AriaSendData.cs
+++ b/DownKyi.Core/Aria2cNet/Client/Entity/AriaSendData.cs
@@ -27,8 +27,8 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
     [JsonObject]
     public class AriaSendOption
     {
-        [JsonProperty("all-proxy")]
-        public string HttpProxy { get; set; } = string.Empty;
+        [JsonProperty("https-proxy")]
+        public string HttpsProxy { get; set; } = string.Empty;
 
         [JsonProperty("out")]
         public string Out { get; set; } = string.Empty;
@@ -53,6 +53,9 @@ namespace DownKyi.Core.Aria2cNet.Client.Entity
 
         [JsonProperty("user-agent")]
         public string UserAgent { get; set; } = string.Empty;
+
+        [JsonProperty("header")]
+        public IReadOnlyList<string> Headers { get; set; } = Array.Empty<string>();
 
         [JsonProperty("split")]
         public string Split { get; set; } = string.Empty;

--- a/DownKyi.Core/Aria2cNet/Server/AriaBinaryIntegrityVerifier.cs
+++ b/DownKyi.Core/Aria2cNet/Server/AriaBinaryIntegrityVerifier.cs
@@ -1,0 +1,55 @@
+using System.Security.Cryptography;
+
+namespace DownKyi.Core.Aria2cNet.Server;
+
+internal static class AriaBinaryIntegrityVerifier
+{
+    internal const string ChecksumSidecarSuffix = ".sha256";
+
+    internal static void Verify(string executablePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(executablePath);
+
+        if (!File.Exists(executablePath))
+        {
+            throw new FileNotFoundException(
+                "The packaged aria2 executable is missing.",
+                executablePath);
+        }
+
+        var checksumPath = executablePath + ChecksumSidecarSuffix;
+        if (!File.Exists(checksumPath))
+        {
+            throw new FileNotFoundException(
+                "The packaged aria2 checksum sidecar is missing.",
+                checksumPath);
+        }
+
+        var checksumText = File.ReadAllText(checksumPath).Trim();
+        if (checksumText.Length != SHA256.HashSizeInBytes * 2)
+        {
+            throw new InvalidDataException(
+                "The packaged aria2 checksum sidecar is malformed.");
+        }
+
+        byte[] expectedHash;
+        try
+        {
+            expectedHash = Convert.FromHexString(checksumText);
+        }
+        catch (FormatException exception)
+        {
+            throw new InvalidDataException(
+                "The packaged aria2 checksum sidecar is malformed.",
+                exception);
+        }
+
+        using var executable = File.OpenRead(executablePath);
+        var actualHash = SHA256.HashData(executable);
+        if (!CryptographicOperations.FixedTimeEquals(actualHash, expectedHash))
+        {
+            throw new InvalidDataException(
+                "The packaged aria2 executable failed its integrity check.");
+        }
+    }
+}

--- a/DownKyi.Core/Aria2cNet/Server/AriaConfig.cs
+++ b/DownKyi.Core/Aria2cNet/Server/AriaConfig.cs
@@ -19,6 +19,4 @@ public class AriaConfig
     public long MaxDownloadLimit { get; set; } // 下载单文件速度限制，取值：1-*
     public bool ContinueDownload { get; set; } // 断点续传
     public AriaConfigFileAllocation FileAllocation { get; set; } // 文件预分配, none prealloc
-
-    public IReadOnlyList<string> Headers { get; set; } = Array.Empty<string>();
 }

--- a/DownKyi.Core/Aria2cNet/Server/AriaProcessSupervisor.cs
+++ b/DownKyi.Core/Aria2cNet/Server/AriaProcessSupervisor.cs
@@ -7,6 +7,7 @@ namespace DownKyi.Core.Aria2cNet.Server;
 
 internal sealed class AriaProcessSupervisor
 {
+    private const int KillWaitMilliseconds = 5000;
     private readonly Lock _sync = new();
     private readonly ILogger<AriaProcessSupervisor> _logger;
     private Process? _process;
@@ -96,8 +97,7 @@ internal sealed class AriaProcessSupervisor
         }
         catch (TimeoutException)
         {
-            Kill("aria2c did not exit before timeout.");
-            return false;
+            return Kill("aria2c did not exit before timeout.");
         }
     }
 
@@ -105,13 +105,9 @@ internal sealed class AriaProcessSupervisor
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(reason);
         Process? process;
-        WindowsProcessJob? processJob;
         lock (_sync)
         {
             process = _process;
-            _process = null;
-            processJob = _windowsProcessJob;
-            _windowsProcessJob = null;
         }
 
         if (process == null)
@@ -127,6 +123,15 @@ internal sealed class AriaProcessSupervisor
                 process.Kill(entireProcessTree: true);
             }
 
+            if (!process.WaitForExit(KillWaitMilliseconds))
+            {
+                _logger.LogErrorMessage(
+                    "aria2 process did not exit after it was terminated.",
+                    new TimeoutException("aria2 process termination timed out."));
+                return false;
+            }
+
+            Release(process);
             return true;
         }
         catch (InvalidOperationException e)
@@ -138,10 +143,6 @@ internal sealed class AriaProcessSupervisor
         {
             _logger.LogErrorMessage("aria2 process cleanup failed at the operating-system boundary.", e);
             return false;
-        }
-        finally
-        {
-            processJob?.Dispose();
         }
     }
 

--- a/DownKyi.Core/Aria2cNet/Server/AriaProcessSupervisor.cs
+++ b/DownKyi.Core/Aria2cNet/Server/AriaProcessSupervisor.cs
@@ -28,6 +28,17 @@ internal sealed class AriaProcessSupervisor
         }
     }
 
+    public bool HasRunningProcess
+    {
+        get
+        {
+            lock (_sync)
+            {
+                return _process is { HasExited: false };
+            }
+        }
+    }
+
     public void Track(Process process)
     {
         ArgumentNullException.ThrowIfNull(process);

--- a/DownKyi.Core/Aria2cNet/Server/AriaRpcSecretFile.cs
+++ b/DownKyi.Core/Aria2cNet/Server/AriaRpcSecretFile.cs
@@ -1,0 +1,96 @@
+using System.Text;
+using DownKyi.Application.Diagnostics;
+using Microsoft.Extensions.Logging;
+
+namespace DownKyi.Core.Aria2cNet.Server;
+
+internal sealed class AriaRpcSecretFile : IDisposable
+{
+    private readonly ILogger _logger;
+    private int _disposed;
+
+    private AriaRpcSecretFile(string path, ILogger logger)
+    {
+        Path = path;
+        _logger = logger;
+    }
+
+    public string Path { get; }
+
+    public static AriaRpcSecretFile Create(
+        string directory,
+        string secret,
+        ILogger logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(secret);
+        ArgumentNullException.ThrowIfNull(logger);
+        if (secret.Any(char.IsControl))
+        {
+            throw new ArgumentException("The aria2 RPC secret contains a control character.", nameof(secret));
+        }
+
+        Directory.CreateDirectory(directory);
+        var path = System.IO.Path.Combine(
+            directory,
+            $".rpc-{Guid.NewGuid():N}.conf");
+        var options = new FileStreamOptions
+        {
+            Access = FileAccess.Write,
+            Mode = FileMode.CreateNew,
+            Share = FileShare.None,
+            Options = FileOptions.WriteThrough
+        };
+        if (!OperatingSystem.IsWindows())
+        {
+            options.UnixCreateMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+        }
+
+        using (var stream = new FileStream(path, options))
+        using (var writer = new StreamWriter(stream, new UTF8Encoding(false)))
+        {
+            writer.Write("rpc-secret=");
+            writer.WriteLine(secret);
+            writer.Flush();
+            stream.Flush(flushToDisk: true);
+        }
+
+        return new AriaRpcSecretFile(path, logger);
+    }
+
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            if (!File.Exists(Path))
+            {
+                return;
+            }
+
+            using (var stream = new FileStream(
+                       Path,
+                       FileMode.Open,
+                       FileAccess.Write,
+                       FileShare.None))
+            {
+                stream.SetLength(0);
+                stream.Flush(flushToDisk: true);
+            }
+
+            File.Delete(Path);
+        }
+        catch (IOException exception)
+        {
+            _logger.LogErrorMessage("The temporary aria2 RPC secret file could not be removed.", exception);
+        }
+        catch (UnauthorizedAccessException exception)
+        {
+            _logger.LogErrorMessage("Removal of the temporary aria2 RPC secret file was denied.", exception);
+        }
+    }
+}

--- a/DownKyi.Core/Aria2cNet/Server/AriaServer.cs
+++ b/DownKyi.Core/Aria2cNet/Server/AriaServer.cs
@@ -137,7 +137,7 @@ namespace DownKyi.Core.Aria2cNet.Server
             }
             catch
             {
-                ReleaseStartupSecrets();
+                KillTrackedServer("aria2 process startup failed.");
                 throw;
             }
 
@@ -168,40 +168,37 @@ namespace DownKyi.Core.Aria2cNet.Server
                 var completed = await Task.WhenAny(shutdown, Task.Delay(waitTimeout)).ConfigureAwait(false);
                 if (completed != shutdown)
                 {
-                    KillTrackedServer("aria2 shutdown rpc timed out.");
-                    return false;
+                    return KillTrackedServer("aria2 shutdown rpc timed out.");
                 }
 
                 var result = await shutdown.ConfigureAwait(false);
                 if (result?.Result != "OK")
                 {
-                    KillTrackedServer("aria2 shutdown rpc failed.");
-                    return false;
+                    return KillTrackedServer("aria2 shutdown rpc failed.");
                 }
 
-                return await WaitForExitOrKillAsync(waitTimeout).ConfigureAwait(false);
+                var exited = await WaitForExitOrKillAsync(waitTimeout).ConfigureAwait(false);
+                if (exited)
+                {
+                    ReleaseStartupSecrets();
+                }
+
+                return exited;
             }
             catch (HttpRequestException e)
             {
                 _logger.LogErrorMessage("aria2 shutdown request failed.", e);
-                KillTrackedServer("aria2 shutdown failed.");
-                return false;
+                return KillTrackedServer("aria2 shutdown failed.");
             }
             catch (InvalidOperationException e)
             {
                 _logger.LogErrorMessage("aria2 shutdown encountered an invalid process state.", e);
-                KillTrackedServer("aria2 shutdown failed.");
-                return false;
+                return KillTrackedServer("aria2 shutdown failed.");
             }
             catch (Newtonsoft.Json.JsonException e)
             {
                 _logger.LogErrorMessage("aria2 shutdown returned an invalid response.", e);
-                KillTrackedServer("aria2 shutdown response was invalid.");
-                return false;
-            }
-            finally
-            {
-                ReleaseStartupSecrets();
+                return KillTrackedServer("aria2 shutdown response was invalid.");
             }
         }
 
@@ -224,53 +221,49 @@ namespace DownKyi.Core.Aria2cNet.Server
                 var completed = await Task.WhenAny(shutdown, Task.Delay(waitTimeout)).ConfigureAwait(false);
                 if (completed != shutdown)
                 {
-                    KillTrackedServer("aria2 force shutdown rpc timed out.");
-                    return false;
+                    return KillTrackedServer("aria2 force shutdown rpc timed out.");
                 }
 
                 var result = await shutdown.ConfigureAwait(false);
                 if (result?.Result != "OK")
                 {
-                    KillTrackedServer("aria2 force shutdown rpc failed.");
-                    return false;
+                    return KillTrackedServer("aria2 force shutdown rpc failed.");
                 }
 
-                return await WaitForExitOrKillAsync(waitTimeout).ConfigureAwait(false);
+                var exited = await WaitForExitOrKillAsync(waitTimeout).ConfigureAwait(false);
+                if (exited)
+                {
+                    ReleaseStartupSecrets();
+                }
+
+                return exited;
             }
             catch (HttpRequestException e)
             {
                 _logger.LogErrorMessage("aria2 force-shutdown request failed.", e);
-                KillTrackedServer("aria2 force shutdown failed.");
-                return false;
+                return KillTrackedServer("aria2 force shutdown failed.");
             }
             catch (InvalidOperationException e)
             {
                 _logger.LogErrorMessage("aria2 force shutdown encountered an invalid process state.", e);
-                KillTrackedServer("aria2 force shutdown failed.");
-                return false;
+                return KillTrackedServer("aria2 force shutdown failed.");
             }
             catch (Newtonsoft.Json.JsonException e)
             {
                 _logger.LogErrorMessage("aria2 force shutdown returned an invalid response.", e);
-                KillTrackedServer("aria2 force shutdown response was invalid.");
-                return false;
-            }
-            finally
-            {
-                ReleaseStartupSecrets();
+                return KillTrackedServer("aria2 force shutdown response was invalid.");
             }
         }
 
         public bool KillTrackedServer(string reason)
         {
-            try
-            {
-                return _processSupervisor.Kill(reason);
-            }
-            finally
+            var exited = _processSupervisor.Kill(reason);
+            if (exited)
             {
                 ReleaseStartupSecrets();
             }
+
+            return exited;
         }
 
         internal void SetTrackedServerForTests(Process? process)
@@ -281,6 +274,11 @@ namespace DownKyi.Core.Aria2cNet.Server
         internal bool HasTrackedServerForTests()
         {
             return _processSupervisor.HasTrackedProcess;
+        }
+
+        internal void SetStartupSecretForTests(AriaRpcSecretFile? secretFile)
+        {
+            Interlocked.Exchange(ref _startupSecret, secretFile)?.Dispose();
         }
 
         internal static string GetLogLevelArgument(AriaConfigLogLevel logLevel)

--- a/DownKyi.Core/Aria2cNet/Server/AriaServer.cs
+++ b/DownKyi.Core/Aria2cNet/Server/AriaServer.cs
@@ -12,6 +12,7 @@ namespace DownKyi.Core.Aria2cNet.Server
     {
         private readonly ILogger<AriaServer> _logger;
         private readonly AriaProcessSupervisor _processSupervisor;
+        private AriaRpcSecretFile? _startupSecret;
 
         public AriaServer(ILoggerFactory loggerFactory)
         {
@@ -49,77 +50,108 @@ namespace DownKyi.Core.Aria2cNet.Server
             var logFile = Path.Combine(ariaDir, "aira.log");
             // 自动保存会话文件的时间间隔
             var saveSessionInterval = 120;
+            var startupSecret = AriaRpcSecretFile.Create(
+                ariaDir,
+                config.Token,
+                _logger);
+            Interlocked.Exchange(ref _startupSecret, startupSecret)?.Dispose();
 
             // The packaged runtime is process-local; custom remote aria2 endpoints are not started here.
-            await Task.Run(() =>
+            try
             {
-                // 创建目录和文件
-                if (!Directory.Exists(ariaDir))
+                await Task.Run(() =>
                 {
-                    Directory.CreateDirectory(ariaDir);
-                }
-
-                if (!File.Exists(sessionFile))
-                {
-                    using var stream = File.Create(sessionFile);
-                }
-
-                if (!File.Exists(logFile))
-                {
-                    using var stream = File.Create(logFile);
-                }
-                else
-                {
-                    // 日志文件存在，如果大于1M，则截断
-                    try
+                    // 创建目录和文件
+                    if (!Directory.Exists(ariaDir))
                     {
-                        using var stream = File.Open(logFile, FileMode.Open);
-                        if (stream.Length >= 1 * 1024 * 1024L)
+                        Directory.CreateDirectory(ariaDir);
+                    }
+
+                    if (!File.Exists(sessionFile))
+                    {
+                        using var stream = File.Create(sessionFile);
+                    }
+
+                    if (!File.Exists(logFile))
+                    {
+                        using var stream = File.Create(logFile);
+                    }
+                    else
+                    {
+                        // 日志文件存在，如果大于1M，则截断
+                        try
                         {
-                            stream.SetLength(0);
+                            using var stream = File.Open(logFile, FileMode.Open);
+                            if (stream.Length >= 1 * 1024 * 1024L)
+                            {
+                                stream.SetLength(0);
+                            }
+                        }
+                        catch (IOException e)
+                        {
+                            _logger.LogErrorMessage("aria2 log rotation failed.", e);
+                        }
+                        catch (UnauthorizedAccessException e)
+                        {
+                            _logger.LogErrorMessage("aria2 log rotation was denied.", e);
+                        }
+                        catch (InvalidOperationException e)
+                        {
+                            _logger.LogErrorMessage("aria2 log rotation encountered an invalid stream state.", e);
                         }
                     }
-                    catch (IOException e)
-                    {
-                        _logger.LogErrorMessage("aria2 log rotation failed.", e);
-                    }
-                    catch (UnauthorizedAccessException e)
-                    {
-                        _logger.LogErrorMessage("aria2 log rotation was denied.", e);
-                    }
-                    catch (InvalidOperationException e)
-                    {
-                        _logger.LogErrorMessage("aria2 log rotation encountered an invalid stream state.", e);
-                    }
-                }
 
-                var executeName = "aria2c";
+                    var executeName = "aria2c";
 
-                if (OperatingSystem.IsWindows())
-                {
-                    executeName += ".exe";
-                }
-                ExecuteProcess($"aria2/{executeName}",
-                    BuildArguments(
-                        config,
-                        sessionFile,
-                        logFile,
-                        saveSessionInterval,
-                        Environment.ProcessId),
-                    null, (s, e) =>
+                    if (OperatingSystem.IsWindows())
                     {
-                        if (string.IsNullOrWhiteSpace(e.Data))
+                        executeName += ".exe";
+                    }
+
+                    var executablePath = Path.Combine(
+                        AppContext.BaseDirectory,
+                        "aria2",
+                        executeName);
+                    AriaBinaryIntegrityVerifier.Verify(executablePath);
+
+                    ExecuteProcess(executablePath,
+                        BuildArguments(
+                            config,
+                            startupSecret.Path,
+                            sessionFile,
+                            logFile,
+                            saveSessionInterval,
+                            Environment.ProcessId),
+                        null, (s, e) =>
                         {
-                            return;
-                        }
+                            if (string.IsNullOrWhiteSpace(e.Data))
+                            {
+                                return;
+                            }
 
-                        _logger.LogDebugMessage(e.Data);
+                            _logger.LogDebugMessage(e.Data);
 
-                        action.Invoke(e.Data);
-                    });
-            }).ConfigureAwait(false);
+                            action.Invoke(e.Data);
+                        });
+                }).ConfigureAwait(false);
+            }
+            catch
+            {
+                ReleaseStartupSecrets();
+                throw;
+            }
 
             return true;
+        }
+
+        public void ReleaseStartupSecrets()
+        {
+            Interlocked.Exchange(ref _startupSecret, null)?.Dispose();
+        }
+
+        public bool IsTrackedServerRunning()
+        {
+            return _processSupervisor.HasRunningProcess;
         }
 
         /// <summary>
@@ -166,6 +198,10 @@ namespace DownKyi.Core.Aria2cNet.Server
                 _logger.LogErrorMessage("aria2 shutdown returned an invalid response.", e);
                 KillTrackedServer("aria2 shutdown response was invalid.");
                 return false;
+            }
+            finally
+            {
+                ReleaseStartupSecrets();
             }
         }
 
@@ -219,11 +255,22 @@ namespace DownKyi.Core.Aria2cNet.Server
                 KillTrackedServer("aria2 force shutdown response was invalid.");
                 return false;
             }
+            finally
+            {
+                ReleaseStartupSecrets();
+            }
         }
 
         public bool KillTrackedServer(string reason)
         {
-            return _processSupervisor.Kill(reason);
+            try
+            {
+                return _processSupervisor.Kill(reason);
+            }
+            finally
+            {
+                ReleaseStartupSecrets();
+            }
         }
 
         internal void SetTrackedServerForTests(Process? process)
@@ -262,51 +309,61 @@ namespace DownKyi.Core.Aria2cNet.Server
             };
         }
 
-        internal static string BuildArguments(
+        internal static IReadOnlyList<string> BuildArguments(
             AriaConfig config,
+            string secretConfigFile,
             string sessionFile,
             string logFile,
             int saveSessionInterval,
             int parentProcessId)
         {
             ArgumentNullException.ThrowIfNull(config);
+            ArgumentException.ThrowIfNullOrWhiteSpace(secretConfigFile);
             ArgumentException.ThrowIfNullOrWhiteSpace(sessionFile);
             ArgumentException.ThrowIfNullOrWhiteSpace(logFile);
             ArgumentOutOfRangeException.ThrowIfNegative(saveSessionInterval);
             ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(parentProcessId, 0);
 
-            var headers = config.Headers.Aggregate(
-                string.Empty,
-                (current, header) => current + $"--header=\"{header}\" ");
-            return $"--enable-rpc --rpc-listen-all=false --rpc-allow-origin-all=false " +
-                   $"--check-certificate=false " +
-                   $"--stop-with-process={parentProcessId} " +
-                   $"--rpc-listen-port={config.ListenPort} " +
-                   $"--rpc-secret={config.Token} " +
-                   $"--input-file=\"{sessionFile}\" --save-session=\"{sessionFile}\" " +
-                   $"--save-session-interval={saveSessionInterval} " +
-                   $"--log=\"{logFile}\" --log-level={GetLogLevelArgument(config.LogLevel)} " +
-                   $"--max-concurrent-downloads={config.MaxConcurrentDownloads} " +
-                   $"--max-connection-per-server={config.MaxConnectionPerServer} " +
-                   $"--split={config.Split} " +
-                   $"--min-split-size={config.MinSplitSize}M " +
-                   $"--max-overall-download-limit={config.MaxOverallDownloadLimit} " +
-                   $"--max-download-limit={config.MaxDownloadLimit} " +
-                   $"--continue={(config.ContinueDownload ? "true" : "false")} " +
-                   $"--allow-overwrite=true " +
-                   $"--auto-file-renaming=false " +
-                   $"--file-allocation={GetFileAllocationArgument(config.FileAllocation)} " +
-                   headers;
+            return
+            [
+                $"--conf-path={secretConfigFile}",
+                "--enable-rpc",
+                "--rpc-listen-all=false",
+                "--rpc-allow-origin-all=false",
+                $"--stop-with-process={parentProcessId}",
+                $"--rpc-listen-port={config.ListenPort}",
+                $"--input-file={sessionFile}",
+                $"--save-session={sessionFile}",
+                $"--save-session-interval={saveSessionInterval}",
+                $"--log={logFile}",
+                $"--log-level={GetLogLevelArgument(config.LogLevel)}",
+                $"--max-concurrent-downloads={config.MaxConcurrentDownloads}",
+                $"--max-connection-per-server={config.MaxConnectionPerServer}",
+                $"--split={config.Split}",
+                $"--min-split-size={config.MinSplitSize}M",
+                $"--max-overall-download-limit={config.MaxOverallDownloadLimit}",
+                $"--max-download-limit={config.MaxDownloadLimit}",
+                $"--continue={(config.ContinueDownload ? "true" : "false")}",
+                "--allow-overwrite=true",
+                "--auto-file-renaming=false",
+                $"--file-allocation={GetFileAllocationArgument(config.FileAllocation)}"
+            ];
         }
 
-        private void ExecuteProcess(string exe, string arg, string? workingDirectory,
+        private void ExecuteProcess(
+            string exe,
+            IReadOnlyList<string> arguments,
+            string? workingDirectory,
             DataReceivedEventHandler output)
         {
             var p = new Process();
             _processSupervisor.Track(p);
 
             p.StartInfo.FileName = exe;
-            p.StartInfo.Arguments = arg;
+            foreach (var argument in arguments)
+            {
+                p.StartInfo.ArgumentList.Add(argument);
+            }
 
             // 工作目录
             if (workingDirectory != null)

--- a/DownKyi.Core/Properties/AssemblyInfo.cs
+++ b/DownKyi.Core/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("DownKyi.Core.Tests")]
+[assembly: InternalsVisibleTo("DownKyi.Tests")]
 [assembly: InternalsVisibleTo("DownKyi.BenchmarkCases")]
 [assembly: InternalsVisibleTo("DownKyi.SystemBenchmarks")]

--- a/DownKyi.Core/Settings/ApplicationSettings.cs
+++ b/DownKyi.Core/Settings/ApplicationSettings.cs
@@ -50,7 +50,6 @@ public sealed record BasicApplicationSettings(
 
 public sealed record NetworkApplicationSettings(
     AllowStatus IsLiftingOfRegion,
-    AllowStatus UseSsl,
     string UserAgent,
     Downloader Downloader,
     AllowStatus HighSpeedDownloadMode,
@@ -167,10 +166,47 @@ internal static class ApplicationSettingsValidator
             customProxy = string.Empty;
         }
 
+        var isAriaHttpsProxy = AllowValue(
+            settings.Network.IsAriaHttpProxy,
+            AllowStatus.No,
+            "Network.IsAriaHttpProxy",
+            corrections);
+        var ariaHttpsProxyPort = Range(
+            settings.Network.AriaHttpProxyListenPort,
+            0,
+            65535,
+            0,
+            "Network.AriaHttpProxyListenPort",
+            corrections);
+        var ariaHttpsProxyHost = settings.Network.AriaHttpProxy ?? string.Empty;
+        if (!string.IsNullOrWhiteSpace(ariaHttpsProxyHost))
+        {
+            if (AriaHttpsProxyPolicy.TryNormalizeLocalHost(
+                    ariaHttpsProxyHost,
+                    out var normalizedProxyHost))
+            {
+                ariaHttpsProxyHost = normalizedProxyHost;
+            }
+            else
+            {
+                corrections.Add("Network.AriaHttpProxy");
+                ariaHttpsProxyHost = string.Empty;
+            }
+        }
+
+        if (isAriaHttpsProxy == AllowStatus.Yes
+            && !AriaHttpsProxyPolicy.TryCreateConnectProxyUri(
+                ariaHttpsProxyHost,
+                ariaHttpsProxyPort,
+                out _))
+        {
+            corrections.Add("Network.IsAriaHttpProxy");
+            isAriaHttpsProxy = AllowStatus.No;
+        }
+
         var network = settings.Network with
         {
             IsLiftingOfRegion = AllowValue(settings.Network.IsLiftingOfRegion, AllowStatus.Yes, "Network.IsLiftingOfRegion", corrections),
-            UseSsl = AllowValue(settings.Network.UseSsl, AllowStatus.Yes, "Network.UseSsl", corrections),
             UserAgent = TextValue(settings.Network.UserAgent, DefaultUserAgent, "Network.UserAgent", corrections),
             Downloader = EnumValue(settings.Network.Downloader, Downloader.Aria, "Network.Downloader", corrections),
             HighSpeedDownloadMode = AllowValue(settings.Network.HighSpeedDownloadMode, AllowStatus.No, "Network.HighSpeedDownloadMode", corrections),
@@ -181,8 +217,10 @@ internal static class ApplicationSettingsValidator
             IsHttpProxy = AllowValue(settings.Network.IsHttpProxy, AllowStatus.No, "Network.IsHttpProxy", corrections),
             HttpProxy = settings.Network.HttpProxy ?? string.Empty,
             HttpProxyListenPort = Range(settings.Network.HttpProxyListenPort, 0, 65535, 0, "Network.HttpProxyListenPort", corrections),
-            AriaToken = settings.Network.AriaToken ?? "downkyi",
-            AriaHost = IsHttpUri(settings.Network.AriaHost) ? settings.Network.AriaHost : Corrected("Network.AriaHost", "http://localhost", corrections),
+            AriaToken = settings.Network.AriaToken ?? string.Empty,
+            AriaHost = IsSecureAriaRpcUri(settings.Network.AriaHost)
+                ? settings.Network.AriaHost
+                : Corrected("Network.AriaHost", "http://localhost", corrections),
             AriaListenPort = Range(settings.Network.AriaListenPort, 1, 65535, 35076, "Network.AriaListenPort", corrections),
             AriaLogLevel = EnumValue(settings.Network.AriaLogLevel, AriaConfigLogLevel.WARN, "Network.AriaLogLevel", corrections),
             AriaSplit = Range(settings.Network.AriaSplit, 1, 16, 5, "Network.AriaSplit", corrections),
@@ -191,9 +229,9 @@ internal static class ApplicationSettingsValidator
             AriaMaxOverallDownloadLimit = NonNegative(settings.Network.AriaMaxOverallDownloadLimit, "Network.AriaMaxOverallDownloadLimit", corrections),
             AriaMaxDownloadLimit = NonNegative(settings.Network.AriaMaxDownloadLimit, "Network.AriaMaxDownloadLimit", corrections),
             AriaFileAllocation = EnumValue(settings.Network.AriaFileAllocation, AriaConfigFileAllocation.NONE, "Network.AriaFileAllocation", corrections),
-            IsAriaHttpProxy = AllowValue(settings.Network.IsAriaHttpProxy, AllowStatus.No, "Network.IsAriaHttpProxy", corrections),
-            AriaHttpProxy = settings.Network.AriaHttpProxy ?? string.Empty,
-            AriaHttpProxyListenPort = Range(settings.Network.AriaHttpProxyListenPort, 0, 65535, 0, "Network.AriaHttpProxyListenPort", corrections)
+            IsAriaHttpProxy = isAriaHttpsProxy,
+            AriaHttpProxy = ariaHttpsProxyHost,
+            AriaHttpProxyListenPort = ariaHttpsProxyPort
         };
         var video = settings.Video with
         {
@@ -341,6 +379,22 @@ internal static class ApplicationSettingsValidator
     {
         return Uri.TryCreate(value, UriKind.Absolute, out var uri)
                && uri.Scheme is "http" or "https";
+    }
+
+    private static bool IsSecureAriaRpcUri(string? value)
+    {
+        if (!Uri.TryCreate(value, UriKind.Absolute, out var uri))
+        {
+            return false;
+        }
+
+        if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        return string.Equals(uri.Scheme, Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+               && uri.IsLoopback;
     }
 
     private static T Corrected<T>(

--- a/DownKyi.Core/Settings/ApplicationSettings.cs
+++ b/DownKyi.Core/Settings/ApplicationSettings.cs
@@ -388,6 +388,11 @@ internal static class ApplicationSettingsValidator
             return false;
         }
 
+        if (!string.IsNullOrEmpty(uri.UserInfo))
+        {
+            return false;
+        }
+
         if (string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
         {
             return true;

--- a/DownKyi.Core/Settings/AriaHttpsProxyPolicy.cs
+++ b/DownKyi.Core/Settings/AriaHttpsProxyPolicy.cs
@@ -1,0 +1,60 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace DownKyi.Core.Settings;
+
+public static class AriaHttpsProxyPolicy
+{
+    private const string Ipv4Loopback = "127.0.0.1";
+    private const string Ipv6Loopback = "::1";
+    private const string Localhost = "localhost";
+
+    public static bool TryNormalizeLocalHost(
+        string? value,
+        [NotNullWhen(true)] out string? normalizedHost)
+    {
+        normalizedHost = value?.Trim();
+        if (string.IsNullOrEmpty(normalizedHost))
+        {
+            normalizedHost = null;
+            return false;
+        }
+
+        if (normalizedHost.Length > 2
+            && normalizedHost[0] == '['
+            && normalizedHost[^1] == ']')
+        {
+            normalizedHost = normalizedHost[1..^1];
+        }
+
+        if (string.Equals(normalizedHost, Localhost, StringComparison.OrdinalIgnoreCase))
+        {
+            normalizedHost = Localhost;
+            return true;
+        }
+
+        if (string.Equals(normalizedHost, Ipv4Loopback, StringComparison.Ordinal)
+            || string.Equals(normalizedHost, Ipv6Loopback, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        normalizedHost = null;
+        return false;
+    }
+
+    public static bool TryCreateConnectProxyUri(
+        string? host,
+        int port,
+        [NotNullWhen(true)] out Uri? proxyUri)
+    {
+        proxyUri = null;
+        if (port is < 1 or > 65535
+            || !TryNormalizeLocalHost(host, out var normalizedHost))
+        {
+            return false;
+        }
+
+        proxyUri = new UriBuilder(Uri.UriSchemeHttp, normalizedHost, port).Uri;
+        return true;
+    }
+}

--- a/DownKyi.Core/Settings/Models/NetworkSettings.cs
+++ b/DownKyi.Core/Settings/Models/NetworkSettings.cs
@@ -1,4 +1,5 @@
 using DownKyi.Core.Aria2cNet.Server;
+using Newtonsoft.Json;
 
 namespace DownKyi.Core.Settings.Models;
 
@@ -9,7 +10,22 @@ public class NetworkSettings
 {
     public AllowStatus IsLiftingOfRegion { get; set; } = AllowStatus.None;
 
-    public AllowStatus UseSsl { get; set; } = AllowStatus.None;
+    [JsonProperty("UseSsl")]
+    private AllowStatus LegacyUseSsl
+    {
+        set => HasLegacyUseSsl = true;
+    }
+
+    [JsonIgnore]
+    internal bool HasLegacyUseSsl { get; private set; }
+
+    internal bool ConsumeLegacyHttpsSwitch()
+    {
+        var wasPresent = HasLegacyUseSsl;
+        HasLegacyUseSsl = false;
+        return wasPresent;
+    }
+
     public string UserAgent { get; set; } = string.Empty;
 
     public Downloader Downloader { get; set; } = Downloader.NotSet;

--- a/DownKyi.Core/Settings/SettingsManager.Aria.cs
+++ b/DownKyi.Core/Settings/SettingsManager.Aria.cs
@@ -5,7 +5,7 @@ namespace DownKyi.Core.Settings
     public partial class SettingsManager
     {
         // Aria服务器token
-        private const string AriaToken = "downkyi";
+        private const string AriaToken = "";
 
         // Aria服务器host
         private const string AriaHost = "http://localhost";

--- a/DownKyi.Core/Settings/SettingsManager.Network.cs
+++ b/DownKyi.Core/Settings/SettingsManager.Network.cs
@@ -7,9 +7,6 @@ namespace DownKyi.Core.Settings
         // 是否开启解除地区限制
         private const AllowStatus IsLiftingOfRegion = AllowStatus.Yes;
 
-        // 启用https
-        private const AllowStatus UseSsl = AllowStatus.Yes;
-
         // UserAgent
         private const string UserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
@@ -57,35 +54,6 @@ namespace DownKyi.Core.Settings
                 _appSettings.Network.IsLiftingOfRegion,
                 isLiftingOfRegion,
                 v => _appSettings.Network.IsLiftingOfRegion = v);
-        }
-
-        /// <summary>
-        /// 获取是否启用https
-        /// </summary>
-        /// <returns></returns>
-        public AllowStatus GetUseSsl()
-        {
-            if (_appSettings.Network.UseSsl == AllowStatus.None)
-            {
-                // 第一次获取，先设置默认值
-                SetUseSsl(UseSsl);
-                return UseSsl;
-            }
-
-            return _appSettings.Network.UseSsl;
-        }
-
-        /// <summary>
-        /// 设置是否启用https
-        /// </summary>
-        /// <param name="useSsl"></param>
-        /// <returns></returns>
-        public bool SetUseSsl(AllowStatus useSsl)
-        {
-            return SetProperty(
-                _appSettings.Network.UseSsl,
-                useSsl,
-                v => _appSettings.Network.UseSsl = v);
         }
 
         /// <summary>

--- a/DownKyi.Core/Settings/SettingsManager.Snapshot.cs
+++ b/DownKyi.Core/Settings/SettingsManager.Snapshot.cs
@@ -55,7 +55,6 @@ public partial class SettingsManager
                 IsRepeatFileAutoAddNumberSuffix()),
             new NetworkApplicationSettings(
                 GetIsLiftingOfRegion(),
-                GetUseSsl(),
                 GetUserAgent(),
                 GetDownloader(),
                 GetHighSpeedDownloadMode(),
@@ -148,7 +147,6 @@ public partial class SettingsManager
                 IsRepeatFileAutoAddNumberSuffix(validated.Basic.RepeatFileAutoAddNumberSuffix);
 
                 SetIsLiftingOfRegion(validated.Network.IsLiftingOfRegion);
-                SetUseSsl(validated.Network.UseSsl);
                 SetUserAgent(validated.Network.UserAgent);
                 SetDownloader(validated.Network.Downloader);
                 SetHighSpeedDownloadMode(validated.Network.HighSpeedDownloadMode);

--- a/DownKyi.Core/Settings/SettingsManager.cs
+++ b/DownKyi.Core/Settings/SettingsManager.cs
@@ -69,7 +69,7 @@ public sealed partial class SettingsManager : IDisposable, IAsyncDisposable
         }
 
         var migration = SettingsSchemaMigrator.Migrate(_appSettings);
-        if (migration.Migrated && loadResult.PersistInitialDefaults)
+        if ((_appSettings.Network.ConsumeLegacyHttpsSwitch() || migration.Migrated) && loadResult.PersistInitialDefaults)
         {
             MarkDirty();
         }

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2,7 +2,7 @@
 
 Status: maintained architecture index
 Schema version: 1.0
-Last reviewed: 2026-07-29
+Last reviewed: 2026-08-01
 
 This document is the first file an AI agent should read before changing DownKyi. Its goal is to preserve stable knowledge about project structure, ownership boundaries, and call relationships so agents do not rediscover the same code paths from scratch.
 
@@ -23,6 +23,11 @@ The target projects exist and the Desktop boundary is operational, but Infrastru
 - `DownKyi.Domain.DownloadTask` is the durable runtime state authority. `DownloadTaskApplicationService` loads by `DownloadTaskId`, invokes legal transitions, persists optimistic versions, and only then publishes committed snapshots. Normal runtime no longer reconstructs Domain state from mutable UI projections.
 - New tasks, resumed tasks, and persisted startup tasks directly enqueue `DownloadTaskId` through `DownloadTaskQueueGateway`; `DownloadOrchestrator` no longer scans a UI collection and each active task has its own linked cancellation owner.
 - Workers and pipeline entry points use `DownloadTaskId`. `DownloadPipeline` is a typed stage sequencer; localized activity rendering and completion-list mutation have separate Desktop owners. `DownloadListState` privately owns mutable collections and exposes stable `ReadOnlyObservableCollection<T>` projections. `DownloadExecutionContext` still exposes a transient `DownloadingItem` for playback/UI context. Bilibili HTTP uses injected Application ports with an async Infrastructure implementation; the old static/synchronous compatibility layer is gone.
+- Packaged aria2 uses an ephemeral loopback endpoint, per-runtime secret,
+  supervised process ownership and platform TLS validation. RPC credentials are
+  not process arguments; Cookie is a host-scoped per-task option. Custom remote
+  RPC requires HTTPS. The legacy settings `UseSsl` field is a one-way migration
+  marker and has no runtime authority.
 - These facts are tracked debt, not stable contracts. The ordered migration and release blockers live in `docs/refactoring-live-plan.md`.
 - `ModuleBoundaryBaselineTests` allows every listed debt item to disappear, but rejects new owners, consumers, duplicate names, UI dependencies, synchronous HTTP debt, or oversized-file growth.
 
@@ -130,6 +135,8 @@ flowchart TD
     Projection["ui.download-projection\nDownloadTaskProjectionStore + mapper"]
     Storage["core.storage\nApplicationStorage"]
     Aria["external.aria2\naria2c process"]
+    AriaSecurity["service.aria2-control-security\nRPC + task-header policy"]
+    AriaTlsTests["test.aria2-tls-security\nreal binary TLS matrix"]
     FFmpeg["external.ffmpeg\nffmpeg process"]
     Logs["infrastructure.logging\nredaction + NLog sink + diagnostic export"]
     Tests["test.suites\ntests/*"]
@@ -138,6 +145,7 @@ flowchart TD
     Benchmarks["test.performance-baseline\nBenchmarkCases + runner"]
     SystemBenchmarks["test.system-performance\nisolated system scenarios"]
     CI["workflow.strict-pr-ci\n.github/workflows/quality.yml"]
+    AriaTlsCI["workflow.aria2-tls-security\nsix RID real-binary gate"]
     Release["workflow.release-packaging\n.github/workflows/build.yml"]
     Nightly["workflow.system-baselines\nnightly cross-platform reports"]
     AnalyzerInventory["workflow.analyzer-inventory\nscript/analyzer-inventory.ps1"]
@@ -246,13 +254,16 @@ flowchart TD
     DownloadBootstrap -->|starts and stops| DownloadService
     DownloadService -->|commands by DownloadTaskId| DownloadCommands
     DownloadService -->|reads transient playback projection| Projection
-    DownloadService -->|executes optional| Aria
+    DownloadService -->|uses| AriaSecurity
+    AriaSecurity -->|executes optional| Aria
     DownloadService -->|executes| FFmpeg
     DownloadService -->|writes| Logs
     BiliHttp -->|throws typed visible failures| BiliApi
     Tests -->|guards| BiliHttp
     Tests -->|guards| DownloadAdd
     Tests -->|guards| DownloadService
+    AriaTlsTests -->|guards trust and control behavior| AriaSecurity
+    AriaTlsTests -->|executes pinned binary| Aria
     ArchitectureTests -->|guards dependency direction| Domain
     ArchitectureTests -->|guards dependency direction| ApplicationLayer
     ArchitectureTests -->|guards dependency direction| Infrastructure
@@ -263,6 +274,8 @@ flowchart TD
     CI -->|guards| Tests
     CI -->|guards| ArchitectureTests
     CI -->|guards| UiSmoke
+    CI -->|runs| AriaTlsCI
+    AriaTlsCI -->|runs| AriaTlsTests
     Release -->|gates and packages| App
     Release -->|runs| Tests
     AnalyzerInventory -->|documents diagnostics| CI
@@ -2259,6 +2272,7 @@ paths:
   - DownKyi.Core/Aria2cNet/Client/AriaClient.Lifecycle.cs
   - DownKyi.Core/Aria2cNet/Client/AriaClient.System.cs
   - DownKyi.Core/Aria2cNet/Server/AriaProcessSupervisor.cs
+  - DownKyi.Core/Aria2cNet/Server/AriaBinaryIntegrityVerifier.cs
   - DownKyi.Core/Aria2cNet/Server/WindowsProcessJob.cs
   - src/DownKyi.Desktop/Services/Download/AriaRuntimeClientRegistry.cs
   - tests/DownKyi.Core.Tests/AriaClientIsolationTests.cs
@@ -2267,6 +2281,9 @@ paths:
   - docs/design-docs/aria2-rpc-client-ownership.md
   - script/aria2.ps1
   - script/aria2.sh
+  - script/assets/external-assets.json
+  - docs/operations/aria2-security.md
+  - docs/operations/aria2-security-baseline.json
 responsibility: Provides optional aria2 RPC download backend and release-packaged aria2 binaries.
 inbound:
   - service.download-runtime
@@ -2280,6 +2297,22 @@ contracts:
   - Manager, server, and process-supervisor diagnostics use typed loggers from the shared application factory; `Aria2cNet` cannot call static `LogManager`.
   - RPC requests use iterative asynchronous retry and cannot occupy a worker thread with synchronous `HttpClient.Send` or recursive retry.
   - Each runtime owns an immutable RPC endpoint and secret; `AriaClient` has no mutable static host, port, or token configuration.
+  - A packaged runtime generates a fresh ephemeral loopback port and 256-bit
+    secret. The secret is supplied through a restricted temporary config and
+    cannot appear in process arguments or logs.
+  - HTTP RPC is loopback-only. Non-loopback custom RPC requires HTTPS, URI user
+    information is rejected and the RPC transport does not follow redirects.
+  - aria2 certificate and hostname validation cannot be disabled by settings,
+    UI or process arguments.
+  - Cookie and other request headers are per task, never process-global. Cookie
+    is eligible only for an exact HTTPS `bilibili.com` host/subdomain. Actual
+    transfer redirects are enforced by the versioned DownKyi aria2 capability:
+    no HTTPS scheme downgrade and no sensitive cross-origin redirect.
+  - The packaged executable must match its manifest-derived SHA-256 sidecar
+    before process creation. Packaged and custom RPC endpoints must expose
+    `downkyi-secure-redirect-v2`; missing evidence fails closed. Error code 33
+    identifies HTTPS downgrade rejection and 34 identifies sensitive-header
+    cross-origin rejection even if aria2 later replaces the status message.
   - Local and custom clients can execute concurrently without endpoint or authentication-token cross-contamination.
   - `AriaClient` is hand-maintained DownKyi protocol code, not generated output. Core transport, download control, status/URI, options, lifecycle and `system.*` methods have separate partial owners below 500 lines.
   - Every public RPC method is covered by a deterministic wire-contract inventory. `aria2.*` calls keep the token first; `system.*` calls do not receive an implicit token; `ChangeUriAsync` maps to `aria2.changeUri`.
@@ -2289,10 +2322,77 @@ contracts:
 hazards:
   - Orphaned aria2 processes prevent clean app exit and lock output files.
   - Temporary `.aria2` files must be removed when user deletes a task.
+  - Selecting an ephemeral port and starting the child are separate OS
+    operations; the high-entropy secret and supervised-child liveness check
+    bound the remaining port-allocation race.
+  - The source/base commits, canonical patch, zlib and OpenSSL sources are
+    locked. Binary reproducibility, SBOM and signed provenance remain unproven.
 tests:
   - test.fake-http-download
   - test.process-cleanup
   - test.release-packaging
+  - test.aria2-tls-security
+```
+
+### service.aria2-control-security
+
+```yaml
+id: service.aria2-control-security
+type: service
+paths:
+  - DownKyi.Core/Aria2cNet/Client/AriaClient.cs
+  - DownKyi.Core/Aria2cNet/Server/AriaRpcSecretFile.cs
+  - DownKyi.Core/Aria2cNet/Server/AriaServer.cs
+  - src/DownKyi.Desktop/Services/Download/LocalAriaRpcEndpoint.cs
+  - src/DownKyi.Desktop/Services/Download/AriaTaskHeaderPolicy.cs
+  - src/DownKyi.Desktop/Services/Download/TlsFailureClassifier.cs
+  - src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
+responsibility: Owns packaged aria2 RPC endpoint creation, startup-secret transfer, process identity checks, task-level credential scope and typed TLS failure behavior.
+inbound:
+  - service.download-runtime
+  - core.settings
+outbound:
+  - external.aria2
+contracts:
+  - No certificate bypass, HTTPS downgrade, fixed packaged secret/port or command-line credential is permitted.
+  - Process startup uses a structured argument list and rejects control-character header injection.
+  - Legacy `UseSsl` can be consumed for one-way settings migration only; it cannot be read by runtime code and is omitted on write.
+  - TLS errors remain distinguishable from timeout, HTTP status, disk and cancellation failures.
+hazards:
+  - Relaxing host matching or enabling credentialed redirects can disclose login state to a different origin.
+  - Failure cleanup must delete the startup secret and stop only the tracked child.
+tests:
+  - test.aria2-tls-security
+  - test.architecture-boundaries
+```
+
+### test.aria2-tls-security
+
+```yaml
+id: test.aria2-tls-security
+type: test
+paths:
+  - tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
+  - tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
+  - tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
+  - tests/TestInfrastructure/LoopbackTlsFileServer.cs
+  - tests/TestInfrastructure/TestCertificateAuthority.cs
+  - tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
+responsibility: Runs the actual pinned aria2 binary against deterministic trust, certificate, redirect, resume and RPC cases without using a real external service.
+inbound:
+  - workflow.aria2-tls-security
+outbound:
+  - external.aria2
+contracts:
+  - Sanitized reports contain environment/backend/case evidence but no path, URL, header, Cookie, token or account identity.
+  - Expected certificate rejection is a passing security assertion; transport downgrade is never used to make a case pass.
+  - Redirect security is proved at the actual aria2 `Location` boundary. The
+    HTTPS-to-HTTP target and sensitive cross-origin target must observe zero
+    requests/connections for GET, HEAD-vs-GET, Range and later-attempt cases.
+hazards:
+  - Platform trust-store setup must be removed in `finally` and cannot modify a developer's permanent application data.
+tests:
+  - self
 ```
 
 ### ui.async-image-loader
@@ -2350,10 +2450,39 @@ contracts:
   - Test projects run in stable path order so one constrained runner cannot make independent xUnit hosts starve one another during discovery or shutdown.
   - Every test project writes a distinct assembly-named TRX; no solution-level logger filename may overwrite earlier project evidence.
   - Windows PR and main jobs must run the Assembly Lifecycle Stability Gate and upload its reports even when a phase fails.
+  - Every PR runs the six-RID real-binary aria2 TLS security matrix; a unit-test-only pass cannot replace it.
 hazards:
   - Turning every historical analyzer suggestion into PR failure makes unrelated PRs impossible.
   - Broad NoWarn, global suppressions, nullable disable, or analyzer exclusions hide new defects.
   - Restoring one parallel solution-level `dotnet test` command can reintroduce Windows foreground-thread timeouts and TRX overwrite.
+tests:
+  - github.actions
+```
+
+### workflow.aria2-tls-security
+
+```yaml
+id: workflow.aria2-tls-security
+type: workflow
+paths:
+  - .github/workflows/quality.yml
+  - script/aria2.ps1
+  - script/aria2.sh
+  - script/assets/external-assets.json
+  - docs/operations/aria2-security-baseline.json
+responsibility: Downloads SHA-pinned aria2 assets and proves TLS/control behavior on Windows x86/x64, Linux x64/arm64 and macOS x64/arm64.
+inbound:
+  - workflow.strict-pr-ci
+outbound:
+  - test.aria2-tls-security
+contracts:
+  - Asset acquisition must use normal TLS, verify archive SHA-256 before
+    extraction and binary SHA-256 after extraction, then write the runtime
+    checksum sidecar. The manifest is the only URL/checksum owner.
+  - All six RID jobs are required for an aria2 security or binary change.
+  - Reports are uploaded even on test failure and must remain sanitized.
+hazards:
+  - A pinned digest proves artifact identity, not source reproducibility or publisher integrity.
 tests:
   - github.actions
 ```

--- a/docs/design-docs/aria2-rpc-client-ownership.md
+++ b/docs/design-docs/aria2-rpc-client-ownership.md
@@ -39,8 +39,13 @@ does not change its public API.
 ## Stable Contract
 
 - The endpoint is an immutable absolute HTTP/HTTPS URI ending in `/jsonrpc`.
+- Plain HTTP is loopback-only. Non-loopback RPC requires HTTPS, URI user
+  information is rejected and the transport does not follow redirects.
 - Each `AriaClient` instance owns its endpoint and secret. No mutable static
   host, port or token state is allowed.
+- A secret is mandatory. The packaged runtime generates a fresh 256-bit value
+  and passes it to aria2 through a temporary restricted config rather than a
+  process argument.
 - `aria2.*` calls place `token:<secret>` first in `params`.
 - `system.*` calls do not automatically add the aria2 token.
 - Request `jsonrpc` remains `2.0`, request IDs remain non-empty and each public

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,6 +1,7 @@
 # Execution Plans
 
-目前唯一即時任務書是 `../refactoring-live-plan.md`。它只保存尚未完成、被阻塞或等待整合的工作。
+目前即時狀態位於 `../refactoring-live-plan.md`。v1.1.1 的安全修補順序、
+範圍、驗證與回滾位於 `v1.1.1-security-patch.md`。
 
 每個 work item 必須包含：
 

--- a/docs/exec-plans/v1.1.1-security-patch.md
+++ b/docs/exec-plans/v1.1.1-security-patch.md
@@ -1,0 +1,109 @@
+# v1.1.1 Item 1 Active Exec Plan
+
+Status: active
+Owner branch: `fix/aria2-tls-certificate-validation`
+Base: `origin/main` at `e2fd83d09b0fa641453fc92912ad238ed5499056`
+Last updated: 2026-08-01
+
+## Goal
+
+Complete only v1.1.1 Item 1: integrate the published aria2 v2 assets into
+DownKyi, prove real runtime security on Windows and all six CI RIDs, pass every
+PR check, and end this branch as soon as the Item 1 PR is merge-ready.
+
+## Scope Control
+
+In scope:
+
+- aria2 v2 asset URLs, archive/binary SHA-256 values and runtime feature check;
+- certificate, redirect, sensitive-header-value, RPC secret, process ownership
+  and local HTTPS CONNECT proxy security;
+- the one-way legacy `UseSsl` migration and its network-settings UI removal;
+- typed TLS/redirect failures needed to preserve secure runtime behavior;
+- deterministic tests, six-RID runtime CI and Item 1 security evidence.
+
+Out of scope:
+
+- PR #120, Bangumi `ep_id`, unrelated runtime defects and general technical debt;
+- architecture redesign, broad file-size cleanup, knowledge-base expansion,
+  workflow cleanup, dependency refreshes or release work unrelated to Item 1;
+- a new aria2 feature version, release or supply-chain rebuild unless v2 is
+  proven to have an actual security failure.
+
+Only a regression caused by this branch, or a security/build/publish blocker
+that prevents Item 1 from shipping, may be fixed here. Every newly discovered
+non-blocking issue goes to the backlog without a product change in this branch.
+
+## Stable Contracts
+
+- HTTPS certificate and hostname validation are always enabled. There is no UI,
+  settings or command-line downgrade switch.
+- HTTP RPC is accepted only for loopback. Remote RPC must be HTTPS and cannot
+  rely on redirects.
+- The packaged aria2 process uses a fresh high-entropy secret and ephemeral
+  loopback port. The secret uses a temporary restricted config, never the
+  process command line.
+- Login Cookie is never a process-global aria2 header. A task may receive it
+  only for an exact HTTPS `bilibili.com` host or subdomain.
+- Process arguments use `ProcessStartInfo.ArgumentList`; header values reject
+  control characters.
+- TLS and secure-redirect failures are terminal. They are not retried or
+  downgraded automatically.
+- Settings JSON can consume legacy `UseSsl` once, but the value has no runtime
+  authority and is omitted on write. SQLite tasks, GIDs, partial files and
+  resume state are unchanged.
+
+## Minimal Gate Evidence
+
+- `origin/main` `Aria2TransferBackend.cs`: 432 lines, zero `.Result` matches.
+- Item 1 before lifecycle extraction: 559 lines, with direct `.Result` accesses
+  in local RPC readiness and custom-endpoint feature verification.
+- The actual pre-extraction Architecture run failed
+  `LegacyPatternArchitectureTests.NewArchitectureCannotSynchronouslyReadTaskResult`
+  with `src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs`, and
+  `ModuleBoundaryBaselineTests.OversizedProductionFilesCannotGrowBeyondTheKnownBaseline`
+  with `Aria2TransferBackend.cs: new oversized file with 559 lines`.
+- Current Item 1 branch: `Aria2TransferBackend.cs` is 420 lines and has zero
+  `.Result` matches. `Aria2RuntimeLifecycle` contains only the extracted
+  startup, capability-check and shutdown code needed to restore both existing
+  gates. No further lifecycle design work is permitted in this branch.
+
+The violations were introduced by Item 1, not inherited from `main`, so the
+minimal extraction remains part of this PR.
+
+## Verification
+
+```powershell
+dotnet restore ./DownKyi.sln
+dotnet build ./DownKyi.sln -c Release --no-restore --no-incremental `
+  -p:EnableNETAnalyzers=true -p:AnalysisMode=All `
+  -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=true `
+  -p:CodeAnalysisTreatWarningsAsErrors=true -p:UseSharedCompilation=false
+pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild
+dotnet format ./DownKyi.sln --verify-no-changes --no-restore
+pwsh ./script/scan-secrets.ps1
+git diff --check
+```
+
+Windows x64 and x86 additionally run the real binary suite locally. The
+`aria2-tls-security` CI matrix must pass the pinned real binary for `win-x86`,
+`win-x64`, `linux-x64`, `linux-arm64`, `osx-x64` and `osx-arm64`. Each job
+uploads a sanitized machine-readable report. All existing PR checks, including
+architecture and lifecycle checks already owned by CI, must pass on the same
+head commit.
+
+## Completion
+
+Item 1 is complete only when Windows local runtime, all six exact-head runtime
+jobs and every PR check are green; reports contain no credential value or local
+path; and the PR has no unresolved merge blocker. At that point this branch
+ends immediately. Completing Item 1 does not start another task or permit a
+release.
+
+## Rollback
+
+Before merge, close the Draft PR and delete only this feature branch. After
+merge, revert the complete Item 1 commit range. Never restore certificate
+bypass, remote plaintext RPC, a fixed local secret or command-line credentials.
+User databases and resume files require no data rollback because this item does
+not migrate them.

--- a/docs/exec-plans/v1.1.1-security-patch.md
+++ b/docs/exec-plans/v1.1.1-security-patch.md
@@ -3,7 +3,7 @@
 Status: active
 Owner branch: `fix/aria2-tls-certificate-validation`
 Base: `origin/main` at `e2fd83d09b0fa641453fc92912ad238ed5499056`
-Last updated: 2026-08-01
+Last updated: 2026-08-03
 
 ## Goal
 
@@ -72,6 +72,20 @@ The violations were introduced by Item 1, not inherited from `main`, so the
 minimal extraction remains part of this PR.
 
 ## Verification
+
+PR #122 review remediation is part of the Item 1 completion gate:
+
+- custom RPC accepts an intentionally empty token but rejects whitespace-only
+  values, and settings reject URI user information before Host bootstrap;
+- credentialed same-origin HTTPS redirects remain valid while cross-origin or
+  non-HTTPS redirects fail closed;
+- startup cancellation reaches the custom aria capability RPC;
+- failed startup and shutdown wait for the child to exit before deleting the
+  RPC secret config;
+- every resumed paused GID replaces both headers and user-agent before unpause,
+  including an empty header list that clears stale credentials;
+- the six-RID trust evidence names the actual operating-system trust boundary,
+  and Linux starts aria2 without an explicit CA-file override.
 
 ```powershell
 dotnet restore ./DownKyi.sln

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -348,6 +348,15 @@ Release packaging downloads aria2 and FFmpeg from the scripts in `script/`.
   immutable release tag, never a mutable `latest` asset. The scripts accept an
   archive only after TLS validation, a successful HTTP status and its SHA-256
   matching the manifest.
+- aria2 manifest entries record the official base commit, exact independent
+  DownKyi source commit, canonical patch digest, immutable build commit,
+  required feature marker, archive digest and extracted binary digest. The
+  installer writes the verified binary digest beside `aria2c`; runtime verifies
+  that sidecar before process creation and then verifies the feature over RPC.
+  These controls identify source and artifact content but do not by themselves
+  prove reproducible builds, an SBOM or signed provenance. Current evidence and
+  residual risk are maintained in `docs/operations/aria2-security.md` and
+  `docs/operations/aria2-security-baseline.json`.
 - `DownKyi.Core` stores the checked-in external asset catalog but does not
   select or copy runtime-specific content. The executable is the sole package
   content owner: it uses the explicit publish target first, otherwise the host
@@ -355,18 +364,32 @@ Release packaging downloads aria2 and FFmpeg from the scripts in `script/`.
   `DownKyiAssetRuntimeIdentifier` must never cross a project-reference
   boundary or assign the .NET SDK `RuntimeIdentifier`; cross-target restore
   and publish remain the SDK RID owners.
-- Packaged local aria2 RPC listens only on loopback. It receives `--stop-with-process` on every OS and also joins a kill-on-close Windows Job Object, so an abrupt App termination cannot leave a local child running. Custom remote aria2 endpoints are not started or terminated by this owner.
+- Packaged local aria2 RPC listens only on a fresh ephemeral loopback port and
+  uses a fresh 256-bit secret. The secret is supplied through a temporary
+  restricted config and never appears in process arguments. It receives
+  `--stop-with-process` on every OS and also joins a kill-on-close Windows Job
+  Object, so an abrupt App termination cannot leave a local child running.
+  Custom remote aria2 endpoints are not started or terminated by this owner;
+  non-loopback RPC requires HTTPS and does not follow redirects.
+- aria2 task headers are per-transfer. Cookie can be attached only to an exact
+  HTTPS `bilibili.com` host or subdomain. The actual patched transfer engine
+  rejects scheme downgrade and credential-bearing cross-origin redirects before
+  another request is emitted. There is no process-global Cookie header and no
+  production certificate-validation or HTTPS-downgrade switch.
 
 When updating an external binary:
 
-1. Update the immutable source URL, version and checksum in
-   `script/assets/external-assets.json`.
-2. Confirm the release URL still returns the intended non-empty archive and
-   compare the manifest checksum with the publisher's release digest.
-3. Invoke the script from the repository root and verify at least one target
-   platform locally.
-4. Confirm `ffmpeg -hide_banner -encoders` lists the expected hardware encoder on a capable machine.
-5. Keep fallback behavior intact; missing GPU support must not block normal downloads.
+1. Update the independent source commit and mechanically regenerate the
+   normal-context canonical patch from the fixed official base.
+2. Verify the patch digest, `git apply --check`, actual apply, applied-source
+   `git diff --check` and exact source tree equality in the static build repo.
+3. Build all six RIDs from the immutable commit and record archive and binary
+   SHA-256 values in `script/assets/external-assets.json`.
+4. Invoke the installer from the repository root and verify its binary sidecar,
+   then run the `aria2-tls-security` matrix for all six RIDs and inspect every
+   sanitized report.
+5. Confirm `ffmpeg -hide_banner -encoders` lists the expected hardware encoder on a capable machine.
+6. Keep fallback behavior intact; missing GPU support must not block normal downloads.
 
 ## Release Tag Validation
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -1,6 +1,8 @@
 # Operations
 
 - `verification-and-rollback.md`：本機與 CI 驗證、產物、失敗判讀及回滾。
+- `aria2-security.md`：aria2 TLS、RPC secret、task header、舊設定遷移與六 RID 驗證政策。
+- `aria2-security-baseline.json`：aria2 binary 來源、TLS backend、信任來源與待驗證狀態。
 - `v1.1.1-release-notes.md`：目前修正版的使用者可見變更與相容性說明。
 - `v1.1.0-release-notes.md`：已撤回 draft 的歷史說明。
 - `bilibili-api-audit.md`：Bilibili 端點、envelope、認證需求、證據、替代方案與回歸測試。

--- a/docs/operations/aria2-security-baseline.json
+++ b/docs/operations/aria2-security-baseline.json
@@ -1,0 +1,75 @@
+{
+  "schemaVersion": 1,
+  "lastUpdatedDate": "2026-08-01",
+  "aria2": {
+    "version": "1.37.0-downkyi.2",
+    "repository": "https://github.com/crazysmile-PhD/downkyi-aria2",
+    "sourceBranch": "downkyi-secure-redirect-v2",
+    "upstreamTag": "release-1.37.0",
+    "upstreamCommit": "02f2d0d8472b3c38c29b4dba8c75ebd5fdd2899a",
+    "sourceCommit": "9938788f7e62af0530a1b28ece752e1de1fd0d46",
+    "canonicalPatchSha256": "1234523d1dadedf2342142b656e64b4c67cbca6545afebc584d50f39a229d094",
+    "requiredFeature": "downkyi-secure-redirect-v2",
+    "buildRepository": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build",
+    "buildTag": "1.37.0-downkyi.2",
+    "buildCommit": "94299bd9bde28a83bcb31346ec1d5f8131d2ec0d",
+    "reproducibleBuild": false,
+    "sbomAvailable": false,
+    "signedProvenanceAvailable": false
+  },
+  "assets": [
+    {
+      "rid": "win-x86",
+      "tlsBackend": "WinTLS",
+      "trustSource": "Windows CurrentUser root store in tests",
+      "archiveSha256": "40ed5587bc08e556826ab0ddd4bcf800599ba14dcde8ec75b7e911d8e5d5e610",
+      "binarySha256": "2a76612d032879e520fa3e4d1adacb900605e850934c8f6d5d7eeaf27377e7c0",
+      "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-required"
+    },
+    {
+      "rid": "win-x64",
+      "tlsBackend": "WinTLS",
+      "trustSource": "Windows CurrentUser root store in tests",
+      "archiveSha256": "ddb13cb8b905299521b66bb3c26fb700830b8ca72c01f7614d9e68efd6f450cb",
+      "binarySha256": "b8fccf898d70531f2335bcbf45ad4210c736a63f3efb0442cb4c75790d7c76b0",
+      "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-required"
+    },
+    {
+      "rid": "linux-x64",
+      "tlsBackend": "OpenSSL",
+      "trustSource": "explicit test CA file",
+      "archiveSha256": "6e297b49d8ad24df6d01b48eeb9d669697c105fedf922e3b7d8d8c8577c5bf7c",
+      "binarySha256": "0e0e3d8a27ab57abb529c49595cd19d49df31a830f09ce65f10d1ef3a4323f41",
+      "verification": "release-asset-verified; runtime-ci-required"
+    },
+    {
+      "rid": "linux-arm64",
+      "tlsBackend": "OpenSSL",
+      "trustSource": "explicit test CA file",
+      "archiveSha256": "75b348219fed7ee0ab909c0daaecae5b9ea021306dda85ef819e6a24190768e6",
+      "binarySha256": "e65850ad7403ba90f051966ed98ef1f88938a95d47f53a344ce07d182311f30c",
+      "verification": "release-asset-verified; runtime-ci-required"
+    },
+    {
+      "rid": "osx-x64",
+      "tlsBackend": "AppleTLS",
+      "trustSource": "temporary login-keychain trust in tests",
+      "archiveSha256": "5579a5dd1d27b02c8a74bf0737ccee7884446f310f0c577972969c757da60c78",
+      "binarySha256": "306abc9c903c4bda1044d8cbc13dfbbc612e66e5ea6b1cbfb6693295e4135b55",
+      "verification": "release-asset-verified; runtime-ci-required"
+    },
+    {
+      "rid": "osx-arm64",
+      "tlsBackend": "AppleTLS",
+      "trustSource": "temporary login-keychain trust in tests",
+      "archiveSha256": "e6a8ebeb17465d592040d9d0430bf6ecbce58409d5424489cce2a9f8b0f8a3d0",
+      "binarySha256": "eb1c4f684c36d8b84cb579ad5079e94044bd2979289355d4a8d18803dbc05b47",
+      "verification": "release-asset-verified; runtime-ci-required"
+    }
+  ],
+  "residualRisks": [
+    "Six-platform runtime TLS behavior still requires the exact DownKyi CI head to pass.",
+    "Cross-platform reproducible-build equivalence has not been established.",
+    "No upstream SBOM or signed build provenance is available."
+  ]
+}

--- a/docs/operations/aria2-security-baseline.json
+++ b/docs/operations/aria2-security-baseline.json
@@ -24,7 +24,7 @@
       "trustSource": "windows-system-root-store; elevated runner uses LocalMachine Root, non-elevated runner uses CurrentUser Root; temporary certificate removed by the test",
       "archiveSha256": "40ed5587bc08e556826ab0ddd4bcf800599ba14dcde8ec75b7e911d8e5d5e610",
       "binarySha256": "2a76612d032879e520fa3e4d1adacb900605e850934c8f6d5d7eeaf27377e7c0",
-      "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-required"
+      "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-pass-run-30799263926"
     },
     {
       "rid": "win-x64",
@@ -32,7 +32,7 @@
       "trustSource": "windows-system-root-store; elevated runner uses LocalMachine Root, non-elevated runner uses CurrentUser Root; temporary certificate removed by the test",
       "archiveSha256": "ddb13cb8b905299521b66bb3c26fb700830b8ca72c01f7614d9e68efd6f450cb",
       "binarySha256": "b8fccf898d70531f2335bcbf45ad4210c736a63f3efb0442cb4c75790d7c76b0",
-      "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-required"
+      "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-pass-run-30799263926"
     },
     {
       "rid": "linux-x64",
@@ -40,7 +40,7 @@
       "trustSource": "linux-system-ca-store; temporary certificate installed and removed; aria2 uses production default trust discovery without --ca-certificate",
       "archiveSha256": "6e297b49d8ad24df6d01b48eeb9d669697c105fedf922e3b7d8d8c8577c5bf7c",
       "binarySha256": "0e0e3d8a27ab57abb529c49595cd19d49df31a830f09ce65f10d1ef3a4323f41",
-      "verification": "release-asset-verified; production-system-trust-runtime-ci-required"
+      "verification": "release-asset-verified; production-system-trust-runtime-ci-pass-run-30799263926"
     },
     {
       "rid": "linux-arm64",
@@ -48,7 +48,7 @@
       "trustSource": "linux-system-ca-store; temporary certificate installed and removed; aria2 uses production default trust discovery without --ca-certificate",
       "archiveSha256": "75b348219fed7ee0ab909c0daaecae5b9ea021306dda85ef819e6a24190768e6",
       "binarySha256": "e65850ad7403ba90f051966ed98ef1f88938a95d47f53a344ce07d182311f30c",
-      "verification": "release-asset-verified; production-system-trust-runtime-ci-required"
+      "verification": "release-asset-verified; production-system-trust-runtime-ci-pass-run-30799263926"
     },
     {
       "rid": "osx-x64",
@@ -56,7 +56,7 @@
       "trustSource": "macos-system-keychain; temporary trust installed and removed with bounded sudo commands",
       "archiveSha256": "5579a5dd1d27b02c8a74bf0737ccee7884446f310f0c577972969c757da60c78",
       "binarySha256": "306abc9c903c4bda1044d8cbc13dfbbc612e66e5ea6b1cbfb6693295e4135b55",
-      "verification": "release-asset-verified; runtime-ci-required"
+      "verification": "release-asset-verified; runtime-ci-pass-run-30799263926"
     },
     {
       "rid": "osx-arm64",
@@ -64,7 +64,7 @@
       "trustSource": "macos-system-keychain; temporary trust installed and removed with bounded sudo commands",
       "archiveSha256": "e6a8ebeb17465d592040d9d0430bf6ecbce58409d5424489cce2a9f8b0f8a3d0",
       "binarySha256": "eb1c4f684c36d8b84cb579ad5079e94044bd2979289355d4a8d18803dbc05b47",
-      "verification": "release-asset-verified; runtime-ci-required"
+      "verification": "release-asset-verified; runtime-ci-pass-run-30799263926"
     }
   ],
   "residualRisks": [

--- a/docs/operations/aria2-security-baseline.json
+++ b/docs/operations/aria2-security-baseline.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "lastUpdatedDate": "2026-08-01",
+  "lastUpdatedDate": "2026-08-03",
   "aria2": {
     "version": "1.37.0-downkyi.2",
     "repository": "https://github.com/crazysmile-PhD/downkyi-aria2",
@@ -21,7 +21,7 @@
     {
       "rid": "win-x86",
       "tlsBackend": "WinTLS",
-      "trustSource": "Windows CurrentUser root store in tests",
+      "trustSource": "windows-system-root-store; elevated runner uses LocalMachine Root, non-elevated runner uses CurrentUser Root; temporary certificate removed by the test",
       "archiveSha256": "40ed5587bc08e556826ab0ddd4bcf800599ba14dcde8ec75b7e911d8e5d5e610",
       "binarySha256": "2a76612d032879e520fa3e4d1adacb900605e850934c8f6d5d7eeaf27377e7c0",
       "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-required"
@@ -29,7 +29,7 @@
     {
       "rid": "win-x64",
       "tlsBackend": "WinTLS",
-      "trustSource": "Windows CurrentUser root store in tests",
+      "trustSource": "windows-system-root-store; elevated runner uses LocalMachine Root, non-elevated runner uses CurrentUser Root; temporary certificate removed by the test",
       "archiveSha256": "ddb13cb8b905299521b66bb3c26fb700830b8ca72c01f7614d9e68efd6f450cb",
       "binarySha256": "b8fccf898d70531f2335bcbf45ad4210c736a63f3efb0442cb4c75790d7c76b0",
       "verification": "release-asset-verified; windows-runtime-local-pass; runtime-ci-required"
@@ -37,23 +37,23 @@
     {
       "rid": "linux-x64",
       "tlsBackend": "OpenSSL",
-      "trustSource": "explicit test CA file",
+      "trustSource": "linux-system-ca-store; temporary certificate installed and removed; aria2 uses production default trust discovery without --ca-certificate",
       "archiveSha256": "6e297b49d8ad24df6d01b48eeb9d669697c105fedf922e3b7d8d8c8577c5bf7c",
       "binarySha256": "0e0e3d8a27ab57abb529c49595cd19d49df31a830f09ce65f10d1ef3a4323f41",
-      "verification": "release-asset-verified; runtime-ci-required"
+      "verification": "release-asset-verified; production-system-trust-runtime-ci-required"
     },
     {
       "rid": "linux-arm64",
       "tlsBackend": "OpenSSL",
-      "trustSource": "explicit test CA file",
+      "trustSource": "linux-system-ca-store; temporary certificate installed and removed; aria2 uses production default trust discovery without --ca-certificate",
       "archiveSha256": "75b348219fed7ee0ab909c0daaecae5b9ea021306dda85ef819e6a24190768e6",
       "binarySha256": "e65850ad7403ba90f051966ed98ef1f88938a95d47f53a344ce07d182311f30c",
-      "verification": "release-asset-verified; runtime-ci-required"
+      "verification": "release-asset-verified; production-system-trust-runtime-ci-required"
     },
     {
       "rid": "osx-x64",
       "tlsBackend": "AppleTLS",
-      "trustSource": "temporary login-keychain trust in tests",
+      "trustSource": "macos-system-keychain; temporary trust installed and removed with bounded sudo commands",
       "archiveSha256": "5579a5dd1d27b02c8a74bf0737ccee7884446f310f0c577972969c757da60c78",
       "binarySha256": "306abc9c903c4bda1044d8cbc13dfbbc612e66e5ea6b1cbfb6693295e4135b55",
       "verification": "release-asset-verified; runtime-ci-required"
@@ -61,7 +61,7 @@
     {
       "rid": "osx-arm64",
       "tlsBackend": "AppleTLS",
-      "trustSource": "temporary login-keychain trust in tests",
+      "trustSource": "macos-system-keychain; temporary trust installed and removed with bounded sudo commands",
       "archiveSha256": "e6a8ebeb17465d592040d9d0430bf6ecbce58409d5424489cce2a9f8b0f8a3d0",
       "binarySha256": "eb1c4f684c36d8b84cb579ad5079e94044bd2979289355d4a8d18803dbc05b47",
       "verification": "release-asset-verified; runtime-ci-required"

--- a/docs/operations/aria2-security.md
+++ b/docs/operations/aria2-security.md
@@ -1,0 +1,148 @@
+# aria2 Transport And Control Security
+
+Status: required runtime contract
+Last updated: 2026-08-01
+
+## Security Boundary
+
+DownKyi owns the packaged aria2 child process and its loopback JSON-RPC control
+channel. A custom aria2 server is external: DownKyi sends RPC requests but does
+not start, kill or configure that process.
+
+```mermaid
+flowchart LR
+    Settings["Validated network settings"]
+    Endpoint["Fresh loopback port + 256-bit secret"]
+    SecretFile["Restricted temporary aria2 config"]
+    Child["Tracked packaged aria2 child"]
+    Rpc["AriaClient JSON-RPC"]
+    Policy["Per-task host header policy"]
+    Media["HTTPS media endpoint"]
+    Trust["Operating-system or packaged CA trust"]
+
+    Settings --> Endpoint
+    Endpoint --> SecretFile
+    SecretFile --> Child
+    Endpoint --> Rpc
+    Rpc --> Child
+    Policy --> Rpc
+    Child --> Media
+    Trust --> Child
+```
+
+## Required Behavior
+
+- aria2 certificate and hostname validation stays enabled. Production source,
+  workflows and scripts must not contain `--check-certificate=false`, insecure
+  TLS callbacks, `curl -k` or equivalent bypasses.
+- Packaged RPC binds loopback only and disallows wildcard origins. Its port and
+  secret are regenerated for every runtime. Startup succeeds only while the
+  supervised child is alive; shutdown addresses only that tracked child.
+- The RPC secret is written to a unique temporary config with mode `0600` on
+  Unix. It is removed after startup or on every failure/shutdown path. Neither
+  the secret nor Cookie is present in `ProcessStartInfo.ArgumentList`.
+- `AriaClient` permits `http` only for loopback. Non-loopback endpoints require
+  `https`; URI user information and redirects are rejected.
+- Every transfer receives an isolated header option. Cookie is eligible only
+  for exact HTTPS `bilibili.com` or its subdomains. The resolver performs a
+  defense-in-depth HTTPS preflight, but it is not the final redirect boundary.
+  The DownKyi aria2 fork rejects HTTPS-to-non-HTTPS redirects while processing
+  the actual `Location`, before another request is emitted. It also rejects an
+  actual cross-origin HTTPS redirect after Cookie, Authorization,
+  Proxy-Authorization, token or API-key material was emitted. Header values
+  containing CR, LF, NUL or other control characters are rejected.
+- Packaged aria2 starts only after its SHA-256 sidecar matches the executable.
+  Both packaged and custom endpoints must report
+  `downkyi-secure-redirect-v2` through `aria2.getVersion().enabledFeatures`;
+  missing integrity or capability evidence fails closed.
+- RPC error code `33` identifies HTTPS downgrade rejection and `34` identifies
+  sensitive-header cross-origin rejection. These machine codes remain stable
+  when aria2 exhausts a URI and replaces the human-readable status message.
+- TLS failures receive a distinct typed classification and visible localized
+  status. They are not converted to generic empty data and never trigger HTTP
+  downgrade.
+
+## Legacy `UseSsl` Migration
+
+`UseSsl` is not a current setting and has no production getter, UI control or
+runtime branch. `NetworkSettings` retains a private, setter-only JSON migration
+member so old files still deserialize. Loading the marker schedules a normal
+settings rewrite; the new serializer cannot emit the field.
+
+```text
+old settings contain UseSsl=No
+  -> compatibility setter records presence only
+  -> runtime still requires HTTPS and certificate validation
+  -> next atomic settings write omits UseSsl
+```
+
+SQLite tasks, GIDs, aria2 session files, partial-file maps and download resume
+state are outside this migration and remain byte/contract compatible.
+
+## Real TLS Matrix
+
+The `aria2-tls-security` quality job runs the actual manifest-pinned binary for
+all six RIDs against a local deterministic certificate authority. It verifies:
+
+- trusted download, split/hash, task headers, redirects and resume;
+- RPC add, status and force-remove;
+- unknown and self-signed CA;
+- expired and not-yet-valid certificates;
+- hostname mismatch and missing SAN/wrong CN;
+- incomplete chain;
+- trusted redirect to an untrusted endpoint;
+- an explicit later application attempt retaining the partial file after TLS
+  failure, without an automatic TLS retry or downgrade.
+- preflight-safe/actual-GET downgrade, HEAD-safe/GET-downgrade, Range-only
+  downgrade and second-attempt downgrade, each with zero HTTP target requests;
+- same-origin and cross-origin HTTPS redirects, plus zero cross-origin
+  connections for Cookie, Authorization, Proxy-Authorization, token and API-key
+  cases.
+
+The report contains only environment metadata, backend, aria2 version, case
+names and pass/fail diagnostics. Header names may identify the tested policy;
+header values, request URLs, filesystem paths, Cookie values, RPC tokens and
+account identifiers are forbidden.
+
+For a local packaged binary:
+
+```powershell
+$env:DOWNKYI_ARIA2_BINARY = '<absolute aria2c path>'
+$env:DOWNKYI_ARIA2_RID = 'win-x64'
+$env:DOWNKYI_ARIA2_TLS_REPORT = './artifacts/aria2-tls/win-x64.json'
+dotnet test ./tests/DownKyi.Tests/DownKyi.Tests.csproj -c Release `
+  --filter Category=Aria2TlsIntegration
+```
+
+## External Binary Evidence
+
+The independent source repository is
+`https://github.com/crazysmile-PhD/downkyi-aria2`. The security branch is based
+on official aria2 `release-1.37.0` commit
+`02f2d0d8472b3c38c29b4dba8c75ebd5fdd2899a`; its reviewed source commit is
+`9938788f7e62af0530a1b28ece752e1de1fd0d46`. The normal-context canonical
+patch SHA-256 is
+`1234523d1dadedf2342142b656e64b4c67cbca6545afebc584d50f39a229d094`.
+`source-lock.json` in the build repository pins those commits, the patch, zlib
+1.3.2 and OpenSSL 3.5.7 with SHA-256 digests. Builds never follow the source
+branch head.
+
+The six immutable assets were published from build commit
+`94299bd9bde28a83bcb31346ec1d5f8131d2ec0d` under tag
+`1.37.0-downkyi.2`. Their archive and executable SHA-256 values are pinned in
+`script/assets/external-assets.json` and independently match the release
+sidecars and build evidence. This is source and artifact identity evidence,
+not reproducible-build or signed-provenance proof; no SBOM or signed provenance
+is currently available. The original aria2 fork and local mirror bundle remain
+preserved until the full integration gate is green.
+
+## Incident Checks
+
+1. Preserve the sanitized TLS report and CI run URL.
+2. Confirm no `aria2c` child remains after the test or application exits.
+3. Run `pwsh ./script/scan-secrets.ps1` and inspect process arguments without
+   recording their contents.
+4. Classify certificate errors separately from DNS, timeout, HTTP status,
+   storage and cancellation failures.
+5. Do not ask users to disable TLS. Fix trust-store packaging or the upstream
+   endpoint and rerun the affected RID.

--- a/docs/operations/aria2-security.md
+++ b/docs/operations/aria2-security.md
@@ -1,7 +1,7 @@
 # aria2 Transport And Control Security
 
 Status: required runtime contract
-Last updated: 2026-08-01
+Last updated: 2026-08-03
 
 ## Security Boundary
 
@@ -39,8 +39,10 @@ flowchart LR
   secret are regenerated for every runtime. Startup succeeds only while the
   supervised child is alive; shutdown addresses only that tracked child.
 - The RPC secret is written to a unique temporary config with mode `0600` on
-  Unix. It is removed after startup or on every failure/shutdown path. Neither
-  the secret nor Cookie is present in `ProcessStartInfo.ArgumentList`.
+  Unix. Startup failure and shutdown first wait for the supervised child to
+  exit, including a bounded kill-and-wait fallback, and only then remove the
+  config. Neither the secret nor Cookie is present in
+  `ProcessStartInfo.ArgumentList`.
 - `AriaClient` permits `http` only for loopback. Non-loopback endpoints require
   `https`; URI user information and redirects are rejected.
 - Every transfer receives an isolated header option. Cookie is eligible only
@@ -49,8 +51,9 @@ flowchart LR
   The DownKyi aria2 fork rejects HTTPS-to-non-HTTPS redirects while processing
   the actual `Location`, before another request is emitted. It also rejects an
   actual cross-origin HTTPS redirect after Cookie, Authorization,
-  Proxy-Authorization, token or API-key material was emitted. Header values
-  containing CR, LF, NUL or other control characters are rejected.
+  Proxy-Authorization, token or API-key material was emitted. A credentialed
+  same-origin HTTPS redirect remains valid. Header values containing CR, LF,
+  NUL or other control characters are rejected.
 - Packaged aria2 starts only after its SHA-256 sidecar matches the executable.
   Both packaged and custom endpoints must report
   `downkyi-secure-redirect-v2` through `aria2.getVersion().enabledFeatures`;
@@ -98,6 +101,13 @@ all six RIDs against a local deterministic certificate authority. It verifies:
 - same-origin and cross-origin HTTPS redirects, plus zero cross-origin
   connections for Cookie, Authorization, Proxy-Authorization, token and API-key
   cases.
+
+Linux installs the fixture root temporarily into the system CA store and starts
+aria2 without `--ca-certificate`, so the trusted case exercises the same default
+trust discovery path used by production. An elevated Windows runner uses
+LocalMachine Root; a non-elevated runner selects CurrentUser Root before any
+store write. Both are Windows system trust stores used by WinTLS. macOS uses
+the System keychain. Each registration is removed during test teardown.
 
 The report contains only environment metadata, backend, aria2 version, case
 names and pass/fail diagnostics. Header names may identify the tested policy;

--- a/docs/operations/v1.1.1-release-notes.md
+++ b/docs/operations/v1.1.1-release-notes.md
@@ -15,6 +15,12 @@ v1.1.1 是 v1.1 系列的正式修正版，包含 v1.1.0 的架构、下载、�
 - 修复 `//host/path` 图片来源在 Windows 被当成 UNC 路径检查，造成图片
   载入或测试执行异常延迟的问题。
 - 发布流程会确认 Git tag 与唯一版本来源 `version.txt` 完全一致。
+- aria2 恢复 HTTPS 凭证与主机名称验证；不再允许旧 `UseSsl` 设置或 UI
+  将下载降级为 HTTP。旧字段仍可一次性读取，下一次保存时会自动移除。
+- 内建 aria2 每次启动使用随机 loopback port 与高强度 RPC secret，Cookie
+  与 secret 不再出现在程序命令列；Cookie 只可附加到符合范围的单一任务。
+- 非本机自订 aria2 RPC 强制 HTTPS，RPC 不跟随重新导向；TLS 错误会明确
+  分类并由六个平台真实 aria2 binary 回归测试保护。
 
 ## v1.1 系列功能
 

--- a/docs/operations/verification-and-rollback.md
+++ b/docs/operations/verification-and-rollback.md
@@ -28,7 +28,8 @@ dotnet build ./DownKyi.sln `
   -p:AnalysisMode=All `
   -p:EnforceCodeStyleInBuild=true `
   -p:TreatWarningsAsErrors=true `
-  -p:CodeAnalysisTreatWarningsAsErrors=true
+  -p:CodeAnalysisTreatWarningsAsErrors=true `
+  -p:UseSharedCompilation=false
 
 pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild
 pwsh ./script/audit-lifecycle-ownership.ps1 `
@@ -40,9 +41,14 @@ pwsh ./script/test-assembly-lifecycle.ps1 `
   -ValidateForensics `
   -ResultsDirectory ./artifacts/assembly-lifecycle/verification
 dotnet format ./DownKyi.sln --no-restore --verify-no-changes
+pwsh ./script/audit-module-boundaries.ps1 `
+  -OutputPath ./artifacts/architecture/module-boundary-audit.json
+$workflowFiles = Get-ChildItem ./.github/workflows -Filter *.yml | `
+  Select-Object -ExpandProperty FullName
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -- $workflowFiles
 git diff --check
 dotnet package list --project ./DownKyi.sln --vulnerable --include-transitive
-dotnet package list --project ./DownKyi.sln --deprecated
+dotnet package list --project ./DownKyi.sln --deprecated --include-transitive
 pwsh ./script/scan-secrets.ps1
 ```
 

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -1,288 +1,87 @@
-# DownKyi Core Live Refactoring Plan
+# DownKyi Live Plan
 
 Status: active
-Last updated: 2026-07-29
-Current group: Gate 10 Windows lifecycle blocker and corrective release
-Current branch: `fix/lifecycle-slow-evidence-arm-window`
+Last updated: 2026-08-01
+Current work item: v1.1.1 item 1, aria2 TLS and control-plane security
+Current branch: `fix/aria2-tls-certificate-validation`
+Current base: `origin/main` at `e2fd83d09b0fa641453fc92912ad238ed5499056`
 
-This file contains only unfinished or not-yet-integrated work. Completed Gate
-1-9 detail is retained in `docs/maintenance.md`, design documents and Git
-history, not repeated here.
+This file contains only unfinished, blocked or integration-pending work. Accepted
+design and completed history belong in `ARCHITECTURE.md`, `docs/design-docs/`,
+`docs/maintenance.md` and release notes. The detailed item contract is
+`docs/exec-plans/v1.1.1-security-patch.md`.
 
-## Current State
+## Current Item
 
-- Gate 1-9 are integrated into
-  `origin/refactor/pr-30-32-release-hardening` at merge commit `182745e`.
-- PR #111 closed the final oversized production owner. Its final head passed
-  Windows/Linux/macOS quality run `30424802172` and CodeQL run `30424802168`;
-  all seven checks had zero annotations and each platform retained seven
-  assembly-named TRX artifacts.
-- Latest `main` and the full stacked branch merge cleanly. Integration commit
-  `fb8c922` has parents `661a7c4` and `182745e`.
-- The pre-version integration commit passes strict `AnalysisMode=All` Release
-  build with zero warnings/errors and all 713 tests across seven projects.
-- `version.txt` is now the only `1.1.0` source. Generated DownKyi metadata is
-  Assembly/File `1.1.0.0` and informational `1.1.0+<commit>`.
-- The local version candidate passes strict build with zero warnings/errors,
-  all 714 tests, format, module audit, vulnerable/deprecated package audits,
-  `git diff --check`, and Gitleaks across 986 candidate files.
-- The latest committed candidate authenticated read-only audit passed its navigation gate
-  and all 14 allowlisted contracts with HTTP 200, Bilibili code 0, required
-  fields present and zero contract drift at `8aa4382`. Gitleaks 8.30.1 then
-  reported zero findings across all 986 candidate files.
-- PR #112 first-head quality run `30426137294`, protobuf run `30426137279`
-  and CodeQL run `30426137276` passed. Each platform uploaded seven distinct
-  TRX files; 713 tests executed successfully and the FFmpeg-dependent seek
-  integration was the only non-executed CI case.
-- Manual package rehearsal `30426554087` then exposed two release-only
-  defects: expired BtbN autobuild URLs on Windows x64/Linux and host-derived
-  `RuntimeIdentifier` contamination during x64 publication on arm64 macOS.
-  Candidate `8aa4382` pins existing immutable FFmpeg releases, resolves all
-  asset scripts from their own directory, uses one manifest on every OS, and
-  separates asset selection from the SDK runtime identifier.
-- Second rehearsal `30428876552` proved those two defects fixed: all release
-  gates passed, along with macOS arm64, Windows x64 and every Linux x64
-  package. macOS x64, Windows x86 and Linux arm64 then exposed one remaining
-  contract: a target asset RID was not propagated through project references,
-  so Core selected host binaries. The executable is now the sole asset-RID and
-  package-content owner and directly includes the selected Core catalog files;
-  no custom RID crosses a project-reference boundary. A clean Windows x86
-  self-contained publish passes the common validator, and its aria2, FFmpeg
-  and ffprobe SHA-256 values exactly match the x86 source assets. Full local
-  validation passes with zero strict build warnings/errors, all 719 tests,
-  format, module boundary, dependency, secret and diff gates. A project
-  reference property-propagation attempt was rejected because a solution build
-  created competing project instances that wrote the same `obj/bin` paths.
-  PR quality `30430722500`, protobuf `30430722468` and CodeQL `30430722421`
-  pass on `1968c9d`; each platform retains seven distinct TRX files, 718
-  tests execute and pass, and only the runner-dependent FFmpeg seek test is
-  not executed. Code and test annotations are zero; the one CodeQL annotation
-  is GitHub's documented 300-file diff-display limit.
-- Third rehearsal `30431043860` passes every release gate and all nine package
-  jobs. Manual dispatch correctly skips release publication. All nine package
-  sidecars match their package SHA-256; the nine manifests contain 54 valid
-  required-file entries with version/RID agreement. Direct archive inspection
-  passes for both Windows zips, both debs, the rpm, both AppImages and both
-  DMGs, with required DownKyi/aria2/FFmpeg/ffprobe files and zero Config, Logs,
-  Cache, Storage, Cookie, database or other user-data paths. Same-RID package
-  manifests agree, and remote Windows asset hashes match the repository
-  catalog.
-- PR #112 is merged into `main` at `fcc1d226`; its tree exactly matches the
-  tested integration head. Annotated tag `v1.1.0` points to that immutable
-  commit.
-- Tag workflow `30434000154` attempt 1 exposed a Windows lifecycle race before
-  Desktop test discovery. The xUnit `-assemblyInfo` child printed valid JSON
-  and then `Waiting 10 seconds for foreground threads to exit`, corrupting the
-  runner protocol. Attempt 2 passed, but a successful rerun is not accepted as
-  evidence that the foreground-thread owner has been fixed.
-- The release produced by attempt 2 was immediately returned to draft. Package
-  publication is frozen until the thread owner, test-host teardown and
-  production Host shutdown path are verified and corrected.
-- Local unmodified baselines currently pass 200 sequential and 400 concurrent
-  `-assemblyInfo` process runs plus 50 full Desktop test runs. This establishes
-  that the failure is intermittent; it does not close the blocker.
-- The foreground output owner is now identified: the old test-data module
-  initializer registered synchronous recursive cleanup on `ProcessExit`, and
-  the xUnit v3 watchdog emitted its foreground-thread warning after valid
-  `-assemblyInfo` JSON. Test isolation is now an async assembly fixture.
-- Desktop tests use Avalonia's assembly-scoped headless xUnit session instead
-  of a custom foreground Dispatcher thread. Production desktop shutdown awaits
-  App, Host and runtime disposal; the production Host smoke also exposed and
-  fixed a pooled SQLite connection surviving store disposal.
-- The Assembly Lifecycle Stability Gate now probes load, assembly info,
-  discovery, execution, assembly teardown and process exit in independent
-  children. Its ownership audit covers production/test/benchmark/tool owners,
-  and Windows delay forensics captures process/thread state and managed stacks.
-- The historical schema 1 local Verification passed all seven test assemblies for five
-  iterations: 211 phase results, zero failures, zero unknown owners, teardown
-  at no more than 65 ms and process exit at no more than 170 ms on this Windows x64
-  worktree. The report is deliberately marked dirty and is not release evidence.
-- Review of that schema 1 report found that marker-aware execution was excluded
-  from slow-phase capture and that process-exit used the collector observation
-  time. Schema 2 captures every phase at the unchanged five-second threshold,
-  fails unexplained missing evidence, separates execution/exit/timeout evidence
-  and measures process exit from the fixture marker to OS `Process.ExitTime`.
-- The first real execution stack identified a separate Windows delay:
-  protocol-relative `//host/path` artwork was passed to `File.Exists` as a UNC
-  path before HTTP classification. External image sources are now classified
-  first; the focused image tests run in 172 ms and a subsequent full
-  `DownKyi.Tests` execution completes in 1.893 seconds without crossing the
-  slow threshold.
-- Schema 2 formal local Verification now passes all seven assemblies for five
-  iterations with 211 phase results, zero failures, zero unowned mechanisms,
-  zero real slow phases and zero missing evidence. Teardown is at most 2 ms,
-  OS-measured process exit is at most 15 ms, and `DownKyi.Tests` execution is
-  1.685-1.716 seconds across the five runs. The 774.833 ms diagnostic capture
-  time belongs to the deliberate marker-aware forensics self-test.
-- The first main-profile 50-iteration run exposed a gate-side Windows sharing
-  race at `DownKyi.Architecture.Tests` iteration 42: the fixture was appending
-  its marker while `ReadAllLines` requested an incompatible handle. The marker
-  reader now uses shared access, bounded retries and contention counters; a
-  deterministic exclusive-lock self-test guards this path without weakening
-  the final-marker contract.
-- The fail-closed marker proof is now a detailed schema object rather than only
-  a green summary bit. A Windows Main-profile five-iteration verification
-  passed 212 phases and all 729 tests: the self-test executed, observed two
-  contentions, recovered, parsed all marker states and reported no error. One
-  5220.745 ms Architecture execution crossed the unchanged five-second
-  threshold and retained evidence; no slow evidence was missing.
-- Follow-up review made the proof predicate explicit rather than relying on
-  derived booleans: positive contention and null error are checked directly,
-  the self-test phase shares the final predicate, and mutation cases reject
-  error-bearing, zero-contention and incomplete nominally-passed states.
-  Unauthorized access and non-sharing I/O now remain marker read errors instead
-  of being mislabeled as contention.
-- The final consistency review removed the duplicate formal predicate: marker
-  phase, summary and gate now consume one complete proof result. Phase schema
-  now has general `failureType` / `errorType`, so marker contract failures no
-  longer masquerade as slow-evidence capture errors.
-- PR #116 is merged into `main` at `6a61247`. Strict PR CI
-  `30450175286` and CodeQL `30450175415` passed. The authoritative Main
-  lifecycle report ran all seven assemblies for 50 iterations: 2,102 phase
-  results, zero failures, zero missing slow evidence, zero marker read errors,
-  teardown at no more than 7 ms and OS process exit at no more than 187 ms.
-  All 14 slow execution phases retained diagnostics. The marker self-test
-  executed, observed two lock contentions, recovered, parsed the marker and
-  passed every mutation check.
-- `v1.1.0` remains an immutable audit tag; its GitHub Release draft is
-  withdrawn. The corrective candidate uses the sole version source `1.1.1`,
-  adds an exact tag/version contract and will publish only after a same-commit
-  Main 50 run plus the complete 100-iteration cross-platform rehearsal.
-- The first v1.1.1 local Verification exposed a gate-side threshold race:
-  Architecture execution exited normally at 5005.587 ms, but the 25 ms
-  monitor moved from below five seconds to an exited child and had no process
-  left to inspect. The five-second classification is unchanged; forensics is
-  now armed 100 ms early and the report discloses pre-threshold capture.
-- The corrected final local Verification passes all seven assemblies for five
-  iterations: 212 phase results, zero failures, five slow phases with five
-  evidence captures, and zero missing evidence. The deterministic capture-lead
-  self-test is true, the marker self-test observed two contentions with no
-  error, teardown is at most 2 ms and OS process exit is at most 145 ms. This
-  dirty-worktree report validates the candidate locally but is not release
-  evidence.
-- PR #117 merged the v1.1.1 corrective candidate into `main` at `c251a4f`.
-  Strict PR CI `30453512364`, CodeQL `30453517140` and the exact-commit Main
-  lifecycle run `30453933568` passed. The Main report contains 2,102 phases,
-  zero failures, four captured slow phases, zero missing evidence, teardown at
-  no more than 3 ms and OS process exit at no more than 24 ms.
-- The first v1.1.1 Rehearsal `30455540672` correctly stopped before packaging.
-  `DownKyi.Tests` assembly-info iteration 78 exited zero with valid xUnit JSON
-  and empty stderr, but the post-exit scan observed one residual child. Schema 2
-  stored only the count, so the hosted runner's exact child identity is
-  unrecoverable. No test, Host, Dispatcher or application service executes in
-  this phase.
-- The same assembly-info command completed 500 isolated local repetitions with
-  zero residual children. This excludes a deterministic application owner but
-  does not erase the low-probability runner race. The corrective gate now
-  preserves sanitized child identity and a residual evidence manifest, captures
-  live managed children, and dynamically proves observation, classification and
-  PID-plus-creation-time cleanup with a synthetic residual process tree.
-- The residual-evidence candidate passes strict `AnalysisMode=All` build with
-  zero warnings/errors and all 731 tests. Formal local lifecycle Verification
-  covers 213 phases with zero failures, zero real residual children, five slow
-  phases with five captures and zero missing evidence. Residual-child,
-  redaction, capture-lead and marker-reader self-tests all pass; teardown is at
-  most 3 ms and OS process exit at most 14 ms. Ownership now includes external
-  process creation with 452 matches and zero violations. Format, module
-  boundaries, vulnerable/deprecated dependency audits, Gitleaks and diff checks
-  pass. This dirty-worktree result is candidate evidence, not Main or release
-  evidence.
-- PR #118 merged the residual-child evidence fix at `ad5ac64`. Strict PR CI
-  `30461103180` and CodeQL `30461103401` passed; its PR lifecycle report has
-  129 phases, zero failures, complete residual identity/evidence/classification/
-  cleanup/redaction proof and zero real residual children.
-- The exact-commit Main 50 run `30461640781` failed closed on one different
-  boundary race: `DownKyi.Tests` execution iteration 24 ended normally at
-  5007.386 ms, but the 100 ms pre-threshold arm was still skipped under runner
-  scheduling. The report contains 2,103 phases, one `SlowEvidenceMissing`,
-  zero real residual processes, and passing residual/marker self-tests. The
-  five-second classification stays unchanged; capture now arms 1,000 ms early.
-  Its held-child test uses a 1.25-second synthetic threshold, proving the full
-  lead dynamically instead of passing through a zero-clamped arm.
-- Clean code commit `ca8103e` passes strict `AnalysisMode=All` build with zero
-  warnings/errors, all 731 tests, format, module boundaries,
-  vulnerable/deprecated dependency audits, Gitleaks and diff checks. Its
-  five-iteration lifecycle run covers seven assemblies and 213 phases with
-  zero failures, seven slow phases, seven evidence captures, zero missing
-  evidence and zero real residual processes. Both dynamic self-tests pass;
-  teardown is at most 7 ms and OS process exit is at most 75 ms. Diagnostic
-  collection consumed 19,765.952 ms in total and remains separately disclosed;
-  exact-commit PR and Main evidence are still required.
+### v1.1.1 Item 1: aria2 TLS And Control Plane
 
-## Gate 10 Checklist
+- [x] Remove the packaged aria2 certificate-validation bypass and every
+      production HTTP downgrade path.
+- [x] Remove Cookie and RPC secret from aria2 process arguments.
+- [x] Replace process-global headers with per-transfer headers and exact HTTPS
+      Bilibili credential scope.
+- [x] Use `ProcessStartInfo.ArgumentList` and reject header control characters.
+- [x] Give each packaged runtime a fresh ephemeral loopback port and 256-bit
+      secret; verify the supervised child remains alive before accepting RPC.
+- [x] Reject non-loopback plaintext RPC, URI credentials and RPC redirects.
+- [x] Make legacy `UseSsl` a read-only migration marker that cannot affect
+      runtime and disappears on the next settings write.
+- [x] Add typed TLS failure classification and user-visible status.
+- [x] Add architecture, settings, RPC, process-argument, header-scope and retry
+      regression tests.
+- [x] Add a real-binary deterministic TLS suite covering valid trust, resume,
+      redirects, RPC lifecycle, unknown/self-signed/expired/future/wrong-host/
+      missing-SAN/incomplete-chain failures, app-level retry, actual GET/Range/
+      second-request downgrade and sensitive cross-origin redirects.
+- [x] Add the six-RID `aria2-tls-security` quality matrix and sanitized report.
+- [x] Preserve the original fork and complete mirror bundle; create independent
+      `downkyi-aria2` source and `downkyi-aria2-static-build` repositories.
+- [x] Generate a normal-context canonical patch from fixed source commit
+      `9938788f7e62af0530a1b28ece752e1de1fd0d46`; verify its SHA, apply and exact
+      resulting tree separately from ordinary repository `git diff --check`.
+- [x] Pin zlib and OpenSSL source URLs and SHA-256 values in `source-lock.json`;
+      build jobs do not follow a movable source branch or dependency page.
+- [x] Require bundled binary SHA verification before process start and the
+      versioned secure-redirect feature for bundled and custom aria2 RPC.
+- [x] Complete all six static binary builds, fix their archive/binary SHA-256
+      values and publish them from immutable tag `1.37.0-downkyi.2`.
+- [ ] Pass the actual-transfer TLS/redirect/header suite on all six binaries and
+      prove downgrade targets receive zero requests. Windows x64/x86 are
+      locally green; Linux/macOS remain exact-head CI evidence.
+- [ ] Pass strict local Release build, all seven tests, format, module audit,
+      lifecycle ownership/gate, package audits, secret scan and diff check on
+      the final manifest and product diff.
+- [ ] Commit and push the complete isolated item to its one feature branch.
+- [ ] Open one Draft PR against `main` and require all six real aria2 RID jobs,
+      normal quality jobs and CodeQL to pass on the exact head commit.
+- [ ] Review uploaded sanitized reports, verify no credential/path leakage and
+      update `aria2-security-baseline.json` with exact CI evidence.
+- [ ] Resolve all item-1 merge blockers and mark the item complete.
 
-- [x] Create the integration branch from latest `origin/main`.
-- [x] Merge the complete release-hardening stack without conflicts.
-- [x] Pass strict build and all tests before changing the version.
-- [x] Verify version-derived assembly, file and informational metadata for
-      `1.1.0`; UI and package validation remains part of the publish rehearsal.
-- [x] Repeat the sanitized authenticated read-only Bilibili contract audit on
-      the final candidate and run Gitleaks.
-- [x] Pass strict PR CI and CodeQL on Windows, Linux and macOS for the final
-      candidate SHA.
-- [x] Manually dispatch `.github/workflows/build.yml` on that SHA.
-- [x] Require Windows x64/x86, Linux x64/arm64 and macOS x64/arm64 package jobs
-      plus their release-gate jobs to pass.
-- [x] Inspect every package, `.sha256` sidecar and publish manifest; confirm
-      DownKyi, aria2, FFmpeg, ffprobe, Fluent theme and version.
-- [x] Confirm settings JSON, legacy SQLite, unfinished tasks, GID, partial file
-      map, completed segment keys and resume fixtures remain green.
-- [x] Confirm the source candidate and inspected packages contain no
-      credential, account data, Config, Logs, Cache, Storage or user database.
-- [x] Merge the integration PR into `main`.
-- [x] Verify clean `main` points at the tested integration tree.
-- [x] Create immutable annotated tag `v1.1.0` and run the tag workflow.
-- [x] Identify the owner of the intermittent Windows foreground thread; record
-      whether it belongs to xUnit discovery, the Avalonia test Dispatcher, a
-      hosted service or production application lifecycle.
-- [x] Replace the custom headless Avalonia foreground thread with the official
-      assembly-scoped headless test session and deterministic async teardown.
-- [x] Exercise production-style Host startup, shutdown and desktop-lifetime
-      exit with bounded completion assertions.
-- [x] Add the ownership audit, six-phase Assembly Lifecycle Stability Gate,
-      automatic Windows timeout forensics and blocking PR/main/rehearsal jobs.
-- [x] Pass the formal local five-iteration lifecycle Verification with managed
-      stack forensics validated and retain its machine-readable report.
-- [x] Correct schema 1 timing/evidence ambiguities and prove marker-aware
-      execution captures a managed stack at the unchanged slow threshold.
-- [x] Remove protocol-relative image UNC probing and add a bounded regression
-      test so `//host/path` reaches HTTPS without blocking local file lookup.
-- [x] Make lifecycle marker sampling tolerate concurrent fixture writes and add
-      an exclusive-lock recovery self-test.
-- [x] Repeat Windows assembly-info and Desktop/full-solution tests enough to
-      make the original race observable if it remains.
-- [x] Pass a new strict PR quality run on the corrected lifecycle commit.
-- [x] Merge v1.1.1 PR #117 and pass its exact-commit Main 50 lifecycle profile.
-- [x] Preserve the failed Rehearsal evidence and classify the remaining gap as
-      missing residual-child identity, not a passing rerun.
-- [x] Repeat the exact failing assembly-info command 500 times without observing
-      a deterministic residual owner.
-- [x] Merge the residual-child identity, evidence and dynamic self-test fix.
-- [x] Preserve the failed post-merge Main report showing the 100 ms arm window
-      is insufficient; do not replace it with a blind rerun.
-- [ ] Merge the one-second pre-threshold capture-arm correction.
-- [ ] Pass a new exact-commit Main 50 lifecycle profile after that fix.
-- [ ] Pass the complete manual release rehearsal on the final versioned
-      candidate commit.
-- [ ] Keep `v1.1.0` immutable. Document the withdrawn draft and publish a
-      `v1.1.1` corrective version only after every lifecycle and release gate
-      is green.
+## Next Items
 
-## Stable Contracts
+These remain deliberately unstarted until the previous item is complete:
 
-- Do not change settings JSON names, SQLite schema semantics, task IDs, GIDs,
-  partial-file maps or resume identity while preparing the release.
-- Do not reintroduce Prism, DryIoc, EventAggregator, RegionManager,
-  ContainerLocator, string ViewName navigation, static HTTP state or another
-  logging sink.
-- `version.txt` remains the only version source; project files cannot define a
-  second `Version`, `VersionPrefix`, `AssemblyVersion`, `FileVersion` or
-  `InformationalVersion`.
-- Manual workflow dispatch may build artifacts but cannot publish a GitHub
-  Release. Only an exact `v1.1.1` tag matching the tested `version.txt` may
-  publish; `v1.1.0` cannot be moved, updated or republished.
-- Release artifacts must not contain developer credentials or application
-  data.
+1. PR #120 scope cleanup and merge-blocking findings.
+2. Bangumi `ep_id` propagation and playback response contract.
+3. Remaining v1.1.1 P1, merge-blocking or core runtime review debt.
+
+Each item must use a separate branch and PR. Do not merge, rebase or copy legacy
+architecture wholesale; migrate only valid behavior into current DI, typed
+navigation and coordinator boundaries.
+
+## Release Blockers
+
+- All four ordered v1.1.1 items must be complete and integrated into current
+  `main`.
+- The exact final commit must pass strict quality, CodeQL, Main lifecycle 50,
+  complete release rehearsal and Windows/Linux/macOS package validation.
+- Settings JSON, legacy SQLite, unfinished tasks, GID, partial-file maps,
+  completed keys and resume fixtures must remain compatible.
+- The source tree and packages must remain free of Cookie, account data, local
+  Config/Logs/Cache/Storage and developer artifacts.
+- `v1.1.0` stays immutable. Do not change `version.txt`, tag or publish v1.1.1
+  until every blocker is green.
 
 ## Verification
 
@@ -294,38 +93,37 @@ pwsh ./script/validate-release-version.ps1
 dotnet build ./DownKyi.sln -c Release --no-restore --no-incremental `
   -p:EnableNETAnalyzers=true -p:AnalysisMode=All `
   -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=true `
-  -p:CodeAnalysisTreatWarningsAsErrors=true
+  -p:CodeAnalysisTreatWarningsAsErrors=true -p:UseSharedCompilation=false
 pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild
 pwsh ./script/audit-lifecycle-ownership.ps1 `
   -OutputDirectory ./artifacts/assembly-lifecycle/ownership
 pwsh ./script/test-assembly-lifecycle.ps1 `
-  -Configuration Release `
-  -Iterations 5 `
-  -NoBuild `
-  -ValidateForensics `
+  -Configuration Release -Iterations 5 -NoBuild -ValidateForensics `
   -ResultsDirectory ./artifacts/assembly-lifecycle/verification
 dotnet format ./DownKyi.sln --verify-no-changes --no-restore
-pwsh ./script/audit-module-boundaries.ps1
+pwsh ./script/audit-module-boundaries.ps1 `
+  -OutputPath ./artifacts/architecture/module-boundary-audit.json
+$workflowFiles = Get-ChildItem ./.github/workflows -Filter *.yml | `
+  Select-Object -ExpandProperty FullName
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -- $workflowFiles
 dotnet package list --project ./DownKyi.sln --vulnerable --include-transitive
 dotnet package list --project ./DownKyi.sln --deprecated --include-transitive
 pwsh ./script/scan-secrets.ps1
 git diff --check
 ```
 
-## Completion
+A result is valid only when its runtime, OS, architecture, commit SHA and
+dirty-worktree state are recorded. Cross-machine timings are not compared
+directly.
 
-Gate 10 is complete only when the Windows foreground-thread owner is identified,
-the relevant test and production teardown paths are deterministic, the formal
-five-iteration Verification report passes, the release `Rehearsal` profile
-runs at least 50 iterations per assembly with diagnostics enabled, a complete
-rehearsal passes on the corrected commit, and the corrective GitHub Release is
-published with validated artifacts and notes. A successful blind rerun is not
-completion evidence.
+## Completion And Rollback
 
-## Rollback
+An item is complete only after implementation, tests, documentation, exact-head
+CI and review are green. Remove it from this file after merge and promote its
+stable facts to architecture/maintenance documentation. Before merge, close its
+Draft PR. After merge, revert the entire item commit range without changing user
+data formats or reintroducing a security bypass.
 
-- Before merge: close the integration PR and leave `main` unchanged.
-- After merge but before tag: revert the merge commit; do not create the tag.
-- After publication: never move or reuse `v1.1.0`. Withdraw invalid artifacts,
-  document the reason and publish the next corrective version. Never repair a
-  release by moving an existing tag.
+Gate 10 is complete only when its formal local lifecycle verification, exact
+Main profile and release rehearsal remain green; item 1 must preserve those
+already-established lifecycle conditions rather than replacing them.

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -45,16 +45,16 @@ design and completed history belong in `ARCHITECTURE.md`, `docs/design-docs/`,
       versioned secure-redirect feature for bundled and custom aria2 RPC.
 - [x] Complete all six static binary builds, fix their archive/binary SHA-256
       values and publish them from immutable tag `1.37.0-downkyi.2`.
-- [ ] Pass the actual-transfer TLS/redirect/header suite on all six binaries and
+- [x] Pass the actual-transfer TLS/redirect/header suite on all six binaries and
       prove downgrade targets receive zero requests. Windows x64/x86 are
-      locally green; Linux/macOS remain exact-head CI evidence.
+      locally green; all six RIDs passed CI run `30799263926`.
 - [x] Pass strict local Release build, all seven tests, format, module audit,
       lifecycle ownership/gate, package audits, secret scan and diff check on
       the final manifest and product diff.
-- [ ] Commit and push the complete isolated item to its one feature branch.
-- [ ] Open one Draft PR against `main` and require all six real aria2 RID jobs,
+- [x] Commit and push the complete isolated item to its one feature branch.
+- [x] Open one Draft PR against `main` and require all six real aria2 RID jobs,
       normal quality jobs and CodeQL to pass on the exact head commit.
-- [ ] Review uploaded sanitized reports, verify no credential/path leakage and
+- [x] Review uploaded sanitized reports, verify no credential/path leakage and
       update `aria2-security-baseline.json` with exact CI evidence.
 - [ ] Resolve all item-1 merge blockers and mark the item complete.
 

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -48,7 +48,7 @@ design and completed history belong in `ARCHITECTURE.md`, `docs/design-docs/`,
 - [ ] Pass the actual-transfer TLS/redirect/header suite on all six binaries and
       prove downgrade targets receive zero requests. Windows x64/x86 are
       locally green; Linux/macOS remain exact-head CI evidence.
-- [ ] Pass strict local Release build, all seven tests, format, module audit,
+- [x] Pass strict local Release build, all seven tests, format, module audit,
       lifecycle ownership/gate, package audits, secret scan and diff check on
       the final manifest and product diff.
 - [ ] Commit and push the complete isolated item to its one feature branch.

--- a/script/aria2.ps1
+++ b/script/aria2.ps1
@@ -53,5 +53,13 @@ if ($null -eq $aria2) {
     throw "aria2c.exe not found in $archive"
 }
 Copy-Item -LiteralPath $aria2.FullName -Destination (Join-Path $destDir "aria2c.exe") -Force
+$installedBinary = Join-Path $destDir "aria2c.exe"
+$installedChecksum = Join-Path $destDir "aria2c.exe.sha256"
+Verify-Asset $installedBinary $asset.binarySha256
+Set-Content `
+    -LiteralPath $installedChecksum `
+    -Value $asset.binarySha256 `
+    -Encoding ascii `
+    -NoNewline
 
 Remove-Item -LiteralPath $extractDir -Recurse -Force

--- a/script/aria2.sh
+++ b/script/aria2.sh
@@ -54,15 +54,19 @@ download_aria2() {
   local rid=$1
   local download_url
   local expected_sha256
+  local expected_binary_sha256
   local save="$save_path/$rid/aria2"
   download_url=$(asset_value "$rid" "url")
   expected_sha256=$(asset_value "$rid" "sha256")
+  expected_binary_sha256=$(asset_value "$rid" "binarySha256")
 
   local archive="$download_dir/aria2-$rid.zip"
   curl --fail --location --show-error "$download_url" -o "$archive"
   verify_asset "$archive" "$expected_sha256"
   create_dir "$save"
   unzip -o -d "$save" "$archive"
+  verify_asset "$save/aria2c" "$expected_binary_sha256"
+  printf '%s' "$expected_binary_sha256" >"$save/aria2c.sha256"
   chmod +x "$save/aria2c"
 }
 

--- a/script/assets/external-assets.json
+++ b/script/assets/external-assets.json
@@ -1,31 +1,39 @@
 {
   "aria2": {
-    "version": "1.37.0",
-    "repository": "https://github.com/yaobiao131/downkyi-aria2-static-build",
+    "version": "1.37.0-downkyi.2",
+    "repository": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build",
+    "sourceTag": "1.37.0-downkyi.2",
+    "sourceCommit": "94299bd9bde28a83bcb31346ec1d5f8131d2ec0d",
     "assets": {
       "win-x86": {
-        "url": "https://github.com/yaobiao131/downkyi-aria2-static-build/releases/download/1.37.0/aria2-i686-w64-mingw32_static.zip",
-        "sha256": "97f1e0dd107abb6c1b1d702d736d9c7bcb7770ee5656e8e56bc220d983548d59"
+        "url": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build/releases/download/1.37.0-downkyi.2/aria2-i686-w64-mingw32_static.zip",
+        "sha256": "40ed5587bc08e556826ab0ddd4bcf800599ba14dcde8ec75b7e911d8e5d5e610",
+        "binarySha256": "2a76612d032879e520fa3e4d1adacb900605e850934c8f6d5d7eeaf27377e7c0"
       },
       "win-x64": {
-        "url": "https://github.com/yaobiao131/downkyi-aria2-static-build/releases/download/1.37.0/aria2-x86_64-w64-mingw32_static.zip",
-        "sha256": "615cb5d8deeed115e3e6041ea46078dbd9695d5113fa7fd2bc22a3feb522fcb8"
+        "url": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build/releases/download/1.37.0-downkyi.2/aria2-x86_64-w64-mingw32_static.zip",
+        "sha256": "ddb13cb8b905299521b66bb3c26fb700830b8ca72c01f7614d9e68efd6f450cb",
+        "binarySha256": "b8fccf898d70531f2335bcbf45ad4210c736a63f3efb0442cb4c75790d7c76b0"
       },
       "linux-x64": {
-        "url": "https://github.com/yaobiao131/downkyi-aria2-static-build/releases/download/1.37.0/aria2-x86_64-linux-musl_static.zip",
-        "sha256": "37d9679f42b7d45b203b6497957c33693d07de3fb01f8009e55d83810f6a5faf"
+        "url": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build/releases/download/1.37.0-downkyi.2/aria2-x86_64-linux-musl_static.zip",
+        "sha256": "6e297b49d8ad24df6d01b48eeb9d669697c105fedf922e3b7d8d8c8577c5bf7c",
+        "binarySha256": "0e0e3d8a27ab57abb529c49595cd19d49df31a830f09ce65f10d1ef3a4323f41"
       },
       "linux-arm64": {
-        "url": "https://github.com/yaobiao131/downkyi-aria2-static-build/releases/download/1.37.0/aria2-aarch64-linux-musl_static.zip",
-        "sha256": "aa0fd7aefb43125c9ea558ada538d1171f2b56866b2acb8d01b2915060f60d37"
+        "url": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build/releases/download/1.37.0-downkyi.2/aria2-aarch64-linux-musl_static.zip",
+        "sha256": "75b348219fed7ee0ab909c0daaecae5b9ea021306dda85ef819e6a24190768e6",
+        "binarySha256": "e65850ad7403ba90f051966ed98ef1f88938a95d47f53a344ce07d182311f30c"
       },
       "osx-x64": {
-        "url": "https://github.com/yaobiao131/downkyi-aria2-static-build/releases/download/1.37.0/aria2-x86_64-apple-darwin_static.zip",
-        "sha256": "95bd7654ae68c9049893c64e83f22a472d1ad9ff8b6aebe1b047106fa5c6bfc2"
+        "url": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build/releases/download/1.37.0-downkyi.2/aria2-x86_64-apple-darwin_static.zip",
+        "sha256": "5579a5dd1d27b02c8a74bf0737ccee7884446f310f0c577972969c757da60c78",
+        "binarySha256": "306abc9c903c4bda1044d8cbc13dfbbc612e66e5ea6b1cbfb6693295e4135b55"
       },
       "osx-arm64": {
-        "url": "https://github.com/yaobiao131/downkyi-aria2-static-build/releases/download/1.37.0/aria2-aarch64-apple-darwin_static.zip",
-        "sha256": "5431ba2e1b81318e07646d53373d2da8348f3fdea3331cef98f02764c105bfe1"
+        "url": "https://github.com/crazysmile-PhD/downkyi-aria2-static-build/releases/download/1.37.0-downkyi.2/aria2-aarch64-apple-darwin_static.zip",
+        "sha256": "e6a8ebeb17465d592040d9d0430bf6ecbce58409d5424489cce2a9f8b0f8a3d0",
+        "binarySha256": "eb1c4f684c36d8b84cb579ad5079e94044bd2979289355d4a8d18803dbc05b47"
       }
     }
   },

--- a/script/validate-publish-output.ps1
+++ b/script/validate-publish-output.ps1
@@ -34,6 +34,7 @@ $PublishDirectory = (Resolve-Path -LiteralPath $PublishDirectory).Path
 $downKyiAssembly = Resolve-RequiredFile "DownKyi assembly" @("DownKyi.dll")
 $downKyiExecutable = Resolve-RequiredFile "DownKyi executable" @("DownKyi.exe", "DownKyi")
 $ariaExecutable = Resolve-RequiredFile "aria2 executable" @("aria2/aria2c.exe", "aria2/aria2c")
+$ariaChecksum = Resolve-RequiredFile "aria2 binary checksum" @("aria2/aria2c.exe.sha256", "aria2/aria2c.sha256")
 $ffmpegExecutable = Resolve-RequiredFile "FFmpeg executable" @("ffmpeg/ffmpeg.exe", "ffmpeg/ffmpeg")
 $ffprobeExecutable = Resolve-RequiredFile "ffprobe executable" @("ffmpeg/ffprobe.exe", "ffmpeg/ffprobe")
 $depsFile = Resolve-RequiredFile "DownKyi dependency manifest" @("DownKyi.deps.json")
@@ -54,10 +55,20 @@ if ($deps.Contains("Avalonia.Themes.Simple", [StringComparison]::Ordinal)) {
     throw "Published dependency manifest still contains Avalonia.Themes.Simple."
 }
 
+$expectedAriaHash = (Get-Content -LiteralPath $ariaChecksum -Raw).Trim()
+if ($expectedAriaHash -notmatch '^[a-fA-F0-9]{64}$') {
+    throw "Published aria2 checksum sidecar is malformed."
+}
+$actualAriaHash = (Get-FileHash -LiteralPath $ariaExecutable -Algorithm SHA256).Hash
+if (-not [String]::Equals($actualAriaHash, $expectedAriaHash, [StringComparison]::OrdinalIgnoreCase)) {
+    throw "Published aria2 executable does not match its checksum sidecar."
+}
+
 $requiredFiles = @(
     $downKyiAssembly,
     $downKyiExecutable,
     $ariaExecutable,
+    $ariaChecksum,
     $ffmpegExecutable,
     $ffprobeExecutable,
     $depsFile

--- a/src/DownKyi.Desktop/Languages/Default.axaml
+++ b/src/DownKyi.Desktop/Languages/Default.axaml
@@ -192,7 +192,12 @@
     <system:String x:Key="RepeatFileAutoAddNumberSuffix">重复文件自动添加数字序号后缀</system:String>
     <system:String x:Key="AutoDownloadAll">解析后自动下载已解析视频</system:String>
     <system:String x:Key="Network">网络</system:String>
-    <system:String x:Key="UseSSL">启用https（若下载器提示SSL错误，则关闭此项）</system:String>
+    <system:String x:Key="DownloadTlsUntrusted">下载失败：服务器证书不受信任</system:String>
+    <system:String x:Key="DownloadTlsExpired">下载失败：服务器证书已过期</system:String>
+    <system:String x:Key="DownloadTlsNotYetValid">下载失败：服务器证书尚未生效</system:String>
+    <system:String x:Key="DownloadTlsHostnameMismatch">下载失败：服务器证书与主机名不匹配</system:String>
+    <system:String x:Key="DownloadTlsInvalidChain">下载失败：服务器证书链无效</system:String>
+    <system:String x:Key="DownloadTlsHandshakeFailed">下载失败：TLS 安全连接验证失败</system:String>
     <system:String x:Key="UserAgent">UserAgent：</system:String>
     <system:String x:Key="NetworkProxySetting">网络代理设置</system:String>
     <system:String x:Key="NetworkProxyNone">无</system:String>
@@ -217,6 +222,9 @@
     <system:String x:Key="AriaMaxDownloadLimit">单任务下载速度限制[0: 无限制]</system:String>
     <system:String x:Key="AriaFileAllocation">Aria文件预分配：</system:String>
     <system:String x:Key="IsHttpProxy">使用Http代理</system:String>
+    <system:String x:Key="IsAriaHttpsDownloadProxy">使用本机 HTTPS 下载代理（HTTP CONNECT）</system:String>
+    <system:String x:Key="AriaHttpsDownloadProxyHost">本机代理地址：</system:String>
+    <system:String x:Key="AriaHttpsDownloadProxyTip">仅允许 127.0.0.1、localhost 或 ::1。代理本身使用 HTTP CONNECT；aria2 仍会验证 HTTPS 证书与主机名。</system:String>
     <system:String x:Key="HttpProxy">代理地址：</system:String>
     <system:String x:Key="HttpProxyPort">端口：</system:String>
     <system:String x:Key="MaxCurrentDownloads">同时下载数：</system:String>

--- a/src/DownKyi.Desktop/Services/Download/Aria2RuntimeLifecycle.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2RuntimeLifecycle.cs
@@ -109,7 +109,9 @@ internal sealed class Aria2RuntimeLifecycle : IDisposable
 
             try
             {
-                var version = await _ariaClient.GetAriaVersionAsync().ConfigureAwait(true);
+                var version = await _ariaClient
+                    .GetAriaVersionAsync(cancellationToken)
+                    .ConfigureAwait(true);
                 if (version is { Result: { } versionResult })
                 {
                     EnsureSecureRedirectFeature(versionResult.EnabledFeatures);
@@ -151,8 +153,9 @@ internal sealed class Aria2RuntimeLifecycle : IDisposable
     private async Task EnsureSecureRedirectFeatureAsync(CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        var version = await _ariaClient.GetAriaVersionAsync().ConfigureAwait(true);
-        cancellationToken.ThrowIfCancellationRequested();
+        var version = await _ariaClient
+            .GetAriaVersionAsync(cancellationToken)
+            .ConfigureAwait(true);
         if (version is not { Result: { } versionResult })
         {
             throw new InvalidOperationException(

--- a/src/DownKyi.Desktop/Services/Download/Aria2RuntimeLifecycle.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2RuntimeLifecycle.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using DownKyi.Application.Diagnostics;
+using DownKyi.Core.Aria2cNet.Client;
+using DownKyi.Core.Aria2cNet.Server;
+using DownKyi.Core.Settings;
+using DownKyi.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace DownKyi.Services.Download;
+
+internal sealed class Aria2RuntimeLifecycle : IDisposable
+{
+    internal const string SecureRedirectFeature = "downkyi-secure-redirect-v2";
+
+    private readonly AriaClient _ariaClient;
+    private readonly AriaServer _ariaServer;
+    private readonly DownloadDiagnosticLogger _diagnosticLogger;
+    private readonly LocalAriaRpcEndpoint? _localEndpoint;
+    private readonly ILogger<Aria2RuntimeLifecycle> _logger;
+    private readonly NetworkApplicationSettings _networkSettings;
+    private readonly bool _ownsAriaServer;
+
+    public Aria2RuntimeLifecycle(
+        NetworkApplicationSettings networkSettings,
+        AriaClient ariaClient,
+        DownloadDiagnosticLogger diagnosticLogger,
+        AriaServer ariaServer,
+        ILogger<Aria2RuntimeLifecycle> logger,
+        bool ownsAriaServer,
+        LocalAriaRpcEndpoint? localEndpoint)
+    {
+        _networkSettings = networkSettings ?? throw new ArgumentNullException(nameof(networkSettings));
+        _ariaClient = ariaClient ?? throw new ArgumentNullException(nameof(ariaClient));
+        _diagnosticLogger = diagnosticLogger ?? throw new ArgumentNullException(nameof(diagnosticLogger));
+        _ariaServer = ariaServer ?? throw new ArgumentNullException(nameof(ariaServer));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _ownsAriaServer = ownsAriaServer;
+        _localEndpoint = localEndpoint;
+        if (ownsAriaServer != (localEndpoint != null))
+        {
+            throw new ArgumentException(
+                "A local aria2 endpoint is required only for an owned aria2 process.",
+                nameof(localEndpoint));
+        }
+    }
+
+    public string Name => _ownsAriaServer ? "aria2-local" : "aria2-custom";
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        return _ownsAriaServer
+            ? StartOwnedServerAsync(cancellationToken)
+            : EnsureSecureRedirectFeatureAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        return _ownsAriaServer
+            ? CloseOwnedServerAsync(cancellationToken)
+            : Task.CompletedTask;
+    }
+
+    public void AbortStartup()
+    {
+        if (_ownsAriaServer)
+        {
+            _ariaServer.KillTrackedServer("aria2 runtime startup failed.");
+        }
+    }
+
+    private async Task StartOwnedServerAsync(CancellationToken cancellationToken)
+    {
+        var endpoint = _localEndpoint
+            ?? throw new InvalidOperationException("The local aria2 endpoint is missing.");
+        var config = CreateServerConfig(endpoint);
+        _diagnosticLogger.LogAriaServerConfig(Name, config, _networkSettings);
+
+        var errors = new ConcurrentQueue<string>();
+        await _ariaServer.StartServerAsync(config, output =>
+        {
+            if (!string.IsNullOrWhiteSpace(output))
+            {
+                errors.Enqueue(output);
+            }
+        }).ConfigureAwait(true);
+
+        if (string.Join(Environment.NewLine, errors)
+            .Contains("ERROR", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new InvalidOperationException("The local aria2 process reported a startup error.");
+        }
+
+        HttpRequestException? lastRpcError = null;
+        for (var attempt = 0; attempt < 10; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!_ariaServer.IsTrackedServerRunning())
+            {
+                throw new InvalidOperationException(
+                    "The supervised aria2 process exited before RPC became ready.");
+            }
+
+            try
+            {
+                var version = await _ariaClient.GetAriaVersionAsync().ConfigureAwait(true);
+                if (version is { Result: { } versionResult })
+                {
+                    EnsureSecureRedirectFeature(versionResult.EnabledFeatures);
+                    _ariaServer.ReleaseStartupSecrets();
+                    return;
+                }
+            }
+            catch (HttpRequestException exception)
+            {
+                lastRpcError = exception;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(true);
+        }
+
+        throw new TimeoutException(
+            "The local aria2 process did not accept RPC requests in time.",
+            lastRpcError);
+    }
+
+    private AriaConfig CreateServerConfig(LocalAriaRpcEndpoint endpoint)
+    {
+        return new AriaConfig
+        {
+            ListenPort = endpoint.Port,
+            Token = endpoint.Secret,
+            LogLevel = _networkSettings.AriaLogLevel,
+            MaxConcurrentDownloads = _networkSettings.MaxCurrentDownloads,
+            MaxConnectionPerServer = _networkSettings.AriaMaxConnectionPerServer,
+            Split = _networkSettings.AriaSplit,
+            MinSplitSize = _networkSettings.AriaMinSplitSize,
+            MaxOverallDownloadLimit = _networkSettings.AriaMaxOverallDownloadLimit * 1024L,
+            MaxDownloadLimit = _networkSettings.AriaMaxDownloadLimit * 1024L,
+            ContinueDownload = true,
+            FileAllocation = _networkSettings.AriaFileAllocation
+        };
+    }
+
+    private async Task EnsureSecureRedirectFeatureAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var version = await _ariaClient.GetAriaVersionAsync().ConfigureAwait(true);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (version is not { Result: { } versionResult })
+        {
+            throw new InvalidOperationException(
+                "The aria2 endpoint did not return its security capabilities.");
+        }
+
+        EnsureSecureRedirectFeature(versionResult.EnabledFeatures);
+    }
+
+    private static void EnsureSecureRedirectFeature(IReadOnlyList<string> features)
+    {
+        if (!features.Contains(SecureRedirectFeature, StringComparer.Ordinal))
+        {
+            throw new InvalidOperationException(
+                "The aria2 endpoint does not enforce DownKyi secure redirects.");
+        }
+    }
+
+    private async Task CloseOwnedServerAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            await _ariaClient.PauseAllAsync()
+                .WaitAsync(TimeSpan.FromSeconds(2), cancellationToken)
+                .ConfigureAwait(true);
+        }
+        catch (Exception exception) when (exception is TimeoutException
+            or HttpRequestException
+            or IOException
+            or InvalidOperationException
+            or Newtonsoft.Json.JsonException)
+        {
+            _logger.LogErrorMessage("Aria server shutdown failed.", exception);
+        }
+
+        if (!await _ariaServer.CloseServerAsync(
+                _ariaClient,
+                TimeSpan.FromSeconds(3)).ConfigureAwait(true))
+        {
+            await _ariaServer.ForceCloseServerAsync(
+                _ariaClient,
+                TimeSpan.FromSeconds(2)).ConfigureAwait(true);
+        }
+    }
+
+    public void Dispose()
+    {
+        if (_ownsAriaServer)
+        {
+            _ariaServer.KillTrackedServer(
+                "aria2 runtime disposed before graceful shutdown completed.");
+        }
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
@@ -324,16 +324,52 @@ internal sealed class Aria2TransferBackend : ITransferBackend
         }
         else if (string.Equals(existingStatus, "paused", StringComparison.Ordinal))
         {
-            var unpaused = await _ariaClient.UnpauseAsync(gid).ConfigureAwait(true);
-            if (unpaused is not { Result: { } unpausedGid } ||
-                string.IsNullOrWhiteSpace(unpausedGid))
-            {
-                throw new InvalidOperationException(
-                    "aria2 rejected the unpause request.");
-            }
+            await RefreshOptionsAndUnpauseAsync(
+                _ariaClient,
+                gid,
+                taskHeaders,
+                request.CancellationToken).ConfigureAwait(true);
         }
 
         return AriaTaskPreparation.Ready(gid);
+    }
+
+    internal static async Task RefreshOptionsAndUnpauseAsync(
+        AriaClient ariaClient,
+        string gid,
+        AriaTaskHeaders taskHeaders,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(ariaClient);
+        ArgumentException.ThrowIfNullOrWhiteSpace(gid);
+        ArgumentNullException.ThrowIfNull(taskHeaders);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var options = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["header"] = taskHeaders.Headers.ToArray(),
+            ["user-agent"] = taskHeaders.UserAgent
+        };
+        var changed = await ariaClient
+            .ChangeOptionAsync(gid, options)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(true);
+        if (changed is not { Result: "OK" })
+        {
+            throw new InvalidOperationException(
+                "aria2 rejected the task credential refresh.");
+        }
+
+        var unpaused = await ariaClient
+            .UnpauseAsync(gid)
+            .WaitAsync(cancellationToken)
+            .ConfigureAwait(true);
+        if (unpaused is not { Result: { } unpausedGid }
+            || string.IsNullOrWhiteSpace(unpausedGid))
+        {
+            throw new InvalidOperationException(
+                "aria2 rejected the unpause request.");
+        }
     }
 
     private static bool IsNotFound(AriaError? error)

--- a/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
@@ -27,10 +26,11 @@ internal sealed class Aria2TransferBackend : ITransferBackend
     private readonly AriaClient _ariaClient;
     private readonly AriaRuntimeClientRegistry _clientRegistry;
     private readonly DownloadDiagnosticLogger _diagnosticLogger;
-    private readonly AriaServer _ariaServer;
+    private readonly AriaDownloadAddressResolver _addressResolver;
+    private readonly Aria2RuntimeLifecycle _runtimeLifecycle;
+    private readonly Uri? _httpsProxyAddress;
     private readonly ILoggerFactory _loggerFactory;
     private readonly NetworkApplicationSettings _networkSettings;
-    private readonly bool _ownsAriaServer;
     private readonly ILogger<Aria2TransferBackend> _logger;
     private IDisposable? _runtimeRegistration;
 
@@ -42,19 +42,28 @@ internal sealed class Aria2TransferBackend : ITransferBackend
         AriaServer ariaServer,
         ILoggerFactory loggerFactory,
         ILogger<Aria2TransferBackend> logger,
-        bool ownsAriaServer)
+        bool ownsAriaServer,
+        LocalAriaRpcEndpoint? localEndpoint)
     {
         _networkSettings = networkSettings ?? throw new ArgumentNullException(nameof(networkSettings));
         _ariaClient = ariaClient ?? throw new ArgumentNullException(nameof(ariaClient));
         _clientRegistry = clientRegistry ?? throw new ArgumentNullException(nameof(clientRegistry));
         _diagnosticLogger = diagnosticLogger ?? throw new ArgumentNullException(nameof(diagnosticLogger));
-        _ariaServer = ariaServer ?? throw new ArgumentNullException(nameof(ariaServer));
+        _httpsProxyAddress = ResolveHttpsProxyAddress(networkSettings);
+        _addressResolver = AriaDownloadAddressResolver.Create(_httpsProxyAddress);
         _loggerFactory = loggerFactory ?? throw new ArgumentNullException(nameof(loggerFactory));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        _ownsAriaServer = ownsAriaServer;
+        _runtimeLifecycle = new Aria2RuntimeLifecycle(
+            networkSettings,
+            ariaClient,
+            diagnosticLogger,
+            ariaServer,
+            loggerFactory.CreateLogger<Aria2RuntimeLifecycle>(),
+            ownsAriaServer,
+            localEndpoint);
     }
 
-    public string Name => _ownsAriaServer ? "aria2-local" : "aria2-custom";
+    public string Name => _runtimeLifecycle.Name;
 
     public async Task StartAsync(CancellationToken cancellationToken = default)
     {
@@ -62,18 +71,11 @@ internal sealed class Aria2TransferBackend : ITransferBackend
         _runtimeRegistration ??= _clientRegistry.Activate(_ariaClient);
         try
         {
-            if (_ownsAriaServer)
-            {
-                await StartAriaServerAsync(cancellationToken).ConfigureAwait(true);
-            }
+            await _runtimeLifecycle.StartAsync(cancellationToken).ConfigureAwait(true);
         }
         catch
         {
-            if (_ownsAriaServer)
-            {
-                _ariaServer.KillTrackedServer("aria2 runtime startup failed.");
-            }
-
+            _runtimeLifecycle.AbortStartup();
             ReleaseRuntimeRegistration();
             throw;
         }
@@ -83,10 +85,7 @@ internal sealed class Aria2TransferBackend : ITransferBackend
     {
         try
         {
-            if (_ownsAriaServer)
-            {
-                await CloseAriaServerAsync(cancellationToken).ConfigureAwait(true);
-            }
+            await _runtimeLifecycle.StopAsync(cancellationToken).ConfigureAwait(true);
         }
         finally
         {
@@ -107,8 +106,28 @@ internal sealed class Aria2TransferBackend : ITransferBackend
         string? activeGid;
         try
         {
-            activeGid = await EnsureAriaTaskAsync(
+            var preparation = await EnsureAriaTaskAsync(
                 request).ConfigureAwait(true);
+            if (preparation.ErrorCode != null)
+            {
+                _logger.LogWarningMessage(
+                    $"aria2 download address was rejected; code={preparation.ErrorCode}");
+                return DownloadTransferResult.Failed(
+                    DownloadTransferFailureKind.Permanent,
+                    preparation.ErrorCode);
+            }
+
+            activeGid = preparation.Gid
+                ?? throw new InvalidOperationException("The prepared aria2 task identifier is missing.");
+        }
+        catch (HttpRequestException exception) when (
+            TlsFailureClassifier.TryClassify(exception, out var tlsErrorCode))
+        {
+            _logger.LogWarningMessage(
+                $"aria2 address validation failed TLS policy; code={tlsErrorCode}");
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Tls,
+                tlsErrorCode);
         }
         catch (Exception exception) when (exception is HttpRequestException
             or IOException
@@ -220,8 +239,23 @@ internal sealed class Aria2TransferBackend : ITransferBackend
         }
     }
 
-    private async Task<string> EnsureAriaTaskAsync(DownloadTransferRequest request)
+    private async Task<AriaTaskPreparation> EnsureAriaTaskAsync(
+        DownloadTransferRequest request)
     {
+        var resolution = await _addressResolver.ResolveAsync(
+            request.Urls[0],
+            _networkSettings.UserAgent,
+            LoginHelper.GetLoginInfoCookiesString(),
+            request.CancellationToken).ConfigureAwait(true);
+        if (resolution.ErrorCode != null)
+        {
+            return AriaTaskPreparation.Rejected(resolution.ErrorCode);
+        }
+
+        var resolvedAddress = resolution.Address
+            ?? throw new InvalidOperationException("The accepted aria2 address is missing.");
+        var taskHeaders = resolution.Headers
+            ?? throw new InvalidOperationException("The accepted aria2 task headers are missing.");
         var gid = string.IsNullOrWhiteSpace(request.BackendIdentity)
             ? null
             : request.BackendIdentity;
@@ -259,7 +293,8 @@ internal sealed class Aria2TransferBackend : ITransferBackend
                 Continue = "true",
                 AllowOverwrite = "true",
                 AutoFileRenaming = "false",
-                UserAgent = _networkSettings.UserAgent,
+                UserAgent = taskHeaders.UserAgent,
+                Headers = taskHeaders.Headers,
                 Split = _networkSettings.AriaSplit.ToString(CultureInfo.InvariantCulture),
                 MaxConnectionPerServer = _networkSettings.AriaMaxConnectionPerServer
                     .ToString(CultureInfo.InvariantCulture),
@@ -269,12 +304,14 @@ internal sealed class Aria2TransferBackend : ITransferBackend
                 AlwaysResume = "false",
                 MaxResumeFailureTries = "0"
             };
-            if (_networkSettings.IsAriaHttpProxy == AllowStatus.Yes)
+            if (_httpsProxyAddress != null)
             {
-                option.HttpProxy = $"http://{_networkSettings.AriaHttpProxy}:{_networkSettings.AriaHttpProxyListenPort}";
+                option.HttpsProxy = _httpsProxyAddress.AbsoluteUri;
             }
 
-            var added = await _ariaClient.AddUriAsync(request.Urls.ToList(), option).ConfigureAwait(true);
+            var added = await _ariaClient.AddUriAsync(
+                [resolvedAddress.AbsoluteUri],
+                option).ConfigureAwait(true);
             if (added is not { Result: { } addedGid } ||
                 string.IsNullOrWhiteSpace(addedGid))
             {
@@ -296,7 +333,7 @@ internal sealed class Aria2TransferBackend : ITransferBackend
             }
         }
 
-        return gid;
+        return AriaTaskPreparation.Ready(gid);
     }
 
     private static bool IsNotFound(AriaError? error)
@@ -306,88 +343,29 @@ internal sealed class Aria2TransferBackend : ITransferBackend
             StringComparison.OrdinalIgnoreCase) == true;
     }
 
+    private static Uri? ResolveHttpsProxyAddress(NetworkApplicationSettings settings)
+    {
+        if (settings.IsAriaHttpProxy != AllowStatus.Yes)
+        {
+            return null;
+        }
+
+        if (!AriaHttpsProxyPolicy.TryCreateConnectProxyUri(
+                settings.AriaHttpProxy,
+                settings.AriaHttpProxyListenPort,
+                out var proxyAddress))
+        {
+            throw new InvalidOperationException(
+                "The aria2 HTTPS download proxy must be a local HTTP CONNECT endpoint.");
+        }
+
+        return proxyAddress;
+    }
+
     internal static bool ShouldClearBackendIdentity(string? errorCode)
     {
         return !string.IsNullOrWhiteSpace(errorCode) &&
                !errorCode.StartsWith("rpc-", StringComparison.Ordinal);
-    }
-
-    private async Task StartAriaServerAsync(CancellationToken cancellationToken)
-    {
-        var config = new AriaConfig
-        {
-            ListenPort = _networkSettings.AriaListenPort,
-            Token = "downkyi",
-            LogLevel = _networkSettings.AriaLogLevel,
-            MaxConcurrentDownloads = _networkSettings.MaxCurrentDownloads,
-            MaxConnectionPerServer = _networkSettings.AriaMaxConnectionPerServer,
-            Split = _networkSettings.AriaSplit,
-            MinSplitSize = _networkSettings.AriaMinSplitSize,
-            MaxOverallDownloadLimit = _networkSettings.AriaMaxOverallDownloadLimit * 1024L,
-            MaxDownloadLimit = _networkSettings.AriaMaxDownloadLimit * 1024L,
-            ContinueDownload = true,
-            FileAllocation = _networkSettings.AriaFileAllocation,
-            Headers =
-            [
-                $"Cookie: {LoginHelper.GetLoginInfoCookiesString()}",
-                "Origin: https://www.bilibili.com",
-                "Referer: https://www.bilibili.com",
-                $"User-Agent: {_networkSettings.UserAgent}"
-            ]
-        };
-        _diagnosticLogger.LogAriaServerConfig(Name, config, _networkSettings);
-
-        var errors = new ConcurrentQueue<string>();
-        await _ariaServer.StartServerAsync(config, output =>
-        {
-            if (!string.IsNullOrWhiteSpace(output))
-            {
-                errors.Enqueue(output);
-            }
-        }).ConfigureAwait(true);
-
-        var message = string.Join(Environment.NewLine, errors);
-        if (message.Contains("ERROR", StringComparison.OrdinalIgnoreCase))
-        {
-            throw new InvalidOperationException("The local aria2 process reported a startup error.");
-        }
-
-        for (var attempt = 0; attempt < 10; attempt++)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            if (await _ariaClient.GetGlobalOptionAsync().ConfigureAwait(true) != null)
-            {
-                return;
-            }
-
-            await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken).ConfigureAwait(true);
-        }
-
-        throw new TimeoutException("The local aria2 process did not accept RPC requests in time.");
-    }
-
-    private async Task CloseAriaServerAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            await _ariaClient.PauseAllAsync()
-                .WaitAsync(TimeSpan.FromSeconds(2), cancellationToken)
-                .ConfigureAwait(true);
-        }
-        catch (Exception e) when (e is TimeoutException or HttpRequestException or IOException
-            or InvalidOperationException or Newtonsoft.Json.JsonException)
-        {
-            _logger.LogErrorMessage("Aria server shutdown failed.", e);
-        }
-
-        if (!await _ariaServer.CloseServerAsync(
-                _ariaClient,
-                TimeSpan.FromSeconds(3)).ConfigureAwait(true))
-        {
-            await _ariaServer.ForceCloseServerAsync(
-                _ariaClient,
-                TimeSpan.FromSeconds(2)).ConfigureAwait(true);
-        }
     }
 
     private DownloadProgress? CreateProgress(string activeGid, AriaProgressEventArgs eventArgs)
@@ -417,16 +395,26 @@ internal sealed class Aria2TransferBackend : ITransferBackend
 
     public void Dispose()
     {
-        if (_ownsAriaServer)
+        try
         {
-            _ariaServer.KillTrackedServer("aria2 runtime disposed before graceful shutdown completed.");
+            _runtimeLifecycle.Dispose();
+            ReleaseRuntimeRegistration();
         }
-
-        ReleaseRuntimeRegistration();
+        finally
+        {
+            _addressResolver.Dispose();
+        }
     }
 
     private void ReleaseRuntimeRegistration()
     {
         Interlocked.Exchange(ref _runtimeRegistration, null)?.Dispose();
     }
+}
+
+internal sealed record AriaTaskPreparation(string? Gid, string? ErrorCode)
+{
+    public static AriaTaskPreparation Ready(string gid) => new(gid, ErrorCode: null);
+
+    public static AriaTaskPreparation Rejected(string errorCode) => new(Gid: null, errorCode);
 }

--- a/src/DownKyi.Desktop/Services/Download/Aria2TransferFailureClassifier.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2TransferFailureClassifier.cs
@@ -8,6 +8,45 @@ internal static class Aria2TransferFailureClassifier
         string? errorCode,
         string? errorMessage)
     {
+        if (string.Equals(errorCode, "33", StringComparison.Ordinal))
+        {
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Permanent,
+                "download.transfer.insecure-redirect");
+        }
+
+        if (string.Equals(errorCode, "34", StringComparison.Ordinal))
+        {
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Permanent,
+                "download.transfer.credentialed-redirect");
+        }
+
+        if (TlsFailureClassifier.TryClassify(errorMessage, out var tlsErrorCode))
+        {
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Tls,
+                tlsErrorCode);
+        }
+
+        if (errorMessage?.Contains(
+                "HTTPS redirect downgrade rejected by DownKyi policy",
+                StringComparison.Ordinal) == true)
+        {
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Permanent,
+                "download.transfer.insecure-redirect");
+        }
+
+        if (errorMessage?.Contains(
+                "Cross-origin redirect with sensitive headers rejected by DownKyi policy",
+                StringComparison.Ordinal) == true)
+        {
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Permanent,
+                "download.transfer.credentialed-redirect");
+        }
+
         if (ContainsHttpStatus(errorMessage, "403") ||
             ContainsHttpStatus(errorMessage, "404"))
         {

--- a/src/DownKyi.Desktop/Services/Download/AriaDownloadAddressResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/AriaDownloadAddressResolver.cs
@@ -104,12 +104,6 @@ internal sealed class AriaDownloadAddressResolver : IDisposable
                     taskHeaders);
             }
 
-            if (taskHeaders.CarriesCredentials)
-            {
-                return AriaDownloadAddressResolution.Rejected(
-                    "download.transfer.credentialed-redirect");
-            }
-
             if (redirectCount >= MaximumRedirects)
             {
                 return AriaDownloadAddressResolution.Rejected(
@@ -122,9 +116,16 @@ internal sealed class AriaDownloadAddressResolver : IDisposable
                 return redirect;
             }
 
-            current = redirect.Address
+            var next = redirect.Address
                 ?? throw new InvalidOperationException(
                     "The accepted aria2 redirect address is missing.");
+            if (taskHeaders.CarriesCredentials && !IsSameOrigin(current, next))
+            {
+                return AriaDownloadAddressResolution.Rejected(
+                    "download.transfer.credentialed-redirect");
+            }
+
+            current = next;
         }
     }
 
@@ -179,6 +180,19 @@ internal sealed class AriaDownloadAddressResolver : IDisposable
             or HttpStatusCode.SeeOther
             or HttpStatusCode.TemporaryRedirect
             or HttpStatusCode.PermanentRedirect;
+    }
+
+    private static bool IsSameOrigin(Uri first, Uri second)
+    {
+        return string.Equals(
+                   first.Scheme,
+                   second.Scheme,
+                   StringComparison.OrdinalIgnoreCase)
+               && string.Equals(
+                   first.IdnHost,
+                   second.IdnHost,
+                   StringComparison.OrdinalIgnoreCase)
+               && first.Port == second.Port;
     }
 
     public void Dispose()

--- a/src/DownKyi.Desktop/Services/Download/AriaDownloadAddressResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/AriaDownloadAddressResolver.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DownKyi.Services.Download;
+
+internal sealed class AriaDownloadAddressResolver : IDisposable
+{
+    private const int MaximumRedirects = 5;
+    private readonly HttpMessageInvoker _http;
+
+    private AriaDownloadAddressResolver(HttpMessageHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        _http = new HttpMessageInvoker(handler, disposeHandler: true);
+    }
+
+    public static AriaDownloadAddressResolver Create(Uri? proxyAddress)
+    {
+        if (proxyAddress is { Scheme: not "http" })
+        {
+            throw new ArgumentException(
+                "The aria2 HTTPS download proxy must be an HTTP CONNECT endpoint.",
+                nameof(proxyAddress));
+        }
+
+        SocketsHttpHandler? handler = new()
+        {
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.None,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+            UseCookies = false,
+            UseProxy = proxyAddress != null
+        };
+        try
+        {
+            if (proxyAddress != null)
+            {
+                handler.Proxy = new WebProxy(proxyAddress)
+                {
+                    BypassProxyOnLocal = false
+                };
+            }
+
+            var resolver = new AriaDownloadAddressResolver(handler);
+            handler = null;
+            return resolver;
+        }
+        finally
+        {
+            handler?.Dispose();
+        }
+    }
+
+    internal static AriaDownloadAddressResolver CreateForTest(HttpMessageHandler handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        HttpMessageHandler? ownedHandler = handler;
+        try
+        {
+            var resolver = new AriaDownloadAddressResolver(ownedHandler);
+            ownedHandler = null;
+            return resolver;
+        }
+        finally
+        {
+            ownedHandler?.Dispose();
+        }
+    }
+
+    public async Task<AriaDownloadAddressResolution> ResolveAsync(
+        string address,
+        string userAgent,
+        string? credentials,
+        CancellationToken cancellationToken)
+    {
+        if (!Uri.TryCreate(address, UriKind.Absolute, out var current)
+            || !string.Equals(current.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return AriaDownloadAddressResolution.Rejected(
+                "download.transfer.insecure-address");
+        }
+
+        for (var redirectCount = 0; ; redirectCount++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var taskHeaders = AriaTaskHeaderPolicy.Create(
+                current.AbsoluteUri,
+                userAgent,
+                credentials);
+            using var request = CreateProbeRequest(current, taskHeaders);
+            using var response = await _http.SendAsync(
+                request,
+                cancellationToken).ConfigureAwait(false);
+            if (!IsRedirect(response.StatusCode))
+            {
+                return AriaDownloadAddressResolution.Accepted(
+                    current.AbsoluteUri,
+                    taskHeaders);
+            }
+
+            if (taskHeaders.CarriesCredentials)
+            {
+                return AriaDownloadAddressResolution.Rejected(
+                    "download.transfer.credentialed-redirect");
+            }
+
+            if (redirectCount >= MaximumRedirects)
+            {
+                return AriaDownloadAddressResolution.Rejected(
+                    "download.transfer.redirect-limit");
+            }
+
+            var redirect = ResolveRedirect(current, response.Headers.Location);
+            if (redirect.ErrorCode != null)
+            {
+                return redirect;
+            }
+
+            current = redirect.Address
+                ?? throw new InvalidOperationException(
+                    "The accepted aria2 redirect address is missing.");
+        }
+    }
+
+    private static HttpRequestMessage CreateProbeRequest(
+        Uri address,
+        AriaTaskHeaders taskHeaders)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, address);
+        request.Headers.Range = new RangeHeaderValue(0, 0);
+        request.Headers.TryAddWithoutValidation("User-Agent", taskHeaders.UserAgent);
+        foreach (var header in taskHeaders.Headers)
+        {
+            var separator = header.IndexOf(':', StringComparison.Ordinal);
+            if (separator <= 0)
+            {
+                request.Dispose();
+                throw new InvalidOperationException("An aria2 task header is malformed.");
+            }
+
+            request.Headers.TryAddWithoutValidation(
+                header[..separator],
+                header[(separator + 1)..].TrimStart());
+        }
+
+        return request;
+    }
+
+    private static AriaDownloadAddressResolution ResolveRedirect(
+        Uri current,
+        Uri? location)
+    {
+        if (location == null)
+        {
+            return AriaDownloadAddressResolution.Rejected(
+                "download.transfer.redirect-location-missing");
+        }
+
+        var next = location.IsAbsoluteUri ? location : new Uri(current, location);
+        if (!string.Equals(next.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+        {
+            return AriaDownloadAddressResolution.Rejected(
+                "download.transfer.insecure-redirect");
+        }
+
+        return AriaDownloadAddressResolution.Redirect(next);
+    }
+
+    private static bool IsRedirect(HttpStatusCode statusCode)
+    {
+        return statusCode is HttpStatusCode.MovedPermanently
+            or HttpStatusCode.Found
+            or HttpStatusCode.SeeOther
+            or HttpStatusCode.TemporaryRedirect
+            or HttpStatusCode.PermanentRedirect;
+    }
+
+    public void Dispose()
+    {
+        _http.Dispose();
+    }
+}
+
+internal sealed record AriaDownloadAddressResolution(
+    Uri? Address,
+    AriaTaskHeaders? Headers,
+    string? ErrorCode)
+{
+    public static AriaDownloadAddressResolution Accepted(
+        string address,
+        AriaTaskHeaders headers) =>
+        new(new Uri(address, UriKind.Absolute), headers, ErrorCode: null);
+
+    public static AriaDownloadAddressResolution Redirect(Uri address) =>
+        new(address, Headers: null, ErrorCode: null);
+
+    public static AriaDownloadAddressResolution Rejected(string errorCode) =>
+        new(Address: null, Headers: null, errorCode);
+}

--- a/src/DownKyi.Desktop/Services/Download/AriaTaskHeaderPolicy.cs
+++ b/src/DownKyi.Desktop/Services/Download/AriaTaskHeaderPolicy.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace DownKyi.Services.Download;
+
+internal static class AriaTaskHeaderPolicy
+{
+    private const string BilibiliHost = "bilibili.com";
+
+    public static AriaTaskHeaders Create(
+        string url,
+        string userAgent,
+        string? credentials)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(url);
+        ValidateValue(userAgent, nameof(userAgent));
+        var headers = new List<string>
+        {
+            "Origin: https://www.bilibili.com",
+            "Referer: https://www.bilibili.com"
+        };
+        var carriesCredentials = IsCredentialEligibleUrl(url);
+        if (carriesCredentials)
+        {
+            if (!string.IsNullOrWhiteSpace(credentials))
+            {
+                ValidateValue(credentials, "credentials");
+                headers.Add($"Cookie: {credentials}");
+            }
+            else
+            {
+                carriesCredentials = false;
+            }
+        }
+
+        return new AriaTaskHeaders(
+            headers,
+            userAgent,
+            carriesCredentials);
+    }
+
+    internal static bool IsCredentialEligibleUrl(string url)
+    {
+        return Uri.TryCreate(url, UriKind.Absolute, out var uri)
+               && string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase)
+               && (string.Equals(uri.IdnHost, BilibiliHost, StringComparison.OrdinalIgnoreCase)
+                   || uri.IdnHost.EndsWith(
+                       "." + BilibiliHost,
+                       StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static void ValidateValue(string value, string parameterName)
+    {
+        if (value.Any(character => character is '\r' or '\n' or '\0'
+            || char.IsControl(character)))
+        {
+            throw new ArgumentException(
+                "An aria2 task header contains a control character.",
+                parameterName);
+        }
+    }
+}
+
+internal sealed record AriaTaskHeaders(
+    IReadOnlyList<string> Headers,
+    string UserAgent,
+    bool CarriesCredentials);

--- a/src/DownKyi.Desktop/Services/Download/BuiltinTransferBackend.cs
+++ b/src/DownKyi.Desktop/Services/Download/BuiltinTransferBackend.cs
@@ -279,6 +279,13 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
         Exception? exception,
         bool reportedCanceled)
     {
+        if (TlsFailureClassifier.TryClassify(exception, out var tlsErrorCode))
+        {
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Tls,
+                tlsErrorCode);
+        }
+
         if (FindException<HttpRequestException>(exception) is { } httpException)
         {
             return httpException.StatusCode switch

--- a/src/DownKyi.Desktop/Services/Download/DownloadActivityPresenter.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadActivityPresenter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
 using DownKyi.Images;
 using DownKyi.Models;
 using DownKyi.Utils;
@@ -77,6 +78,19 @@ internal sealed class DownloadActivityPresenter
             "download.runtime.failed",
             DictionaryResource.GetString("DownloadFailed"),
             true);
+    }
+
+    public static DownloadFailure CreateFailure(OperationError? error)
+    {
+        if (error == null || !TlsFailureClassifier.IsTlsErrorCode(error.Code))
+        {
+            return CreateRetryableFailure();
+        }
+
+        return new DownloadFailure(
+            error.Code,
+            DictionaryResource.GetString(TlsFailureClassifier.GetResourceKey(error.Code)),
+            false);
     }
 
     public static string CreateDirectoryError(string path)

--- a/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
@@ -252,9 +252,7 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
                 cancellationToken).ConfigureAwait(true);
         }
 
-        NormalizeTransferSchemes(
-            urls,
-            context.Settings.Network.UseSsl == AllowStatus.Yes);
+        RequireSecureTransferSchemes(urls);
         var targetFile = Path.Combine(path, fileName);
         var transferRequest = DownloadTransferRequestFactory.Create(
                 context.TaskId,
@@ -381,9 +379,7 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
         }
 
         var addresses = CreateAddresses(media);
-        NormalizeTransferSchemes(
-            addresses,
-            context.Settings.Network.UseSsl == AllowStatus.Yes);
+        RequireSecureTransferSchemes(addresses);
         return addresses;
     }
 
@@ -419,18 +415,14 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
         return result.IsUsable;
     }
 
-    private static void NormalizeTransferSchemes(List<string> urls, bool useSsl)
+    private static void RequireSecureTransferSchemes(List<string> urls)
     {
         for (var index = 0; index < urls.Count; index++)
         {
             var url = urls[index];
-            if (useSsl && url.StartsWith("http://", StringComparison.Ordinal))
+            if (url.StartsWith("http://", StringComparison.Ordinal))
             {
                 urls[index] = "https://" + url["http://".Length..];
-            }
-            else if (!useSsl && url.StartsWith("https://", StringComparison.Ordinal))
-            {
-                urls[index] = "http://" + url["https://".Length..];
             }
         }
     }

--- a/src/DownKyi.Desktop/Services/Download/DownloadPipeline.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadPipeline.cs
@@ -55,7 +55,10 @@ internal sealed class DownloadPipeline : IDownloadTaskExecutor
             _logger.LogWarningMessage(
                 $"Download stage {failedStage ?? "unknown"} failed with " +
                 $"{stageResult.Error?.Code ?? "unknown"}.");
-            await MarkFailedAsync(taskId, cancellationToken).ConfigureAwait(true);
+            await _stateWriter.FailAsync(
+                taskId,
+                DownloadActivityPresenter.CreateFailure(stageResult.Error),
+                cancellationToken).ConfigureAwait(true);
         }
         catch (OperationCanceledException exception)
         {

--- a/src/DownKyi.Desktop/Services/Download/DownloadRetryPolicy.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadRetryPolicy.cs
@@ -63,6 +63,7 @@ internal sealed class DownloadRetryPolicy
                 : Stop(),
             DownloadTransferFailureKind.None or
                 DownloadTransferFailureKind.Disk or
+                DownloadTransferFailureKind.Tls or
                 DownloadTransferFailureKind.Permanent => Stop(),
             _ => Stop()
         };

--- a/src/DownKyi.Desktop/Services/Download/DownloadRuntimeFactory.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadRuntimeFactory.cs
@@ -80,15 +80,7 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
                 _settingsStore,
                 _diagnosticLogger,
                 _loggerFactory.CreateLogger<BuiltinTransferBackend>()),
-            DownloaderSetting.Aria => new Aria2TransferBackend(
-                network,
-                new AriaClient(listenPort: network.AriaListenPort),
-                _ariaClientRegistry,
-                _diagnosticLogger,
-                _ariaServer,
-                _loggerFactory,
-                _loggerFactory.CreateLogger<Aria2TransferBackend>(),
-                ownsAriaServer: true),
+            DownloaderSetting.Aria => CreateLocalAriaBackend(network),
             DownloaderSetting.CustomAria => new Aria2TransferBackend(
                 network,
                 new AriaClient(network.AriaHost, network.AriaListenPort, network.AriaToken),
@@ -97,7 +89,8 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
                 _ariaServer,
                 _loggerFactory,
                 _loggerFactory.CreateLogger<Aria2TransferBackend>(),
-                ownsAriaServer: false),
+                ownsAriaServer: false,
+                localEndpoint: null),
             _ => null
         };
 
@@ -168,5 +161,21 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
             _tasks,
             network.MaxCurrentDownloads,
             _loggerFactory.CreateLogger<DownloadOrchestrator>());
+    }
+
+    private Aria2TransferBackend CreateLocalAriaBackend(
+        NetworkApplicationSettings network)
+    {
+        var endpoint = LocalAriaRpcEndpoint.Create();
+        return new Aria2TransferBackend(
+            network,
+            new AriaClient("http://localhost", endpoint.Port, endpoint.Secret),
+            _ariaClientRegistry,
+            _diagnosticLogger,
+            _ariaServer,
+            _loggerFactory,
+            _loggerFactory.CreateLogger<Aria2TransferBackend>(),
+            ownsAriaServer: true,
+            endpoint);
     }
 }

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskProjectionMapper.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskProjectionMapper.cs
@@ -176,7 +176,8 @@ internal static class DownloadTaskProjectionMapper
         {
             DownloadPhase.Queued => DictionaryResource.GetString("Waiting"),
             DownloadPhase.Pausing or DownloadPhase.Paused => DictionaryResource.GetString("Pausing"),
-            DownloadPhase.Failed => DictionaryResource.GetString("DownloadFailed"),
+            DownloadPhase.Failed => task.Failure?.Message
+                ?? DictionaryResource.GetString("DownloadFailed"),
             DownloadPhase.Downloading when string.IsNullOrWhiteSpace(task.Transfer.StatusText) =>
                 DictionaryResource.GetString("WhileDownloading"),
             _ => task.Transfer.StatusText

--- a/src/DownKyi.Desktop/Services/Download/ITransferBackend.cs
+++ b/src/DownKyi.Desktop/Services/Download/ITransferBackend.cs
@@ -49,6 +49,7 @@ internal enum DownloadTransferFailureKind
     ResumeRejected,
     InvalidMedia,
     Disk,
+    Tls,
     Permanent
 }
 

--- a/src/DownKyi.Desktop/Services/Download/LocalAriaRpcEndpoint.cs
+++ b/src/DownKyi.Desktop/Services/Download/LocalAriaRpcEndpoint.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+
+namespace DownKyi.Services.Download;
+
+internal sealed record LocalAriaRpcEndpoint(int Port, string Secret)
+{
+    public static LocalAriaRpcEndpoint Create()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var endpoint = (IPEndPoint)listener.LocalEndpoint;
+        var secret = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+        return new LocalAriaRpcEndpoint(endpoint.Port, secret);
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/TlsFailureClassifier.cs
+++ b/src/DownKyi.Desktop/Services/Download/TlsFailureClassifier.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Net.Http;
+using System.Security.Authentication;
+
+namespace DownKyi.Services.Download;
+
+internal static class TlsFailureClassifier
+{
+    private const string Prefix = "download.transfer.tls.";
+
+    public static bool TryClassify(Exception? exception, out string errorCode)
+    {
+        var current = exception;
+        var isSecureConnectionFailure = false;
+        while (current != null)
+        {
+            if (current is HttpRequestException
+                {
+                    HttpRequestError: HttpRequestError.SecureConnectionError
+                })
+            {
+                isSecureConnectionFailure = true;
+            }
+
+            if (current is AuthenticationException)
+            {
+                isSecureConnectionFailure = true;
+            }
+
+            if (TryClassify(current.Message, out errorCode))
+            {
+                return true;
+            }
+
+            current = current.InnerException;
+        }
+
+        errorCode = isSecureConnectionFailure ? Prefix + "handshake" : string.Empty;
+        return isSecureConnectionFailure;
+    }
+
+    public static bool TryClassify(string? message, out string errorCode)
+    {
+        if (ContainsAny(message,
+                "not yet valid",
+                "not valid yet",
+                "尚未生效",
+                "尚未有效"))
+        {
+            errorCode = Prefix + "not-yet-valid";
+            return true;
+        }
+
+        if (ContainsAny(message,
+                "expired",
+                "validity period",
+                "已过期",
+                "已過期",
+                "800b0101"))
+        {
+            errorCode = Prefix + "expired";
+            return true;
+        }
+
+        if (ContainsAny(message,
+                "hostname",
+                "host name",
+                "common name",
+                "does not match",
+                "wrong principal",
+                "名称不匹配",
+                "名稱不匹配",
+                "80090322",
+                "800b010f"))
+        {
+            errorCode = Prefix + "hostname";
+            return true;
+        }
+
+        if (ContainsAny(message,
+                "untrusted",
+                "unknown ca",
+                "self-signed",
+                "self signed",
+                "unable to get local issuer",
+                "unable to verify the first certificate",
+                "不受信任",
+                "80090325",
+                "800b0109"))
+        {
+            errorCode = Prefix + "untrusted";
+            return true;
+        }
+
+        if (ContainsAny(message,
+                "certificate chain",
+                "chain building",
+                "issuer certificate",
+                "certificate verify failed",
+                "certificate verification failed",
+                "wrong chain",
+                "800b010a"))
+        {
+            errorCode = Prefix + "chain";
+            return true;
+        }
+
+        if (ContainsAny(message,
+                "ssl/tls handshake",
+                "tls handshake",
+                "ssl handshake",
+                "secure connection",
+                "authentication failed",
+                "certificate"))
+        {
+            errorCode = Prefix + "handshake";
+            return true;
+        }
+
+        errorCode = string.Empty;
+        return false;
+    }
+
+    public static bool IsTlsErrorCode(string? errorCode)
+    {
+        return errorCode?.StartsWith(Prefix, StringComparison.Ordinal) == true;
+    }
+
+    public static string GetResourceKey(string errorCode)
+    {
+        return errorCode switch
+        {
+            Prefix + "untrusted" => "DownloadTlsUntrusted",
+            Prefix + "expired" => "DownloadTlsExpired",
+            Prefix + "not-yet-valid" => "DownloadTlsNotYetValid",
+            Prefix + "hostname" => "DownloadTlsHostnameMismatch",
+            Prefix + "chain" => "DownloadTlsInvalidChain",
+            _ => "DownloadTlsHandshakeFailed"
+        };
+    }
+
+    private static bool ContainsAny(string? value, params string[] candidates)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        foreach (var candidate in candidates)
+        {
+            if (value.Contains(candidate, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/DownKyi.Desktop/ViewModels/Settings/ViewNetworkViewModel.AriaCommands.cs
+++ b/src/DownKyi.Desktop/ViewModels/Settings/ViewNetworkViewModel.AriaCommands.cs
@@ -197,13 +197,13 @@ internal partial class ViewNetworkViewModel
             settings => settings.AriaMaxDownloadLimit == AriaMaxDownloadLimit);
     }
 
-    // 是否开启Aria http代理事件
+    // Toggle the local HTTP CONNECT proxy used by aria2 HTTPS downloads.
     private RelayCommand? _isAriaHttpProxyCommand;
 
     public RelayCommand IsAriaHttpProxyCommand => _isAriaHttpProxyCommand ??= new RelayCommand(ExecuteIsAriaHttpProxyCommand);
 
     /// <summary>
-    /// 是否开启Aria http代理事件
+    /// Toggles the local HTTP CONNECT proxy used by aria2 HTTPS downloads.
     /// </summary>
     private void ExecuteIsAriaHttpProxyCommand()
     {
@@ -214,13 +214,13 @@ internal partial class ViewNetworkViewModel
             settings => settings.IsAriaHttpProxy == isAriaHttpProxy);
     }
 
-    // Aria的http代理的地址事件
+    // Apply the local aria2 HTTPS-download proxy host.
     private RelayCommand<string>? _ariaHttpProxyCommand;
 
     public RelayCommand<string> AriaHttpProxyCommand => _ariaHttpProxyCommand ??= RequiredParameterCommand.Create<string>(ExecuteAriaHttpProxyCommand);
 
     /// <summary>
-    /// Aria的http代理的地址事件
+    /// Applies the local aria2 HTTPS-download proxy host.
     /// </summary>
     /// <param name="parameter"></param>
     private void ExecuteAriaHttpProxyCommand(string parameter)
@@ -230,13 +230,13 @@ internal partial class ViewNetworkViewModel
             settings => settings.AriaHttpProxy == parameter);
     }
 
-    // Aria的http代理的端口事件
+    // Apply the local aria2 HTTPS-download proxy port.
     private RelayCommand<string>? _ariaHttpProxyPortCommand;
 
     public RelayCommand<string> AriaHttpProxyPortCommand => _ariaHttpProxyPortCommand ??= RequiredParameterCommand.Create<string>(ExecuteAriaHttpProxyPortCommand);
 
     /// <summary>
-    /// Aria的http代理的端口事件
+    /// Applies the local aria2 HTTPS-download proxy port.
     /// </summary>
     /// <param name="parameter"></param>
     private void ExecuteAriaHttpProxyPortCommand(string parameter)

--- a/src/DownKyi.Desktop/ViewModels/Settings/ViewNetworkViewModel.State.cs
+++ b/src/DownKyi.Desktop/ViewModels/Settings/ViewNetworkViewModel.State.cs
@@ -8,14 +8,6 @@ internal partial class ViewNetworkViewModel
 {
     #region 页面属性申明
 
-    private bool _useSsl;
-
-    public bool UseSsl
-    {
-        get => _useSsl;
-        set => SetProperty(ref _useSsl, value);
-    }
-
     private string _userAgent = string.Empty;
 
     public string UserAgent

--- a/src/DownKyi.Desktop/ViewModels/Settings/ViewNetworkViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Settings/ViewNetworkViewModel.cs
@@ -47,10 +47,7 @@ internal partial class ViewNetworkViewModel : ViewModelBase
 
         _isOnNavigatedTo = true;
 
-        // 启用https
         var network = _coordinator.Current;
-        var useSsl = network.UseSsl;
-        UseSsl = useSsl == AllowStatus.Yes;
 
         // UserAgent
         UserAgent = network.UserAgent;
@@ -123,14 +120,14 @@ internal partial class ViewNetworkViewModel : ViewModelBase
         // Aria下载单文件速度限制
         AriaMaxDownloadLimit = network.AriaMaxDownloadLimit;
 
-        // 是否开启Aria http代理
+        // Whether to use a local HTTP CONNECT proxy for aria2 HTTPS downloads.
         var isAriaHttpProxy = network.IsAriaHttpProxy;
         IsAriaHttpProxy = isAriaHttpProxy == AllowStatus.Yes;
 
-        // Aria的http代理的地址
+        // Local aria2 HTTPS-download proxy host.
         AriaHttpProxy = network.AriaHttpProxy;
 
-        // Aria的http代理的端口
+        // Local aria2 HTTPS-download proxy port.
         AriaHttpProxyPort = network.AriaHttpProxyListenPort;
 
         // Aria文件预分配
@@ -141,23 +138,6 @@ internal partial class ViewNetworkViewModel : ViewModelBase
     }
 
     #region 命令申明
-
-    // 是否启用https事件
-    private RelayCommand? _useSslCommand;
-
-    public RelayCommand UseSslCommand => _useSslCommand ??= new RelayCommand(ExecuteUseSslCommand);
-
-    /// <summary>
-    /// 是否启用https事件
-    /// </summary>
-    private void ExecuteUseSslCommand()
-    {
-        var useSsl = UseSsl ? AllowStatus.Yes : AllowStatus.No;
-
-        ApplyNetwork(
-            settings => settings with { UseSsl = useSsl },
-            settings => settings.UseSsl == useSsl);
-    }
 
     // 设置UserAgent事件
     private RelayCommand? _userAgentCommand;

--- a/src/DownKyi.Desktop/Views/Settings/AriaDownloaderSettingsView.axaml
+++ b/src/DownKyi.Desktop/Views/Settings/AriaDownloaderSettingsView.axaml
@@ -4,30 +4,6 @@
              x:Class="DownKyi.Views.Settings.AriaDownloaderSettingsView"
              x:DataType="vms:ViewNetworkViewModel">
     <StackPanel x:Name="NameAria" IsVisible="{Binding Aria2C}">
-        <StackPanel
-            Margin="0,20,0,0"
-            Orientation="Horizontal"
-            ToolTip.Tip="{DynamicResource PressEnterToApplySettingTip}">
-            <TextBlock
-                Width="100"
-                VerticalAlignment="Center"
-                FontSize="12"
-                Foreground="{DynamicResource BrushTextDark}"
-                Text="{DynamicResource AriaServerPort}" />
-            <TextBox
-                Name="NameAriaListenPort"
-                Width="100"
-                VerticalContentAlignment="Center"
-                Text="{Binding AriaListenPort}">
-                <TextBox.KeyBindings>
-                    <KeyBinding
-                        Command="{Binding AriaListenPortCommand}"
-                        CommandParameter="{Binding #NameAriaListenPort.Text}"
-                        Gesture="Enter" />
-                </TextBox.KeyBindings>
-            </TextBox>
-        </StackPanel>
-
         <StackPanel Margin="0,20,0,0" Orientation="Horizontal">
             <TextBlock
                 Width="100"
@@ -193,32 +169,34 @@
         </HeaderedContentControl>
 
         <CheckBox
-            Name="NameIsAriaHttpProxy"
+            Name="NameIsAriaHttpsDownloadProxy"
             Margin="0,20,0,0"
             HorizontalAlignment="Left"
             VerticalAlignment="Top"
             Command="{Binding IsAriaHttpProxyCommand}"
-            Content="{DynamicResource IsHttpProxy}"
+            Content="{DynamicResource IsAriaHttpsDownloadProxy}"
             FontSize="12"
             Foreground="{DynamicResource BrushTextDark}"
-            IsChecked="{Binding IsAriaHttpProxy, Mode=TwoWay}" />
+            IsChecked="{Binding IsAriaHttpProxy, Mode=TwoWay}"
+            ToolTip.Tip="{DynamicResource AriaHttpsDownloadProxyTip}" />
 
         <StackPanel
-            Name="NameAriaHttpProxyPanel"
+            Name="NameAriaHttpsDownloadProxyPanel"
             Margin="0,20,0,0"
             Orientation="Horizontal"
             ToolTip.Tip="{DynamicResource PressEnterToApplySettingTip}"
-            IsVisible="{Binding ElementName=NameIsAriaHttpProxy,Path=IsChecked}">
+            IsVisible="{Binding ElementName=NameIsAriaHttpsDownloadProxy,Path=IsChecked}">
             <StackPanel Orientation="Horizontal">
                 <TextBlock
                     VerticalAlignment="Center"
                     FontSize="12"
                     Foreground="{DynamicResource BrushTextDark}"
-                    Text="{DynamicResource HttpProxy}" />
+                    Text="{DynamicResource AriaHttpsDownloadProxyHost}" />
                 <TextBox
                     Name="NameAriaHttpProxy"
                     Width="200"
                     VerticalContentAlignment="Center"
+                    PlaceholderText="127.0.0.1 / localhost / ::1"
                     Text="{Binding AriaHttpProxy}">
                     <TextBox.KeyBindings>
                         <KeyBinding

--- a/src/DownKyi.Desktop/Views/Settings/CustomAriaSettingsView.axaml
+++ b/src/DownKyi.Desktop/Views/Settings/CustomAriaSettingsView.axaml
@@ -63,6 +63,7 @@
             <TextBox
                 Name="NameAriaToken"
                 Width="100"
+                PasswordChar="*"
                 VerticalContentAlignment="Center"
                 Text="{Binding AriaToken}">
                 <TextBox.KeyBindings>

--- a/src/DownKyi.Desktop/Views/Settings/NetworkGeneralSettingsView.axaml
+++ b/src/DownKyi.Desktop/Views/Settings/NetworkGeneralSettingsView.axaml
@@ -12,17 +12,6 @@
                 Text="{DynamicResource Network}" />
         </StackPanel>
 
-        <CheckBox
-            Name="NameUseSsl"
-            Margin="0,20,0,0"
-            HorizontalAlignment="Left"
-            VerticalAlignment="Top"
-            Command="{Binding UseSslCommand}"
-            Content="{DynamicResource UseSSL}"
-            FontSize="12"
-            Foreground="{DynamicResource BrushTextDark}"
-            IsChecked="{Binding UseSsl, Mode=TwoWay}" />
-
         <HeaderedContentControl
             Margin="0,20,0,0"
             Padding="10,5"

--- a/tests/DownKyi.Architecture.Tests/NetworkSettingsViewArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/NetworkSettingsViewArchitectureTests.cs
@@ -56,11 +56,11 @@ public sealed class NetworkSettingsViewArchitectureTests
     {
         var source = string.Join(Environment.NewLine, ViewNames.Select(Read));
 
-        Assert.Equal(94, Count(source, @"\{Binding\s+([^},]+)"));
-        Assert.Equal(40, Count(source, @"(?:x:Name|Name)=""([^""]+)"""));
-        Assert.Equal(72, Count(source, @"\{DynamicResource\s+([^}]+)\}"));
+        Assert.Equal(89, Count(source, @"\{Binding\s+([^},]+)"));
+        Assert.Equal(38, Count(source, @"(?:x:Name|Name)=""([^""]+)"""));
+        Assert.Equal(68, Count(source, @"\{DynamicResource\s+([^}]+)\}"));
         Assert.Equal(4, Count(source, @"\{StaticResource\s+([^}]+)\}"));
-        Assert.Equal(26, Count(source, @"CommandParameter=""([^""]+)"""));
+        Assert.Equal(25, Count(source, @"CommandParameter=""([^""]+)"""));
     }
 
     [Fact]
@@ -68,10 +68,10 @@ public sealed class NetworkSettingsViewArchitectureTests
     {
         var source = Read("AriaDownloaderSettingsView.axaml");
 
-        Assert.Contains("Name=\"NameIsAriaHttpProxy\"", source, StringComparison.Ordinal);
-        Assert.Contains("Name=\"NameAriaHttpProxyPanel\"", source, StringComparison.Ordinal);
+        Assert.Contains("Name=\"NameIsAriaHttpsDownloadProxy\"", source, StringComparison.Ordinal);
+        Assert.Contains("Name=\"NameAriaHttpsDownloadProxyPanel\"", source, StringComparison.Ordinal);
         Assert.Contains(
-            "IsVisible=\"{Binding ElementName=NameIsAriaHttpProxy,Path=IsChecked}\"",
+            "IsVisible=\"{Binding ElementName=NameIsAriaHttpsDownloadProxy,Path=IsChecked}\"",
             source,
             StringComparison.Ordinal);
     }

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -123,11 +123,30 @@ public sealed class ReleaseWorkflowArchitectureTests
             "external-assets.json");
         using var manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
 
+        var aria2 = manifest.RootElement.GetProperty("aria2");
+        var sourceCommit = Assert.IsType<string>(
+            aria2.GetProperty("sourceCommit").GetString());
+        var sourceTag = Assert.IsType<string>(
+            aria2.GetProperty("sourceTag").GetString());
+        var version = Assert.IsType<string>(
+            aria2.GetProperty("version").GetString());
+        Assert.Matches(
+            "^[0-9a-f]{40}$",
+            sourceCommit);
+        Assert.Equal(version, sourceTag);
+
         foreach (var tool in manifest.RootElement.EnumerateObject())
         {
             foreach (var asset in tool.Value.GetProperty("assets").EnumerateObject())
             {
                 AssertPinnedAsset(asset.Value, "url", "sha256");
+
+                if (string.Equals(tool.Name, "aria2", StringComparison.Ordinal))
+                {
+                    var binaryChecksum = asset.Value.GetProperty("binarySha256").GetString();
+                    Assert.NotNull(binaryChecksum);
+                    Assert.Matches("^[a-f0-9]{64}$", binaryChecksum);
+                }
 
                 if (asset.Value.TryGetProperty("ffprobeUrl", out _))
                 {

--- a/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
@@ -240,6 +240,7 @@ public sealed class TlsSecurityArchitectureTests
             "Aria2RuntimeLifecycle.cs");
         var powerShellInstaller = ReadProductionSource("script", "aria2.ps1");
         var shellInstaller = ReadProductionSource("script", "aria2.sh");
+        var qualityWorkflow = ReadProductionSource(".github", "workflows", "quality.yml");
 
         Assert.Contains("AppContext.BaseDirectory", server, StringComparison.Ordinal);
         Assert.True(
@@ -255,6 +256,10 @@ public sealed class TlsSecurityArchitectureTests
         Assert.Contains("aria2c.exe.sha256", powerShellInstaller, StringComparison.Ordinal);
         Assert.Contains("binarySha256", shellInstaller, StringComparison.Ordinal);
         Assert.Contains("aria2c.sha256", shellInstaller, StringComparison.Ordinal);
+        Assert.Contains(
+            "run: bash ./script/aria2.sh '${{ matrix.asset-argument }}'",
+            qualityWorkflow,
+            StringComparison.Ordinal);
     }
 
     private static string ReadProductionSource(params string[] segments)

--- a/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
@@ -1,0 +1,313 @@
+namespace DownKyi.Architecture.Tests;
+
+public sealed class TlsSecurityArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    public void ProductionCodeDoesNotDisableCertificateValidation()
+    {
+        var forbidden = new[]
+        {
+            "--check-certificate=" + "false",
+            "check-certificate=" + "false",
+            "--no-check-" + "certificate",
+            "DangerousAccept" + "AnyServerCertificateValidator",
+            "ServerCertificate" + "CustomValidationCallback",
+            "RemoteCertificate" + "ValidationCallback",
+            "NODE_TLS_REJECT_UNAUTHORIZED" + "=0",
+            "CURLOPT_SSL_VERIFYPEER" + ", 0",
+            "CURLOPT_SSL_VERIFYHOST" + ", 0"
+        };
+
+        foreach (var file in EnumerateProductionTextFiles())
+        {
+            var source = File.ReadAllText(file);
+            foreach (var token in forbidden)
+            {
+                Assert.DoesNotContain(token, source, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+    }
+
+    [Fact]
+    public void DownloadRuntimeCannotDowngradeHttpsToHttp()
+    {
+        var mediaStage = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "DownloadMediaStage.cs"));
+        var settingsView = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "src",
+            "DownKyi.Desktop",
+            "Views",
+            "Settings",
+            "NetworkGeneralSettingsView.axaml"));
+
+        Assert.Contains("RequireSecureTransferSchemes", mediaStage, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "http://\" + url[\"https://",
+            mediaStage,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("UseSslCommand", settingsView, StringComparison.Ordinal);
+        Assert.DoesNotContain("NameUseSsl", settingsView, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LegacyUseSslExistsOnlyAtTheOneWaySettingsMigrationBoundary()
+    {
+        var productionSources = EnumerateProductionTextFiles()
+            .Select(file => new
+            {
+                File = Path.GetRelativePath(RepositoryRoot, file),
+                Source = File.ReadAllText(file)
+            })
+            .Where(item => item.Source.Contains("UseSsl", StringComparison.Ordinal))
+            .ToArray();
+
+        var migrationSource = Assert.Single(productionSources);
+        Assert.Equal(
+            Path.Combine("DownKyi.Core", "Settings", "Models", "NetworkSettings.cs"),
+            migrationSource.File);
+        Assert.Contains("private AllowStatus LegacyUseSsl", migrationSource.Source, StringComparison.Ordinal);
+        Assert.Contains("[JsonProperty(\"UseSsl\")]", migrationSource.Source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AriaControlPlaneKeepsSecretsOutOfProcessArgumentsAndGlobalHeaders()
+    {
+        var server = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Server",
+            "AriaServer.cs");
+        var config = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Server",
+            "AriaConfig.cs");
+        var client = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Client",
+            "AriaClient.cs");
+        var backend = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "Aria2TransferBackend.cs");
+        var addressResolver = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "AriaDownloadAddressResolver.cs");
+        var factory = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "DownloadRuntimeFactory.cs");
+        var customSettings = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Views",
+            "Settings",
+            "CustomAriaSettingsView.axaml");
+
+        Assert.Contains("ArgumentList.Add", server, StringComparison.Ordinal);
+        Assert.DoesNotContain("StartInfo.Arguments", server, StringComparison.Ordinal);
+        Assert.DoesNotContain("--rpc-secret=", server, StringComparison.Ordinal);
+        Assert.DoesNotContain("--header=", server, StringComparison.Ordinal);
+        Assert.DoesNotContain("Headers", config, StringComparison.Ordinal);
+        Assert.Contains("AriaRpcSecretFile.Create", server, StringComparison.Ordinal);
+        Assert.Contains("AllowAutoRedirect = false", client, StringComparison.Ordinal);
+        Assert.Contains("!hostUri.IsLoopback", client, StringComparison.Ordinal);
+        Assert.Contains("AriaTaskHeaderPolicy.Create", addressResolver, StringComparison.Ordinal);
+        Assert.Contains("LocalAriaRpcEndpoint.Create", factory, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"downkyi\"", factory, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("PasswordChar=\"*\"", customSettings, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AriaHttpsProxyAndPreflightCannotBroadenTheTransferScope()
+    {
+        var sendOption = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Client",
+            "Entity",
+            "AriaSendData.cs");
+        var ariaOption = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Client",
+            "Entity",
+            "AriaOption.cs");
+        var addressResolver = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "AriaDownloadAddressResolver.cs");
+        var backend = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "Aria2TransferBackend.cs");
+        var runtimeLifecycle = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "Aria2RuntimeLifecycle.cs");
+        var proxyPolicy = ReadProductionSource(
+            "DownKyi.Core",
+            "Settings",
+            "AriaHttpsProxyPolicy.cs");
+        var redirectRuntimeTests = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "tests",
+            "DownKyi.Tests",
+            "Aria2TlsRedirectIntegrationTests.cs"));
+        var tlsRuntime = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "tests",
+            "DownKyi.Tests",
+            "Aria2TlsTestRuntime.cs"));
+
+        Assert.Contains("[JsonProperty(\"https-proxy\")]", sendOption, StringComparison.Ordinal);
+        Assert.DoesNotContain("all-proxy", sendOption, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("all-proxy", ariaOption, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("max-redirect", sendOption, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("AllowAutoRedirect = false", addressResolver, StringComparison.Ordinal);
+        Assert.Contains("download.transfer.insecure-redirect", addressResolver, StringComparison.Ordinal);
+        Assert.Contains("MaximumRedirects", addressResolver, StringComparison.Ordinal);
+        Assert.True(
+            backend.IndexOf("_addressResolver.ResolveAsync", StringComparison.Ordinal)
+            < backend.IndexOf("_ariaClient.AddUriAsync", StringComparison.Ordinal),
+            "The defense-in-depth redirect preflight must run before aria2 receives the address.");
+        Assert.Contains(
+            "downkyi-secure-redirect-v2",
+            runtimeLifecycle,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "downkyi-secure-redirect-v2",
+            tlsRuntime,
+            StringComparison.Ordinal);
+        Assert.Contains("RunPreflightThenActualDowngradeRejectedAsync", redirectRuntimeTests, StringComparison.Ordinal);
+        Assert.Contains("RunHeadSafeGetDowngradeRejectedAsync", redirectRuntimeTests, StringComparison.Ordinal);
+        Assert.Contains("RunRangeDowngradeRejectedAsync", redirectRuntimeTests, StringComparison.Ordinal);
+        Assert.Contains("RunSecondRoundDowngradeRejectedAsync", redirectRuntimeTests, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(0, target.RequestCount)", redirectRuntimeTests, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(0, target.ConnectionCount)", redirectRuntimeTests, StringComparison.Ordinal);
+        Assert.Contains("127.0.0.1", proxyPolicy, StringComparison.Ordinal);
+        Assert.Contains("localhost", proxyPolicy, StringComparison.Ordinal);
+        Assert.Contains("::1", proxyPolicy, StringComparison.Ordinal);
+        Assert.DoesNotContain("NetworkCredential", proxyPolicy, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PackagedAria2IsVerifiedBeforeProcessStartAndCustomAriaRequiresTheFeature()
+    {
+        var server = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Server",
+            "AriaServer.cs");
+        var verifier = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Server",
+            "AriaBinaryIntegrityVerifier.cs");
+        var backend = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "Aria2TransferBackend.cs");
+        var runtimeLifecycle = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "Aria2RuntimeLifecycle.cs");
+        var powerShellInstaller = ReadProductionSource("script", "aria2.ps1");
+        var shellInstaller = ReadProductionSource("script", "aria2.sh");
+
+        Assert.Contains("AppContext.BaseDirectory", server, StringComparison.Ordinal);
+        Assert.True(
+            server.IndexOf("AriaBinaryIntegrityVerifier.Verify", StringComparison.Ordinal)
+            < server.IndexOf("ExecuteProcess(executablePath", StringComparison.Ordinal),
+            "The packaged binary digest must be verified before Process.Start can be reached.");
+        Assert.Contains("CryptographicOperations.FixedTimeEquals", verifier, StringComparison.Ordinal);
+        Assert.Contains("ChecksumSidecarSuffix", verifier, StringComparison.Ordinal);
+        Assert.Contains("_runtimeLifecycle.StartAsync", backend, StringComparison.Ordinal);
+        Assert.Contains("EnsureSecureRedirectFeatureAsync", runtimeLifecycle, StringComparison.Ordinal);
+        Assert.Contains("EnsureSecureRedirectFeature(versionResult.EnabledFeatures)", runtimeLifecycle, StringComparison.Ordinal);
+        Assert.Contains("binarySha256", powerShellInstaller, StringComparison.Ordinal);
+        Assert.Contains("aria2c.exe.sha256", powerShellInstaller, StringComparison.Ordinal);
+        Assert.Contains("binarySha256", shellInstaller, StringComparison.Ordinal);
+        Assert.Contains("aria2c.sha256", shellInstaller, StringComparison.Ordinal);
+    }
+
+    private static string ReadProductionSource(params string[] segments)
+    {
+        return File.ReadAllText(Path.Combine([RepositoryRoot, .. segments]));
+    }
+
+    private static IEnumerable<string> EnumerateProductionTextFiles()
+    {
+        var roots = new[]
+        {
+            Path.Combine(RepositoryRoot, "DownKyi"),
+            Path.Combine(RepositoryRoot, "DownKyi.Core"),
+            Path.Combine(RepositoryRoot, "src"),
+            Path.Combine(RepositoryRoot, "script"),
+            Path.Combine(RepositoryRoot, ".github", "workflows")
+        };
+        var extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ".cs",
+            ".axaml",
+            ".json",
+            ".ps1",
+            ".sh",
+            ".yml",
+            ".yaml"
+        };
+
+        return roots
+            .Where(Directory.Exists)
+            .SelectMany(root => Directory.EnumerateFiles(root, "*", SearchOption.AllDirectories))
+            .Where(file => extensions.Contains(Path.GetExtension(file)))
+            .Where(file => !file.Contains(
+                $"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}",
+                StringComparison.OrdinalIgnoreCase))
+            .Where(file => !file.Contains(
+                $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the DownKyi repository root.");
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
@@ -189,6 +189,7 @@ public sealed class TlsSecurityArchitectureTests
         Assert.Contains("AllowAutoRedirect = false", addressResolver, StringComparison.Ordinal);
         Assert.Contains("download.transfer.insecure-redirect", addressResolver, StringComparison.Ordinal);
         Assert.Contains("MaximumRedirects", addressResolver, StringComparison.Ordinal);
+        Assert.Contains("IsSameOrigin(current, next)", addressResolver, StringComparison.Ordinal);
         Assert.True(
             backend.IndexOf("_addressResolver.ResolveAsync", StringComparison.Ordinal)
             < backend.IndexOf("_ariaClient.AddUriAsync", StringComparison.Ordinal),
@@ -201,6 +202,7 @@ public sealed class TlsSecurityArchitectureTests
             "downkyi-secure-redirect-v2",
             tlsRuntime,
             StringComparison.Ordinal);
+        Assert.DoesNotContain("--ca-certificate=", tlsRuntime, StringComparison.Ordinal);
         Assert.Contains("RunPreflightThenActualDowngradeRejectedAsync", redirectRuntimeTests, StringComparison.Ordinal);
         Assert.Contains("RunHeadSafeGetDowngradeRejectedAsync", redirectRuntimeTests, StringComparison.Ordinal);
         Assert.Contains("RunRangeDowngradeRejectedAsync", redirectRuntimeTests, StringComparison.Ordinal);
@@ -211,6 +213,56 @@ public sealed class TlsSecurityArchitectureTests
         Assert.Contains("localhost", proxyPolicy, StringComparison.Ordinal);
         Assert.Contains("::1", proxyPolicy, StringComparison.Ordinal);
         Assert.DoesNotContain("NetworkCredential", proxyPolicy, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AriaStartupAndResumeSecurityContractsRemainFailClosed()
+    {
+        var applicationSettings = ReadProductionSource(
+            "DownKyi.Core",
+            "Settings",
+            "ApplicationSettings.cs");
+        var processSupervisor = ReadProductionSource(
+            "DownKyi.Core",
+            "Aria2cNet",
+            "Server",
+            "AriaProcessSupervisor.cs");
+        var runtimeLifecycle = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "Aria2RuntimeLifecycle.cs");
+        var backend = ReadProductionSource(
+            "src",
+            "DownKyi.Desktop",
+            "Services",
+            "Download",
+            "Aria2TransferBackend.cs");
+        var baseline = ReadProductionSource(
+            "docs",
+            "operations",
+            "aria2-security-baseline.json");
+        var tlsRuntime = ReadProductionSource(
+            "tests",
+            "DownKyi.Tests",
+            "Aria2TlsTestRuntime.cs");
+
+        Assert.Contains("uri.UserInfo", applicationSettings, StringComparison.Ordinal);
+        Assert.Contains(
+            "GetAriaVersionAsync(cancellationToken)",
+            runtimeLifecycle,
+            StringComparison.Ordinal);
+        Assert.Contains("WaitForExit(KillWaitMilliseconds)", processSupervisor, StringComparison.Ordinal);
+        Assert.True(
+            backend.IndexOf("ChangeOptionAsync(gid, options)", StringComparison.Ordinal)
+            < backend.IndexOf("UnpauseAsync(gid)", StringComparison.Ordinal),
+            "Existing aria2 task headers must be replaced before the task is resumed.");
+        Assert.Contains("windows-system-root-store", baseline, StringComparison.Ordinal);
+        Assert.Contains("windows-local-machine-root-store", tlsRuntime, StringComparison.Ordinal);
+        Assert.Contains("windows-current-user-root-store", tlsRuntime, StringComparison.Ordinal);
+        Assert.Contains("linux-system-ca-store", baseline, StringComparison.Ordinal);
+        Assert.Contains("macos-system-keychain", baseline, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/DownKyi.Core.Tests/AriaClientIsolationTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaClientIsolationTests.cs
@@ -31,7 +31,7 @@ public sealed class AriaClientIsolationTests
         List<(Uri Endpoint, string Payload)> requests)
     {
         return new AriaClient(
-            $"http://{host}",
+            $"https://{host}",
             port,
             token,
             (endpoint, payload) =>

--- a/tests/DownKyi.Core.Tests/AriaClientRpcContractTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaClientRpcContractTests.cs
@@ -28,7 +28,7 @@ public sealed class AriaClientRpcContractTests
             string? capturedPayload = null;
             var captureSignal = new InvalidOperationException("RPC payload captured.");
             var client = new AriaClient(
-                "http://aria-contract.example",
+                "https://aria-contract.example",
                 35076,
                 "contract-token",
                 (_, payload) =>

--- a/tests/DownKyi.Core.Tests/AriaClientSecurityTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaClientSecurityTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using DownKyi.Core.Aria2cNet.Client;
+using DownKyi.Core.Aria2cNet.Client.Entity;
+using DownKyi.TestInfrastructure;
+using Newtonsoft.Json;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class AriaClientSecurityTests
+{
+    [Theory]
+    [InlineData("http://192.0.2.10")]
+    [InlineData("http://aria.example")]
+    public void RemotePlaintextRpcEndpointsAreRejected(string host)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            new AriaClient(host, 6800, "test-token"));
+
+        Assert.Contains("must use HTTPS", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("http://localhost")]
+    [InlineData("http://127.0.0.1")]
+    [InlineData("http://[::1]")]
+    [InlineData("https://aria.example")]
+    public void LoopbackHttpAndRemoteHttpsRpcEndpointsAreAccepted(string host)
+    {
+        _ = new AriaClient(host, 6800, "test-token");
+    }
+
+    [Fact]
+    public void RpcEndpointUserInformationIsRejected()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new AriaClient("https://user:password@aria.example", 6800, "test-token"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void RpcSecretMustNotBeEmpty(string token)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            new AriaClient("http://localhost", 6800, token));
+    }
+
+    [Fact]
+    public async Task RemoteHttpsRpcRejectsAnUntrustedCertificate()
+    {
+        using var certificate = TestCertificateAuthority.CreateSelfSignedServerCertificate();
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            "{}"u8.ToArray());
+        await using var serverLifetime = server.ConfigureAwait(false);
+        var client = new AriaClient(
+            "https://localhost",
+            server.Url.Port,
+            "test-token");
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetGlobalOptionAsync())
+            .ConfigureAwait(true);
+    }
+
+    [Fact]
+    public async Task RpcTransportDoesNotFollowRedirects()
+    {
+        var target = new LoopbackHttpServer(_ =>
+            new LoopbackResponse(HttpStatusCode.OK, "{}"));
+        await using var targetLifetime = target.ConfigureAwait(true);
+        var redirect = new LoopbackHttpServer(_ =>
+            new LoopbackResponse(
+                HttpStatusCode.Redirect,
+                Headers: new Dictionary<string, string>
+                {
+                    ["Location"] = target.Url.AbsoluteUri
+                }));
+        await using var redirectLifetime = redirect.ConfigureAwait(true);
+        var client = new AriaClient(
+            $"http://127.0.0.1",
+            redirect.Url.Port,
+            "test-token");
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => client.GetGlobalOptionAsync())
+            .ConfigureAwait(true);
+
+        Assert.Equal(1, redirect.RequestCount);
+        Assert.Equal(0, target.RequestCount);
+    }
+
+    [Fact]
+    public void DownloadProxyUsesHttpsScopeWithoutEmbeddingCredentials()
+    {
+        var option = new AriaSendOption
+        {
+            HttpsProxy = "http://127.0.0.1:7890/"
+        };
+
+        var json = JsonConvert.SerializeObject(option);
+
+        Assert.Contains("\"https-proxy\":\"http://127.0.0.1:7890/\"", json, StringComparison.Ordinal);
+        Assert.DoesNotContain("all-proxy", json, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("Proxy-Authorization", json, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/DownKyi.Core.Tests/AriaClientSecurityTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaClientSecurityTests.cs
@@ -3,6 +3,7 @@ using DownKyi.Core.Aria2cNet.Client;
 using DownKyi.Core.Aria2cNet.Client.Entity;
 using DownKyi.TestInfrastructure;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace DownKyi.Core.Tests;
 
@@ -36,13 +37,63 @@ public sealed class AriaClientSecurityTests
             new AriaClient("https://user:password@aria.example", 6800, "test-token"));
     }
 
-    [Theory]
-    [InlineData("")]
-    [InlineData("   ")]
-    public void RpcSecretMustNotBeEmpty(string token)
+    [Fact]
+    public async Task EmptyRpcSecretUsesTheUnauthenticatedAriaContract()
+    {
+        string? capturedPayload = null;
+        var client = new AriaClient(
+            "http://localhost",
+            6800,
+            string.Empty,
+            (_, payload) =>
+            {
+                capturedPayload = payload;
+                return Task.FromResult<string?>(
+                    "{\"id\":\"test\",\"jsonrpc\":\"2.0\",\"result\":{\"version\":\"1.37.0\",\"enabledFeatures\":[]}}");
+            });
+
+        var response = await client.GetAriaVersionAsync(
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("1.37.0", response.Result?.Version);
+        var request = JObject.Parse(Assert.IsType<string>(capturedPayload));
+        Assert.Empty(Assert.IsType<JArray>(request["params"]));
+    }
+
+    [Fact]
+    public void WhitespaceOnlyRpcSecretIsRejected()
     {
         Assert.Throws<ArgumentException>(() =>
-            new AriaClient("http://localhost", 6800, token));
+            new AriaClient("http://localhost", 6800, "   "));
+    }
+
+    [Fact]
+    public async Task CapabilityRequestPropagatesCancellationToTheRpcTransport()
+    {
+        CancellationToken observedToken = default;
+        var entered = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var client = new AriaClient(
+            "https://aria.example",
+            6800,
+            "test-token",
+            async (_, _, cancellationToken) =>
+            {
+                observedToken = cancellationToken;
+                entered.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                    .ConfigureAwait(false);
+                return null;
+            });
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+
+        var request = client.GetAriaVersionAsync(cancellation.Token);
+        await entered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => request);
+        Assert.Equal(cancellation.Token, observedToken);
     }
 
     [Fact]

--- a/tests/DownKyi.Core.Tests/AriaRpcSecretFileTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaRpcSecretFileTests.cs
@@ -1,0 +1,69 @@
+using DownKyi.Core.Aria2cNet.Server;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class AriaRpcSecretFileTests
+{
+    [Fact]
+    public void SecretFileIsPrivateAndRemovedAfterStartupUse()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-aria-secret-{Guid.NewGuid():N}");
+        const string secret = "test-secret-without-account-data";
+        try
+        {
+            var lease = AriaRpcSecretFile.Create(
+                directory,
+                secret,
+                NullLogger.Instance);
+            var path = lease.Path;
+
+            Assert.True(File.Exists(path));
+            Assert.Equal($"rpc-secret={secret}{Environment.NewLine}", File.ReadAllText(path));
+            if (!OperatingSystem.IsWindows())
+            {
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                    File.GetUnixFileMode(path));
+            }
+
+            lease.Dispose();
+
+            Assert.False(File.Exists(path));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("test\rsecret")]
+    [InlineData("test\nsecret")]
+    [InlineData("test\0secret")]
+    public void SecretFileRejectsControlCharacters(string secret)
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-aria-secret-{Guid.NewGuid():N}");
+        try
+        {
+            Assert.Throws<ArgumentException>(() => AriaRpcSecretFile.Create(
+                directory,
+                secret,
+                NullLogger.Instance));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+}

--- a/tests/DownKyi.Core.Tests/AriaServerProcessTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaServerProcessTests.cs
@@ -7,6 +7,39 @@ namespace DownKyi.Core.Tests;
 public sealed class AriaServerProcessTests
 {
     [Fact]
+    public void PackagedBinaryIntegrityAcceptsTheManifestDigest()
+    {
+        using var fixture = AriaBinaryFixture.Create("trusted aria2 binary");
+
+        AriaBinaryIntegrityVerifier.Verify(fixture.ExecutablePath);
+    }
+
+    [Fact]
+    public void PackagedBinaryIntegrityRejectsAReplacedExecutable()
+    {
+        using var fixture = AriaBinaryFixture.Create("trusted aria2 binary");
+        File.WriteAllText(fixture.ExecutablePath, "replaced aria2 binary");
+
+        var exception = Assert.Throws<InvalidDataException>(
+            () => AriaBinaryIntegrityVerifier.Verify(fixture.ExecutablePath));
+
+        Assert.Contains("integrity", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void PackagedBinaryIntegrityRejectsMissingOrMalformedSidecars()
+    {
+        using var fixture = AriaBinaryFixture.Create("trusted aria2 binary");
+        File.Delete(fixture.ChecksumPath);
+        Assert.Throws<FileNotFoundException>(
+            () => AriaBinaryIntegrityVerifier.Verify(fixture.ExecutablePath));
+
+        File.WriteAllText(fixture.ChecksumPath, "not-a-sha256");
+        Assert.Throws<InvalidDataException>(
+            () => AriaBinaryIntegrityVerifier.Verify(fixture.ExecutablePath));
+    }
+
+    [Fact]
     public async Task WindowsLifetimeJobTerminatesTheAssignedProcessWhenReleased()
     {
         if (!OperatingSystem.IsWindows())
@@ -41,25 +74,29 @@ public sealed class AriaServerProcessTests
             Split = 5,
             MinSplitSize = 10,
             ContinueDownload = true,
-            FileAllocation = AriaConfigFileAllocation.NONE,
-            Headers = ["Origin: https://www.bilibili.com"]
+            FileAllocation = AriaConfigFileAllocation.NONE
         };
 
         var arguments = AriaServer.BuildArguments(
             config,
+            "private rpc.conf",
             "aria.session",
             "aria.log",
             saveSessionInterval: 120,
             parentProcessId: 4242);
 
-        Assert.Contains("--stop-with-process=4242", arguments, StringComparison.Ordinal);
-        Assert.Contains("--rpc-listen-all=false", arguments, StringComparison.Ordinal);
-        Assert.Contains("--rpc-allow-origin-all=false", arguments, StringComparison.Ordinal);
-        Assert.DoesNotContain("--rpc-listen-all=true", arguments, StringComparison.Ordinal);
-        Assert.Contains("--input-file=\"aria.session\"", arguments, StringComparison.Ordinal);
-        Assert.Contains("--save-session=\"aria.session\"", arguments, StringComparison.Ordinal);
-        Assert.Contains("--continue=true", arguments, StringComparison.Ordinal);
-        Assert.Contains("--header=\"Origin: https://www.bilibili.com\"", arguments, StringComparison.Ordinal);
+        Assert.Contains("--conf-path=private rpc.conf", arguments);
+        Assert.Contains("--stop-with-process=4242", arguments);
+        Assert.Contains("--rpc-listen-all=false", arguments);
+        Assert.Contains("--rpc-allow-origin-all=false", arguments);
+        Assert.DoesNotContain("--rpc-listen-all=true", arguments);
+        Assert.DoesNotContain("--check-certificate=false", arguments);
+        Assert.Contains("--input-file=aria.session", arguments);
+        Assert.Contains("--save-session=aria.session", arguments);
+        Assert.Contains("--continue=true", arguments);
+        Assert.DoesNotContain(
+            arguments,
+            argument => argument.Contains(config.Token, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -101,5 +138,47 @@ public sealed class AriaServerProcessTests
 
         return Process.Start(startInfo)
                ?? throw new InvalidOperationException("Could not start the process used by the cleanup test.");
+    }
+
+    private sealed class AriaBinaryFixture : IDisposable
+    {
+        private AriaBinaryFixture(string rootPath, string executablePath)
+        {
+            RootPath = rootPath;
+            ExecutablePath = executablePath;
+        }
+
+        public string RootPath { get; }
+
+        public string ExecutablePath { get; }
+
+        public string ChecksumPath =>
+            ExecutablePath + AriaBinaryIntegrityVerifier.ChecksumSidecarSuffix;
+
+        public static AriaBinaryFixture Create(string content)
+        {
+            var rootPath = Path.Combine(
+                Path.GetTempPath(),
+                $"downkyi-aria-integrity-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(rootPath);
+            var executablePath = Path.Combine(rootPath, "aria2c-test");
+            File.WriteAllText(executablePath, content);
+            var hash = Convert.ToHexString(
+                    System.Security.Cryptography.SHA256.HashData(
+                        System.Text.Encoding.UTF8.GetBytes(content)))
+                .ToUpperInvariant();
+            File.WriteAllText(
+                executablePath + AriaBinaryIntegrityVerifier.ChecksumSidecarSuffix,
+                hash);
+            return new AriaBinaryFixture(rootPath, executablePath);
+        }
+
+        public void Dispose()
+        {
+            if (Directory.Exists(RootPath))
+            {
+                Directory.Delete(RootPath, recursive: true);
+            }
+        }
     }
 }

--- a/tests/DownKyi.Core.Tests/AriaServerProcessTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaServerProcessTests.cs
@@ -126,6 +126,64 @@ public sealed class AriaServerProcessTests
         }
     }
 
+    [Fact]
+    public async Task WindowsStartupFailureWaitsForChildExitBeforeDeletingRpcSecret()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-aria-secret-exit-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        var readyPath = Path.Combine(directory, "child-ready");
+        var server = new AriaServer(NullLoggerFactory.Instance);
+        Process? process = null;
+        try
+        {
+            using var secretFile = AriaRpcSecretFile.Create(
+                directory,
+                "fixture-secret",
+                NullLogger.Instance);
+            var secretPath = secretFile.Path;
+            server.SetStartupSecretForTests(secretFile);
+            process = StartSecretHoldingProcess(secretPath, readyPath);
+            server.SetTrackedServerForTests(process);
+            using var readyTimeout = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+            readyTimeout.CancelAfter(TimeSpan.FromSeconds(5));
+            while (!File.Exists(readyPath))
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(20), readyTimeout.Token)
+                    .ConfigureAwait(true);
+            }
+
+            Assert.True(server.KillTrackedServer("test startup cleanup"));
+
+            Assert.True(process.HasExited);
+            Assert.False(File.Exists(secretPath));
+            Assert.False(server.HasTrackedServerForTests());
+        }
+        finally
+        {
+            server.SetStartupSecretForTests(null);
+            server.SetTrackedServerForTests(null);
+            if (process is { HasExited: false })
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(true);
+            }
+
+            process?.Dispose();
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
     private static Process StartLongRunningProcess()
     {
         var startInfo = OperatingSystem.IsWindows()
@@ -138,6 +196,34 @@ public sealed class AriaServerProcessTests
 
         return Process.Start(startInfo)
                ?? throw new InvalidOperationException("Could not start the process used by the cleanup test.");
+    }
+
+    private static Process StartSecretHoldingProcess(
+        string secretPath,
+        string readyPath)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-NoLogo");
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(
+            "$stream = [System.IO.File]::Open($env:DOWNKYI_SECRET_PATH, " +
+            "[System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, " +
+            "[System.IO.FileShare]::Read); " +
+            "[System.IO.File]::WriteAllText($env:DOWNKYI_READY_PATH, 'ready'); " +
+            "Start-Sleep -Seconds 30");
+        startInfo.Environment["DOWNKYI_SECRET_PATH"] = secretPath;
+        startInfo.Environment["DOWNKYI_READY_PATH"] = readyPath;
+
+        return Process.Start(startInfo)
+               ?? throw new InvalidOperationException(
+                   "Could not start the process used by the secret cleanup test.");
     }
 
     private sealed class AriaBinaryFixture : IDisposable

--- a/tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj
+++ b/tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DownKyi.Application\DownKyi.Application.csproj" />
     <ProjectReference Include="..\..\DownKyi.Core\DownKyi.Core.csproj" />
+    <ProjectReference Include="..\TestInfrastructure\DownKyi.TestInfrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DownKyi.Core.Tests/EnumValueContractTests.cs
+++ b/tests/DownKyi.Core.Tests/EnumValueContractTests.cs
@@ -87,7 +87,9 @@ public sealed class EnumValueContractTests
     private sealed class TestAriaManager : AriaManager
     {
         public TestAriaManager()
-            : base(new AriaClient(), NullLogger<AriaManager>.Instance)
+            : base(
+                new AriaClient("http://localhost", 35076, "test-token"),
+                NullLogger<AriaManager>.Instance)
         {
         }
 

--- a/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
+++ b/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
@@ -8,6 +8,143 @@ namespace DownKyi.Core.Tests;
 public sealed class SettingsStoreTests
 {
     [Fact]
+    public async Task LegacyPlainHttpSettingIsMigratedToRequiredHttps()
+    {
+        var directory = CreateTestDirectory();
+        var settingsPath = Path.Combine(directory, "settings.json");
+        const string source = """
+            {
+              "Network": {
+                "UseSsl": 1
+              }
+            }
+            """;
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                settingsPath,
+                source,
+                TestContext.Current.CancellationToken);
+            using var store = new SettingsStore(settingsPath);
+
+            Assert.Null(typeof(NetworkApplicationSettings).GetProperty("UseSsl"));
+
+            await store.FlushAsync(TestContext.Current.CancellationToken);
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(
+                settingsPath,
+                TestContext.Current.CancellationToken));
+            Assert.False(document.RootElement.GetProperty("Network").TryGetProperty(
+                "UseSsl",
+                out _));
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public async Task RemotePlaintextAriaRpcSettingIsRestoredToLoopback()
+    {
+        var directory = CreateTestDirectory();
+        var settingsPath = Path.Combine(directory, "settings.json");
+        const string source = """
+            {
+              "Network": {
+                "AriaHost": "http://192.0.2.10"
+              }
+            }
+            """;
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                settingsPath,
+                source,
+                TestContext.Current.CancellationToken);
+            using var store = new SettingsStore(settingsPath);
+
+            Assert.Equal("http://localhost", store.Current.Network.AriaHost);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public async Task LegacyRemoteAriaDownloadProxyIsDisabledAndRemoved()
+    {
+        var directory = CreateTestDirectory();
+        var settingsPath = Path.Combine(directory, "settings.json");
+        const string source = """
+            {
+              "Network": {
+                "IsAriaHttpProxy": 2,
+                "AriaHttpProxy": "192.0.2.10",
+                "AriaHttpProxyListenPort": 7890
+              }
+            }
+            """;
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                settingsPath,
+                source,
+                TestContext.Current.CancellationToken);
+            using var store = new SettingsStore(settingsPath);
+
+            Assert.Equal(AllowStatus.No, store.Current.Network.IsAriaHttpProxy);
+            Assert.Empty(store.Current.Network.AriaHttpProxy);
+
+            await store.FlushAsync(TestContext.Current.CancellationToken);
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(
+                settingsPath,
+                TestContext.Current.CancellationToken));
+            var network = document.RootElement.GetProperty("Network");
+            Assert.Equal(1, network.GetProperty("IsAriaHttpProxy").GetInt32());
+            Assert.Equal(string.Empty, network.GetProperty("AriaHttpProxy").GetString());
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void LocalAriaDownloadProxySurvivesValidationAsHttpConnectEndpoint()
+    {
+        var directory = CreateTestDirectory();
+        try
+        {
+            using var store = new SettingsStore(Path.Combine(directory, "settings.json"));
+            var updated = store.Update(settings => settings with
+            {
+                Network = settings.Network with
+                {
+                    IsAriaHttpProxy = AllowStatus.Yes,
+                    AriaHttpProxy = "[::1]",
+                    AriaHttpProxyListenPort = 7890
+                }
+            });
+
+            Assert.Equal(AllowStatus.Yes, updated.Network.IsAriaHttpProxy);
+            Assert.Equal("::1", updated.Network.AriaHttpProxy);
+            Assert.True(AriaHttpsProxyPolicy.TryCreateConnectProxyUri(
+                updated.Network.AriaHttpProxy,
+                updated.Network.AriaHttpProxyListenPort,
+                out var proxyUri));
+            Assert.Equal("http://[::1]:7890/", proxyUri.AbsoluteUri);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
     public async Task NewStoreDoesNotPersistDefaultsUntilASettingChanges()
     {
         var directory = CreateTestDirectory();

--- a/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
+++ b/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using DownKyi.Core.Aria2cNet.Client;
 using DownKyi.Core.FileName;
 using DownKyi.Core.Settings;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -7,6 +8,38 @@ namespace DownKyi.Core.Tests;
 
 public sealed class SettingsStoreTests
 {
+    [Fact]
+    public void CustomAriaAcceptsTheDefaultEmptyRpcSecretWithoutBootstrapFailure()
+    {
+        var directory = CreateTestDirectory();
+        try
+        {
+            using var store = new SettingsStore(Path.Combine(directory, "settings.json"));
+            var updated = store.Update(settings => settings with
+            {
+                Network = settings.Network with
+                {
+                    Downloader = Downloader.CustomAria,
+                    AriaHost = "https://aria.example",
+                    AriaToken = string.Empty
+                }
+            });
+
+            var client = new AriaClient(
+                updated.Network.AriaHost,
+                updated.Network.AriaListenPort,
+                updated.Network.AriaToken);
+
+            Assert.NotNull(client);
+            Assert.Equal(Downloader.CustomAria, updated.Network.Downloader);
+            Assert.Empty(updated.Network.AriaToken);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
     [Fact]
     public async Task LegacyPlainHttpSettingIsMigratedToRequiredHttps()
     {
@@ -66,6 +99,70 @@ public sealed class SettingsStoreTests
             using var store = new SettingsStore(settingsPath);
 
             Assert.Equal("http://localhost", store.Current.Network.AriaHost);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public async Task CredentialBearingAriaRpcSettingIsRestoredBeforeBootstrap()
+    {
+        var directory = CreateTestDirectory();
+        var settingsPath = Path.Combine(directory, "settings.json");
+        const string source = """
+            {
+              "Network": {
+                "Downloader": 3,
+                "AriaHost": "https://user:password@aria.example"
+              }
+            }
+            """;
+
+        try
+        {
+            await File.WriteAllTextAsync(
+                settingsPath,
+                source,
+                TestContext.Current.CancellationToken);
+            using var store = new SettingsStore(settingsPath);
+
+            Assert.Equal("http://localhost", store.Current.Network.AriaHost);
+            Assert.Empty(new Uri(store.Current.Network.AriaHost).UserInfo);
+
+            await store.FlushAsync(TestContext.Current.CancellationToken);
+            using var document = JsonDocument.Parse(await File.ReadAllTextAsync(
+                settingsPath,
+                TestContext.Current.CancellationToken));
+            Assert.Equal(
+                "http://localhost",
+                document.RootElement.GetProperty("Network").GetProperty("AriaHost").GetString());
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
+    public void CredentialBearingAriaRpcUpdateIsRejectedByTheSnapshotContract()
+    {
+        var directory = CreateTestDirectory();
+        try
+        {
+            using var store = new SettingsStore(Path.Combine(directory, "settings.json"));
+
+            var updated = store.Update(settings => settings with
+            {
+                Network = settings.Network with
+                {
+                    AriaHost = "https://user:password@aria.example"
+                }
+            });
+
+            Assert.Equal("http://localhost", updated.Network.AriaHost);
+            Assert.Empty(new Uri(updated.Network.AriaHost).UserInfo);
         }
         finally
         {

--- a/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
@@ -146,7 +146,11 @@ public sealed partial class Aria2TlsIntegrationTests
                 "unknown-ca",
                 unknownCertificate,
                 payload,
-                ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"],
+                [
+                    "download.transfer.tls.untrusted",
+                    "download.transfer.tls.handshake",
+                    "download.transfer.tls.chain"
+                ],
                 results,
                 cancellationToken).ConfigureAwait(true);
             await RunRejectedCertificateAsync(
@@ -154,7 +158,11 @@ public sealed partial class Aria2TlsIntegrationTests
                 "self-signed",
                 selfSignedCertificate,
                 payload,
-                ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"],
+                [
+                    "download.transfer.tls.untrusted",
+                    "download.transfer.tls.handshake",
+                    "download.transfer.tls.chain"
+                ],
                 results,
                 cancellationToken).ConfigureAwait(true);
             await RunRejectedCertificateAsync(
@@ -162,7 +170,11 @@ public sealed partial class Aria2TlsIntegrationTests
                 "expired",
                 expiredCertificate,
                 payload,
-                ["download.transfer.tls.expired", "download.transfer.tls.handshake"],
+                [
+                    "download.transfer.tls.expired",
+                    "download.transfer.tls.handshake",
+                    "download.transfer.tls.chain"
+                ],
                 results,
                 cancellationToken).ConfigureAwait(true);
             await RunRejectedCertificateAsync(
@@ -170,7 +182,12 @@ public sealed partial class Aria2TlsIntegrationTests
                 "not-yet-valid",
                 notYetValidCertificate,
                 payload,
-                ["download.transfer.tls.not-yet-valid", "download.transfer.tls.handshake"],
+                [
+                    "download.transfer.tls.not-yet-valid",
+                    "download.transfer.tls.expired",
+                    "download.transfer.tls.handshake",
+                    "download.transfer.tls.chain"
+                ],
                 results,
                 cancellationToken).ConfigureAwait(true);
             await RunRejectedCertificateAsync(
@@ -178,7 +195,11 @@ public sealed partial class Aria2TlsIntegrationTests
                 "hostname-mismatch",
                 hostnameMismatchCertificate,
                 payload,
-                ["download.transfer.tls.hostname", "download.transfer.tls.handshake"],
+                [
+                    "download.transfer.tls.hostname",
+                    "download.transfer.tls.handshake",
+                    "download.transfer.tls.chain"
+                ],
                 results,
                 cancellationToken).ConfigureAwait(true);
             await RunRejectedCertificateAsync(
@@ -186,7 +207,11 @@ public sealed partial class Aria2TlsIntegrationTests
                 "missing-san-wrong-common-name",
                 missingSanCertificate,
                 payload,
-                ["download.transfer.tls.hostname", "download.transfer.tls.handshake"],
+                [
+                    "download.transfer.tls.hostname",
+                    "download.transfer.tls.handshake",
+                    "download.transfer.tls.chain"
+                ],
                 results,
                 cancellationToken).ConfigureAwait(true);
             await RunRejectedCertificateAsync(
@@ -234,7 +259,10 @@ public sealed partial class Aria2TlsIntegrationTests
         List<Aria2TlsCaseResult> results,
         CancellationToken cancellationToken)
     {
-        var server = new LoopbackTlsFileServer(_ => certificate, payload);
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            chunkDelay: TimeSpan.FromMilliseconds(10));
         await using var serverLifetime = server.ConfigureAwait(false);
         const string outputName = "trusted-split.bin";
         var gid = await runtime.AddDownloadAsync(
@@ -335,7 +363,11 @@ public sealed partial class Aria2TlsIntegrationTests
             status,
             runtime.GetOutputPath(outputName),
             payload,
-            ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"]);
+            [
+                "download.transfer.tls.untrusted",
+                "download.transfer.tls.handshake",
+                "download.transfer.tls.chain"
+            ]);
 
         Assert.Contains("localhost:443", proxy.ConnectAuthorities);
         Assert.Equal(0, proxy.AbsoluteUriRequestCount);
@@ -470,7 +502,11 @@ public sealed partial class Aria2TlsIntegrationTests
             status,
             runtime.GetOutputPath(outputName),
             payload,
-            ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"]);
+            [
+                "download.transfer.tls.untrusted",
+                "download.transfer.tls.handshake",
+                "download.transfer.tls.chain"
+            ]);
         Assert.NotEmpty(redirect.Requests);
         results.Add(new Aria2TlsCaseResult(
             "trusted-redirect-to-untrusted",
@@ -522,7 +558,11 @@ public sealed partial class Aria2TlsIntegrationTests
             status,
             runtime.GetOutputPath(outputName),
             payload,
-            ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"]);
+            [
+                "download.transfer.tls.untrusted",
+                "download.transfer.tls.handshake",
+                "download.transfer.tls.chain"
+            ]);
         Assert.True(server.ConnectionCount >= 2);
         results.Add(new Aria2TlsCaseResult(
             "application-retry-resumes-to-untrusted",

--- a/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
@@ -76,6 +76,7 @@ public sealed partial class Aria2TlsIntegrationTests
             await RunPreflightThenActualDowngradeRejectedAsync(
                 runtime,
                 trustedCertificate,
+                trustedAuthority.RootCertificate,
                 payload,
                 results,
                 cancellationToken).ConfigureAwait(true);

--- a/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
@@ -1,0 +1,715 @@
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Text.Json;
+using DownKyi.Core.Aria2cNet.Client.Entity;
+using DownKyi.Services.Download;
+using DownKyi.TestInfrastructure;
+
+namespace DownKyi.Tests;
+
+public sealed partial class Aria2TlsIntegrationTests
+{
+    private const int ExpectedCaseCount = 26;
+    private static readonly TimeSpan DownloadTimeout = TimeSpan.FromSeconds(20);
+    private static readonly JsonSerializerOptions ReportJsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    public async Task PackagedAria2EnforcesCertificateValidationAcrossTransferFlows()
+    {
+        var binaryPath = Environment.GetEnvironmentVariable("DOWNKYI_ARIA2_BINARY");
+        if (string.IsNullOrWhiteSpace(binaryPath))
+        {
+            Assert.Skip("DOWNKYI_ARIA2_BINARY is required for the packaged aria2 TLS integration test.");
+        }
+
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var payload = CreatePayload(4 * 1024 * 1024 + 257);
+        using var trustedAuthority = new TestCertificateAuthority(
+            $"DownKyi TLS Test {Guid.NewGuid():N}");
+        using var unknownAuthority = new TestCertificateAuthority(
+            $"DownKyi Unknown TLS Test {Guid.NewGuid():N}");
+        using var trustedCertificate = trustedAuthority.IssueServerCertificate();
+        using var unknownCertificate = unknownAuthority.IssueServerCertificate();
+        using var selfSignedCertificate =
+            TestCertificateAuthority.CreateSelfSignedServerCertificate();
+        using var expiredCertificate = trustedAuthority.IssueServerCertificate(
+            notBefore: DateTimeOffset.UtcNow.AddHours(-12),
+            notAfter: DateTimeOffset.UtcNow.AddHours(-6));
+        using var notYetValidCertificate = trustedAuthority.IssueServerCertificate(
+            notBefore: DateTimeOffset.UtcNow.AddHours(6),
+            notAfter: DateTimeOffset.UtcNow.AddHours(18));
+        using var hostnameMismatchCertificate = trustedAuthority.IssueServerCertificate(
+            dnsSubjectAlternativeName: "wrong.invalid");
+        using var missingSanCertificate = trustedAuthority.IssueServerCertificate(
+            commonName: "wrong.invalid",
+            dnsSubjectAlternativeName: null);
+        using var intermediateCertificate =
+            trustedAuthority.IssueIntermediateCertificate("DownKyi Test Intermediate");
+        using var incompleteChainCertificate = trustedAuthority.IssueServerCertificate(
+            issuer: intermediateCertificate);
+
+        var runtime = await Aria2TlsTestRuntime.StartAsync(
+            binaryPath,
+            trustedAuthority.RootCertificate,
+            cancellationToken).ConfigureAwait(true);
+        await using var runtimeLifetime = runtime.ConfigureAwait(false);
+        var results = new List<Aria2TlsCaseResult>();
+        try
+        {
+            await RunTrustedSplitDownloadAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunHttpsRedirectToHttpRejectedAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunPreflightThenActualDowngradeRejectedAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunHeadSafeGetDowngradeRejectedAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRangeDowngradeRejectedAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunSecondRoundDowngradeRejectedAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunSensitiveCrossOriginRedirectsRejectedAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunSameOriginHttpsRedirectAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunCrossOriginHttpsRedirectAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunTrustedConnectProxyDownloadAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunProxyInterceptionRejectedAsync(
+                runtime,
+                unknownCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunTrustedResumeAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRpcRemovalAsync(
+                runtime,
+                trustedCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+
+            await RunRejectedCertificateAsync(
+                runtime,
+                "unknown-ca",
+                unknownCertificate,
+                payload,
+                ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"],
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRejectedCertificateAsync(
+                runtime,
+                "self-signed",
+                selfSignedCertificate,
+                payload,
+                ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"],
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRejectedCertificateAsync(
+                runtime,
+                "expired",
+                expiredCertificate,
+                payload,
+                ["download.transfer.tls.expired", "download.transfer.tls.handshake"],
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRejectedCertificateAsync(
+                runtime,
+                "not-yet-valid",
+                notYetValidCertificate,
+                payload,
+                ["download.transfer.tls.not-yet-valid", "download.transfer.tls.handshake"],
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRejectedCertificateAsync(
+                runtime,
+                "hostname-mismatch",
+                hostnameMismatchCertificate,
+                payload,
+                ["download.transfer.tls.hostname", "download.transfer.tls.handshake"],
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRejectedCertificateAsync(
+                runtime,
+                "missing-san-wrong-common-name",
+                missingSanCertificate,
+                payload,
+                ["download.transfer.tls.hostname", "download.transfer.tls.handshake"],
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRejectedCertificateAsync(
+                runtime,
+                "incomplete-chain",
+                incompleteChainCertificate,
+                payload,
+                [
+                    "download.transfer.tls.chain",
+                    "download.transfer.tls.untrusted",
+                    "download.transfer.tls.handshake"
+                ],
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunRedirectToUntrustedAsync(
+                runtime,
+                trustedCertificate,
+                unknownCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+            await RunResumeToUntrustedAsync(
+                runtime,
+                trustedCertificate,
+                unknownCertificate,
+                payload,
+                results,
+                cancellationToken).ConfigureAwait(true);
+
+            Assert.All(results, result => Assert.True(result.Passed, result.Name));
+        }
+        finally
+        {
+            await WriteReportAsync(
+                runtime,
+                results,
+                CancellationToken.None).ConfigureAwait(true);
+        }
+    }
+
+    private static async Task RunTrustedSplitDownloadAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var server = new LoopbackTlsFileServer(_ => certificate, payload);
+        await using var serverLifetime = server.ConfigureAwait(false);
+        const string outputName = "trusted-split.bin";
+        var gid = await runtime.AddDownloadAsync(
+            server.Url,
+            outputName,
+            split: 4,
+            maximumTries: 1,
+            headers: ["X-DownKyi-Tls-Test: trusted"],
+            cancellationToken).ConfigureAwait(false);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        var outputPath = runtime.GetOutputPath(outputName);
+        AssertCompleted(status, "trusted-split", server.Failures);
+        AssertPayload(payload, outputPath);
+        Assert.Contains(
+            server.Requests,
+            request => request.RangeStart > 0);
+        Assert.Contains(
+            server.Requests,
+            request => request.Headers.TryGetValue("X-DownKyi-Tls-Test", out var value)
+                && string.Equals(value, "trusted", StringComparison.Ordinal));
+        results.Add(new Aria2TlsCaseResult("trusted-split", true, "complete"));
+    }
+
+    private static async Task RunTrustedConnectProxyDownloadAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var server = new LoopbackTlsFileServer(_ => certificate, payload);
+        await using var serverLifetime = server.ConfigureAwait(false);
+        var proxy = new LoopbackHttpConnectProxy();
+        await using var proxyLifetime = proxy.ConfigureAwait(false);
+        const string outputName = "trusted-connect-proxy.bin";
+        var url = new UriBuilder(server.Url)
+        {
+            Query = "signature=fixture"
+        }.Uri;
+        var gid = await runtime.AddDownloadAsync(
+            url,
+            outputName,
+            split: 1,
+            maximumTries: 1,
+            headers: ["Cookie: test-session=fixture"],
+            httpsProxy: proxy.Address.AbsoluteUri,
+            cancellationToken).ConfigureAwait(false);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+
+        AssertCompleted(status, "trusted-local-connect-proxy", server.Failures);
+        AssertPayload(payload, runtime.GetOutputPath(outputName));
+        Assert.NotEmpty(proxy.ConnectAuthorities);
+        Assert.All(
+            proxy.ConnectAuthorities,
+            authority => Assert.Equal($"localhost:{server.Url.Port}", authority));
+        Assert.Equal(0, proxy.AbsoluteUriRequestCount);
+        Assert.Equal(0, proxy.CookieHeaderCount);
+        Assert.Equal(0, proxy.ProxyAuthorizationHeaderCount);
+        Assert.Equal(0, proxy.NonConnectRequestCount);
+        Assert.Contains(
+            server.Requests,
+            request => request.Headers.ContainsKey("Cookie"));
+        results.Add(new Aria2TlsCaseResult(
+            "trusted-local-connect-proxy",
+            true,
+            "connect-authority-only"));
+    }
+
+    private static async Task RunProxyInterceptionRejectedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 unknownCertificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var proxy = new LoopbackHttpConnectProxy(unknownCertificate);
+        await using var proxyLifetime = proxy.ConfigureAwait(false);
+        const string outputName = "proxy-untrusted-interception.bin";
+        var gid = await runtime.AddDownloadAsync(
+            new Uri("https://localhost:443/media.bin"),
+            outputName,
+            split: 1,
+            maximumTries: 1,
+            headers: ["Cookie: test-session=fixture"],
+            httpsProxy: proxy.Address.AbsoluteUri,
+            cancellationToken).ConfigureAwait(false);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        var classification = AssertRejectedTlsStatus(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"]);
+
+        Assert.Contains("localhost:443", proxy.ConnectAuthorities);
+        Assert.Equal(0, proxy.AbsoluteUriRequestCount);
+        Assert.Equal(0, proxy.CookieHeaderCount);
+        Assert.Equal(0, proxy.ProxyAuthorizationHeaderCount);
+        Assert.Equal(0, proxy.NonConnectRequestCount);
+        results.Add(new Aria2TlsCaseResult(
+            "proxy-untrusted-interception",
+            true,
+            classification));
+    }
+
+    private static async Task RunTrustedResumeAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            truncateFirstResponse: true);
+        await using var serverLifetime = server.ConfigureAwait(false);
+        const string outputName = "trusted-resume.bin";
+        var gid = await runtime.AddDownloadAsync(
+            server.Url,
+            outputName,
+            split: 1,
+            maximumTries: 2,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        AssertCompleted(status, "trusted-resume", server.Failures);
+        AssertPayload(payload, runtime.GetOutputPath(outputName));
+        Assert.Contains(server.Requests, request => request.RangeStart > 0);
+        results.Add(new Aria2TlsCaseResult("trusted-resume", true, "complete"));
+    }
+
+    private static async Task RunRpcRemovalAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            chunkDelay: TimeSpan.FromMilliseconds(100));
+        await using var serverLifetime = server.ConfigureAwait(false);
+        var gid = await runtime.AddDownloadAsync(
+            server.Url,
+            "rpc-removal.bin",
+            split: 1,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        await WaitForActiveStatusAsync(runtime, gid, cancellationToken).ConfigureAwait(false);
+        var removed = await runtime.Client.ForceRemoveAsync(gid).ConfigureAwait(false);
+        Assert.Equal(gid, removed.Result);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        Assert.Equal("removed", status.Status);
+        results.Add(new Aria2TlsCaseResult("rpc-add-query-remove", true, "removed"));
+    }
+
+    private static async Task RunRejectedCertificateAsync(
+        Aria2TlsTestRuntime runtime,
+        string name,
+        X509Certificate2 certificate,
+        byte[] payload,
+        IReadOnlyList<string> acceptedErrorCodes,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var server = new LoopbackTlsFileServer(_ => certificate, payload);
+        await using var serverLifetime = server.ConfigureAwait(false);
+        var outputName = $"rejected-{name}.bin";
+        var gid = await runtime.AddDownloadAsync(
+            server.Url,
+            outputName,
+            split: 1,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        var classification = AssertRejectedTlsStatus(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            acceptedErrorCodes);
+        results.Add(new Aria2TlsCaseResult(name, true, classification));
+    }
+
+    private static async Task RunRedirectToUntrustedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 trustedCertificate,
+        X509Certificate2 unknownCertificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var target = new LoopbackTlsFileServer(_ => unknownCertificate, payload);
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => trustedCertificate,
+            [],
+            redirectTarget: target.Url);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+        const string outputName = "redirect-to-untrusted.bin";
+        var gid = await runtime.AddDownloadAsync(
+            redirect.Url,
+            outputName,
+            split: 1,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        var classification = AssertRejectedTlsStatus(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"]);
+        Assert.NotEmpty(redirect.Requests);
+        results.Add(new Aria2TlsCaseResult(
+            "trusted-redirect-to-untrusted",
+            true,
+            classification));
+    }
+
+    private static async Task RunResumeToUntrustedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 trustedCertificate,
+        X509Certificate2 unknownCertificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var server = new LoopbackTlsFileServer(
+            connection => connection == 1 ? trustedCertificate : unknownCertificate,
+            payload,
+            truncateFirstResponse: true);
+        await using var serverLifetime = server.ConfigureAwait(false);
+        const string outputName = "resume-to-untrusted.bin";
+        var gid = await runtime.AddDownloadAsync(
+            server.Url,
+            outputName,
+            split: 1,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        var interruptedStatus = await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        Assert.Equal("error", interruptedStatus.Status);
+        Assert.Equal(1, server.ConnectionCount);
+        await runtime.Client.RemoveDownloadResultAsync(gid).ConfigureAwait(false);
+
+        var retryGid = await runtime.AddDownloadAsync(
+            server.Url,
+            outputName,
+            split: 1,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        var status = await runtime.WaitForTerminalStatusAsync(
+            retryGid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        var classification = AssertRejectedTlsStatus(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            ["download.transfer.tls.untrusted", "download.transfer.tls.handshake"]);
+        Assert.True(server.ConnectionCount >= 2);
+        results.Add(new Aria2TlsCaseResult(
+            "application-retry-resumes-to-untrusted",
+            true,
+            classification));
+    }
+
+    private static string AssertRejectedTlsStatus(
+        AriaTellStatusResult status,
+        string outputPath,
+        byte[] payload,
+        IReadOnlyList<string> acceptedErrorCodes)
+    {
+        Assert.Equal("error", status.Status);
+        Assert.Equal("1", status.ErrorCode);
+        Assert.True(
+            TlsFailureClassifier.TryClassify(status.ErrorMessage, out var errorCode),
+            "aria2 TLS failure was not classified as a safe TLS diagnostic.");
+        Assert.Contains(errorCode, acceptedErrorCodes);
+        Assert.False(IsCompletePayload(payload, outputPath));
+        return errorCode;
+    }
+
+    private static void AssertCompleted(
+        AriaTellStatusResult status,
+        string caseName,
+        IReadOnlyList<Exception> serverFailures)
+    {
+        TlsFailureClassifier.TryClassify(status.ErrorMessage, out var tlsErrorCode);
+        var serverFailure = serverFailures.Count > 0 ? serverFailures[0] : null;
+        Assert.True(
+            string.Equals(status.Status, "complete", StringComparison.Ordinal),
+            $"{caseName} failed with aria2 code '{status.ErrorCode}', TLS category '{tlsErrorCode}', and server failure type '{serverFailure?.GetType().Name}'.");
+    }
+
+    private static async Task WaitForActiveStatusAsync(
+        Aria2TlsTestRuntime runtime,
+        string gid,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + DownloadTimeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var response = await runtime.Client.TellStatus(gid).ConfigureAwait(false);
+            if (response.Result is { } status
+                && (string.Equals(status.Status, "active", StringComparison.Ordinal)
+                    || string.Equals(status.Status, "waiting", StringComparison.Ordinal)))
+            {
+                return;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(25), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new TimeoutException("aria2 did not expose an active task before removal.");
+    }
+
+    private static void AssertPayload(byte[] expected, string path)
+    {
+        Assert.True(File.Exists(path));
+        Assert.Equal(expected.LongLength, new FileInfo(path).Length);
+        Assert.Equal(SHA256.HashData(expected), SHA256.HashData(File.ReadAllBytes(path)));
+    }
+
+    private static bool IsCompletePayload(byte[] expected, string path)
+    {
+        return File.Exists(path)
+            && new FileInfo(path).Length == expected.LongLength
+            && SHA256.HashData(expected).SequenceEqual(
+                SHA256.HashData(File.ReadAllBytes(path)));
+    }
+
+    private static byte[] CreatePayload(int length)
+    {
+        var payload = new byte[length];
+        for (var index = 0; index < payload.Length; index++)
+        {
+            payload[index] = (byte)(index % 251);
+        }
+
+        return payload;
+    }
+
+    private static async Task WriteReportAsync(
+        Aria2TlsTestRuntime runtime,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var reportPath = Environment.GetEnvironmentVariable("DOWNKYI_ARIA2_TLS_REPORT");
+        if (string.IsNullOrWhiteSpace(reportPath))
+        {
+            return;
+        }
+
+        var directory = Path.GetDirectoryName(Path.GetFullPath(reportPath));
+        if (directory != null)
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        var report = new Aria2TlsReport(
+            SchemaVersion: 2,
+            Complete: results.Count == ExpectedCaseCount,
+            Passed: results.Count == ExpectedCaseCount && results.All(result => result.Passed),
+            Runtime: RuntimeInformation.FrameworkDescription,
+            OperatingSystem: RuntimeInformation.OSDescription,
+            Architecture: RuntimeInformation.ProcessArchitecture.ToString(),
+            RuntimeIdentifier: RuntimeInformation.RuntimeIdentifier,
+            AssetRuntimeIdentifier: Environment.GetEnvironmentVariable("DOWNKYI_ARIA2_RID")
+                ?? "unspecified",
+            CommitSha: Environment.GetEnvironmentVariable("GITHUB_SHA") ?? "unavailable",
+            AriaVersion: runtime.AriaVersion,
+            BinarySha256: runtime.BinarySha256,
+            RequiredFeature: Aria2TlsTestRuntime.SecureRedirectFeature,
+            TlsBackend: GetTlsBackend(),
+            CertificateAuthoritySource: runtime.CertificateAuthoritySource,
+            Cases: results);
+        var reportJson = JsonSerializer.Serialize(report, ReportJsonOptions);
+        AssertSanitizedReport(reportJson);
+        await File.WriteAllTextAsync(
+            reportPath,
+            reportJson,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void AssertSanitizedReport(string reportJson)
+    {
+        string[] forbiddenTerms =
+        {
+            "test-session=fixture",
+            "Bearer fixture",
+            "Basic Zml4dHVyZQ==",
+            "X-Access-Token: fixture",
+            "X-API-Key: fixture",
+            "sessdata",
+            "bili_jct",
+            "dedeuserid",
+            "http://",
+            "https://",
+            "C:\\Users\\",
+            "/Users/",
+            "/home/"
+        };
+        foreach (var forbiddenTerm in forbiddenTerms)
+        {
+            Assert.DoesNotContain(
+                forbiddenTerm,
+                reportJson,
+                StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string GetTlsBackend()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return "WinTLS";
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            return "AppleTLS";
+        }
+
+        return "OpenSSL";
+    }
+}
+
+internal sealed record Aria2TlsCaseResult(
+    string Name,
+    bool Passed,
+    string Outcome);
+
+internal sealed record Aria2TlsReport(
+    int SchemaVersion,
+    bool Complete,
+    bool Passed,
+    string Runtime,
+    string OperatingSystem,
+    string Architecture,
+    string RuntimeIdentifier,
+    string AssetRuntimeIdentifier,
+    string CommitSha,
+    string AriaVersion,
+    string BinarySha256,
+    string RequiredFeature,
+    string TlsBackend,
+    string CertificateAuthoritySource,
+    IReadOnlyCollection<Aria2TlsCaseResult> Cases);

--- a/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
@@ -47,6 +47,7 @@ public sealed partial class Aria2TlsIntegrationTests
     private static async Task RunPreflightThenActualDowngradeRejectedAsync(
         Aria2TlsTestRuntime runtime,
         X509Certificate2 certificate,
+        X509Certificate2 trustedRoot,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
         CancellationToken cancellationToken)
@@ -58,7 +59,7 @@ public sealed partial class Aria2TlsIntegrationTests
             payload,
             redirectFactory: (connection, _) => connection > 1 ? target.Url : null);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
-        using var resolver = AriaDownloadAddressResolver.Create(proxyAddress: null);
+        using var resolver = CreateTrustedAddressResolver(trustedRoot);
         var resolution = await resolver.ResolveAsync(
             redirect.Url.AbsoluteUri,
             "DownKyi-TLS-Test",
@@ -88,6 +89,38 @@ public sealed partial class Aria2TlsIntegrationTests
             "preflight-safe-actual-downgrade",
             true,
             "zero-http-requests"));
+    }
+
+    private static AriaDownloadAddressResolver CreateTrustedAddressResolver(
+        X509Certificate2 trustedRoot)
+    {
+        var chainPolicy = new X509ChainPolicy
+        {
+            TrustMode = X509ChainTrustMode.CustomRootTrust,
+            RevocationMode = X509RevocationMode.NoCheck
+        };
+        chainPolicy.CustomTrustStore.Add(trustedRoot);
+
+        SocketsHttpHandler? handler = new()
+        {
+            AllowAutoRedirect = false,
+            AutomaticDecompression = DecompressionMethods.None,
+            ConnectTimeout = TimeSpan.FromSeconds(15),
+            PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+            UseCookies = false,
+            UseProxy = false
+        };
+        handler.SslOptions.CertificateChainPolicy = chainPolicy;
+        try
+        {
+            var resolver = AriaDownloadAddressResolver.CreateForTest(handler);
+            handler = null;
+            return resolver;
+        }
+        finally
+        {
+            handler?.Dispose();
+        }
     }
 
     private static async Task RunHeadSafeGetDowngradeRejectedAsync(

--- a/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
@@ -352,7 +352,7 @@ public sealed partial class Aria2TlsIntegrationTests
             server.Url,
             outputName,
             maximumTries: 1,
-            headers: null,
+            headers: ["Cookie: test-session=fixture"],
             cancellationToken).ConfigureAwait(false);
 
         AssertCompleted(status, "same-origin-https-redirect", server.Failures);
@@ -363,6 +363,11 @@ public sealed partial class Aria2TlsIntegrationTests
         Assert.Contains(
             server.Requests,
             request => request.RequestTarget.StartsWith("/final.bin", StringComparison.Ordinal));
+        Assert.All(
+            server.Requests,
+            request => Assert.Equal(
+                "test-session=fixture",
+                request.Headers["Cookie"]));
         results.Add(new Aria2TlsCaseResult(
             "same-origin-https-redirect",
             true,

--- a/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
@@ -1,0 +1,426 @@
+using System.Net;
+using System.Security.Cryptography.X509Certificates;
+using DownKyi.Core.Aria2cNet.Client.Entity;
+using DownKyi.Services.Download;
+using DownKyi.TestInfrastructure;
+
+namespace DownKyi.Tests;
+
+public sealed partial class Aria2TlsIntegrationTests
+{
+    private static async Task RunHttpsRedirectToHttpRejectedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var target = CreatePlainHttpTarget();
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => certificate,
+            [],
+            redirectTarget: target.Url);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+
+        const string outputName = "https-to-http-redirect.bin";
+        var status = await DownloadToTerminalStatusAsync(
+            runtime,
+            redirect.Url,
+            outputName,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+
+        AssertRedirectRejected(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            "download.transfer.insecure-redirect");
+        Assert.Equal(0, target.RequestCount);
+        results.Add(new Aria2TlsCaseResult(
+            "https-to-http-redirect",
+            true,
+            "zero-http-requests"));
+    }
+
+    private static async Task RunPreflightThenActualDowngradeRejectedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var target = CreatePlainHttpTarget();
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            redirectFactory: (connection, _) => connection > 1 ? target.Url : null);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+        using var resolver = AriaDownloadAddressResolver.Create(proxyAddress: null);
+        var resolution = await resolver.ResolveAsync(
+            redirect.Url.AbsoluteUri,
+            "DownKyi-TLS-Test",
+            credentials: null,
+            cancellationToken).ConfigureAwait(false);
+        var acceptedAddress = Assert.IsType<Uri>(resolution.Address);
+        var acceptedHeaders = Assert.IsType<AriaTaskHeaders>(resolution.Headers);
+        Assert.Null(resolution.ErrorCode);
+
+        const string outputName = "preflight-then-actual-downgrade.bin";
+        var status = await DownloadToTerminalStatusAsync(
+            runtime,
+            acceptedAddress,
+            outputName,
+            maximumTries: 1,
+            acceptedHeaders.Headers,
+            cancellationToken).ConfigureAwait(false);
+
+        AssertRedirectRejected(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            "download.transfer.insecure-redirect");
+        Assert.Equal(0, target.RequestCount);
+        Assert.True(redirect.ConnectionCount >= 2);
+        results.Add(new Aria2TlsCaseResult(
+            "preflight-safe-actual-downgrade",
+            true,
+            "zero-http-requests"));
+    }
+
+    private static async Task RunHeadSafeGetDowngradeRejectedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var target = CreatePlainHttpTarget();
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            redirectFactory: (_, request) =>
+                string.Equals(request.Method, "GET", StringComparison.OrdinalIgnoreCase)
+                    ? target.Url
+                    : null);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+
+        using (var handler = new HttpClientHandler { AllowAutoRedirect = false })
+        {
+            var expectedCertificateHash = certificate.GetCertHashString(
+                System.Security.Cryptography.HashAlgorithmName.SHA256);
+            handler.ServerCertificateCustomValidationCallback = (_, presented, _, _) =>
+                presented != null
+                && string.Equals(
+                    presented.GetCertHashString(
+                        System.Security.Cryptography.HashAlgorithmName.SHA256),
+                    expectedCertificateHash,
+                    StringComparison.Ordinal);
+            using var client = new HttpClient(handler, disposeHandler: false);
+            using var request = new HttpRequestMessage(HttpMethod.Head, redirect.Url);
+            using var response = await client.SendAsync(
+                request,
+                cancellationToken).ConfigureAwait(false);
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        const string outputName = "head-safe-get-downgrade.bin";
+        var status = await DownloadToTerminalStatusAsync(
+            runtime,
+            redirect.Url,
+            outputName,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+
+        AssertRedirectRejected(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            "download.transfer.insecure-redirect");
+        Assert.Equal(0, target.RequestCount);
+        Assert.Contains(
+            redirect.Requests,
+            request => string.Equals(request.Method, "HEAD", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(
+            redirect.Requests,
+            request => string.Equals(request.Method, "GET", StringComparison.OrdinalIgnoreCase));
+        results.Add(new Aria2TlsCaseResult(
+            "head-safe-get-downgrade",
+            true,
+            "zero-http-requests"));
+    }
+
+    private static async Task RunRangeDowngradeRejectedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var target = CreatePlainHttpTarget();
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            redirectFactory: (_, request) => request.RangeStart is > 0 ? target.Url : null);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+
+        const string outputName = "range-downgrade.bin";
+        var outputPath = runtime.GetOutputPath(outputName);
+        await File.WriteAllBytesAsync(
+            outputPath,
+            payload[..(payload.Length / 2)],
+            cancellationToken).ConfigureAwait(false);
+        var status = await DownloadToTerminalStatusAsync(
+            runtime,
+            redirect.Url,
+            outputName,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+
+        AssertRedirectRejected(
+            status,
+            outputPath,
+            payload,
+            "download.transfer.insecure-redirect");
+        Assert.Equal(0, target.RequestCount);
+        Assert.Contains(redirect.Requests, request => request.RangeStart is > 0);
+        results.Add(new Aria2TlsCaseResult(
+            "range-downgrade",
+            true,
+            "zero-http-requests"));
+    }
+
+    private static async Task RunSecondRoundDowngradeRejectedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var target = CreatePlainHttpTarget();
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            truncateFirstResponse: true,
+            redirectFactory: (connection, _) => connection > 1 ? target.Url : null);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+        const string outputName = "second-round-downgrade.bin";
+        var firstGid = await runtime.AddDownloadAsync(
+            redirect.Url,
+            outputName,
+            split: 1,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        var firstStatus = await runtime.WaitForTerminalStatusAsync(
+            firstGid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+        Assert.Equal("error", firstStatus.Status);
+        Assert.Equal(1, redirect.ConnectionCount);
+        await runtime.Client.RemoveDownloadResultAsync(firstGid).ConfigureAwait(false);
+
+        var secondStatus = await DownloadToTerminalStatusAsync(
+            runtime,
+            redirect.Url,
+            outputName,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+        AssertRedirectRejected(
+            secondStatus,
+            runtime.GetOutputPath(outputName),
+            payload,
+            "download.transfer.insecure-redirect");
+        Assert.Equal(0, target.RequestCount);
+        Assert.True(redirect.ConnectionCount >= 2);
+        results.Add(new Aria2TlsCaseResult(
+            "second-round-downgrade",
+            true,
+            "zero-http-requests"));
+    }
+
+    private static async Task RunSensitiveCrossOriginRedirectsRejectedAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var cases = new (string ReportName, string Header)[]
+        {
+            ("sensitive-cross-origin-cookie", "Cookie: test-session=fixture"),
+            ("sensitive-cross-origin-authorization", "Authorization: Bearer fixture"),
+            ("sensitive-cross-origin-proxy-authorization", "Proxy-Authorization: Basic Zml4dHVyZQ=="),
+            ("sensitive-cross-origin-token", "X-Access-Token: fixture"),
+            ("sensitive-cross-origin-api-key", "X-API-Key: fixture")
+        };
+
+        foreach (var testCase in cases)
+        {
+            var target = new LoopbackTlsFileServer(_ => certificate, payload);
+            await using var targetLifetime = target.ConfigureAwait(false);
+            var redirect = new LoopbackTlsFileServer(
+                _ => certificate,
+                [],
+                redirectTarget: target.Url);
+            await using var redirectLifetime = redirect.ConfigureAwait(false);
+            var outputName = $"{testCase.ReportName}.bin";
+            var status = await DownloadToTerminalStatusAsync(
+                runtime,
+                redirect.Url,
+                outputName,
+                maximumTries: 1,
+                headers: [testCase.Header],
+                cancellationToken).ConfigureAwait(false);
+
+            AssertRedirectRejected(
+                status,
+                runtime.GetOutputPath(outputName),
+                payload,
+                "download.transfer.credentialed-redirect");
+            Assert.Equal(0, target.ConnectionCount);
+            Assert.Empty(target.Requests);
+            results.Add(new Aria2TlsCaseResult(
+                testCase.ReportName,
+                true,
+                "zero-cross-origin-requests"));
+        }
+    }
+
+    private static async Task RunSameOriginHttpsRedirectAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        Uri? finalAddress = null;
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            redirectFactory: (_, request) =>
+                request.RequestTarget.StartsWith("/media.bin", StringComparison.Ordinal)
+                    ? finalAddress
+                    : null);
+        await using var serverLifetime = server.ConfigureAwait(false);
+        finalAddress = new Uri(server.Url, "/final.bin");
+
+        const string outputName = "same-origin-https-redirect.bin";
+        var status = await DownloadToTerminalStatusAsync(
+            runtime,
+            server.Url,
+            outputName,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+
+        AssertCompleted(status, "same-origin-https-redirect", server.Failures);
+        AssertPayload(payload, runtime.GetOutputPath(outputName));
+        Assert.Contains(
+            server.Requests,
+            request => request.RequestTarget.StartsWith("/media.bin", StringComparison.Ordinal));
+        Assert.Contains(
+            server.Requests,
+            request => request.RequestTarget.StartsWith("/final.bin", StringComparison.Ordinal));
+        results.Add(new Aria2TlsCaseResult(
+            "same-origin-https-redirect",
+            true,
+            "complete"));
+    }
+
+    private static async Task RunCrossOriginHttpsRedirectAsync(
+        Aria2TlsTestRuntime runtime,
+        X509Certificate2 certificate,
+        byte[] payload,
+        List<Aria2TlsCaseResult> results,
+        CancellationToken cancellationToken)
+    {
+        var target = new LoopbackTlsFileServer(_ => certificate, payload);
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => certificate,
+            [],
+            redirectTarget: target.Url);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+
+        const string outputName = "cross-origin-https-redirect.bin";
+        var status = await DownloadToTerminalStatusAsync(
+            runtime,
+            redirect.Url,
+            outputName,
+            maximumTries: 1,
+            headers: null,
+            cancellationToken).ConfigureAwait(false);
+
+        AssertCompleted(status, "cross-origin-https-redirect", target.Failures);
+        AssertPayload(payload, runtime.GetOutputPath(outputName));
+        Assert.NotEmpty(redirect.Requests);
+        Assert.NotEmpty(target.Requests);
+        results.Add(new Aria2TlsCaseResult(
+            "cross-origin-https-redirect",
+            true,
+            "complete"));
+    }
+
+    private static LoopbackHttpServer CreatePlainHttpTarget()
+    {
+        return new LoopbackHttpServer(_ => new LoopbackResponse(
+            HttpStatusCode.OK,
+            Body: "blocked-target"));
+    }
+
+    private static async Task<AriaTellStatusResult> DownloadToTerminalStatusAsync(
+        Aria2TlsTestRuntime runtime,
+        Uri address,
+        string outputName,
+        int maximumTries,
+        IReadOnlyList<string>? headers,
+        CancellationToken cancellationToken)
+    {
+        var gid = await runtime.AddDownloadAsync(
+            address,
+            outputName,
+            split: 1,
+            maximumTries,
+            headers,
+            cancellationToken).ConfigureAwait(false);
+        return await runtime.WaitForTerminalStatusAsync(
+            gid,
+            DownloadTimeout,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static void AssertRedirectRejected(
+        AriaTellStatusResult status,
+        string outputPath,
+        byte[] payload,
+        string expectedErrorCode)
+    {
+        Assert.Equal("error", status.Status);
+        var expectedAriaErrorCode = expectedErrorCode switch
+        {
+            "download.transfer.insecure-redirect" => "33",
+            "download.transfer.credentialed-redirect" => "34",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(expectedErrorCode),
+                expectedErrorCode,
+                "Unknown secure redirect diagnostic.")
+        };
+        Assert.Equal(expectedAriaErrorCode, status.ErrorCode);
+        var classification = Aria2TransferFailureClassifier.Classify(
+            status.ErrorCode,
+            status.ErrorMessage);
+        Assert.Equal(DownloadTransferOutcome.Failed, classification.Outcome);
+        Assert.Equal(DownloadTransferFailureKind.Permanent, classification.FailureKind);
+        Assert.Equal(expectedErrorCode, classification.ErrorCode);
+        Assert.False(IsCompletePayload(payload, outputPath));
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
+++ b/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
@@ -3,8 +3,10 @@ using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using System.Security.Principal;
 using DownKyi.Core.Aria2cNet.Client;
 using DownKyi.Core.Aria2cNet.Client.Entity;
 using DownKyi.Core.Aria2cNet.Server;
@@ -86,6 +88,7 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
             cancellationToken).ConfigureAwait(false);
         var trustedRootScope = await TrustedRootScope.InstallAsync(
             trustedRoot,
+            rootPath,
             rootCertificatePath,
             cancellationToken).ConfigureAwait(false);
         Process? process = null;
@@ -104,7 +107,6 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
                 binaryPath,
                 workingDirectory,
                 secretFile,
-                rootPath,
                 port);
             process = new Process { StartInfo = startInfo };
             if (!process.Start())
@@ -232,7 +234,6 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
         string binaryPath,
         string workingDirectory,
         string secretFile,
-        string rootPath,
         int port)
     {
         var startInfo = new ProcessStartInfo
@@ -266,11 +267,6 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
             "--console-log-level=warn",
             "--summary-interval=0"
         };
-        if (OperatingSystem.IsLinux())
-        {
-            arguments.Add($"--ca-certificate={rootPath}");
-        }
-
         foreach (var argument in arguments)
         {
             startInfo.ArgumentList.Add(argument);
@@ -296,7 +292,9 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
 
             try
             {
-                var response = await client.GetAriaVersionAsync().ConfigureAwait(false);
+                var response = await client
+                    .GetAriaVersionAsync(cancellationToken)
+                    .ConfigureAwait(false);
                 if (!string.IsNullOrWhiteSpace(response.Result?.Version)
                     && response.Result.EnabledFeatures.Contains(
                         SecureRedirectFeature,
@@ -412,16 +410,19 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
 internal sealed class TrustedRootScope : IAsyncDisposable
 {
     private const string MacSystemKeychain = "/Library/Keychains/System.keychain";
+    private readonly string? _linuxCertificatePath;
     private readonly string? _macCommonName;
     private readonly WindowsTrustedRootRegistration? _windowsRoot;
 
     private TrustedRootScope(
         string source,
         WindowsTrustedRootRegistration? windowsRoot = null,
+        string? linuxCertificatePath = null,
         string? macCommonName = null)
     {
         Source = source;
         _windowsRoot = windowsRoot;
+        _linuxCertificatePath = linuxCertificatePath;
         _macCommonName = macCommonName;
     }
 
@@ -429,22 +430,53 @@ internal sealed class TrustedRootScope : IAsyncDisposable
 
     public static async Task<TrustedRootScope> InstallAsync(
         X509Certificate2 root,
-        string rootPath,
+        string rootPemPath,
+        string rootCertificatePath,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(root);
-        ArgumentException.ThrowIfNullOrWhiteSpace(rootPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootPemPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootCertificatePath);
 
         if (OperatingSystem.IsLinux())
         {
-            return new TrustedRootScope("aria2-ca-file");
+            var installedPath = Path.Combine(
+                "/usr/local/share/ca-certificates",
+                $"downkyi-aria2-{root.Thumbprint}.crt");
+            await RunBoundedProcessAsync(
+                "sudo",
+                ["-n", "install", "-m", "0644", "--", rootPemPath, installedPath],
+                cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await RunBoundedProcessAsync(
+                    "sudo",
+                    ["-n", "update-ca-certificates"],
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch
+            {
+                await RunBoundedProcessAsync(
+                    "sudo",
+                    ["-n", "rm", "-f", "--", installedPath],
+                    CancellationToken.None).ConfigureAwait(false);
+                await RunBoundedProcessAsync(
+                    "sudo",
+                    ["-n", "update-ca-certificates"],
+                    CancellationToken.None).ConfigureAwait(false);
+                throw;
+            }
+
+            return new TrustedRootScope(
+                "linux-system-ca-store",
+                linuxCertificatePath: installedPath);
         }
 
         if (OperatingSystem.IsWindows())
         {
             var registration = WindowsTrustedRootRegistration.Install(root.RawData);
             return new TrustedRootScope(
-                "windows-local-machine-root-store",
+                registration.Source,
                 windowsRoot: registration);
         }
 
@@ -460,7 +492,7 @@ internal sealed class TrustedRootScope : IAsyncDisposable
                 "trustRoot",
                 "-k",
                 MacSystemKeychain,
-                rootPath
+                rootCertificatePath
             ],
             cancellationToken).ConfigureAwait(false);
         return new TrustedRootScope(
@@ -520,6 +552,18 @@ internal sealed class TrustedRootScope : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        if (_linuxCertificatePath != null)
+        {
+            await RunBoundedProcessAsync(
+                "sudo",
+                ["-n", "rm", "-f", "--", _linuxCertificatePath],
+                CancellationToken.None).ConfigureAwait(false);
+            await RunBoundedProcessAsync(
+                "sudo",
+                ["-n", "update-ca-certificates"],
+                CancellationToken.None).ConfigureAwait(false);
+        }
+
         if (_windowsRoot != null)
         {
             _windowsRoot.Dispose();
@@ -545,6 +589,7 @@ internal sealed class TrustedRootScope : IAsyncDisposable
 internal sealed class WindowsTrustedRootRegistration : IDisposable
 {
     private const uint CertificateEncoding = 0x00000001;
+    private const uint CurrentUserStore = 0x00010000;
     private const uint LocalMachineStore = 0x00020000;
     private const uint StoreAddUseExisting = 2;
     private IntPtr _certificateContext;
@@ -552,24 +597,54 @@ internal sealed class WindowsTrustedRootRegistration : IDisposable
 
     private WindowsTrustedRootRegistration(
         IntPtr store,
-        IntPtr certificateContext)
+        IntPtr certificateContext,
+        string source)
     {
         _store = store;
         _certificateContext = certificateContext;
+        Source = source;
     }
 
+    public string Source { get; }
+
+    [SupportedOSPlatform("windows")]
     public static WindowsTrustedRootRegistration Install(byte[] certificate)
     {
         ArgumentNullException.ThrowIfNull(certificate);
+        using var identity = WindowsIdentity.GetCurrent();
+        var elevated = new WindowsPrincipal(identity)
+            .IsInRole(WindowsBuiltInRole.Administrator);
+        var storeLocation = elevated ? LocalMachineStore : CurrentUserStore;
+        var source = elevated
+            ? "windows-local-machine-root-store"
+            : "windows-current-user-root-store";
+        var registration = TryInstall(
+            certificate,
+            storeLocation,
+            source,
+            out var error);
+        return registration
+               ?? throw CreateNativeError(
+                   "The selected Windows root certificate store could not be updated.",
+                   error);
+    }
+
+    private static WindowsTrustedRootRegistration? TryInstall(
+        byte[] certificate,
+        uint storeLocation,
+        string source,
+        out int error)
+    {
         var store = CertOpenStore(
             new IntPtr(10),
             encodingType: 0,
             cryptographicProvider: IntPtr.Zero,
-            LocalMachineStore,
+            storeLocation,
             "Root");
         if (store == IntPtr.Zero)
         {
-            throw CreateNativeError("The Windows root certificate store could not be opened.");
+            error = Marshal.GetLastPInvokeError();
+            return null;
         }
 
         if (CertAddEncodedCertificateToStore(
@@ -580,19 +655,23 @@ internal sealed class WindowsTrustedRootRegistration : IDisposable
                 StoreAddUseExisting,
                 out var context))
         {
-            return new WindowsTrustedRootRegistration(store, context);
+            error = 0;
+            return new WindowsTrustedRootRegistration(store, context, source);
         }
 
-        var error = Marshal.GetLastPInvokeError();
+        error = Marshal.GetLastPInvokeError();
         CertCloseStore(store, flags: 0);
-        throw new InvalidOperationException(
-            $"The Windows test root certificate could not be installed (code {error}).");
+        return null;
     }
 
     private static InvalidOperationException CreateNativeError(string message)
     {
-        return new InvalidOperationException(
-            $"{message} Native error code: {Marshal.GetLastPInvokeError()}.");
+        return CreateNativeError(message, Marshal.GetLastPInvokeError());
+    }
+
+    private static InvalidOperationException CreateNativeError(string message, int error)
+    {
+        return new InvalidOperationException($"{message} Native error code: {error}.");
     }
 
     public void Dispose()

--- a/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
+++ b/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
@@ -1,0 +1,499 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Net;
+using System.Net.Sockets;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using DownKyi.Core.Aria2cNet.Client;
+using DownKyi.Core.Aria2cNet.Client.Entity;
+using DownKyi.Core.Aria2cNet.Server;
+
+namespace DownKyi.Tests;
+
+internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
+{
+    public const string SecureRedirectFeature = "downkyi-secure-redirect-v2";
+    private readonly Process _process;
+    private readonly Task<string> _standardError;
+    private readonly Task<string> _standardOutput;
+    private readonly TrustedRootScope _trustedRoot;
+    private readonly string _workingDirectory;
+    private bool _disposed;
+
+    private Aria2TlsTestRuntime(
+        Process process,
+        Task<string> standardOutput,
+        Task<string> standardError,
+        AriaClient client,
+        TrustedRootScope trustedRoot,
+        string workingDirectory,
+        string ariaVersion,
+        string binarySha256)
+    {
+        _process = process;
+        _standardOutput = standardOutput;
+        _standardError = standardError;
+        Client = client;
+        _trustedRoot = trustedRoot;
+        _workingDirectory = workingDirectory;
+        AriaVersion = ariaVersion;
+        BinarySha256 = binarySha256;
+    }
+
+    public AriaClient Client { get; }
+
+    public string AriaVersion { get; }
+
+    public string BinarySha256 { get; }
+
+    public string CertificateAuthoritySource => _trustedRoot.Source;
+
+    public static async Task<Aria2TlsTestRuntime> StartAsync(
+        string binaryPath,
+        X509Certificate2 trustedRoot,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(binaryPath);
+        ArgumentNullException.ThrowIfNull(trustedRoot);
+        if (!File.Exists(binaryPath))
+        {
+            throw new FileNotFoundException("The aria2 integration binary was not found.", binaryPath);
+        }
+
+        AriaBinaryIntegrityVerifier.Verify(binaryPath);
+        string binarySha256;
+        var binary = File.OpenRead(binaryPath);
+        await using (binary.ConfigureAwait(false))
+        {
+            binarySha256 = Convert.ToHexString(
+                await SHA256.HashDataAsync(binary, cancellationToken).ConfigureAwait(false));
+        }
+
+        var workingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-aria2-tls-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workingDirectory);
+        var rootPath = Path.Combine(workingDirectory, "trusted-root.pem");
+        await File.WriteAllTextAsync(
+            rootPath,
+            trustedRoot.ExportCertificatePem(),
+            cancellationToken).ConfigureAwait(false);
+        var trustedRootScope = await TrustedRootScope.InstallAsync(
+            trustedRoot,
+            rootPath,
+            cancellationToken).ConfigureAwait(false);
+        Process? process = null;
+        try
+        {
+            var port = GetAvailablePort();
+            var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+            var secretFile = Path.Combine(workingDirectory, $".rpc-{Guid.NewGuid():N}.conf");
+            await File.WriteAllTextAsync(
+                secretFile,
+                $"rpc-secret={token}{Environment.NewLine}",
+                cancellationToken).ConfigureAwait(false);
+            RestrictSecretFile(secretFile);
+
+            var startInfo = CreateStartInfo(
+                binaryPath,
+                workingDirectory,
+                secretFile,
+                rootPath,
+                port);
+            process = new Process { StartInfo = startInfo };
+            if (!process.Start())
+            {
+                throw new InvalidOperationException("The aria2 TLS test process did not start.");
+            }
+
+            var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+            var client = new AriaClient("http://127.0.0.1", port, token);
+            var version = await WaitForReadyAsync(
+                process,
+                client,
+                cancellationToken).ConfigureAwait(false);
+            DeleteSecretFile(secretFile);
+            return new Aria2TlsTestRuntime(
+                process,
+                standardOutput,
+                standardError,
+                client,
+                trustedRootScope,
+                workingDirectory,
+                version,
+                binarySha256);
+        }
+        catch
+        {
+            if (process is { HasExited: false })
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
+            process?.Dispose();
+            await trustedRootScope.DisposeAsync().ConfigureAwait(false);
+            DeleteDirectory(workingDirectory);
+            throw;
+        }
+    }
+
+    public async Task<string> AddDownloadAsync(
+        Uri url,
+        string outputName,
+        int split,
+        int maximumTries,
+        IReadOnlyList<string>? headers,
+        CancellationToken cancellationToken)
+    {
+        return await AddDownloadAsync(
+            url,
+            outputName,
+            split,
+            maximumTries,
+            headers,
+            httpsProxy: null,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<string> AddDownloadAsync(
+        Uri url,
+        string outputName,
+        int split,
+        int maximumTries,
+        IReadOnlyList<string>? headers,
+        string? httpsProxy,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputName);
+        var result = await Client.AddUriAsync(
+            [url.AbsoluteUri],
+            new AriaSendOption
+            {
+                Dir = _workingDirectory,
+                Out = outputName,
+                Continue = "true",
+                AllowOverwrite = "true",
+                AutoFileRenaming = "false",
+                Split = split.ToString(CultureInfo.InvariantCulture),
+                MaxConnectionPerServer = split.ToString(CultureInfo.InvariantCulture),
+                MinSplitSize = "1M",
+                MaxTries = maximumTries.ToString(CultureInfo.InvariantCulture),
+                RetryWait = "0",
+                AlwaysResume = "false",
+                MaxResumeFailureTries = "0",
+                Headers = headers ?? [],
+                HttpsProxy = httpsProxy ?? string.Empty
+            }).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        return result.Result
+            ?? throw new InvalidOperationException("aria2 did not return a download identifier.");
+    }
+
+    public string GetOutputPath(string outputName)
+    {
+        return Path.Combine(_workingDirectory, outputName);
+    }
+
+    public async Task<AriaTellStatusResult> WaitForTerminalStatusAsync(
+        string gid,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var status = await Client.TellStatus(gid).ConfigureAwait(false);
+            if (status.Result is { } result
+                && (string.Equals(result.Status, "complete", StringComparison.Ordinal)
+                    || string.Equals(result.Status, "error", StringComparison.Ordinal)
+                    || string.Equals(result.Status, "removed", StringComparison.Ordinal)))
+            {
+                return result;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new TimeoutException("aria2 did not reach a terminal status before the test deadline.");
+    }
+
+    private static ProcessStartInfo CreateStartInfo(
+        string binaryPath,
+        string workingDirectory,
+        string secretFile,
+        string rootPath,
+        int port)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = binaryPath,
+            WorkingDirectory = workingDirectory,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        var arguments = new List<string>
+        {
+            $"--conf-path={secretFile}",
+            "--enable-rpc=true",
+            "--rpc-listen-all=false",
+            "--rpc-allow-origin-all=false",
+            $"--rpc-listen-port={port}",
+            "--disable-ipv6=true",
+            "--check-certificate=true",
+            "--file-allocation=none",
+            "--allow-overwrite=true",
+            "--auto-file-renaming=false",
+            "--continue=true",
+            "--max-concurrent-downloads=4",
+            "--max-connection-per-server=4",
+            "--split=4",
+            "--min-split-size=1M",
+            "--max-tries=1",
+            "--retry-wait=0",
+            "--console-log-level=warn",
+            "--summary-interval=0"
+        };
+        if (OperatingSystem.IsLinux())
+        {
+            arguments.Add($"--ca-certificate={rootPath}");
+        }
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
+
+    private static async Task<string> WaitForReadyAsync(
+        Process process,
+        AriaClient client,
+        CancellationToken cancellationToken)
+    {
+        Exception? lastError = null;
+        for (var attempt = 0; attempt < 100; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (process.HasExited)
+            {
+                throw new InvalidOperationException(
+                    $"The aria2 TLS test process exited before RPC became ready (code {process.ExitCode}).");
+            }
+
+            try
+            {
+                var response = await client.GetAriaVersionAsync().ConfigureAwait(false);
+                if (!string.IsNullOrWhiteSpace(response.Result?.Version)
+                    && response.Result.EnabledFeatures.Contains(
+                        SecureRedirectFeature,
+                        StringComparer.Ordinal))
+                {
+                    return response.Result.Version;
+                }
+            }
+            catch (HttpRequestException error)
+            {
+                lastError = error;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(50), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        throw new TimeoutException(
+            "aria2 RPC did not become ready before the test deadline.",
+            lastError);
+    }
+
+    private static int GetAvailablePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        return ((IPEndPoint)listener.LocalEndpoint).Port;
+    }
+
+    private static void RestrictSecretFile(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+    }
+
+    private static void DeleteSecretFile(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return;
+        }
+
+        var length = new FileInfo(path).Length;
+        using (var stream = new FileStream(
+                   path,
+                   FileMode.Open,
+                   FileAccess.Write,
+                   FileShare.None))
+        {
+            stream.SetLength(length);
+            stream.Write(new byte[length]);
+            stream.Flush(flushToDisk: true);
+        }
+
+        File.Delete(path);
+    }
+
+    private static void DeleteDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        try
+        {
+            if (!_process.HasExited)
+            {
+                try
+                {
+                    await Client.ForceShutdownAsync().ConfigureAwait(false);
+                }
+                catch (HttpRequestException)
+                {
+                }
+
+                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                try
+                {
+                    await _process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+                {
+                    _process.Kill(entireProcessTree: true);
+                    await _process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+                }
+            }
+
+            await Task.WhenAll(_standardOutput, _standardError).ConfigureAwait(false);
+        }
+        finally
+        {
+            _process.Dispose();
+            await _trustedRoot.DisposeAsync().ConfigureAwait(false);
+            DeleteDirectory(_workingDirectory);
+        }
+    }
+}
+
+internal sealed class TrustedRootScope : IAsyncDisposable
+{
+    private readonly string? _cleanupCommand;
+    private readonly IReadOnlyList<string>? _cleanupArguments;
+
+    private TrustedRootScope(
+        string source,
+        string? cleanupCommand = null,
+        IReadOnlyList<string>? cleanupArguments = null)
+    {
+        Source = source;
+        _cleanupCommand = cleanupCommand;
+        _cleanupArguments = cleanupArguments;
+    }
+
+    public string Source { get; }
+
+    public static async Task<TrustedRootScope> InstallAsync(
+        X509Certificate2 root,
+        string rootPath,
+        CancellationToken cancellationToken)
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            return new TrustedRootScope("aria2-ca-file");
+        }
+
+        if (OperatingSystem.IsMacOS())
+        {
+            var commonName = root.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+            var keychain = Path.Combine(home, "Library", "Keychains", "login.keychain-db");
+            await RunProcessAsync(
+                "security",
+                ["add-trusted-cert", "-r", "trustRoot", "-k", keychain, rootPath],
+                cancellationToken).ConfigureAwait(false);
+            return new TrustedRootScope(
+                "macos-user-keychain",
+                "security",
+                ["delete-certificate", "-c", commonName, keychain]);
+        }
+
+        await RunProcessAsync(
+            "certutil",
+            ["-user", "-addstore", "-f", "Root", rootPath],
+            cancellationToken).ConfigureAwait(false);
+        return new TrustedRootScope(
+            "windows-current-user-root-store",
+            "certutil",
+            ["-user", "-delstore", "Root", root.SerialNumber]);
+    }
+
+    private static async Task RunProcessAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException("The certificate trust tool did not start.");
+        var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+        var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        await Task.WhenAll(standardOutput, standardError).ConfigureAwait(false);
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"The certificate trust command failed with code {process.ExitCode}.");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_cleanupCommand != null && _cleanupArguments != null)
+        {
+            await RunProcessAsync(
+                _cleanupCommand,
+                _cleanupArguments,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
+++ b/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using DownKyi.Core.Aria2cNet.Client;
@@ -78,9 +79,14 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
             rootPath,
             trustedRoot.ExportCertificatePem(),
             cancellationToken).ConfigureAwait(false);
+        var rootCertificatePath = Path.Combine(workingDirectory, "trusted-root.cer");
+        await File.WriteAllBytesAsync(
+            rootCertificatePath,
+            trustedRoot.Export(X509ContentType.Cert),
+            cancellationToken).ConfigureAwait(false);
         var trustedRootScope = await TrustedRootScope.InstallAsync(
             trustedRoot,
-            rootPath,
+            rootCertificatePath,
             cancellationToken).ConfigureAwait(false);
         Process? process = null;
         try
@@ -405,17 +411,18 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
 
 internal sealed class TrustedRootScope : IAsyncDisposable
 {
-    private readonly string? _cleanupCommand;
-    private readonly IReadOnlyList<string>? _cleanupArguments;
+    private const string MacSystemKeychain = "/Library/Keychains/System.keychain";
+    private readonly string? _macCommonName;
+    private readonly WindowsTrustedRootRegistration? _windowsRoot;
 
     private TrustedRootScope(
         string source,
-        string? cleanupCommand = null,
-        IReadOnlyList<string>? cleanupArguments = null)
+        WindowsTrustedRootRegistration? windowsRoot = null,
+        string? macCommonName = null)
     {
         Source = source;
-        _cleanupCommand = cleanupCommand;
-        _cleanupArguments = cleanupArguments;
+        _windowsRoot = windowsRoot;
+        _macCommonName = macCommonName;
     }
 
     public string Source { get; }
@@ -425,37 +432,43 @@ internal sealed class TrustedRootScope : IAsyncDisposable
         string rootPath,
         CancellationToken cancellationToken)
     {
+        ArgumentNullException.ThrowIfNull(root);
+        ArgumentException.ThrowIfNullOrWhiteSpace(rootPath);
+
         if (OperatingSystem.IsLinux())
         {
             return new TrustedRootScope("aria2-ca-file");
         }
 
-        if (OperatingSystem.IsMacOS())
+        if (OperatingSystem.IsWindows())
         {
-            var commonName = root.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
-            var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            var keychain = Path.Combine(home, "Library", "Keychains", "login.keychain-db");
-            await RunProcessAsync(
-                "security",
-                ["add-trusted-cert", "-r", "trustRoot", "-k", keychain, rootPath],
-                cancellationToken).ConfigureAwait(false);
+            var registration = WindowsTrustedRootRegistration.Install(root.RawData);
             return new TrustedRootScope(
-                "macos-user-keychain",
-                "security",
-                ["delete-certificate", "-c", commonName, keychain]);
+                "windows-local-machine-root-store",
+                windowsRoot: registration);
         }
 
-        await RunProcessAsync(
-            "certutil",
-            ["-user", "-addstore", "-f", "Root", rootPath],
+        var commonName = root.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
+        await RunBoundedProcessAsync(
+            "sudo",
+            [
+                "-n",
+                "security",
+                "add-trusted-cert",
+                "-d",
+                "-r",
+                "trustRoot",
+                "-k",
+                MacSystemKeychain,
+                rootPath
+            ],
             cancellationToken).ConfigureAwait(false);
         return new TrustedRootScope(
-            "windows-current-user-root-store",
-            "certutil",
-            ["-user", "-delstore", "Root", root.SerialNumber]);
+            "macos-system-keychain",
+            macCommonName: commonName);
     }
 
-    private static async Task RunProcessAsync(
+    private static async Task RunBoundedProcessAsync(
         string fileName,
         IReadOnlyList<string> arguments,
         CancellationToken cancellationToken)
@@ -473,12 +486,31 @@ internal sealed class TrustedRootScope : IAsyncDisposable
             startInfo.ArgumentList.Add(argument);
         }
 
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(TimeSpan.FromSeconds(15));
         using var process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("The certificate trust tool did not start.");
-        var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
-        var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
-        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        var standardError = process.StandardError.ReadToEndAsync(CancellationToken.None);
+        var standardOutput = process.StandardOutput.ReadToEndAsync(CancellationToken.None);
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
+            await Task.WhenAll(standardOutput, standardError).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new TimeoutException("The certificate trust tool did not finish in time.");
+        }
+
         await Task.WhenAll(standardOutput, standardError).ConfigureAwait(false);
+
         if (process.ExitCode != 0)
         {
             throw new InvalidOperationException(
@@ -488,12 +520,128 @@ internal sealed class TrustedRootScope : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_cleanupCommand != null && _cleanupArguments != null)
+        if (_windowsRoot != null)
         {
-            await RunProcessAsync(
-                _cleanupCommand,
-                _cleanupArguments,
+            _windowsRoot.Dispose();
+        }
+
+        if (_macCommonName != null)
+        {
+            await RunBoundedProcessAsync(
+                "sudo",
+                [
+                    "-n",
+                    "security",
+                    "delete-certificate",
+                    "-c",
+                    _macCommonName,
+                    MacSystemKeychain
+                ],
                 CancellationToken.None).ConfigureAwait(false);
         }
     }
+}
+
+internal sealed class WindowsTrustedRootRegistration : IDisposable
+{
+    private const uint CertificateEncoding = 0x00000001;
+    private const uint LocalMachineStore = 0x00020000;
+    private const uint StoreAddUseExisting = 2;
+    private IntPtr _certificateContext;
+    private IntPtr _store;
+
+    private WindowsTrustedRootRegistration(
+        IntPtr store,
+        IntPtr certificateContext)
+    {
+        _store = store;
+        _certificateContext = certificateContext;
+    }
+
+    public static WindowsTrustedRootRegistration Install(byte[] certificate)
+    {
+        ArgumentNullException.ThrowIfNull(certificate);
+        var store = CertOpenStore(
+            new IntPtr(10),
+            encodingType: 0,
+            cryptographicProvider: IntPtr.Zero,
+            LocalMachineStore,
+            "Root");
+        if (store == IntPtr.Zero)
+        {
+            throw CreateNativeError("The Windows root certificate store could not be opened.");
+        }
+
+        if (CertAddEncodedCertificateToStore(
+                store,
+                CertificateEncoding,
+                certificate,
+                certificate.Length,
+                StoreAddUseExisting,
+                out var context))
+        {
+            return new WindowsTrustedRootRegistration(store, context);
+        }
+
+        var error = Marshal.GetLastPInvokeError();
+        CertCloseStore(store, flags: 0);
+        throw new InvalidOperationException(
+            $"The Windows test root certificate could not be installed (code {error}).");
+    }
+
+    private static InvalidOperationException CreateNativeError(string message)
+    {
+        return new InvalidOperationException(
+            $"{message} Native error code: {Marshal.GetLastPInvokeError()}.");
+    }
+
+    public void Dispose()
+    {
+        var context = Interlocked.Exchange(ref _certificateContext, IntPtr.Zero);
+        var store = Interlocked.Exchange(ref _store, IntPtr.Zero);
+        try
+        {
+            if (context != IntPtr.Zero && !CertDeleteCertificateFromStore(context))
+            {
+                throw CreateNativeError("The Windows test root certificate could not be removed.");
+            }
+        }
+        finally
+        {
+            if (store != IntPtr.Zero)
+            {
+                CertCloseStore(store, flags: 0);
+            }
+        }
+    }
+
+    [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    private static extern IntPtr CertOpenStore(
+        IntPtr storeProvider,
+        uint encodingType,
+        IntPtr cryptographicProvider,
+        uint flags,
+        string storeName);
+
+    [DllImport("crypt32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CertAddEncodedCertificateToStore(
+        IntPtr certificateStore,
+        uint certificateEncodingType,
+        byte[] certificate,
+        int certificateLength,
+        uint addDisposition,
+        out IntPtr certificateContext);
+
+    [DllImport("crypt32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CertDeleteCertificateFromStore(IntPtr certificateContext);
+
+    [DllImport("crypt32.dll", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool CertCloseStore(IntPtr certificateStore, uint flags);
 }

--- a/tests/DownKyi.Tests/AriaRuntimeClientRegistryTests.cs
+++ b/tests/DownKyi.Tests/AriaRuntimeClientRegistryTests.cs
@@ -9,8 +9,8 @@ public sealed class AriaRuntimeClientRegistryTests
     public void RegistryOwnsOneRuntimeClientAndReleasesItDeterministically()
     {
         var registry = new AriaRuntimeClientRegistry();
-        var first = new AriaClient();
-        var second = new AriaClient();
+        var first = new AriaClient("http://localhost", 35076, "first-test-token");
+        var second = new AriaClient("http://localhost", 35077, "second-test-token");
 
         using (registry.Activate(first))
         {

--- a/tests/DownKyi.Tests/AriaSecurityTests.cs
+++ b/tests/DownKyi.Tests/AriaSecurityTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http;
+using DownKyi.Core.Settings;
+using DownKyi.Services.Download;
+
+namespace DownKyi.Tests;
+
+public sealed class AriaSecurityTests
+{
+    [Fact]
+    public void LocalEndpointsUseFreshHighEntropySecretsAndEphemeralPorts()
+    {
+        var first = LocalAriaRpcEndpoint.Create();
+        var second = LocalAriaRpcEndpoint.Create();
+
+        Assert.InRange(first.Port, 1024, 65535);
+        Assert.InRange(second.Port, 1024, 65535);
+        Assert.Equal(64, first.Secret.Length);
+        Assert.Equal(64, second.Secret.Length);
+        Assert.NotEqual(first.Secret, second.Secret);
+        Assert.Matches("^[0-9A-F]{64}$", first.Secret);
+        Assert.Matches("^[0-9A-F]{64}$", second.Secret);
+    }
+
+    [Fact]
+    public void CredentialsAreScopedToHttpsBilibiliTasks()
+    {
+        var result = AriaTaskHeaderPolicy.Create(
+            "https://api.bilibili.com/media",
+            "DownKyi-Test-Agent",
+            "test-cookie=value");
+
+        Assert.True(result.CarriesCredentials);
+        Assert.Contains("Cookie: test-cookie=value", result.Headers);
+        Assert.Contains("Origin: https://www.bilibili.com", result.Headers);
+        Assert.Contains("Referer: https://www.bilibili.com", result.Headers);
+    }
+
+    [Theory]
+    [InlineData("http://api.bilibili.com/media")]
+    [InlineData("https://bilibili.com.attacker.example/media")]
+    [InlineData("https://bilivideo.com/media")]
+    [InlineData("https://example.com/media")]
+    public void CredentialsAreNotSentOutsideTheExactHttpsBilibiliScope(string address)
+    {
+        var result = AriaTaskHeaderPolicy.Create(
+            address,
+            "DownKyi-Test-Agent",
+            "test-cookie=value");
+
+        Assert.False(result.CarriesCredentials);
+        Assert.DoesNotContain(
+            result.Headers,
+            header => header.StartsWith("Cookie:", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Theory]
+    [InlineData("unsafe\r\nX-Injected: value", "safe-cookie=value")]
+    [InlineData("DownKyi-Test-Agent", "unsafe\r\nX-Injected: value")]
+    [InlineData("unsafe\0agent", "safe-cookie=value")]
+    public void TaskHeadersRejectControlCharacterInjection(
+        string userAgent,
+        string credentials)
+    {
+        Assert.Throws<ArgumentException>(() => AriaTaskHeaderPolicy.Create(
+            "https://www.bilibili.com/media",
+            userAgent,
+            credentials));
+    }
+
+    [Fact]
+    public void TlsReportSchemaExposesOnlySanitizedEvidenceFields()
+    {
+        var actual = typeof(Aria2TlsReport)
+            .GetProperties()
+            .Select(property => property.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var expected = new[]
+        {
+            nameof(Aria2TlsReport.Architecture),
+            nameof(Aria2TlsReport.AriaVersion),
+            nameof(Aria2TlsReport.AssetRuntimeIdentifier),
+            nameof(Aria2TlsReport.BinarySha256),
+            nameof(Aria2TlsReport.Cases),
+            nameof(Aria2TlsReport.CertificateAuthoritySource),
+            nameof(Aria2TlsReport.CommitSha),
+            nameof(Aria2TlsReport.Complete),
+            nameof(Aria2TlsReport.OperatingSystem),
+            nameof(Aria2TlsReport.Passed),
+            nameof(Aria2TlsReport.Runtime),
+            nameof(Aria2TlsReport.RuntimeIdentifier),
+            nameof(Aria2TlsReport.RequiredFeature),
+            nameof(Aria2TlsReport.SchemaVersion),
+            nameof(Aria2TlsReport.TlsBackend)
+        }.Order(StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("127.0.0.1", "http://127.0.0.1:7890/")]
+    [InlineData("localhost", "http://localhost:7890/")]
+    [InlineData("::1", "http://[::1]:7890/")]
+    [InlineData("[::1]", "http://[::1]:7890/")]
+    public void HttpsDownloadProxyAcceptsOnlyExplicitLoopbackHosts(
+        string host,
+        string expected)
+    {
+        Assert.True(AriaHttpsProxyPolicy.TryCreateConnectProxyUri(
+            host,
+            7890,
+            out var proxyUri));
+        Assert.Equal(expected, proxyUri.AbsoluteUri);
+        Assert.Equal(Uri.UriSchemeHttp, proxyUri.Scheme);
+    }
+
+    [Theory]
+    [InlineData("192.0.2.10")]
+    [InlineData("proxy.example")]
+    [InlineData("http://127.0.0.1")]
+    [InlineData("user:password@127.0.0.1")]
+    [InlineData("127.0.0.2")]
+    public void HttpsDownloadProxyRejectsRemoteOrCredentialBearingHosts(string host)
+    {
+        Assert.False(AriaHttpsProxyPolicy.TryCreateConnectProxyUri(
+            host,
+            7890,
+            out _));
+    }
+
+    [Fact]
+    public async Task AddressResolverRejectsHttpsToHttpRedirectBeforeAriaReceivesIt()
+    {
+        using var handler = new StubHttpMessageHandler((_, _) => new HttpResponseMessage(
+            HttpStatusCode.Found)
+        {
+            Headers = { Location = new Uri("http://download.example/media") }
+        });
+        using var resolver = AriaDownloadAddressResolver.CreateForTest(handler);
+
+        var result = await resolver.ResolveAsync(
+            "https://download.example/media?signature=private",
+            "DownKyi-Test-Agent",
+            credentials: null,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("download.transfer.insecure-redirect", result.ErrorCode);
+        Assert.Null(result.Address);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task AddressResolverRejectsEveryCredentialBearingRedirect()
+    {
+        using var handler = new StubHttpMessageHandler((_, _) => new HttpResponseMessage(
+            HttpStatusCode.Found)
+        {
+            Headers = { Location = new Uri("https://api.bilibili.com/final") }
+        });
+        using var resolver = AriaDownloadAddressResolver.CreateForTest(handler);
+
+        var result = await resolver.ResolveAsync(
+            "https://api.bilibili.com/media",
+            "DownKyi-Test-Agent",
+            "test-cookie=value",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("download.transfer.credentialed-redirect", result.ErrorCode);
+        Assert.Null(result.Address);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task AddressResolverFollowsOnlyBoundedHttpsRedirects()
+    {
+        using var handler = new StubHttpMessageHandler((request, requestNumber) =>
+        {
+            if (requestNumber == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.TemporaryRedirect)
+                {
+                    Headers = { Location = new Uri("/final", UriKind.Relative) }
+                };
+            }
+
+            Assert.Equal("https://download.example/final", request.RequestUri?.AbsoluteUri);
+            return new HttpResponseMessage(HttpStatusCode.PartialContent);
+        });
+        using var resolver = AriaDownloadAddressResolver.CreateForTest(handler);
+
+        var result = await resolver.ResolveAsync(
+            "https://download.example/media",
+            "DownKyi-Test-Agent",
+            credentials: null,
+            TestContext.Current.CancellationToken);
+
+        var acceptedAddress = Assert.IsType<Uri>(result.Address);
+        var acceptedHeaders = Assert.IsType<AriaTaskHeaders>(result.Headers);
+        Assert.Equal("https://download.example/final", acceptedAddress.AbsoluteUri);
+        Assert.False(acceptedHeaders.CarriesCredentials);
+        Assert.Equal(2, handler.RequestCount);
+    }
+
+    private sealed class StubHttpMessageHandler(
+        Func<HttpRequestMessage, int, HttpResponseMessage> responseFactory)
+        : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var requestNumber = Interlocked.Increment(ref _requestCount);
+            return Task.FromResult(responseFactory(request, requestNumber));
+        }
+    }
+}

--- a/tests/DownKyi.Tests/AriaSecurityTests.cs
+++ b/tests/DownKyi.Tests/AriaSecurityTests.cs
@@ -1,7 +1,11 @@
 using System.Net;
 using System.Net.Http;
+using DownKyi.Core.Aria2cNet.Client;
+using DownKyi.Core.Aria2cNet.Server;
 using DownKyi.Core.Settings;
 using DownKyi.Services.Download;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json.Linq;
 
 namespace DownKyi.Tests;
 
@@ -151,12 +155,12 @@ public sealed class AriaSecurityTests
     }
 
     [Fact]
-    public async Task AddressResolverRejectsEveryCredentialBearingRedirect()
+    public async Task AddressResolverRejectsCredentialBearingCrossOriginRedirect()
     {
         using var handler = new StubHttpMessageHandler((_, _) => new HttpResponseMessage(
             HttpStatusCode.Found)
         {
-            Headers = { Location = new Uri("https://api.bilibili.com/final") }
+            Headers = { Location = new Uri("https://cdn.example/final") }
         });
         using var resolver = AriaDownloadAddressResolver.CreateForTest(handler);
 
@@ -169,6 +173,38 @@ public sealed class AriaSecurityTests
         Assert.Equal("download.transfer.credentialed-redirect", result.ErrorCode);
         Assert.Null(result.Address);
         Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task AddressResolverAllowsCredentialBearingSameOriginHttpsRedirect()
+    {
+        using var handler = new StubHttpMessageHandler((request, requestNumber) =>
+        {
+            Assert.Equal("api.bilibili.com", request.RequestUri?.Host);
+            Assert.True(request.Headers.TryGetValues("Cookie", out var cookies));
+            Assert.Contains("test-cookie=value", cookies);
+            if (requestNumber == 1)
+            {
+                return new HttpResponseMessage(HttpStatusCode.Found)
+                {
+                    Headers = { Location = new Uri("/final", UriKind.Relative) }
+                };
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.PartialContent);
+        });
+        using var resolver = AriaDownloadAddressResolver.CreateForTest(handler);
+
+        var result = await resolver.ResolveAsync(
+            "https://api.bilibili.com/media",
+            "DownKyi-Test-Agent",
+            "test-cookie=value",
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result.ErrorCode);
+        Assert.Equal("https://api.bilibili.com/final", result.Address?.AbsoluteUri);
+        Assert.True(result.Headers?.CarriesCredentials);
+        Assert.Equal(2, handler.RequestCount);
     }
 
     [Fact]
@@ -200,6 +236,129 @@ public sealed class AriaSecurityTests
         Assert.Equal("https://download.example/final", acceptedAddress.AbsoluteUri);
         Assert.False(acceptedHeaders.CarriesCredentials);
         Assert.Equal(2, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task CustomAriaCapabilityProbeStopsWhenStartupIsCanceled()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-custom-aria-cancel-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using var settings = new SettingsStore(Path.Combine(directory, "settings.json"));
+            var entered = new TaskCompletionSource(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            var client = new AriaClient(
+                "https://aria.example",
+                6800,
+                string.Empty,
+                async (_, _, cancellationToken) =>
+                {
+                    entered.TrySetResult();
+                    await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                        .ConfigureAwait(false);
+                    return null;
+                });
+            using var lifecycle = new Aria2RuntimeLifecycle(
+                settings.Current.Network,
+                client,
+                new DownloadDiagnosticLogger(
+                    NullLogger<DownloadDiagnosticLogger>.Instance),
+                new AriaServer(NullLoggerFactory.Instance),
+                NullLogger<Aria2RuntimeLifecycle>.Instance,
+                ownsAriaServer: false,
+                localEndpoint: null);
+            using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+                TestContext.Current.CancellationToken);
+
+            var startup = lifecycle.StartAsync(cancellation.Token);
+            await entered.Task.WaitAsync(TestContext.Current.CancellationToken);
+            await cancellation.CancelAsync();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() => startup);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task PausedGidRefreshesCurrentCredentialsBeforeUnpause()
+    {
+        var requests = new List<JObject>();
+        var client = CreatePausedTaskClient(requests);
+        var headers = new AriaTaskHeaders(
+            ["Cookie: current-session=fixture"],
+            "Current-Agent",
+            CarriesCredentials: true);
+
+        await Aria2TransferBackend.RefreshOptionsAndUnpauseAsync(
+            client,
+            "existing-gid",
+            headers,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(["aria2.changeOption", "aria2.unpause"],
+            requests.Select(request => request["method"]?.Value<string>()));
+        var options = Assert.IsType<JObject>(
+            Assert.IsType<JArray>(requests[0]["params"])[2]);
+        Assert.Equal("Current-Agent", options["user-agent"]?.Value<string>());
+        Assert.Equal(
+            ["Cookie: current-session=fixture"],
+            Assert.IsType<JArray>(options["header"])
+                .Values<string>()
+                .OfType<string>()
+                .ToArray());
+    }
+
+    [Fact]
+    public async Task PausedGidCanClearStoredCredentialsBeforeUnpause()
+    {
+        var requests = new List<JObject>();
+        var client = CreatePausedTaskClient(requests);
+        var headers = new AriaTaskHeaders(
+            [],
+            "Current-Agent",
+            CarriesCredentials: false);
+
+        await Aria2TransferBackend.RefreshOptionsAndUnpauseAsync(
+            client,
+            "existing-gid",
+            headers,
+            TestContext.Current.CancellationToken);
+
+        var options = Assert.IsType<JObject>(
+            Assert.IsType<JArray>(requests[0]["params"])[2]);
+        Assert.Empty(Assert.IsType<JArray>(options["header"]));
+        Assert.Equal("aria2.unpause", requests[1]["method"]?.Value<string>());
+    }
+
+    private static AriaClient CreatePausedTaskClient(
+        List<JObject> requests)
+    {
+        return new AriaClient(
+            "http://localhost",
+            6800,
+            "test-token",
+            (_, payload) =>
+            {
+                var request = JObject.Parse(payload);
+                requests.Add(request);
+                var result = request["method"]?.Value<string>() switch
+                {
+                    "aria2.changeOption" => "OK",
+                    "aria2.unpause" => "existing-gid",
+                    _ => throw new InvalidOperationException("Unexpected aria2 RPC method.")
+                };
+                return Task.FromResult<string?>(
+                    $"{{\"id\":\"test\",\"jsonrpc\":\"2.0\",\"result\":\"{result}\"}}");
+            });
     }
 
     private sealed class StubHttpMessageHandler(

--- a/tests/DownKyi.Tests/DownKyi.Tests.csproj
+++ b/tests/DownKyi.Tests/DownKyi.Tests.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\DownKyi.Desktop\DownKyi.Desktop.csproj" />
+    <ProjectReference Include="..\TestInfrastructure\DownKyi.TestInfrastructure.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/DownKyi.Tests/DownloadRetryPolicyTests.cs
+++ b/tests/DownKyi.Tests/DownloadRetryPolicyTests.cs
@@ -1,5 +1,7 @@
 using System.Net;
+using System.Net.Http;
 using System.Net.Sockets;
+using System.Security.Authentication;
 using DownKyi.Services.Download;
 using Downloader.Exceptions;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -139,6 +141,25 @@ public sealed class DownloadRetryPolicyTests
             TestContext.Current.CancellationToken);
 
         Assert.Equal(DownloadTransferOutcome.Failed, result.Outcome);
+        Assert.Single(backend.Requests);
+    }
+
+    [Fact]
+    public async Task CoordinatorDoesNotRetryTlsFailureOrTryBackupAddresses()
+    {
+        using var backend = new RecordingBackend(
+            DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Tls,
+                "download.transfer.tls.untrusted"));
+        var coordinator = CreateCoordinator(backend, maximumAttempts: 5);
+
+        var result = await coordinator.TransferAsync(
+            CreateRequest("https://primary.invalid/media", "https://backup.invalid/media"),
+            static _ => Task.FromResult<IReadOnlyList<string>>([]),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(DownloadTransferOutcome.Failed, result.Outcome);
+        Assert.Equal(DownloadTransferFailureKind.Tls, result.FailureKind);
         Assert.Single(backend.Requests);
     }
 
@@ -293,6 +314,42 @@ public sealed class DownloadRetryPolicyTests
         Assert.Equal(DownloadTransferFailureKind.Disk, result.FailureKind);
     }
 
+    [Fact]
+    public void BuiltinBackendClassifiesCertificateAuthenticationFailures()
+    {
+        var exception = new HttpRequestException(
+            "The SSL connection could not be established.",
+            new AuthenticationException(
+                "The remote certificate is invalid because the certificate chain is untrusted."));
+
+        var result = BuiltinTransferBackend.ClassifyFailure(
+            exception,
+            reportedCanceled: false);
+
+        Assert.Equal(DownloadTransferFailureKind.Tls, result.FailureKind);
+        Assert.Equal("download.transfer.tls.untrusted", result.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("SSL/TLS handshake failure: unknown CA", "download.transfer.tls.untrusted")]
+    [InlineData("certificate has expired", "download.transfer.tls.expired")]
+    [InlineData("certificate is not yet valid", "download.transfer.tls.not-yet-valid")]
+    [InlineData("certificate hostname does not match", "download.transfer.tls.hostname")]
+    [InlineData("certificate chain building failed", "download.transfer.tls.chain")]
+    [InlineData("SSL/TLS handshake failure", "download.transfer.tls.handshake")]
+    [InlineData("SSL/TLS handshake failure (80090325)", "download.transfer.tls.untrusted")]
+    [InlineData("SSL/TLS handshake failure (80090322)", "download.transfer.tls.hostname")]
+    public void AriaBackendClassifiesTlsFailuresWithoutExposingRawMessages(
+        string errorMessage,
+        string expectedCode)
+    {
+        var result = Aria2TransferFailureClassifier.Classify("1", errorMessage);
+
+        Assert.Equal(DownloadTransferFailureKind.Tls, result.FailureKind);
+        Assert.Equal(expectedCode, result.ErrorCode);
+        Assert.DoesNotContain(errorMessage, result.ErrorCode, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("22", "HTTP response status was 403", (int)DownloadTransferFailureKind.ExpiredAddress)]
     [InlineData("22", "HTTP response status was 429", (int)DownloadTransferFailureKind.RateLimited)]
@@ -314,6 +371,22 @@ public sealed class DownloadRetryPolicyTests
         Assert.Equal(DownloadTransferOutcome.Failed, result.Outcome);
         Assert.Equal((DownloadTransferFailureKind)expectedValue, result.FailureKind);
         Assert.Equal($"download.transfer.aria2-{errorCode}", result.ErrorCode);
+    }
+
+    [Theory]
+    [InlineData("33", "No URI available.", "download.transfer.insecure-redirect")]
+    [InlineData("34", "No URI available.", "download.transfer.credentialed-redirect")]
+    public void AriaBackendPreservesSecureRedirectRejectionCodes(
+        string errorCode,
+        string errorMessage,
+        string expectedDiagnostic)
+    {
+        var result = Aria2TransferFailureClassifier.Classify(errorCode, errorMessage);
+
+        Assert.Equal(DownloadTransferOutcome.Failed, result.Outcome);
+        Assert.Equal(DownloadTransferFailureKind.Permanent, result.FailureKind);
+        Assert.Equal(expectedDiagnostic, result.ErrorCode);
+        Assert.DoesNotContain(errorMessage, result.ErrorCode, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/TestInfrastructure/LoopbackHttpConnectProxy.cs
+++ b/tests/TestInfrastructure/LoopbackHttpConnectProxy.cs
@@ -1,0 +1,341 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace DownKyi.TestInfrastructure;
+
+public sealed class LoopbackHttpConnectProxy : IAsyncDisposable
+{
+    private const int MaximumHeaderBytes = 16 * 1024;
+    private readonly ConcurrentDictionary<int, TcpClient> _clients = new();
+    private readonly ConcurrentQueue<string> _connectAuthorities = new();
+    private readonly X509Certificate2? _interceptCertificate;
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly TcpListener _listener;
+    private readonly Task _serverTask;
+    private int _absoluteUriRequestCount;
+    private int _connectionSequence;
+    private int _cookieHeaderCount;
+    private int _nonConnectRequestCount;
+    private int _proxyAuthorizationHeaderCount;
+
+    public LoopbackHttpConnectProxy(X509Certificate2? interceptCertificate = null)
+    {
+        _interceptCertificate = interceptCertificate;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        var endpoint = (IPEndPoint)_listener.LocalEndpoint;
+        Address = new Uri($"http://127.0.0.1:{endpoint.Port}/");
+        _serverTask = RunAsync(_shutdown.Token);
+    }
+
+    public Uri Address { get; }
+
+    public IReadOnlyList<string> ConnectAuthorities => _connectAuthorities.ToArray();
+
+    public int AbsoluteUriRequestCount => Volatile.Read(ref _absoluteUriRequestCount);
+
+    public int CookieHeaderCount => Volatile.Read(ref _cookieHeaderCount);
+
+    public int NonConnectRequestCount => Volatile.Read(ref _nonConnectRequestCount);
+
+    public int ProxyAuthorizationHeaderCount =>
+        Volatile.Read(ref _proxyAuthorizationHeaderCount);
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var handlers = new List<Task>();
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var client = await _listener.AcceptTcpClientAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                var id = Interlocked.Increment(ref _connectionSequence);
+                _clients[id] = client;
+                handlers.Add(HandleClientAsync(id, client, cancellationToken));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (SocketException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            await Task.WhenAll(handlers).ConfigureAwait(false);
+        }
+    }
+
+    private async Task HandleClientAsync(
+        int id,
+        TcpClient client,
+        CancellationToken cancellationToken)
+    {
+        using (client)
+        {
+            try
+            {
+                var clientStream = client.GetStream();
+                await using var clientStreamLifetime = clientStream.ConfigureAwait(false);
+                var request = await ReadConnectRequestAsync(
+                    clientStream,
+                    cancellationToken).ConfigureAwait(false);
+                if (request == null)
+                {
+                    return;
+                }
+
+                RecordRequestMetadata(request);
+                if (!string.Equals(request.Method, "CONNECT", StringComparison.OrdinalIgnoreCase))
+                {
+                    Interlocked.Increment(ref _nonConnectRequestCount);
+                    await WriteResponseAsync(
+                        clientStream,
+                        "HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n\r\n",
+                        cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                _connectAuthorities.Enqueue(request.Target);
+                if (_interceptCertificate != null)
+                {
+                    await InterceptAsync(
+                        clientStream,
+                        _interceptCertificate,
+                        cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                await TunnelAsync(
+                    clientStream,
+                    request.Target,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (AuthenticationException)
+            {
+            }
+            catch (IOException) when (!cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (SocketException) when (!cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            finally
+            {
+                _clients.TryRemove(id, out _);
+            }
+        }
+    }
+
+    private void RecordRequestMetadata(ConnectRequest request)
+    {
+        if (request.Target.Contains("://", StringComparison.Ordinal)
+            || request.Target.Contains('?', StringComparison.Ordinal))
+        {
+            Interlocked.Increment(ref _absoluteUriRequestCount);
+        }
+
+        if (request.Headers.Contains("Cookie"))
+        {
+            Interlocked.Increment(ref _cookieHeaderCount);
+        }
+
+        if (request.Headers.Contains("Proxy-Authorization"))
+        {
+            Interlocked.Increment(ref _proxyAuthorizationHeaderCount);
+        }
+    }
+
+    private static async Task TunnelAsync(
+        NetworkStream clientStream,
+        string authority,
+        CancellationToken cancellationToken)
+    {
+        if (!TryParseAuthority(authority, out var host, out var port))
+        {
+            await WriteResponseAsync(
+                clientStream,
+                "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n",
+                cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        using var target = new TcpClient();
+        await target.ConnectAsync(host, port, cancellationToken).ConfigureAwait(false);
+        var targetStream = target.GetStream();
+        await using var targetStreamLifetime = targetStream.ConfigureAwait(false);
+        await WriteResponseAsync(
+            clientStream,
+            "HTTP/1.1 200 Connection Established\r\n\r\n",
+            cancellationToken).ConfigureAwait(false);
+
+        await CopyTunnelAsync(
+            clientStream,
+            targetStream,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task CopyTunnelAsync(
+        Stream clientStream,
+        Stream targetStream,
+        CancellationToken cancellationToken)
+    {
+        using var tunnelCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken);
+        var clientToTarget = clientStream.CopyToAsync(
+            targetStream,
+            tunnelCancellation.Token);
+        var targetToClient = targetStream.CopyToAsync(
+            clientStream,
+            tunnelCancellation.Token);
+        await Task.WhenAny(clientToTarget, targetToClient).ConfigureAwait(false);
+        await tunnelCancellation.CancelAsync().ConfigureAwait(false);
+        try
+        {
+            await Task.WhenAll(clientToTarget, targetToClient).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (tunnelCancellation.IsCancellationRequested)
+        {
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    private static async Task InterceptAsync(
+        NetworkStream clientStream,
+        X509Certificate2 certificate,
+        CancellationToken cancellationToken)
+    {
+        await WriteResponseAsync(
+            clientStream,
+            "HTTP/1.1 200 Connection Established\r\n\r\n",
+            cancellationToken).ConfigureAwait(false);
+        var tlsStream = new SslStream(clientStream, leaveInnerStreamOpen: true);
+        await using var tlsStreamLifetime = tlsStream.ConfigureAwait(false);
+        await tlsStream.AuthenticateAsServerAsync(
+            new SslServerAuthenticationOptions
+            {
+                ServerCertificate = certificate,
+                EnabledSslProtocols = SslProtocols.None
+            },
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<ConnectRequest?> ReadConnectRequestAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        var bytes = new List<byte>();
+        var buffer = new byte[1];
+        while (bytes.Count < MaximumHeaderBytes)
+        {
+            var count = await stream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
+            if (count == 0)
+            {
+                return null;
+            }
+
+            bytes.Add(buffer[0]);
+            var length = bytes.Count;
+            if (length >= 4
+                && bytes[length - 4] == '\r'
+                && bytes[length - 3] == '\n'
+                && bytes[length - 2] == '\r'
+                && bytes[length - 1] == '\n')
+            {
+                break;
+            }
+        }
+
+        if (bytes.Count >= MaximumHeaderBytes)
+        {
+            throw new InvalidDataException("The CONNECT request header exceeded the test limit.");
+        }
+
+        var lines = Encoding.ASCII.GetString(bytes.ToArray())
+            .Split("\r\n", StringSplitOptions.RemoveEmptyEntries);
+        var requestParts = lines[0].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (requestParts.Length < 2)
+        {
+            return null;
+        }
+
+        var headerNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in lines.Skip(1))
+        {
+            var separator = line.IndexOf(':', StringComparison.Ordinal);
+            if (separator > 0)
+            {
+                headerNames.Add(line[..separator].Trim());
+            }
+        }
+
+        return new ConnectRequest(requestParts[0], requestParts[1], headerNames);
+    }
+
+    private static bool TryParseAuthority(
+        string authority,
+        out string host,
+        out int port)
+    {
+        host = string.Empty;
+        port = 0;
+        if (!Uri.TryCreate($"http://{authority}", UriKind.Absolute, out var uri)
+            || uri.Port is < 1 or > 65535)
+        {
+            return false;
+        }
+
+        host = uri.IdnHost;
+        port = uri.Port;
+        return true;
+    }
+
+    private static Task WriteResponseAsync(
+        Stream stream,
+        string response,
+        CancellationToken cancellationToken)
+    {
+        return stream.WriteAsync(
+            Encoding.ASCII.GetBytes(response),
+            cancellationToken).AsTask();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _shutdown.CancelAsync().ConfigureAwait(false);
+        _listener.Stop();
+        foreach (var client in _clients.Values)
+        {
+            client.Dispose();
+        }
+
+        try
+        {
+            await _serverTask.ConfigureAwait(false);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+        finally
+        {
+            _listener.Dispose();
+            _shutdown.Dispose();
+        }
+    }
+
+    private sealed record ConnectRequest(
+        string Method,
+        string Target,
+        IReadOnlySet<string> Headers);
+}

--- a/tests/TestInfrastructure/LoopbackTlsFileServer.cs
+++ b/tests/TestInfrastructure/LoopbackTlsFileServer.cs
@@ -1,0 +1,324 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Security;
+using System.Net.Sockets;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+
+namespace DownKyi.TestInfrastructure;
+
+public sealed record LoopbackTlsRequest(
+    string Method,
+    string RequestTarget,
+    IReadOnlyDictionary<string, string> Headers,
+    long? RangeStart,
+    long? RangeEnd);
+
+public sealed class LoopbackTlsFileServer : IAsyncDisposable
+{
+    private readonly CancellationTokenSource _shutdown = new();
+    private readonly Func<int, X509Certificate2> _certificateFactory;
+    private readonly Func<int, LoopbackTlsRequest, Uri?>? _redirectFactory;
+    private readonly byte[] _payload;
+    private readonly bool _truncateFirstResponse;
+    private readonly TimeSpan _chunkDelay;
+    private readonly ConcurrentQueue<LoopbackTlsRequest> _requests = new();
+    private readonly ConcurrentQueue<Exception> _failures = new();
+    private readonly TcpListener _listener;
+    private readonly Task _serverTask;
+    private int _connectionCount;
+
+    public LoopbackTlsFileServer(
+        Func<int, X509Certificate2> certificateFactory,
+        byte[] payload,
+        Uri? redirectTarget = null,
+        bool truncateFirstResponse = false,
+        TimeSpan chunkDelay = default,
+        Func<int, LoopbackTlsRequest, Uri?>? redirectFactory = null)
+    {
+        _certificateFactory = certificateFactory
+            ?? throw new ArgumentNullException(nameof(certificateFactory));
+        _payload = payload ?? throw new ArgumentNullException(nameof(payload));
+        _redirectFactory = redirectFactory;
+        if (_redirectFactory == null && redirectTarget != null)
+        {
+            _redirectFactory = (_, _) => redirectTarget;
+        }
+        _truncateFirstResponse = truncateFirstResponse;
+        _chunkDelay = chunkDelay;
+        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _listener.Start();
+        var endpoint = (IPEndPoint)_listener.LocalEndpoint;
+        Url = new Uri($"https://localhost:{endpoint.Port}/media.bin");
+        _serverTask = RunAsync(_shutdown.Token);
+    }
+
+    public Uri Url { get; }
+
+    public int ConnectionCount => Volatile.Read(ref _connectionCount);
+
+    public IReadOnlyList<LoopbackTlsRequest> Requests => _requests.ToArray();
+
+    public IReadOnlyList<Exception> Failures => _failures.ToArray();
+
+    private async Task RunAsync(CancellationToken cancellationToken)
+    {
+        var connections = new List<Task>();
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var client = await _listener.AcceptTcpClientAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                var connectionNumber = Interlocked.Increment(ref _connectionCount);
+                connections.Add(HandleClientAsync(
+                    client,
+                    connectionNumber,
+                    cancellationToken));
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (SocketException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        finally
+        {
+            await Task.WhenAll(connections).ConfigureAwait(false);
+        }
+    }
+
+    private async Task HandleClientAsync(
+        TcpClient client,
+        int connectionNumber,
+        CancellationToken cancellationToken)
+    {
+        using (client)
+        {
+            var networkStream = client.GetStream();
+            await using var networkLifetime = networkStream.ConfigureAwait(false);
+            var tlsStream = new SslStream(networkStream, leaveInnerStreamOpen: true);
+            await using var tlsLifetime = tlsStream.ConfigureAwait(false);
+            try
+            {
+                await tlsStream.AuthenticateAsServerAsync(
+                    new SslServerAuthenticationOptions
+                    {
+                        ServerCertificate = _certificateFactory(connectionNumber),
+                        EnabledSslProtocols = SslProtocols.None
+                    },
+                    cancellationToken).ConfigureAwait(false);
+                var request = await ReadRequestAsync(tlsStream, cancellationToken)
+                    .ConfigureAwait(false);
+                if (request == null)
+                {
+                    return;
+                }
+
+                _requests.Enqueue(request);
+                var redirectTarget = _redirectFactory?.Invoke(
+                    connectionNumber,
+                    request);
+                if (redirectTarget != null)
+                {
+                    await WriteRedirectAsync(
+                        tlsStream,
+                        redirectTarget,
+                        cancellationToken).ConfigureAwait(false);
+                    return;
+                }
+
+                await WritePayloadAsync(
+                    tlsStream,
+                    request,
+                    connectionNumber,
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (AuthenticationException error)
+            {
+                _failures.Enqueue(error);
+            }
+            catch (IOException error) when (!cancellationToken.IsCancellationRequested)
+            {
+                _failures.Enqueue(error);
+            }
+            catch (InvalidOperationException error)
+            {
+                _failures.Enqueue(error);
+            }
+            catch (IOException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+            }
+        }
+    }
+
+    private static async Task<LoopbackTlsRequest?> ReadRequestAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        using var reader = new StreamReader(
+            stream,
+            Encoding.ASCII,
+            detectEncodingFromByteOrderMarks: false,
+            bufferSize: 4096,
+            leaveOpen: true);
+        var requestLine = await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(requestLine))
+        {
+            return null;
+        }
+
+        var requestParts = requestLine.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (requestParts.Length < 1)
+        {
+            return null;
+        }
+
+        var headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        while (await reader.ReadLineAsync(cancellationToken).ConfigureAwait(false) is { } line
+               && line.Length > 0)
+        {
+            var separator = line.IndexOf(':', StringComparison.Ordinal);
+            if (separator > 0)
+            {
+                headers[line[..separator].Trim()] = line[(separator + 1)..].Trim();
+            }
+        }
+
+        var (rangeStart, rangeEnd) = ParseRange(headers);
+        return new LoopbackTlsRequest(
+            requestParts[0],
+            requestParts.Length > 1 ? requestParts[1] : "/",
+            headers,
+            rangeStart,
+            rangeEnd);
+    }
+
+    private static async Task WriteRedirectAsync(
+        Stream stream,
+        Uri redirectTarget,
+        CancellationToken cancellationToken)
+    {
+        var response = $"HTTP/1.1 302 Found\r\nLocation: {redirectTarget}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+        await stream.WriteAsync(
+            Encoding.ASCII.GetBytes(response),
+            cancellationToken).ConfigureAwait(false);
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task WritePayloadAsync(
+        Stream stream,
+        LoopbackTlsRequest request,
+        int connectionNumber,
+        CancellationToken cancellationToken)
+    {
+        var start = Math.Clamp(request.RangeStart ?? 0, 0, _payload.LongLength);
+        var end = Math.Clamp(
+            request.RangeEnd ?? (_payload.LongLength - 1),
+            start,
+            _payload.LongLength - 1);
+        var length = end - start + 1;
+        var isPartial = request.RangeStart.HasValue;
+        var response = new StringBuilder()
+            .Append("HTTP/1.1 ")
+            .Append(isPartial ? "206 Partial Content" : "200 OK")
+            .Append("\r\nAccept-Ranges: bytes\r\nContent-Type: application/octet-stream\r\nContent-Length: ")
+            .Append(length)
+            .Append("\r\n");
+        if (isPartial)
+        {
+            response.Append("Content-Range: bytes ")
+                .Append(start)
+                .Append('-')
+                .Append(end)
+                .Append('/')
+                .Append(_payload.LongLength)
+                .Append("\r\n");
+        }
+
+        response.Append("Connection: close\r\n\r\n");
+        await stream.WriteAsync(
+            Encoding.ASCII.GetBytes(response.ToString()),
+            cancellationToken).ConfigureAwait(false);
+        if (string.Equals(request.Method, "HEAD", StringComparison.OrdinalIgnoreCase))
+        {
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        var bytesToWrite = length;
+        if (_truncateFirstResponse && connectionNumber == 1 && bytesToWrite > 1)
+        {
+            bytesToWrite /= 2;
+        }
+
+        const int chunkSize = 64 * 1024;
+        var offset = start;
+        var remaining = bytesToWrite;
+        while (remaining > 0)
+        {
+            var count = (int)Math.Min(chunkSize, remaining);
+            await stream.WriteAsync(
+                _payload.AsMemory((int)offset, count),
+                cancellationToken).ConfigureAwait(false);
+            offset += count;
+            remaining -= count;
+            if (_chunkDelay > TimeSpan.Zero)
+            {
+                await Task.Delay(_chunkDelay, cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static (long? Start, long? End) ParseRange(
+        Dictionary<string, string> headers)
+    {
+        if (!headers.TryGetValue("Range", out var range)
+            || !range.StartsWith("bytes=", StringComparison.OrdinalIgnoreCase))
+        {
+            return (null, null);
+        }
+
+        var value = range["bytes=".Length..];
+        var separator = value.IndexOf('-', StringComparison.Ordinal);
+        if (separator <= 0 || !long.TryParse(
+                value[..separator],
+                System.Globalization.NumberStyles.None,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out var start))
+        {
+            return (null, null);
+        }
+
+        var endText = value[(separator + 1)..];
+        return long.TryParse(
+            endText,
+            System.Globalization.NumberStyles.None,
+            System.Globalization.CultureInfo.InvariantCulture,
+            out var end)
+            ? (start, end)
+            : (start, null);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _shutdown.CancelAsync().ConfigureAwait(false);
+        _listener.Stop();
+        try
+        {
+            await _serverTask.ConfigureAwait(false);
+        }
+        finally
+        {
+            _listener.Dispose();
+            _shutdown.Dispose();
+        }
+    }
+}

--- a/tests/TestInfrastructure/TestCertificateAuthority.cs
+++ b/tests/TestInfrastructure/TestCertificateAuthority.cs
@@ -1,0 +1,180 @@
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace DownKyi.TestInfrastructure;
+
+public sealed class TestCertificateAuthority : IDisposable
+{
+    private readonly List<X509Certificate2> _issuedCertificates = [];
+
+    public TestCertificateAuthority(string commonName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(commonName);
+        RootCertificate = CreateSelfSignedCertificate(
+            commonName,
+            isCertificateAuthority: true,
+            dnsSubjectAlternativeName: null,
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(2));
+    }
+
+    public X509Certificate2 RootCertificate { get; }
+
+    public X509Certificate2 IssueServerCertificate(
+        string commonName = "localhost",
+        string? dnsSubjectAlternativeName = "localhost",
+        DateTimeOffset? notBefore = null,
+        DateTimeOffset? notAfter = null,
+        X509Certificate2? issuer = null)
+    {
+        var certificate = CreateSignedCertificate(
+            commonName,
+            issuer ?? RootCertificate,
+            isCertificateAuthority: false,
+            dnsSubjectAlternativeName,
+            notBefore ?? DateTimeOffset.UtcNow.AddHours(-1),
+            notAfter ?? DateTimeOffset.UtcNow.AddHours(12));
+        _issuedCertificates.Add(certificate);
+        return certificate;
+    }
+
+    public X509Certificate2 IssueIntermediateCertificate(string commonName)
+    {
+        var certificate = CreateSignedCertificate(
+            commonName,
+            RootCertificate,
+            isCertificateAuthority: true,
+            dnsSubjectAlternativeName: null,
+            DateTimeOffset.UtcNow.AddDays(-1),
+            DateTimeOffset.UtcNow.AddDays(1));
+        _issuedCertificates.Add(certificate);
+        return certificate;
+    }
+
+    public static X509Certificate2 CreateSelfSignedServerCertificate(
+        string commonName = "localhost",
+        string? dnsSubjectAlternativeName = "localhost")
+    {
+        return CreateSelfSignedCertificate(
+            commonName,
+            isCertificateAuthority: false,
+            dnsSubjectAlternativeName,
+            DateTimeOffset.UtcNow.AddHours(-1),
+            DateTimeOffset.UtcNow.AddDays(1));
+    }
+
+    public string WriteRootCertificatePem(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        File.WriteAllText(path, RootCertificate.ExportCertificatePem());
+        return path;
+    }
+
+    private static X509Certificate2 CreateSelfSignedCertificate(
+        string commonName,
+        bool isCertificateAuthority,
+        string? dnsSubjectAlternativeName,
+        DateTimeOffset notBefore,
+        DateTimeOffset notAfter)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = CreateRequest(
+            commonName,
+            rsa,
+            isCertificateAuthority,
+            dnsSubjectAlternativeName);
+        using var generated = request.CreateSelfSigned(notBefore, notAfter);
+        return LoadExportedCertificate(generated);
+    }
+
+    private static X509Certificate2 CreateSignedCertificate(
+        string commonName,
+        X509Certificate2 issuer,
+        bool isCertificateAuthority,
+        string? dnsSubjectAlternativeName,
+        DateTimeOffset notBefore,
+        DateTimeOffset notAfter)
+    {
+        using var rsa = RSA.Create(2048);
+        var request = CreateRequest(
+            commonName,
+            rsa,
+            isCertificateAuthority,
+            dnsSubjectAlternativeName);
+        var serial = RandomNumberGenerator.GetBytes(16);
+        serial[0] &= 0x7f;
+        using var generated = request.Create(issuer, notBefore, notAfter, serial);
+        using var certificateWithKey = generated.CopyWithPrivateKey(rsa);
+        return LoadExportedCertificate(certificateWithKey);
+    }
+
+    private static CertificateRequest CreateRequest(
+        string commonName,
+        RSA rsa,
+        bool isCertificateAuthority,
+        string? dnsSubjectAlternativeName)
+    {
+        var request = new CertificateRequest(
+            $"CN={commonName}",
+            rsa,
+            HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        request.CertificateExtensions.Add(new X509BasicConstraintsExtension(
+            isCertificateAuthority,
+            isCertificateAuthority,
+            0,
+            critical: true));
+        request.CertificateExtensions.Add(new X509SubjectKeyIdentifierExtension(
+            request.PublicKey,
+            critical: false));
+
+        if (isCertificateAuthority)
+        {
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(
+                X509KeyUsageFlags.KeyCertSign | X509KeyUsageFlags.CrlSign,
+                critical: true));
+        }
+        else
+        {
+            request.CertificateExtensions.Add(new X509KeyUsageExtension(
+                X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment,
+                critical: true));
+            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(
+                new OidCollection
+                {
+                    new("1.3.6.1.5.5.7.3.1")
+                },
+                critical: true));
+            if (dnsSubjectAlternativeName != null)
+            {
+                var subjectAlternativeName = new SubjectAlternativeNameBuilder();
+                subjectAlternativeName.AddDnsName(dnsSubjectAlternativeName);
+                request.CertificateExtensions.Add(subjectAlternativeName.Build());
+            }
+        }
+
+        return request;
+    }
+
+    private static X509Certificate2 LoadExportedCertificate(X509Certificate2 certificate)
+    {
+        var keyStorageFlags = X509KeyStorageFlags.Exportable;
+        keyStorageFlags |= OperatingSystem.IsWindows()
+            ? X509KeyStorageFlags.UserKeySet
+            : X509KeyStorageFlags.EphemeralKeySet;
+        return X509CertificateLoader.LoadPkcs12(
+            certificate.Export(X509ContentType.Pkcs12),
+            password: null,
+            keyStorageFlags);
+    }
+
+    public void Dispose()
+    {
+        foreach (var certificate in _issuedCertificates)
+        {
+            certificate.Dispose();
+        }
+
+        RootCertificate.Dispose();
+    }
+}

--- a/tests/TestInfrastructure/TestCertificateAuthority.cs
+++ b/tests/TestInfrastructure/TestCertificateAuthority.cs
@@ -159,9 +159,15 @@ public sealed class TestCertificateAuthority : IDisposable
     private static X509Certificate2 LoadExportedCertificate(X509Certificate2 certificate)
     {
         var keyStorageFlags = X509KeyStorageFlags.Exportable;
-        keyStorageFlags |= OperatingSystem.IsWindows()
-            ? X509KeyStorageFlags.UserKeySet
-            : X509KeyStorageFlags.EphemeralKeySet;
+        if (OperatingSystem.IsWindows())
+        {
+            keyStorageFlags |= X509KeyStorageFlags.UserKeySet;
+        }
+        else if (!OperatingSystem.IsMacOS())
+        {
+            keyStorageFlags |= X509KeyStorageFlags.EphemeralKeySet;
+        }
+
         return X509CertificateLoader.LoadPkcs12(
             certificate.Export(X509ContentType.Pkcs12),
             password: null,


### PR DESCRIPTION
## Summary

- integrate the immutable `1.37.0-downkyi.2` aria2 assets and verify archive/binary SHA-256 before startup
- require `downkyi-secure-redirect-v2` for packaged and custom aria2 endpoints
- force HTTPS certificate/hostname validation, reject transfer downgrade and sensitive cross-origin redirects
- move RPC secrets and task credentials out of process arguments, restrict HTTP RPC/proxy use to loopback, and migrate legacy `UseSsl` without runtime authority
- add deterministic TLS, redirect, Range, resume, proxy, process-lifecycle and settings contract tests plus a six-RID real-binary CI matrix

## Scope

This PR is limited to v1.1.1 Item 1. PR #120, Bangumi work, general architecture cleanup and unrelated technical debt remain out of scope.

`Aria2RuntimeLifecycle` is a minimal gate repair caused by this Item 1 diff: `origin/main` had a 432-line backend with no `.Result`; the unsplit security implementation reached 559 lines and introduced direct `.Result` access, failing the existing oversized-file and synchronous-result architecture gates. The extracted backend is 420 lines with no `.Result`.

## Local verification

- strict Release build with `AnalysisMode=All` and warnings as errors: 0 warnings, 0 errors
- seven test projects: 794 passed, 0 failed, 1 expected real-binary test skipped in the ordinary suite
- Windows v2 real-binary preflight completed 26/26 cases on both x64 and x86; the final exact-PR Windows proof is recorded below with the deterministic LocalMachine trust fixture
- `dotnet format --verify-no-changes`
- Gitleaks secret scan: 1021 candidate files, 0 findings
- workflow lint and `git diff --check`

## Exact PR evidence

- head: `5faffca8e685d0f8911a15a1c93e926d53b2c2c8`
- Strict PR CI run: `30701441843` passed
- CodeQL run: `30701441851` passed
- all six real-binary jobs passed with 26/26 unique cases:
  - `win-x86`, `win-x64`: WinTLS, LocalMachine test root
  - `linux-x64`, `linux-arm64`: OpenSSL, pinned CA file
  - `osx-x64`, `osx-arm64`: AppleTLS, bounded system-keychain fixture
- every report contains `downkyi-secure-redirect-v2`, matches the manifest binary SHA-256, and passed the sanitized report scan
- reports record PR merge commit `c6bc45212961fb07116e1807a9f70e5a4918fa87`; its parents are base `e2fd83d09b0fa641453fc92912ad238ed5499056` and this head `5faffca8e685d0f8911a15a1c93e926d53b2c2c8`
- normal Windows/Linux/macOS build-test, format, package audit, architecture coverage, assembly lifecycle and CodeQL all passed on the same head