### PR TITLE
test(aria2): synchronize secret holder startup

### DIFF
--- a/docs/testing/assembly-lifecycle-stability.md
+++ b/docs/testing/assembly-lifecycle-stability.md
@@ -59,6 +59,13 @@ Every phase result also has general `failureType` and `errorType` fields.
 `slowEvidenceErrorType` is reserved for failures inside slow-evidence capture
 and must not carry unrelated self-test or lifecycle contract failures.
 
+Process tests that require a child to acquire a file, pipe, socket or other
+resource must wait for a deterministic handshake emitted after acquisition.
+Fixed sleeps and short ready-file polling deadlines are not readiness proofs:
+runner load can delay child startup without indicating a product teardown
+failure. The xUnit operation token remains the outer bound for a missing or
+failed handshake.
+
 ### Measurement Definitions
 
 - `load`, `assembly-info`, `discovery` and `execution` duration starts

--- a/tests/DownKyi.Core.Tests/AriaServerProcessTests.cs
+++ b/tests/DownKyi.Core.Tests/AriaServerProcessTests.cs
@@ -138,7 +138,6 @@ public sealed class AriaServerProcessTests
             Path.GetTempPath(),
             $"downkyi-aria-secret-exit-{Guid.NewGuid():N}");
         Directory.CreateDirectory(directory);
-        var readyPath = Path.Combine(directory, "child-ready");
         var server = new AriaServer(NullLoggerFactory.Instance);
         Process? process = null;
         try
@@ -149,16 +148,12 @@ public sealed class AriaServerProcessTests
                 NullLogger.Instance);
             var secretPath = secretFile.Path;
             server.SetStartupSecretForTests(secretFile);
-            process = StartSecretHoldingProcess(secretPath, readyPath);
+            process = StartSecretHoldingProcess(secretPath);
             server.SetTrackedServerForTests(process);
-            using var readyTimeout = CancellationTokenSource.CreateLinkedTokenSource(
-                TestContext.Current.CancellationToken);
-            readyTimeout.CancelAfter(TimeSpan.FromSeconds(5));
-            while (!File.Exists(readyPath))
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(20), readyTimeout.Token)
-                    .ConfigureAwait(true);
-            }
+            var readySignal = await process.StandardOutput
+                .ReadLineAsync(TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+            Assert.Equal("ready", readySignal);
 
             Assert.True(server.KillTrackedServer("test startup cleanup"));
 
@@ -198,15 +193,14 @@ public sealed class AriaServerProcessTests
                ?? throw new InvalidOperationException("Could not start the process used by the cleanup test.");
     }
 
-    private static Process StartSecretHoldingProcess(
-        string secretPath,
-        string readyPath)
+    private static Process StartSecretHoldingProcess(string secretPath)
     {
         var startInfo = new ProcessStartInfo
         {
             FileName = "powershell.exe",
             UseShellExecute = false,
-            CreateNoWindow = true
+            CreateNoWindow = true,
+            RedirectStandardOutput = true
         };
         startInfo.ArgumentList.Add("-NoLogo");
         startInfo.ArgumentList.Add("-NoProfile");
@@ -216,10 +210,9 @@ public sealed class AriaServerProcessTests
             "$stream = [System.IO.File]::Open($env:DOWNKYI_SECRET_PATH, " +
             "[System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, " +
             "[System.IO.FileShare]::Read); " +
-            "[System.IO.File]::WriteAllText($env:DOWNKYI_READY_PATH, 'ready'); " +
+            "[Console]::Out.WriteLine('ready'); " +
             "Start-Sleep -Seconds 30");
         startInfo.Environment["DOWNKYI_SECRET_PATH"] = secretPath;
-        startInfo.Environment["DOWNKYI_READY_PATH"] = readyPath;
 
         return Process.Start(startInfo)
                ?? throw new InvalidOperationException(


### PR DESCRIPTION
## Summary

- replace the Windows aria2 secret-holder ready-file poll and arbitrary 5-second timeout with a stdout handshake
- emit the handshake only after the child has opened and retained the RPC secret stream
- document deterministic child-process readiness as the lifecycle test contract

## Root cause

PR #124 Windows CI failed before product teardown ran: a loaded runner took more than five seconds to start the PowerShell child, so the test's ready-file timeout canceled itself. The same test passed on PR #125, confirming an intermittent scheduling dependency. The product `KillTrackedServer` path was not changed.

## Verification

- strict Core.Tests Release build with AnalysisMode=All: 0 warnings, 0 errors
- focused Windows test: 20 consecutive passes
- complete Core.Tests: 197 passed, 0 failed
- format and diff check passed

## Stack

Base `stack/pr-120-frozen-a2119be` points exactly to PR #120 head `a2119be`. Merge this PR after #120 and before #124/#125.