### PR TITLE
fix(dialogs): make migration cancellation explicit

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -1169,13 +1169,20 @@ contracts:
   - Non-dialog ViewModels cannot reference EventAggregator, RegionManager, legacy dialog services, navigation/message events, or the string-route helper.
   - The Avalonia dialog adapter marshals calls to the UI thread; download/add services await only `IAppDialogService` and cannot dispatch framework work themselves.
   - `DialogWindow` is the single borderless, non-resizable custom-chrome host. Each of its six dialog contents marks exactly one custom title region with the Avalonia `TitleBar` role so the window remains draggable without restoring system chrome.
+  - Startup awaits the legacy-data migration dialog before checking for updates; startup-only modals cannot overlap, and the shared dialog service does not impose a global serialization policy on unrelated workflows.
+  - Active legacy migration rejects ordinary window close and exposes one inline confirmation flow. Continue leaves the coordinator running; confirmed cancel closes with a canceled outcome; host cancellation bypasses the user-close guard and still runs ViewModel teardown.
+  - Legacy download records are persisted in batches. Cancellation stops remaining work and retains the legacy source for retry, but already persisted batches may remain; UI copy and diagnostics must not promise transactional rollback.
 hazards:
   - Bypassing typed routes/dialog results with raw view construction would reintroduce untestable UI ownership and history drift.
+  - Treating every close as user cancellation can block host shutdown; only the dialog host owns the forced-close bypass.
 tests:
   - test.desktop-interactions
   - test.typed-navigation
   - test.architecture-boundaries
   - test.ui-smoke
+  - `DialogWindowChromeTests`
+  - `StartupDialogOrderingTests`
+  - `LegacyUpgradeViewModelTests`
 ```
 
 ### service.typed-navigation

--- a/docs/exec-plans/v1.1.1-dialog-and-startup.md
+++ b/docs/exec-plans/v1.1.1-dialog-and-startup.md
@@ -1,9 +1,12 @@
 # v1.1.1 Dialog And Startup Hardening
 
+Status: completed locally on 2026-08-08; awaiting integration with the current v1.1.1 runtime
+hardening branch.
+
 ## Goal
 
-Fix Issue #123's shared custom-window regression and serialize startup-only modal flows without
-introducing a second dialog framework or changing migration cancellation policy.
+Fix Issue #123's shared custom-window regression, serialize startup-only modal flows and make the
+existing migration cancellation behavior explicit without introducing a second dialog framework.
 
 ## Item A: Shared Custom Chrome
 
@@ -24,25 +27,45 @@ introducing a second dialog framework or changing migration cancellation policy.
 - `AvaloniaDialogService` is not given a global semaphore; legitimate sequential dialogs elsewhere
   retain their current behavior.
 
-## Deferred Product Decision
+## Item C: Explicit Migration Cancellation
 
-The migration view currently allows cancellation while its text says not to close the app. Do not
-change close policy in Items A or B. A later product decision must choose between explicit cancel
-with confirmation, truly nonclosable migration, or corrected advisory copy.
+The selected product contract is explicit cancellation with confirmation:
 
-The currently observed code and tests support safe cancellation, so the preferred follow-up is an
-explicit `Cancel migration` action with confirmation. The confirmation must explain that no partial
-migration is applied and that migration can be retried on the next launch. This remains a product
-decision and is not part of Issue #123 or startup-dialog serialization.
+- While migration is active, the dialog exposes `Cancel migration` instead of relying on hidden
+  Alt+F4 behavior.
+- A close attempt while migration is active opens the same inline confirmation state and does not
+  immediately close the dialog.
+- `Continue migration` dismisses confirmation without canceling the coordinator.
+- `Cancel migration` cancels the coordinator and closes the dialog with a canceled outcome.
+- Application-forced shutdown remains able to close the dialog and cancel the coordinator; the
+  user-facing close guard must not block host shutdown.
+- Once migration completes or fails, the dialog may close normally.
 
-Acceptance for the deferred decision must select exactly one policy:
+The confirmation copy must match the current persistence contract. Legacy records are written in
+batches, so cancellation is not an all-or-nothing rollback: already persisted records may remain,
+remaining work stops, and the legacy source is retained for a later retry. Do not claim that no
+partial migration has been applied unless persistence is first made transactional in a separate
+change.
 
-- nonclosable migration while preserving an application-forced shutdown path;
-- explicit cancel with confirmation and retry-on-next-launch semantics; or
-- advisory-only copy that accurately states closing cancels migration.
+Regression tests must prove the close guard, confirmation, continue, confirmed cancellation,
+forced host closure and completed-state behavior.
 
 ## Verification And Rollback
 
 Run strict Release build, Desktop headless/smoke tests, architecture tests and the full solution.
 On Windows, visually confirm one title and one close action with draggable custom chrome. Roll back
-the two items independently; neither changes user data or migration schema.
+the three items independently; none changes user data or migration schema. Rolling back Item C
+restores implicit window-close cancellation but does not change the coordinator or stored records.
+
+Local pre-commit evidence:
+
+- strict Release build: 0 warnings, 0 errors;
+- seven test projects: 834 passed, 1 skipped, 0 failed;
+- architecture tests: 228 passed;
+- lifecycle ownership audit: 479 matches, 0 violations;
+- five-iteration assembly lifecycle gate: 7 assemblies, 213 phase results, 0 failures;
+- format verification and `git diff --check`: passed.
+
+The skipped test is the existing packaged-aria2 TLS integration test. The first sandboxed lifecycle
+attempt could not use the Windows user certificate store or observe the residual-child self-test;
+the formal result above is from the elevated run with a process-local Git `safe.directory` value.

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -98,33 +98,6 @@ Detailed contract: `docs/exec-plans/v1.1.1-runtime-hardening.md`.
         NFO write failures must not be hidden when metadata output is required.
 12. [ ] Reject non-positive, duplicate or structurally invalid DURL order identities before transfer.
 
-## Dialog And Startup Backlog
-
-Detailed contract: `docs/exec-plans/v1.1.1-dialog-and-startup.md`.
-
-### P1 Issue #123 Custom Chrome
-
-- [x] Set shared `DialogWindow` to borderless custom chrome and disable unsupported resize,
-      minimize and maximize actions.
-- [x] Mark all six custom title regions as `WindowDecorationProperties.ElementRole="TitleBar"`
-      so borderless dialogs remain draggable.
-- [x] Fix `ViewParsingSelector` and `ViewAlertDialog` to use two valid columns and place close
-      buttons in column 1.
-- [x] Add headless tests for window decorations, XAML construction, title-bar role and valid
-      close-button bounds for all six dialogs.
-
-### P1 Startup Modal Ordering
-
-- [x] Sequence legacy-data migration before update checking in one observed async startup flow.
-- [x] Prove the update dialog cannot open while the migration dialog is active.
-- [x] Do not add a global dialog semaphore for a local startup-ordering defect.
-
-### Pending Product Decision
-
-- [ ] Align migration-dialog copy and close behavior. Current code allows cancellation while the
-      text implies closing is forbidden. Do not change this policy inside Issue #123 without an
-      explicit product contract.
-
 ## Naming And Responsibility Clarity
 
 - [ ] Audit and, where behavior is unchanged, rename update/migration entry points to express

--- a/src/DownKyi.Desktop/Platform/AvaloniaDialogService.cs
+++ b/src/DownKyi.Desktop/Platform/AvaloniaDialogService.cs
@@ -62,6 +62,7 @@ internal sealed class AvaloniaDialogService : IAppDialogService
             AppDialogOutcome.Canceled,
             new Dictionary<string, object?>(StringComparer.Ordinal));
         var closeRequested = false;
+        var forcedCloseRequested = false;
         void OnCloseRequested(object? sender, AppDialogResult requestedResult)
         {
             result = requestedResult;
@@ -71,7 +72,7 @@ internal sealed class AvaloniaDialogService : IAppDialogService
 
         void OnClosing(object? sender, WindowClosingEventArgs args)
         {
-            if (!closeRequested && !viewModel.CanCloseDialog())
+            if (ShouldCancelClose(closeRequested, forcedCloseRequested, viewModel))
             {
                 args.Cancel = true;
             }
@@ -80,7 +81,11 @@ internal sealed class AvaloniaDialogService : IAppDialogService
         viewModel.CloseRequested += OnCloseRequested;
         window.Closing += OnClosing;
         using var cancellationRegistration = cancellationToken.Register(() =>
-            Dispatcher.UIThread.Post(window.Close));
+            Dispatcher.UIThread.Post(() =>
+            {
+                forcedCloseRequested = true;
+                window.Close();
+            }));
         try
         {
             viewModel.OnDialogOpened(request);
@@ -98,6 +103,15 @@ internal sealed class AvaloniaDialogService : IAppDialogService
                 disposable.Dispose();
             }
         }
+    }
+
+    internal static bool ShouldCancelClose(
+        bool closeRequested,
+        bool forcedCloseRequested,
+        BaseDialogViewModel viewModel)
+    {
+        ArgumentNullException.ThrowIfNull(viewModel);
+        return !closeRequested && !forcedCloseRequested && !viewModel.CanCloseDialog();
     }
 
     internal static (Type View, Type ViewModel) GetDialogTypes(AppDialog dialog)

--- a/src/DownKyi.Desktop/ViewModels/Dialogs/ViewUpgradingDialogViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Dialogs/ViewUpgradingDialogViewModel.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
 using DownKyi.Application.Desktop;
 using DownKyi.Application.Diagnostics;
 using DownKyi.Application.Lifetime;
@@ -19,6 +20,8 @@ internal sealed class ViewUpgradingDialogViewModel : BaseDialogViewModel, IDispo
     private readonly ILogger<ViewUpgradingDialogViewModel> _logger;
     private readonly ILegacyUpgradeCoordinator _upgradeCoordinator;
     private CancellationTokenSource? _upgradeCancellation;
+    private bool _isMigrationActive;
+    private bool _cancelConfirmationVisible;
 
     private double _percent;
 
@@ -44,10 +47,37 @@ internal sealed class ViewUpgradingDialogViewModel : BaseDialogViewModel, IDispo
         set => SetProperty(ref _restartedVisible, value);
     }
 
+    public bool IsMigrationActive
+    {
+        get => _isMigrationActive;
+        private set => SetProperty(ref _isMigrationActive, value);
+    }
+
+    public bool CancelConfirmationVisible
+    {
+        get => _cancelConfirmationVisible;
+        private set => SetProperty(ref _cancelConfirmationVisible, value);
+    }
+
     private DownKyiAsyncDelegateCommand? _restartCommand;
 
     public DownKyiAsyncDelegateCommand RestartCommand =>
         _restartCommand ??= new DownKyiAsyncDelegateCommand(ExecuteRestartAsync, _logger);
+
+    private RelayCommand? _requestCancelMigrationCommand;
+
+    public RelayCommand RequestCancelMigrationCommand =>
+        _requestCancelMigrationCommand ??= new RelayCommand(ShowCancelConfirmation);
+
+    private RelayCommand? _continueMigrationCommand;
+
+    public RelayCommand ContinueMigrationCommand =>
+        _continueMigrationCommand ??= new RelayCommand(HideCancelConfirmation);
+
+    private RelayCommand? _confirmCancelMigrationCommand;
+
+    public RelayCommand ConfirmCancelMigrationCommand =>
+        _confirmCancelMigrationCommand ??= new RelayCommand(ConfirmCancelMigration);
 
     public ViewUpgradingDialogViewModel(
         ILegacyUpgradeCoordinator upgradeCoordinator,
@@ -60,18 +90,32 @@ internal sealed class ViewUpgradingDialogViewModel : BaseDialogViewModel, IDispo
         _applicationLifecycle = applicationLifecycle
             ?? throw new ArgumentNullException(nameof(applicationLifecycle));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        Message = "数据迁移中，请不要关闭软件";
+        Message = "数据迁移中；如需停止，请使用“取消迁移”";
     }
 
     public override void OnDialogOpened(AppDialogRequest request)
     {
         CancelUpgrade();
+        IsMigrationActive = true;
+        CancelConfirmationVisible = false;
         _upgradeCancellation = new CancellationTokenSource();
         _ = UpgradeAsync(_upgradeCancellation.Token);
     }
 
+    public override bool CanCloseDialog()
+    {
+        if (!IsMigrationActive)
+        {
+            return true;
+        }
+
+        ShowCancelConfirmation();
+        return false;
+    }
+
     public override void OnDialogClosed()
     {
+        FinishMigrationActivity();
         CancelUpgrade();
         base.OnDialogClosed();
     }
@@ -88,15 +132,18 @@ internal sealed class ViewUpgradingDialogViewModel : BaseDialogViewModel, IDispo
             switch (result.Outcome)
             {
                 case LegacyUpgradeOutcome.NoMigration:
+                    FinishMigrationActivity();
                     CloseDialog(AppDialogOutcome.Canceled);
                     break;
                 case LegacyUpgradeOutcome.Completed:
+                    FinishMigrationActivity();
                     _downloadLists.ReplaceDownloaded(result.DownloadedItems);
                     Percent = 100;
                     Message = "下载信息迁移完成";
                     RestartVisible = true;
                     break;
                 case LegacyUpgradeOutcome.Failed:
+                    FinishMigrationActivity();
                     Message = result.ErrorMessage ?? "数据迁移失败，请查看日志";
                     RestartVisible = false;
                     break;
@@ -111,6 +158,7 @@ internal sealed class ViewUpgradingDialogViewModel : BaseDialogViewModel, IDispo
         catch (InvalidOperationException e)
         {
             _logger.LogErrorMessage("Legacy data migration dialog failed.", e);
+            FinishMigrationActivity();
             Message = "数据迁移失败，请查看日志";
             RestartVisible = false;
         }
@@ -132,6 +180,37 @@ internal sealed class ViewUpgradingDialogViewModel : BaseDialogViewModel, IDispo
             Message = "无法重新启动应用，请查看日志";
             RestartVisible = true;
         }
+    }
+
+    private void ShowCancelConfirmation()
+    {
+        if (IsMigrationActive)
+        {
+            CancelConfirmationVisible = true;
+        }
+    }
+
+    private void HideCancelConfirmation()
+    {
+        CancelConfirmationVisible = false;
+    }
+
+    private void ConfirmCancelMigration()
+    {
+        if (!IsMigrationActive)
+        {
+            return;
+        }
+
+        FinishMigrationActivity();
+        CancelUpgrade();
+        CloseDialog(AppDialogOutcome.Canceled);
+    }
+
+    private void FinishMigrationActivity()
+    {
+        IsMigrationActive = false;
+        CancelConfirmationVisible = false;
     }
 
     private void CancelUpgrade()

--- a/src/DownKyi.Desktop/Views/Dialogs/ViewUpgradingDialog.axaml
+++ b/src/DownKyi.Desktop/Views/Dialogs/ViewUpgradingDialog.axaml
@@ -24,15 +24,46 @@
                     Foreground="{DynamicResource BrushCaptionForeground}"
                     Text="{Binding Title}" />
             </Grid>
-            <StackPanel Grid.Row="1" VerticalAlignment="Center" HorizontalAlignment="Center">
+            <StackPanel Grid.Row="1"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        IsVisible="{Binding !CancelConfirmationVisible}">
                 <customControl:Loading Foreground="Gray" Width="50" Height="50" IsActive="True" />
                 <TextBlock TextAlignment="Center" Margin="0,10,0,0" Text="{Binding Message}" />
                 <ProgressBar Value="{Binding Percent}" ShowProgressText="True" Margin="0,10,0,0" />
+                <Button Theme="{StaticResource BtnStyle}"
+                        Margin="0,10,0,0"
+                        IsVisible="{Binding IsMigrationActive}"
+                        Command="{Binding RequestCancelMigrationCommand}">
+                    取消迁移
+                </Button>
                 <Button Theme="{StaticResource BtnStyle}" Margin="0,10,0,0"
                         IsVisible="{Binding RestartVisible}"
                         Command="{Binding RestartCommand}">
                     立即重启
                 </Button>
+            </StackPanel>
+            <StackPanel Grid.Row="1"
+                        Width="420"
+                        VerticalAlignment="Center"
+                        HorizontalAlignment="Center"
+                        IsVisible="{Binding CancelConfirmationVisible}">
+                <TextBlock TextAlignment="Center"
+                           TextWrapping="Wrap"
+                           Text="确定要取消数据迁移吗？已完成写入的数据会保留；剩余迁移可在下次启动时重新尝试。" />
+                <StackPanel Orientation="Horizontal"
+                            HorizontalAlignment="Center"
+                            Spacing="10"
+                            Margin="0,20,0,0">
+                    <Button Theme="{StaticResource BtnStyle}"
+                            Command="{Binding ContinueMigrationCommand}">
+                        继续迁移
+                    </Button>
+                    <Button Theme="{StaticResource BtnStyle}"
+                            Command="{Binding ConfirmCancelMigrationCommand}">
+                        取消迁移
+                    </Button>
+                </StackPanel>
             </StackPanel>
         </Grid>
     </Border>

--- a/tests/DownKyi.Tests/LegacyUpgradeViewModelTests.cs
+++ b/tests/DownKyi.Tests/LegacyUpgradeViewModelTests.cs
@@ -1,6 +1,7 @@
 using DownKyi.Application.Desktop;
 using DownKyi.Application.Lifetime;
 using DownKyi.Models;
+using DownKyi.Platform;
 using DownKyi.Services.Download;
 using DownKyi.Services.Migration;
 using DownKyi.ViewModels.Dialogs;
@@ -30,6 +31,116 @@ public sealed class LegacyUpgradeViewModelTests
     }
 
     [Fact]
+    public async Task ActiveMigrationCloseShowsConfirmationAndContinueKeepsMigrationRunning()
+    {
+        var coordinator = new BlockingLegacyUpgradeCoordinator();
+        using var viewModel = new ViewUpgradingDialogViewModel(
+            coordinator,
+            new DownloadListState(),
+            new StubApplicationLifecycle(),
+            NullLogger<ViewUpgradingDialogViewModel>.Instance);
+
+        viewModel.OnDialogOpened(new AppDialogRequest(AppDialog.LegacyUpgrade));
+        await coordinator.Started.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(viewModel.CanCloseDialog());
+        Assert.True(viewModel.CancelConfirmationVisible);
+
+        viewModel.ContinueMigrationCommand.Execute(null);
+
+        Assert.False(viewModel.CancelConfirmationVisible);
+        Assert.True(viewModel.IsMigrationActive);
+        Assert.False(coordinator.Canceled.Task.IsCompleted);
+
+        viewModel.OnDialogClosed();
+        await coordinator.Canceled.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+    }
+
+    [Fact]
+    public async Task ConfirmedCancellationStopsMigrationAndClosesDialog()
+    {
+        var coordinator = new BlockingLegacyUpgradeCoordinator();
+        using var viewModel = new ViewUpgradingDialogViewModel(
+            coordinator,
+            new DownloadListState(),
+            new StubApplicationLifecycle(),
+            NullLogger<ViewUpgradingDialogViewModel>.Instance);
+        AppDialogResult? closeResult = null;
+        viewModel.CloseRequested += (_, result) => closeResult = result;
+
+        viewModel.OnDialogOpened(new AppDialogRequest(AppDialog.LegacyUpgrade));
+        await coordinator.Started.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        viewModel.RequestCancelMigrationCommand.Execute(null);
+        viewModel.ConfirmCancelMigrationCommand.Execute(null);
+
+        await coordinator.Canceled.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        Assert.False(viewModel.IsMigrationActive);
+        Assert.False(viewModel.CancelConfirmationVisible);
+        Assert.Equal(AppDialogOutcome.Canceled, Assert.IsType<AppDialogResult>(closeResult).Outcome);
+    }
+
+    [Fact]
+    public async Task ForcedHostCloseBypassesMigrationCloseGuard()
+    {
+        var coordinator = new BlockingLegacyUpgradeCoordinator();
+        using var viewModel = new ViewUpgradingDialogViewModel(
+            coordinator,
+            new DownloadListState(),
+            new StubApplicationLifecycle(),
+            NullLogger<ViewUpgradingDialogViewModel>.Instance);
+
+        viewModel.OnDialogOpened(new AppDialogRequest(AppDialog.LegacyUpgrade));
+        await coordinator.Started.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(AvaloniaDialogService.ShouldCancelClose(
+            closeRequested: false,
+            forcedCloseRequested: true,
+            viewModel));
+        Assert.False(viewModel.CancelConfirmationVisible);
+
+        viewModel.OnDialogClosed();
+        await coordinator.Canceled.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+    }
+
+    [Fact]
+    public async Task MigrationCompletionDismissesPendingCancelConfirmation()
+    {
+        var item = new DownloadedItem
+        {
+            DownloadBase = new DownloadBase { Id = "completed", MainTitle = "Completed" },
+            Downloaded = new Downloaded { Id = "completed" }
+        };
+        var coordinator = new ControllableLegacyUpgradeCoordinator();
+        var state = new DownloadListState();
+        using var viewModel = new ViewUpgradingDialogViewModel(
+            coordinator,
+            state,
+            new StubApplicationLifecycle(),
+            NullLogger<ViewUpgradingDialogViewModel>.Instance);
+
+        viewModel.OnDialogOpened(new AppDialogRequest(AppDialog.LegacyUpgrade));
+        await coordinator.Started.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        viewModel.RequestCancelMigrationCommand.Execute(null);
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        viewModel.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(ViewUpgradingDialogViewModel.RestartVisible) &&
+                viewModel.RestartVisible)
+            {
+                completed.TrySetResult();
+            }
+        };
+
+        coordinator.Complete(item);
+        await completed.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(viewModel.CancelConfirmationVisible);
+        Assert.False(viewModel.IsMigrationActive);
+        Assert.True(viewModel.RestartVisible);
+        Assert.Same(item, Assert.Single(state.Downloaded));
+    }
+
+    [Fact]
     public void CompletedMigrationReplacesDownloadedProjection()
     {
         var item = new DownloadedItem
@@ -49,6 +160,8 @@ public sealed class LegacyUpgradeViewModelTests
         Assert.Same(item, Assert.Single(state.Downloaded));
         Assert.Equal(100, viewModel.Percent);
         Assert.True(viewModel.RestartVisible);
+        Assert.False(viewModel.IsMigrationActive);
+        Assert.True(viewModel.CanCloseDialog());
     }
 
     private sealed class BlockingLegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
@@ -84,6 +197,30 @@ public sealed class LegacyUpgradeViewModelTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(new LegacyUpgradeResult(
+                LegacyUpgradeOutcome.Completed,
+                [item]));
+        }
+    }
+
+    private sealed class ControllableLegacyUpgradeCoordinator : ILegacyUpgradeCoordinator
+    {
+        private readonly TaskCompletionSource<LegacyUpgradeResult> _completion =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<LegacyUpgradeResult> UpgradeAsync(
+            IProgress<LegacyUpgradeProgress> progress,
+            CancellationToken cancellationToken)
+        {
+            Started.TrySetResult();
+            return await _completion.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public void Complete(DownloadedItem item)
+        {
+            _completion.TrySetResult(new LegacyUpgradeResult(
                 LegacyUpgradeOutcome.Completed,
                 [item]));
         }


### PR DESCRIPTION
## Summary

- keep all six custom dialogs borderless and draggable under Avalonia 12
- fix invalid title-bar grid columns and serialize startup migration/update dialogs
- make migration cancellation explicit while preserving forced host shutdown
- add headless dialog chrome, close-policy, and startup sequencing regressions

## Root cause

The shared dialog host combined custom chrome with incomplete native decoration settings, while migration close behavior and startup modal ownership were implicit. That allowed duplicate chrome, invalid layout, overlapping startup modals, and ambiguous cancellation.

## Verification

- strict Release build with AnalysisMode=All: 0 warnings, 0 errors
- seven test projects: 834 passed, 1 skipped
- Architecture tests: 228 passed
- lifecycle gate: 7 assemblies, 213 phase results, 0 failures
- format, module boundaries, package audits, workflow lint, Gitleaks, and diff check passed

## Stack

Base `stack/pr-120-frozen-a2119be` points exactly to PR #120 head `a2119be`. This PR contains only commit `6216050` and must merge after PR #120; retarget it to `main` after PR #120 merges.