### PR TITLE
test(ci): turn review findings into permanent invariants

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,6 +67,14 @@ jobs:
           -c Release
           --no-restore
           --no-build
+      - name: Run review invariant failure corpus
+        shell: pwsh
+        run: >
+          ./script/test-review-invariants.ps1
+          -Configuration Release
+          -NoRestore
+          -NoBuild
+          -ResultsDirectory ./TestResults/review-invariants
       - name: Test
         shell: pwsh
         run: >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@
 4. 涉及 Bilibili API、WBI、JSON envelope 或登入契約時，先閱讀並同步更新 `docs/operations/bilibili-api-audit.md`。
 5. 涉及建置、依賴、外部 binary、分析器或發版時，再閱讀 `docs/maintenance.md` 與 `docs/operations/verification-and-rollback.md`。
 6. 新增、刪除、移動或重新導向模組責任的 PR，必須同步更新知識圖譜、架構文件與即時計畫。
+7. 修正 reviewer 或 Codex 找到的一般性缺陷前，先閱讀 `docs/testing/review-invariant-policy.md` 與 `docs/testing/review-invariant-corpus.json`。相同根因合併成一條永久 invariant；deterministic failure/contract 放 PR CI，重型 race/stress/systematic 證據留在 Main/rehearsal；architecture/static gate 本身必須有 adversarial fixture，禁止只修 production code 後依賴對話記憶。
 
 ## 專案概況
 
@@ -199,6 +200,10 @@ dotnet build .\DownKyi.sln `
   -p:TreatWarningsAsErrors=true `
   -p:CodeAnalysisTreatWarningsAsErrors=true
 
+pwsh .\script\test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
 pwsh .\script\test-solution.ps1 -Configuration Release -NoRestore -NoBuild
 pwsh .\script\audit-lifecycle-ownership.ps1 `
   -OutputDirectory .\artifacts\assembly-lifecycle\ownership
@@ -228,6 +233,9 @@ dotnet package list --project .\DownKyi.sln --deprecated
 - SQLite migration/resume、download shutdown recovery、DURL identity/seekability tests
 
 每次修正行為都應新增能在舊實作上失敗的測試；不要只以 build 成功代表 runtime 正常。
+review finding 若具有一般性根因，還必須更新或重用
+`docs/testing/review-invariant-corpus.json` 中的一條 invariant，不得把每個
+comment 機械式複製成近似測試。
 
 PR 會對每個 test assembly 執行 3 次 assembly lifecycle gate，`main`
 執行 50 次，release rehearsal 執行 100 次。涉及 thread、Dispatcher、

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,14 @@
 4. 涉及 Bilibili API、WBI、JSON envelope 或登入契約時，先閱讀並同步更新 `docs/operations/bilibili-api-audit.md`。
 5. 涉及建置、依賴、外部 binary、分析器或發版時，再閱讀 `docs/maintenance.md` 與 `docs/operations/verification-and-rollback.md`。
 6. 新增、刪除、移動或重新導向模組責任的 PR，必須同步更新知識圖譜、架構文件與即時計畫。
-7. 修正 reviewer 或 Codex 找到的一般性缺陷前，先閱讀 `docs/testing/review-invariant-policy.md` 與 `docs/testing/review-invariant-corpus.json`。相同根因合併成一條永久 invariant；deterministic failure/contract 放 PR CI，重型 race/stress/systematic 證據留在 Main/rehearsal；architecture/static gate 本身必須有 adversarial fixture，禁止只修 production code 後依賴對話記憶。
+7. 收到 PR/GitHub/Codex/CI review finding 時，先閱讀 `docs/testing/review-invariant-policy.md` 與 `docs/testing/review-invariant-corpus.json`。Finding 只是症狀證據，不是 patch instruction；修改前必須找出 violated invariant、完整 failure path、同族 sibling paths，以及最早丟失語意或做錯 state transition 的 boundary。
+
+## Review Remediation Gate
+
+- Result model、failure taxonomy、sentinel、cleanup、commit boundary、ownership 或 transaction boundary 若是根因，必須修正 shared abstraction/owner；禁止只在 reviewer 指出的 caller 疊加 `if`、catch 或另一個模糊 sentinel。
+- Regression 由 invariant 或外部 protocol contract 推導。Retry、cleanup、classification、lifecycle、persistence 與 state-machine finding 必須建立或更新 failure/transition matrix，不得一個 comment 配一個近似 test。
+- 同一 PR 後續 review 若再次出現相同 failure family，視為前次未修到 root cause。立即停止 local patch，重新審查 typed result、shared abstraction、state machine、commit boundary、ownership 與 transaction，直到同族入口由一個共同 invariant 封閉。
+- 相同根因只保留一條永久 invariant；deterministic failure/contract 放 PR CI，重型 race/stress/systematic 證據留在 Main/rehearsal；architecture/static gate 本身必須有 adversarial fixture。
 
 ## 專案概況
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,10 +21,12 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="NLog" Version="6.1.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
     <PackageVersion Include="QRCoder" Version="1.8.0" />
     <PackageVersion Include="SQLite3MC.PCLRaw.bundle" Version="2.3.6" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/DownKyi.Core/DownKyi.Core.csproj
+++ b/DownKyi.Core/DownKyi.Core.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.Data.Sqlite.Core"/>
         <PackageReference Include="Microsoft.Extensions.Logging"/>
         <PackageReference Include="Newtonsoft.Json"/>
+        <PackageReference Include="NuGet.Versioning"/>
         <PackageReference Include="SQLite3MC.PCLRaw.bundle"/>
     </ItemGroup>
 

--- a/DownKyi.Core/Settings/ApplicationSettings.cs
+++ b/DownKyi.Core/Settings/ApplicationSettings.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using DownKyi.Core.Aria2cNet.Server;
 using DownKyi.Core.FileName;
+using DownKyi.Core.Versioning;
 
 namespace DownKyi.Core.Settings;
 
@@ -266,8 +267,10 @@ internal static class ApplicationSettingsValidator
         {
             IsReceiveBetaVersion = AllowValue(settings.About.IsReceiveBetaVersion, AllowStatus.No, "About.IsReceiveBetaVersion", corrections),
             AutoUpdateWhenLaunch = AllowValue(settings.About.AutoUpdateWhenLaunch, AllowStatus.No, "About.AutoUpdateWhenLaunch", corrections),
-            SkipVersionOnLaunch = Version.TryParse(settings.About.SkipVersionOnLaunch, out _)
-                ? settings.About.SkipVersionOnLaunch
+            SkipVersionOnLaunch = SemanticVersionPolicy.TryNormalizeIdentity(
+                settings.About.SkipVersionOnLaunch,
+                out var normalizedSkipVersion)
+                ? normalizedSkipVersion
                 : string.Empty
         };
         var user = settings.User with

--- a/DownKyi.Core/Settings/SettingsManager.About.cs
+++ b/DownKyi.Core/Settings/SettingsManager.About.cs
@@ -1,3 +1,5 @@
+using DownKyi.Core.Versioning;
+
 namespace DownKyi.Core.Settings;
 
 public sealed partial class SettingsManager
@@ -68,11 +70,13 @@ public sealed partial class SettingsManager
 
     public bool SetSkipVersionOnLaunch(string skipVersionOnLaunch)
     {
-        if (Version.TryParse(skipVersionOnLaunch, out var _))
+        if (SemanticVersionPolicy.TryNormalizeIdentity(
+                skipVersionOnLaunch,
+                out var normalizedVersion))
         {
             return SetProperty(
                 _appSettings.About.SkipVersionOnLaunch,
-                skipVersionOnLaunch,
+                normalizedVersion,
                 v => _appSettings.About.SkipVersionOnLaunch = v);
         }
 
@@ -81,9 +85,11 @@ public sealed partial class SettingsManager
 
     public string GetSkipVersionOnLaunch()
     {
-        if (Version.TryParse(_appSettings.About.SkipVersionOnLaunch, out var _))
+        if (SemanticVersionPolicy.TryNormalizeIdentity(
+                _appSettings.About.SkipVersionOnLaunch,
+                out var normalizedVersion))
         {
-            return _appSettings.About.SkipVersionOnLaunch;
+            return normalizedVersion;
         }
         return string.Empty;
     }

--- a/DownKyi.Core/Versioning/SemanticVersionPolicy.cs
+++ b/DownKyi.Core/Versioning/SemanticVersionPolicy.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using NuGet.Versioning;
+
+namespace DownKyi.Core.Versioning;
+
+public static class SemanticVersionPolicy
+{
+    public static string NormalizeForDisplay(string? value)
+    {
+        return TryParse(value, out var version)
+            ? Format(version, includeMetadata: false)
+            : string.Empty;
+    }
+
+    public static bool TryNormalizeIdentity(string? value, out string normalized)
+    {
+        if (!TryParse(value, out var version))
+        {
+            normalized = string.Empty;
+            return false;
+        }
+
+        normalized = Format(version, includeMetadata: true);
+        return true;
+    }
+
+    public static bool IsNewer(string? candidate, string? current)
+    {
+        return TryParse(candidate, out var candidateVersion) &&
+               TryParse(current, out var currentVersion) &&
+               VersionComparer.VersionRelease.Compare(candidateVersion, currentVersion) > 0;
+    }
+
+    public static bool HasSamePrecedence(string? left, string? right)
+    {
+        return TryParse(left, out var leftVersion) &&
+               TryParse(right, out var rightVersion) &&
+               VersionComparer.VersionRelease.Equals(leftVersion, rightVersion);
+    }
+
+    internal static bool TryParse(
+        string? value,
+        [NotNullWhen(true)] out NuGetVersion? version)
+    {
+        version = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var candidate = value.Trim();
+        if (candidate.Length > 1 &&
+            (candidate[0] == 'v' || candidate[0] == 'V') &&
+            char.IsAsciiDigit(candidate[1]))
+        {
+            candidate = candidate[1..];
+        }
+
+        var coreEnd = candidate.IndexOfAny('-', '+');
+        var core = coreEnd < 0 ? candidate : candidate[..coreEnd];
+        var coreParts = core.Split('.');
+        if (coreParts.Length != 3 || coreParts.Any(part =>
+                part.Length == 0 ||
+                (part.Length > 1 && part[0] == '0') ||
+                !int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out _)))
+        {
+            return false;
+        }
+
+        return NuGetVersion.TryParse(candidate, out version);
+    }
+
+    private static string Format(NuGetVersion version, bool includeMetadata)
+    {
+        var normalized = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{version.Major}.{version.Minor}.{version.Patch}");
+        if (!string.IsNullOrEmpty(version.Release))
+        {
+            normalized = $"{normalized}-{version.Release}";
+        }
+        if (includeMetadata && !string.IsNullOrEmpty(version.Metadata))
+        {
+            normalized = $"{normalized}+{version.Metadata}";
+        }
+
+        return normalized;
+    }
+}

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2481,6 +2481,7 @@ contracts:
   - Windows PR and main jobs must run the Assembly Lifecycle Stability Gate and upload its reports even when a phase fails.
   - Every PR runs the six-RID real-binary aria2 TLS security matrix; a unit-test-only pass cannot replace it.
   - General reviewer/Codex findings become one permanent invariant per root cause. Deterministic failure injection, contracts and architecture self-tests run in PR CI; repeated race, stress, process and systematic evidence stay in Main/rehearsal unless an existing security policy requires PR coverage.
+  - A review finding is symptom evidence, not a patch instruction. Remediation identifies the violated invariant, traces the full failure path and sibling callers, and fixes the earliest shared semantic/transition boundary. A repeated failure family in the same PR blocks further local patches and requires a systemic typed-result/state/ownership/transaction review.
   - The review corpus must resolve to real classes across all seven test projects. Missing classes/projects, duplicate IDs, incomplete Main/rehearsal evidence or an unexecuted declared test fail closed.
   - Static C# architecture rules use Roslyn where syntax or semantics matter and carry adversarial fixtures for modifiers, filenames, receiver names, root-level files and nullable static fields.
 hazards:

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2,7 +2,7 @@
 
 Status: maintained architecture index
 Schema version: 1.0
-Last reviewed: 2026-08-01
+Last reviewed: 2026-08-09
 
 This document is the first file an AI agent should read before changing DownKyi. Its goal is to preserve stable knowledge about project structure, ownership boundaries, and call relationships so agents do not rediscover the same code paths from scratch.
 
@@ -145,6 +145,7 @@ flowchart TD
     Benchmarks["test.performance-baseline\nBenchmarkCases + runner"]
     SystemBenchmarks["test.system-performance\nisolated system scenarios"]
     CI["workflow.strict-pr-ci\n.github/workflows/quality.yml"]
+    ReviewInvariants["test.review-invariant-corpus\nroot-cause failure corpus + adversarial gate tests"]
     AriaTlsCI["workflow.aria2-tls-security\nsix RID real-binary gate"]
     Release["workflow.release-packaging\n.github/workflows/build.yml"]
     Nightly["workflow.system-baselines\nnightly cross-platform reports"]
@@ -179,6 +180,9 @@ flowchart TD
     SystemBenchmarks -->|measures| FFmpeg
     Nightly -->|runs| SystemBenchmarks
     CI -->|runs PR and main profiles| LifecycleGate
+    CI -->|runs deterministic corpus| ReviewInvariants
+    ReviewInvariants -->|guards| Tests
+    ReviewInvariants -->|guards gate behavior| ArchitectureTests
     Release -->|runs rehearsal profile| LifecycleGate
     LifecycleOwners -->|governs| LifecycleGate
     LifecycleGate -->|guards| Tests
@@ -2457,7 +2461,9 @@ paths:
   - .github/workflows/quality.yml
   - .github/workflows/build.yml
   - script/test-solution.ps1
-responsibility: Blocks PRs that break formatting, restore, Release build, warnings-as-errors, unit tests, or vulnerable package policy.
+  - script/test-review-invariants.ps1
+  - docs/testing/review-invariant-corpus.json
+responsibility: Blocks PRs that break formatting, restore, Release build, warnings-as-errors, unit tests, root-cause review invariants, or vulnerable package policy.
 inbound:
   - github.pull_request
 outbound:
@@ -2474,11 +2480,15 @@ contracts:
   - Every test project writes a distinct assembly-named TRX; no solution-level logger filename may overwrite earlier project evidence.
   - Windows PR and main jobs must run the Assembly Lifecycle Stability Gate and upload its reports even when a phase fails.
   - Every PR runs the six-RID real-binary aria2 TLS security matrix; a unit-test-only pass cannot replace it.
+  - General reviewer/Codex findings become one permanent invariant per root cause. Deterministic failure injection, contracts and architecture self-tests run in PR CI; repeated race, stress, process and systematic evidence stay in Main/rehearsal unless an existing security policy requires PR coverage.
+  - The review corpus must resolve to real classes across all seven test projects. Missing classes/projects, duplicate IDs, incomplete Main/rehearsal evidence or an unexecuted declared test fail closed.
+  - Static C# architecture rules use Roslyn where syntax or semantics matter and carry adversarial fixtures for modifiers, filenames, receiver names, root-level files and nullable static fields.
 hazards:
   - Turning every historical analyzer suggestion into PR failure makes unrelated PRs impossible.
   - Broad NoWarn, global suppressions, nullable disable, or analyzer exclusions hide new defects.
   - Restoring one parallel solution-level `dotnet test` command can reintroduce Windows foreground-thread timeouts and TRX overwrite.
 tests:
+  - test.review-invariant-corpus
   - github.actions
 ```
 
@@ -3313,6 +3323,21 @@ test.assembly-lifecycle-architecture:
     - formal Verification cannot omit the ownership audit, five-iteration local gate or Rehearsal report
     - Desktop main-loop teardown awaits async App and Host disposal
     - every declared lifecycle owner documents start, stop, teardown, paths and allowed mechanisms
+
+test.review-invariant-corpus:
+  paths:
+    - docs/testing/review-invariant-policy.md
+    - docs/testing/review-invariant-corpus.json
+    - script/test-review-invariants.ps1
+    - tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
+    - tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
+  guards:
+    - historical review comments with one root cause map to one invariant instead of duplicate test cases
+    - deterministic PR coverage resolves to existing test classes in all seven test projects and executes at least one test per declared project
+    - durable output ownership remains a transactional SQLite unique claim behind DownloadTaskAdmissionService; no mutable path registry, full unfinished-task scan or silent suffixing can replace it
+    - Main/rehearsal evidence retains lifecycle stress and real-binary transfer security profiles
+    - corpus schema, workflow integration and Roslyn source policies have adversarial fail-closed fixtures
+    - the two existing presentation-bound service contracts remain an exact non-growth baseline until a dedicated boundary change removes them
 
 test.infrastructure-clock:
   paths:

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -5,6 +5,7 @@
 目前 PR #120 的範圍收斂契約位於 `v1.1.1-pr-120-scope-cleanup.md`。
 下載 runtime P0/P1/P2 清單位於 `v1.1.1-runtime-hardening.md`。
 對話框 Issue #123 與啟動模態排序位於 `v1.1.1-dialog-and-startup.md`。
+review finding 去重、永久 invariant 與 CI 分層位於 `review-invariant-gates.md`。
 
 每個 work item 必須包含：
 

--- a/docs/exec-plans/review-invariant-gates.md
+++ b/docs/exec-plans/review-invariant-gates.md
@@ -1,6 +1,6 @@
 # Review Invariant Gates
 
-Status: local Verification complete; exact-head GitHub CI pending
+Status: complete
 
 ## Goal
 
@@ -49,7 +49,7 @@ Out of scope:
 - [x] SemVer prerelease/build/skip and manual-update dialog defects have deterministic regressions.
 - [x] Agent, testing, verification and knowledge documentation are synchronized.
 - [x] Complete every local command in Verification.
-- [ ] Push semantic commits and require exact-head GitHub CI on Windows, Linux and macOS.
+- [x] Push semantic commits and require exact-head GitHub CI on Windows, Linux and macOS.
 
 Local evidence on 2026-08-09:
 
@@ -61,6 +61,8 @@ Local evidence on 2026-08-09:
 - Assembly lifecycle: 7 assemblies, 213 phase results, 0 failures.
 - Format, Gitleaks 8.30.1, Actionlint, version contract, package vulnerability,
   package deprecation and `git diff --check`: passed.
+- GitHub PR #129: Windows/Linux/macOS build and test, six-RID aria2 security,
+  assembly lifecycle, format, package audit, protobuf and CodeQL passed.
 
 The Roslyn audit exposed two pre-existing presentation-bound service contracts:
 `DownloadManagerCoordinator.cs` and `LegacyUpgradeCoordinator.cs`. They are an

--- a/docs/exec-plans/review-invariant-gates.md
+++ b/docs/exec-plans/review-invariant-gates.md
@@ -1,0 +1,112 @@
+# Review Invariant Gates
+
+Status: local Verification complete; exact-head GitHub CI pending
+
+## Goal
+
+Turn recurring Codex/reviewer findings into a small, permanent and executable failure corpus. Fix production behavior only when the overlap audit proves that the reviewed root cause still exists. Do not create one test per historical comment or a second implementation of an existing runtime contract.
+
+## Scope
+
+In scope:
+
+- Group historical findings by root cause and point each invariant at representative existing regression tests.
+- Run deterministic failure injection, contract and architecture self-tests in PR CI.
+- Keep expensive lifecycle repetition and real-binary/systematic checks in their existing Main or rehearsal profiles.
+- Add adversarial fixtures for source-policy and corpus gates so renaming a file, receiver or modifier cannot bypass them.
+- Repair SemVer prerelease/build/skip handling and the manual update-dialog contract because the overlap audit confirmed both defects still exist.
+- Update `AGENTS.md`, testing policy, the knowledge graph and this plan.
+
+Out of scope:
+
+- New download architecture, backend, path registry, retry policy or lifecycle owner.
+- Reimplementing tests already covering durable SQLite output reservations, FFmpeg concurrency, JSON envelopes, request security or process teardown.
+- Heavy benchmark thresholds in PR CI.
+- Unrelated review backlog or product work.
+
+## Overlap Audit
+
+- Cancellation, durable output reservation, FFmpeg diagnostic concurrency, JSON envelope presence, aria2 redirect/header security and lifecycle teardown already have focused tests. Reuse them through the corpus.
+- Output ownership remains a transactional SQLite unique claim coordinated only by `DownloadTaskAdmissionService`. The invariant runner references the existing store/admission tests and does not add a mutable path registry, cache or full unfinished-task scan.
+- The existing module policy uses filename and receiver-name-sensitive scans in a few places. Replace the C# gate with Roslyn-backed inspection and adversarial tests; keep the PowerShell audit as reporting evidence.
+- Existing version tests strip prerelease identifiers and do not cover build/skip precedence. This is a live product defect, not missing test-only metadata.
+- The manual About-page update request omits the required `enableSkipVersion` dialog parameter. This is a live dialog-contract defect.
+
+## Steps
+
+1. Add a machine-readable root-cause corpus and fail-closed validator.
+2. Add a filtered runner and invoke it in the existing cross-platform PR matrix.
+3. Replace fragile C# source scans with Roslyn inspection and adversarial fixtures.
+4. Fix the two confirmed update/version defects and add deterministic regressions.
+5. Update Agent/testing/architecture documentation.
+6. Run the repository's complete strict Verification.
+
+## Progress
+
+- [x] Root-cause corpus covers all seven test projects without one-comment-one-test duplication.
+- [x] Cross-platform PR matrix runs the deterministic corpus.
+- [x] Roslyn-backed source rules include adversarial modifier, receiver, filename, root-path and nullable-static-field fixtures.
+- [x] SemVer prerelease/build/skip and manual-update dialog defects have deterministic regressions.
+- [x] Agent, testing, verification and knowledge documentation are synchronized.
+- [x] Complete every local command in Verification.
+- [ ] Push semantic commits and require exact-head GitHub CI on Windows, Linux and macOS.
+
+Local evidence on 2026-08-09:
+
+- Strict Release build: 0 warnings, 0 errors.
+- Review invariant corpus: 12 root-cause invariants, 7 projects, 309 tests.
+- Full solution: 884 passed, 0 failed, 1 real-binary integration test skipped locally.
+- Module boundary audit: 0 violations.
+- Lifecycle ownership: 493 matches, 0 violations.
+- Assembly lifecycle: 7 assemblies, 213 phase results, 0 failures.
+- Format, Gitleaks 8.30.1, Actionlint, version contract, package vulnerability,
+  package deprecation and `git diff --check`: passed.
+
+The Roslyn audit exposed two pre-existing presentation-bound service contracts:
+`DownloadManagerCoordinator.cs` and `LegacyUpgradeCoordinator.cs`. They are an
+exact non-growth ratchet, not a claim of zero debt, and are outside this CI PR.
+
+## Verification
+
+```powershell
+dotnet restore .\DownKyi.sln
+
+dotnet build .\DownKyi.sln `
+  -c Release `
+  --no-restore `
+  --no-incremental `
+  -p:EnableNETAnalyzers=true `
+  -p:AnalysisMode=All `
+  -p:EnforceCodeStyleInBuild=true `
+  -p:TreatWarningsAsErrors=true `
+  -p:CodeAnalysisTreatWarningsAsErrors=true `
+  -p:UseSharedCompilation=false
+
+pwsh .\script\test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
+pwsh .\script\test-solution.ps1 -Configuration Release -NoRestore -NoBuild
+pwsh .\script\audit-module-boundaries.ps1 `
+  -OutputPath .\artifacts\architecture\module-boundary-audit.json
+pwsh .\script\audit-lifecycle-ownership.ps1 `
+  -OutputDirectory .\artifacts\assembly-lifecycle\ownership
+pwsh .\script\test-assembly-lifecycle.ps1 `
+  -Configuration Release `
+  -Iterations 5 `
+  -NoBuild `
+  -ValidateForensics `
+  -ResultsDirectory .\artifacts\assembly-lifecycle\verification
+dotnet format .\DownKyi.sln --no-restore --verify-no-changes
+pwsh .\script\scan-secrets.ps1
+go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -- .github/workflows/*.yml
+dotnet package list --project .\DownKyi.sln --vulnerable --include-transitive
+dotnet package list --project .\DownKyi.sln --deprecated
+git diff --check
+```
+
+Pass means every command exits zero, every corpus entry resolves to a real test class, the filtered run executes at least one test per declared project, all seven test projects pass, and no architecture/self-test can be bypassed by the supplied adversarial fixtures.
+
+## Rollback
+
+Revert the corpus/gate commit and the version-contract commit independently. Do not change user data, SQLite state, download files or settings schema. Existing skip-version values remain string-compatible if the version-contract commit is reverted.

--- a/docs/exec-plans/review-invariant-gates.md
+++ b/docs/exec-plans/review-invariant-gates.md
@@ -48,6 +48,7 @@ Out of scope:
 - [x] Roslyn-backed source rules include adversarial modifier, receiver, filename, root-path and nullable-static-field fixtures.
 - [x] SemVer prerelease/build/skip and manual-update dialog defects have deterministic regressions.
 - [x] Agent, testing, verification and knowledge documentation are synchronized.
+- [x] Root-cause remediation, failure/transition matrices and repeated-review escalation are durable Agent/testing rules.
 - [x] Complete every local command in Verification.
 - [x] Push semantic commits and require exact-head GitHub CI on Windows, Linux and macOS.
 

--- a/docs/operations/verification-and-rollback.md
+++ b/docs/operations/verification-and-rollback.md
@@ -31,6 +31,10 @@ dotnet build ./DownKyi.sln `
   -p:CodeAnalysisTreatWarningsAsErrors=true `
   -p:UseSharedCompilation=false
 
+pwsh ./script/test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
 pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild
 pwsh ./script/audit-lifecycle-ownership.ps1 `
   -OutputDirectory ./artifacts/assembly-lifecycle/ownership
@@ -53,6 +57,11 @@ pwsh ./script/scan-secrets.ps1
 ```
 
 `scan-secrets.ps1` 使用 Gitleaks 掃描目前 tracked 與尚未追蹤、但未被 `.gitignore` 排除的候選提交檔。固定驗證版本為 Gitleaks `8.30.1`；Windows x64 release zip 必須先依官方 `gitleaks_8.30.1_checksums.txt` 驗證 SHA-256，再解壓到 `.tools/gitleaks/bin/`。`.gitleaks.toml` 只允許公開 WBI 測試 fixture 與精確的 Avalonia brush resource 行，不得加入整個目錄或一般測試檔的寬鬆排除。
+
+`test-review-invariants.ps1` 是正式 PR failure corpus gate。它按根因重用
+七個測試專案中的代表性 regression，不能用單一歷史 comment 對應一份
+重複測試；Main/rehearsal 的重型證據由 corpus 明確列出並由架構測試
+fail closed 驗證。
 
 Lifecycle ownership audit 與 5 次全 test-assembly gate 是同一套嚴格
 Verification 的必要步驟，不是選用診斷工具。每個 assembly 必須通過

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -161,6 +161,8 @@ dotnet build ./DownKyi.sln -c Release --no-restore --no-incremental `
   -p:EnableNETAnalyzers=true -p:AnalysisMode=All `
   -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=true `
   -p:CodeAnalysisTreatWarningsAsErrors=true -p:UseSharedCompilation=false
+pwsh ./script/test-review-invariants.ps1 `
+  -Configuration Release -NoRestore -NoBuild
 pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild
 pwsh ./script/audit-lifecycle-ownership.ps1 `
   -OutputDirectory ./artifacts/assembly-lifecycle/ownership

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -15,7 +15,22 @@
 - `module-boundary-ratchets.md`
 - `assembly-lifecycle-stability.md`
 - `assembly-lifecycle-owners.json`
+- `review-invariant-policy.md`
+- `review-invariant-corpus.json`
 - `../maintenance.md`
 - `../operations/verification-and-rollback.md`
 
 測試不得讀取使用者真實 settings、cookie、下載 DB 或 aria2 session。網路 contract tests 使用 fixture 或 loopback server。
+
+Reviewer/Codex 發現的一般性缺陷必須依 `review-invariant-policy.md` 先做
+重疊審查，再依根因合併為永久 invariant。PR CI 執行 deterministic
+failure injection、contract 與 architecture self-test；反覆 race、process、
+GC、real-binary 和系統性平台檢查保留在 Main/rehearsal。規則本身需要
+adversarial fixture，避免 gate 被改名、修飾詞或檔案位置繞過。
+
+```powershell
+pwsh ./script/test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
+```

--- a/docs/testing/review-invariant-corpus.json
+++ b/docs/testing/review-invariant-corpus.json
@@ -1,0 +1,265 @@
+{
+  "schemaVersion": 1,
+  "prInvariants": [
+    {
+      "id": "cancellation-semantics",
+      "historicalRoots": ["PR #85 F057", "PR #91", "PR #120"],
+      "guards": "User cancellation, pause, shutdown and timeout retain distinct outcomes and are never swallowed into retry or failure.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Domain.Tests/DownKyi.Domain.Tests.csproj",
+          "class": "DownKyi.Domain.Tests.DownloadTaskStateMachineTests"
+        },
+        {
+          "project": "tests/DownKyi.Application.Tests/DownKyi.Application.Tests.csproj",
+          "class": "DownKyi.Application.Tests.ApplicationCancellationTests"
+        },
+        {
+          "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj",
+          "class": "DownKyi.Infrastructure.Tests.BilibiliHttpTransportTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadRetryPolicyTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadShutdownCoordinatorTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.AsyncDelegateCommandTests"
+        }
+      ]
+    },
+    {
+      "id": "runtime-ownership",
+      "historicalRoots": ["PR #85 F049", "PR #94", "PR #113", "PR #122"],
+      "guards": "Scopes, GIDs, processes, flush barriers and operation identities remain owned until asynchronous cleanup completes.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Application.Tests/DownKyi.Application.Tests.csproj",
+          "class": "DownKyi.Application.Tests.DownloadTaskApplicationServiceTests"
+        },
+        {
+          "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj",
+          "class": "DownKyi.Infrastructure.Tests.ApplicationLogProviderTests"
+        },
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.AriaServerProcessTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadOrchestratorTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.AriaRuntimeClientRegistryTests"
+        }
+      ]
+    },
+    {
+      "id": "file-and-output-ownership",
+      "historicalRoots": ["PR #85", "PR #120", "PR #125"],
+      "guards": "DownloadTaskAdmissionService coordinates transactional SQLite unique claims without a mutable registry or full unfinished-task scan; output paths, sidecars, temporary files and segment identities stay fail-closed, macOS path claims ignore case, and disabled suffixing rejects collisions.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj",
+          "class": "DownKyi.Infrastructure.Tests.SqliteDownloadTaskStoreTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadTaskAdmissionServiceTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadTaskFileServiceTests"
+        }
+      ]
+    },
+    {
+      "id": "failure-classification",
+      "historicalRoots": ["PR #127"],
+      "guards": "Corrupt media, permission or infrastructure failure, missing runtime, timeout, process failure and transport failure do not collapse into one exit-code branch.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.FfmpegProcessorMergeTests"
+        },
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.FfmpegConcatRuntimeTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.MuxFailureRecoveryTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadRetryPolicyTests"
+        }
+      ]
+    },
+    {
+      "id": "ffmpeg-concurrency-budget",
+      "historicalRoots": ["PR #127"],
+      "guards": "Normal work, failure diagnostics and retries share the configured FfmpegMaxParallelJobs budget.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.FfmpegProcessorMergeTests"
+        }
+      ]
+    },
+    {
+      "id": "json-contract-presence",
+      "historicalRoots": ["PR #85 F060-F061", "PR #120"],
+      "guards": "Missing, null, empty, malformed and valid JSON remain distinct; optional collections and result/error envelopes cannot invent success payloads.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.JsonEnvelopePresenceTests"
+        },
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.PlayUrlEnvelopeContractTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadArtifactStageTests"
+        }
+      ]
+    },
+    {
+      "id": "request-origin-and-credential-contracts",
+      "historicalRoots": ["PR #85 F065-F066", "PR #91", "PR #122"],
+      "guards": "Endpoint parameters, cookie deduplication, required headers and redirect/origin security remain explicit and credential-safe.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.PlayUrlEnvelopeContractTests"
+        },
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.AriaClientSecurityTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.AriaSecurityTests"
+        }
+      ]
+    },
+    {
+      "id": "architecture-rule-self-defense",
+      "historicalRoots": ["PR #85 F052-F055", "PR #98", "PR #104"],
+      "guards": "Architecture and CI ratchets are tested with adversarial declarations, receiver names, file names and missing corpus entries.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ModuleBoundaryBaselineTests"
+        },
+        {
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ReviewInvariantCorpusTests"
+        }
+      ]
+    },
+    {
+      "id": "cross-platform-backend-contract",
+      "historicalRoots": ["PR #122", "PR #125", "PR #127"],
+      "guards": "Selectable download backends and output-path comparison obey the same safety result on Windows, Linux and macOS.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.DownloadRetryPolicyTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.AriaSecurityTests"
+        }
+      ]
+    },
+    {
+      "id": "ui-async-state-and-dialogs",
+      "historicalRoots": ["PR #85 F056-F059", "PR #120", "Issue #123"],
+      "guards": "Newer UI operations reject stale data, selection and command state remain coherent, and dialog chrome/parameters remain complete.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Desktop.Tests/DownKyi.Desktop.Tests.csproj",
+          "class": "DownKyi.Desktop.Tests.DialogWindowChromeTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.VideoDetailWorkflowCoordinatorTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.VideoSelectionStateTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.AsyncDelegateCommandTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.StartupDialogOrderingTests"
+        }
+      ]
+    },
+    {
+      "id": "host-process-and-log-lifecycle",
+      "historicalRoots": ["PR #94", "PR #113", "PR #120", "PR #122"],
+      "guards": "Host, process and logging owners dispose, exit and persist deterministically; accepted work is not reported as completed before durable flush.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Desktop.Tests/DownKyi.Desktop.Tests.csproj",
+          "class": "DownKyi.Desktop.Tests.UiSmokeTests"
+        },
+        {
+          "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj",
+          "class": "DownKyi.Infrastructure.Tests.ApplicationLogProviderTests"
+        },
+        {
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.AssemblyLifecycleArchitectureTests"
+        }
+      ]
+    },
+    {
+      "id": "semantic-version-contract",
+      "historicalRoots": ["PR #85 F045-F046", "PR #85 F051"],
+      "guards": "Stable, prerelease and build metadata precedence plus skipped-release identity follow one SemVer contract in automatic and manual update flows.",
+      "testClasses": [
+        {
+          "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+          "class": "DownKyi.Core.Tests.SemanticVersionPolicyTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.VersionCheckerServiceTests"
+        },
+        {
+          "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+          "class": "DownKyi.Tests.ManualUpdateDialogContractTests"
+        }
+      ]
+    }
+  ],
+  "mainRehearsalEvidence": [
+    {
+      "id": "assembly-lifecycle-stress",
+      "historicalRoots": ["PR #113"],
+      "workflow": ".github/workflows/quality.yml",
+      "profiles": ["Main", "Rehearsal"],
+      "guards": "Repeated assembly load, discovery, execution, teardown and process exit with timeout forensics."
+    },
+    {
+      "id": "real-binary-transfer-security",
+      "historicalRoots": ["PR #122"],
+      "workflow": ".github/workflows/quality.yml",
+      "profiles": ["PR", "Main", "Rehearsal"],
+      "guards": "Six-RID aria2 TLS, redirect, Range and credential behavior against the packaged binary."
+    }
+  ]
+}

--- a/docs/testing/review-invariant-policy.md
+++ b/docs/testing/review-invariant-policy.md
@@ -1,0 +1,65 @@
+# Review Invariant Policy
+
+## Purpose
+
+Reviewer and Codex findings are not complete when only the immediate production
+defect is fixed. A finding with a reusable root cause must also become a
+permanent, executable invariant so later refactors cannot recreate it under a
+different class, receiver, backend or platform.
+
+## Required Workflow
+
+1. Search current production code and tests before adding anything. Reuse or
+   extend the existing owner; never create a parallel registry, limiter,
+   validator, retry policy or lifecycle owner.
+2. Classify the finding by root cause. Findings with the same cause share one
+   invariant even when they came from different PR comments.
+3. Fix production behavior only when the defect still exists on the current
+   base. A historical finding already covered by current code is linked to its
+   representative tests instead of reimplemented.
+4. Add a regression that fails on the defective behavior. Prefer behavior,
+   failure injection and contract assertions over implementation text.
+5. Put deterministic failure injection, contract tests and architecture
+   self-tests in PR CI. Keep repeated race, stress, GC, process, real-binary and
+   systematic platform evidence in Main or release rehearsal unless security
+   policy already requires the PR matrix.
+6. Test the gate itself. Static C# policy should use Roslyn when syntax or
+   semantics matter, and every rule needs an adversarial fixture that proves a
+   rename, modifier, file location or incomplete report cannot bypass it.
+
+## Executable Corpus
+
+`review-invariant-corpus.json` maps one root-cause invariant to representative
+test classes. It does not replace focused tests and must not list every historical
+comment separately. `ReviewInvariantCorpusTests` rejects missing projects,
+missing classes, duplicate IDs, incomplete heavy-profile evidence and removal of
+the seven-project coverage.
+
+Run the deterministic PR corpus with:
+
+```powershell
+pwsh ./script/test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
+```
+
+The runner fails closed if an entry resolves to no test, a referenced project is
+missing, a test fails or a declared test is not executed.
+
+## Durable Output Ownership Example
+
+Output reservation truth belongs to the existing Domain/SQLite store.
+`DownloadTaskAdmissionService` remains the only admission coordinator and uses
+transactional unique claims through the store. Tests may probe `(1)`/`(2)`
+candidates, but admission must not scan all unfinished tasks and must not create
+a mutable path registry or cache. Windows and macOS compare path claims without
+case; Linux uses ordinal comparison. With automatic numbering disabled, a
+conflict is rejected rather than silently renamed.
+
+## Completion Rule
+
+A general review finding is complete only when production behavior, the
+representative invariant, the relevant CI tier and this corpus agree. Heavy
+evidence remains machine-readable and cannot be replaced by a single green
+rerun.

--- a/docs/testing/review-invariant-policy.md
+++ b/docs/testing/review-invariant-policy.md
@@ -9,23 +9,99 @@ different class, receiver, backend or platform.
 
 ## Required Workflow
 
-1. Search current production code and tests before adding anything. Reuse or
-   extend the existing owner; never create a parallel registry, limiter,
-   validator, retry policy or lifecycle owner.
-2. Classify the finding by root cause. Findings with the same cause share one
-   invariant even when they came from different PR comments.
-3. Fix production behavior only when the defect still exists on the current
-   base. A historical finding already covered by current code is linked to its
-   representative tests instead of reimplemented.
-4. Add a regression that fails on the defective behavior. Prefer behavior,
-   failure injection and contract assertions over implementation text.
-5. Put deterministic failure injection, contract tests and architecture
-   self-tests in PR CI. Keep repeated race, stress, GC, process, real-binary and
-   systematic platform evidence in Main or release rehearsal unless security
-   policy already requires the PR matrix.
-6. Test the gate itself. Static C# policy should use Roslyn when syntax or
-   semantics matter, and every rule needs an adversarial fixture that proves a
-   rename, modifier, file location or incomplete report cannot bypass it.
+Every actionable review finding starts a root-cause investigation. Complete
+these steps before modifying production code:
+
+1. **Identify the violated invariant.** Name the system contract, protocol,
+   ownership rule, state transition or lifecycle invariant. A source line is
+   evidence, not the invariant.
+2. **Trace the complete failure path.** Follow the input or external event into
+   result classification, retry, cleanup, persistence, physical files,
+   finalization and the observable UI outcome. Locate the earliest boundary
+   that lost required information or made the wrong transition.
+3. **Search sibling paths.** Inspect every caller of the same result, helper,
+   owner, exception mapper, sentinel, cleanup path, retry path and state
+   mutation. A failure class must be closed across all its entry points.
+4. **Classify local versus systemic.** A local patch is permitted only with
+   evidence that no sibling path shares the defect. Weak result models,
+   incomplete failure taxonomy, ambiguous sentinels, non-atomic transitions,
+   duplicate owners and missing commit boundaries require a fix in the shared
+   abstraction or true owner.
+5. **Preserve information.** Do not compress failure kinds needed for retry,
+   cleanup, persistence or user outcome into `bool`, `null`, an empty
+   collection, generic exception, exit code or free-form text. Use a typed
+   result, enum or discriminated state, and never make callers infer semantics
+   from side effects.
+6. **Delay irreversible side effects.** Source deletion, resume-identity
+   removal, completed-key invalidation, destination overwrite and completed
+   publication occur only after the final required validation. Workflows that
+   cross filesystem, backend and durable Domain state need an explicit success
+   order and failure recovery; a single owner does not make them atomic.
+
+Before adding code, search current production modules and tests. Reuse or extend
+the existing owner; never create a parallel registry, limiter, validator, retry
+policy or lifecycle owner. Fix production behavior only when the defect still
+exists on the current base. A historical finding already covered by current
+code is linked to representative tests instead of reimplemented.
+
+## Prohibited Remediation
+
+Do not close a finding with any of these patterns unless evidence proves it is
+the complete root cause:
+
+- add one condition to the reported `if` or catch only the reported exception;
+- introduce another sentinel such as `null`, empty collection, exit code or
+  `File.Exists == false` to guess protocol or failure semantics;
+- encode current implementation behavior as an architecture contract merely to
+  make a regression green;
+- add only the reported example without inspecting its failure family;
+- revoke durable state after cleanup failed, or perform destructive cleanup
+  before the operation commit boundary;
+- treat green CI or existing architecture tests as proof that the semantic
+  contract is correct.
+
+## Failure And Transition Matrix
+
+Classification, retry, cleanup, lifecycle, persistence and state-machine fixes
+must create or update a matrix derived from the invariant. At minimum classify
+the applicable rows separately:
+
+- invalid or corrupt input;
+- missing input;
+- inaccessible input or destination;
+- dependency/runtime/process failure;
+- timeout or transport failure;
+- destination conflict;
+- cleanup failure;
+- caller cancellation, pause and shutdown.
+
+For every row, define expected physical source, partial/sidecar, completed key,
+backend/resume identity, destination output, retry eligibility and durable task
+state. A new failure kind must fit this matrix; it cannot fall into a generic
+fallback that callers reinterpret.
+
+Tests are derived from this invariant or the external protocol contract, not
+from the implementation just written. Prefer behavior, failure injection and
+transition assertions over source-text details. Findings with the same root
+cause share one invariant even when they came from different PR comments.
+
+## External Protocol Evidence
+
+For Bilibili API, protobuf, HTTP, FFmpeg, aria2, SQLite and other external
+contracts, one successful or failed fixture is insufficient. Termination,
+absence, empty result and failure remain distinct. Before promoting an
+assumption into architecture documentation or a regression, confirm it against
+the repository protocol definition, official behavior, a real sanitized fixture
+or another primary source. Insufficient evidence stays marked as an assumption
+or unresolved contract.
+
+## Repeated-Review Escalation
+
+If a later review round on the same PR exposes the same failure family, the
+previous remediation did not close the root cause. Stop local patches. Reopen
+the shared abstraction, typed result, state machine, commit boundary, ownership
+or transaction analysis and replace the patch chain with one systemic invariant
+and failure/transition matrix.
 
 ## Executable Corpus
 
@@ -59,7 +135,11 @@ conflict is rejected rather than silently renamed.
 
 ## Completion Rule
 
-A general review finding is complete only when production behavior, the
-representative invariant, the relevant CI tier and this corpus agree. Heavy
-evidence remains machine-readable and cannot be replaced by a single green
-rerun.
+A finding is complete only when the violated invariant and earliest incorrect
+boundary are documented, sibling paths are searched, the fix lives in the
+smallest correct shared owner, the invariant-derived regression or matrix is
+green, and architecture/knowledge/plan documents match executable behavior. No
+new undocumented sentinel, failure interpretation or destructive lifecycle rule
+may remain. The representative invariant, relevant CI tier and this corpus must
+agree; heavy evidence remains machine-readable and cannot be replaced by a
+single green rerun.

--- a/script/audit-module-boundaries.ps1
+++ b/script/audit-module-boundaries.ps1
@@ -29,6 +29,9 @@ function Get-ProductionFiles {
     )
 
     return @(
+        foreach ($pattern in $Patterns) {
+            Get-ChildItem -LiteralPath $repositoryRoot -File -Filter $pattern
+        }
         foreach ($root in $roots) {
             foreach ($pattern in $Patterns) {
                 Get-ChildItem -LiteralPath $root -Recurse -File -Filter $pattern |
@@ -86,8 +89,7 @@ function Get-SourceRootMetrics {
 
 function Get-TypeDeclarations {
     $namespacePattern = '(?m)^\s*namespace\s+([A-Za-z_][\w\.]*)\s*[;{]'
-    $typePattern = '(?m)^\s*(?:public|internal|protected|private|file)?\s*' +
-        '(?:sealed\s+|abstract\s+|static\s+|partial\s+)*' +
+    $typePattern = '(?m)^\s*(?:(?:public|internal|protected|private|file|new|unsafe|readonly|ref|sealed|abstract|static|partial)\s+)*' +
         '(?:class|record(?:\s+class|\s+struct)?|struct|interface|enum)\s+' +
         '([A-Za-z_][\w]*)'
     $declarations = @()
@@ -152,9 +154,11 @@ $coreUiDependencies = @(
 
 $servicesRoot = Join-Path $repositoryRoot "src/DownKyi.Desktop/Services"
 $presentationBoundContracts = @(
-    Get-ChildItem -LiteralPath $servicesRoot -Recurse -File -Filter "I*.cs" |
+    Get-ChildItem -LiteralPath $servicesRoot -Recurse -File -Filter "*.cs" |
         Where-Object {
-            (Get-Content -LiteralPath $_.FullName -Raw).Contains("DownKyi.ViewModels")
+            $source = Get-Content -LiteralPath $_.FullName -Raw
+            $source.Contains("DownKyi.ViewModels") -and
+                $source -match '\binterface\s+[A-Za-z_]'
         } |
         ForEach-Object { Convert-ToRelativePath $_.FullName } |
         Sort-Object
@@ -185,8 +189,7 @@ $genericTypeNames = @(
         Sort-Object path, name
 )
 
-$typePattern = '(?m)^\s*(?:public|internal|protected|private|file)?\s*' +
-    '(?:sealed\s+|abstract\s+|static\s+|partial\s+)*' +
+$typePattern = '(?m)^\s*(?:(?:public|internal|protected|private|file|new|unsafe|readonly|ref|sealed|abstract|static|partial)\s+)*' +
     '(?:class|record(?:\s+class|\s+struct)?|struct|interface|enum)\s+' +
     '([A-Za-z_][\w]*)'
 $fileTypeMismatches = @(

--- a/script/test-review-invariants.ps1
+++ b/script/test-review-invariants.ps1
@@ -1,0 +1,103 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+
+    [switch]$NoRestore,
+
+    [switch]$NoBuild,
+
+    [string]$ResultsDirectory = "artifacts/review-invariants"
+)
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$manifestPath = Join-Path $repositoryRoot "docs/testing/review-invariant-corpus.json"
+$resultRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot $ResultsDirectory))
+
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw "Review invariant corpus is missing: $manifestPath"
+}
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+if ($manifest.schemaVersion -ne 1) {
+    throw "Unsupported review invariant corpus schema: $($manifest.schemaVersion)"
+}
+
+$invariants = @($manifest.prInvariants)
+if ($invariants.Count -eq 0) {
+    throw "The PR review invariant corpus is empty."
+}
+
+$duplicateIds = @(
+    $invariants |
+        Group-Object id |
+        Where-Object Count -gt 1 |
+        Select-Object -ExpandProperty Name
+)
+if ($duplicateIds.Count -gt 0) {
+    throw "Duplicate review invariant ids: $($duplicateIds -join ', ')"
+}
+
+$testClasses = @(
+    $invariants |
+        ForEach-Object { @($_.testClasses) } |
+        Where-Object { $_ -and $_.project -and $_.class }
+)
+if ($testClasses.Count -eq 0) {
+    throw "The PR review invariant corpus does not reference any tests."
+}
+
+New-Item -ItemType Directory -Path $resultRoot -Force | Out-Null
+$projectGroups = @($testClasses | Group-Object project | Sort-Object Name)
+$totalPassed = 0
+
+foreach ($projectGroup in $projectGroups) {
+    $projectPath = Join-Path $repositoryRoot $projectGroup.Name
+    if (-not (Test-Path -LiteralPath $projectPath -PathType Leaf)) {
+        throw "Review invariant test project is missing: $($projectGroup.Name)"
+    }
+
+    $classNames = @($projectGroup.Group.class | Sort-Object -Unique)
+    $filter = ($classNames | ForEach-Object { "FullyQualifiedName~$_" }) -join "|"
+    $safeName = [IO.Path]::GetFileNameWithoutExtension($projectPath)
+    $trxName = "$safeName.trx"
+    $arguments = @(
+        "test",
+        $projectPath,
+        "-c", $Configuration,
+        "--filter", $filter,
+        "--logger", "trx;LogFileName=$trxName",
+        "--results-directory", $resultRoot
+    )
+    if ($NoRestore) {
+        $arguments += "--no-restore"
+    }
+    if ($NoBuild) {
+        $arguments += "--no-build"
+    }
+
+    Write-Host "Running review invariants in $($projectGroup.Name)"
+    & dotnet @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Review invariant tests failed for $($projectGroup.Name)."
+    }
+
+    $trxPath = Join-Path $resultRoot $trxName
+    if (-not (Test-Path -LiteralPath $trxPath -PathType Leaf)) {
+        throw "Review invariant test report is missing: $trxPath"
+    }
+
+    [xml]$trx = Get-Content -LiteralPath $trxPath -Raw
+    $counters = $trx.TestRun.ResultSummary.Counters
+    $passed = [int]$counters.passed
+    $failed = [int]$counters.failed
+    $notExecuted = [int]$counters.notExecuted
+    if ($failed -ne 0 -or $notExecuted -ne 0 -or $passed -lt $classNames.Count) {
+        throw "Review invariant coverage was incomplete for $($projectGroup.Name): passed=$passed failed=$failed notExecuted=$notExecuted requiredClasses=$($classNames.Count)."
+    }
+
+    $totalPassed += $passed
+}
+
+Write-Host "Review invariant gate passed: $($invariants.Count) root-cause invariants, $($projectGroups.Count) test projects, $totalPassed tests."

--- a/src/DownKyi.Desktop/Models/AppInfo.cs
+++ b/src/DownKyi.Desktop/Models/AppInfo.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 using System.Reflection;
-using System.Text.RegularExpressions;
+using DownKyi.Core.Versioning;
 
 namespace DownKyi.Models;
 
@@ -25,13 +25,7 @@ internal class AppInfo
 
     public static string NormalizeVersionName(string? versionName)
     {
-        if (string.IsNullOrWhiteSpace(versionName))
-        {
-            return string.Empty;
-        }
-
-        var match = Regex.Match(versionName, @"v?(\d+\.\d+\.\d+)", RegexOptions.IgnoreCase);
-        return match.Success ? match.Groups[1].Value : string.Empty;
+        return SemanticVersionPolicy.NormalizeForDisplay(versionName);
     }
 
     public static int VersionNameToCode(string versionName)
@@ -39,21 +33,18 @@ internal class AppInfo
         var code = 0;
         var normalizedVersion = NormalizeVersionName(versionName);
 
-        var isMatch = Regex.IsMatch(normalizedVersion, @"^\d+\.\d+\.\d+$");
-        if (!isMatch)
+        var coreVersion = normalizedVersion.Split('-', 2)[0];
+        var parts = coreVersion.Split('.');
+        if (parts.Length != 3)
         {
             return 0;
         }
 
-        var parts = normalizedVersion.Split('.');
-        if (parts.Length == 3)
+        var i = 2;
+        foreach (var item in parts)
         {
-            var i = 2;
-            foreach (var item in parts)
-            {
-                code += int.Parse(item, CultureInfo.InvariantCulture) * (int)Math.Pow(100, i);
-                i--;
-            }
+            code += int.Parse(item, CultureInfo.InvariantCulture) * (int)Math.Pow(100, i);
+            i--;
         }
 
         return code;

--- a/src/DownKyi.Desktop/Services/VersionCheckerService.cs
+++ b/src/DownKyi.Desktop/Services/VersionCheckerService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using DownKyi.Core.Versioning;
 using DownKyi.Models;
 
 namespace DownKyi.Services;
@@ -21,11 +22,20 @@ internal sealed class VersionCheckerService
     }
 
     internal VersionCheckerService(HttpClient httpClient, string repoOwner, string repoName)
+        : this(httpClient, repoOwner, repoName, new AppInfo().VersionName)
+    {
+    }
+
+    internal VersionCheckerService(
+        HttpClient httpClient,
+        string repoOwner,
+        string repoName,
+        string currentVersion)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _repoOwner = repoOwner ?? throw new ArgumentNullException(nameof(repoOwner));
         _repoName = repoName ?? throw new ArgumentNullException(nameof(repoName));
-        _currentVersion = AppInfo.NormalizeVersionName(new AppInfo().VersionName);
+        _currentVersion = SemanticVersionPolicy.NormalizeForDisplay(currentVersion);
     }
 
     public async Task<GitHubRelease?> GetLatestReleaseAsync(
@@ -45,30 +55,27 @@ internal sealed class VersionCheckerService
             var releases = JsonSerializer.Deserialize(
                 responseJson,
                 GitHubJsonContext.Default.GitHubReleaseArray);
-            return string.IsNullOrEmpty(excludedVersion)
-                ? releases?.FirstOrDefault()
-                : releases?.FirstOrDefault(release =>
-                    release.TagName.TrimStart('v') != excludedVersion);
+            return releases?.FirstOrDefault(release => !IsExcluded(
+                release.TagName,
+                excludedVersion));
         }
 
         var latestRelease = JsonSerializer.Deserialize(
             responseJson,
             GitHubJsonContext.Default.GitHubRelease);
-        return string.IsNullOrEmpty(excludedVersion) ||
-               latestRelease?.TagName.TrimStart('v') != excludedVersion
+        return latestRelease != null && !IsExcluded(latestRelease.TagName, excludedVersion)
             ? latestRelease
             : null;
     }
 
     public bool IsNewVersionAvailable(string latestVersion)
     {
-        var latestReleaseVersion = AppInfo.NormalizeVersionName(latestVersion);
-        if (!Version.TryParse(_currentVersion, out var current) ||
-            !Version.TryParse(latestReleaseVersion, out var latest))
-        {
-            return false;
-        }
+        return SemanticVersionPolicy.IsNewer(latestVersion, _currentVersion);
+    }
 
-        return latest > current;
+    private static bool IsExcluded(string releaseVersion, string? excludedVersion)
+    {
+        return !string.IsNullOrWhiteSpace(excludedVersion) &&
+               SemanticVersionPolicy.HasSamePrecedence(releaseVersion, excludedVersion);
     }
 }

--- a/src/DownKyi.Desktop/ViewModels/Dialogs/NewVersionAvailableDialogViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Dialogs/NewVersionAvailableDialogViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using DownKyi.Application.Desktop;
 using DownKyi.Commands;
 using DownKyi.Core.Settings;
+using DownKyi.Core.Versioning;
 using DownKyi.Models;
 using Microsoft.Extensions.Logging;
 
@@ -94,7 +95,11 @@ namespace DownKyi.ViewModels.Dialogs
             EnableSkipVersionOnLaunch = GetRequiredParameter<bool>(request, "enableSkipVersion");
             MarkdownText = release.Body;
             TagName = release.TagName;
-            NewVersion = release.TagName.TrimStart('v');
+            NewVersion = SemanticVersionPolicy.TryNormalizeIdentity(
+                release.TagName,
+                out var normalizedVersion)
+                ? normalizedVersion
+                : string.Empty;
         }
     }
 }

--- a/src/DownKyi.Desktop/ViewModels/Settings/ViewAboutViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Settings/ViewAboutViewModel.cs
@@ -152,7 +152,8 @@ internal class ViewAboutViewModel : ViewModelBase
                     AppDialog.NewVersionAvailable,
                     new Dictionary<string, object?>
                     {
-                        ["release"] = release
+                        ["release"] = release,
+                        ["enableSkipVersion"] = false
                     })).ConfigureAwait(true);
             }
             else

--- a/tests/DownKyi.Architecture.Tests/AgentEnvironmentArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AgentEnvironmentArchitectureTests.cs
@@ -167,7 +167,10 @@ public sealed class AgentEnvironmentArchitectureTests
 
         var ratchets = Read("tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs");
         Assert.Contains("CoreHasNoUiOrQrRenderingDependencies", ratchets, StringComparison.Ordinal);
-        Assert.Contains("ServiceContractsCannotAddPresentationDependencies", ratchets, StringComparison.Ordinal);
+        Assert.Contains(
+            "PresentationBoundServiceContractsCannotGrowBeyondTheKnownBaseline",
+            ratchets,
+            StringComparison.Ordinal);
         Assert.Contains("OversizedProductionFilesCannotGrowBeyondTheKnownBaseline", ratchets, StringComparison.Ordinal);
     }
 

--- a/tests/DownKyi.Architecture.Tests/CSharpSourceInspector.cs
+++ b/tests/DownKyi.Architecture.Tests/CSharpSourceInspector.cs
@@ -1,0 +1,146 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DownKyi.Architecture.Tests;
+
+internal static class CSharpSourceInspector
+{
+    private static readonly ImmutableArray<MetadataReference> PlatformReferences =
+        CreatePlatformReferences();
+
+    public static IReadOnlyList<CSharpTypeDeclaration> ReadTypeDeclarations(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var root = Parse(source);
+        return root
+            .DescendantNodes()
+            .OfType<BaseTypeDeclarationSyntax>()
+            .Select(declaration =>
+            {
+                var namespaceName = string.Join(
+                    ".",
+                    declaration
+                        .Ancestors()
+                        .OfType<BaseNamespaceDeclarationSyntax>()
+                        .Reverse()
+                        .Select(item => item.Name.ToString()));
+                var name = declaration.Identifier.ValueText;
+                var fullName = string.IsNullOrEmpty(namespaceName)
+                    ? name
+                    : $"{namespaceName}.{name}";
+                return new CSharpTypeDeclaration(name, fullName);
+            })
+            .ToArray();
+    }
+
+    public static bool DeclaresInterfaceWithNamespaceDependency(
+        string source,
+        string namespacePrefix)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        ArgumentException.ThrowIfNullOrWhiteSpace(namespacePrefix);
+        var root = Parse(source);
+        var importsPresentation = root.Usings.Any(usingDirective =>
+            StartsWithNamespace(usingDirective.Name?.ToString(), namespacePrefix));
+
+        return root
+            .DescendantNodes()
+            .OfType<InterfaceDeclarationSyntax>()
+            .Any(declaration =>
+                importsPresentation || declaration
+                    .DescendantNodes()
+                    .OfType<NameSyntax>()
+                    .Any(name => StartsWithNamespace(name.ToString(), namespacePrefix)));
+    }
+
+    public static IReadOnlyList<string> FindSynchronousRuntimeOperations(string source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var syntaxTree = CSharpSyntaxTree.ParseText(
+            source,
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview));
+        var compilation = CSharpCompilation.Create(
+            "ArchitecturePolicyProbe",
+            [syntaxTree],
+            PlatformReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var semanticModel = compilation.GetSemanticModel(syntaxTree);
+        var root = syntaxTree.GetCompilationUnitRoot();
+        var violations = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var field in root.DescendantNodes().OfType<FieldDeclarationSyntax>())
+        {
+            var fieldType = field.Declaration.Type is NullableTypeSyntax nullableType
+                ? nullableType.ElementType.ToString()
+                : field.Declaration.Type.ToString();
+            if (field.Modifiers.Any(SyntaxKind.StaticKeyword) &&
+                fieldType.EndsWith("BilibiliHttpClient", StringComparison.Ordinal))
+            {
+                violations.Add("static BilibiliHttpClient field");
+            }
+        }
+
+        foreach (var invocation in root.DescendantNodes().OfType<InvocationExpressionSyntax>())
+        {
+            if (semanticModel.GetSymbolInfo(invocation).Symbol is not IMethodSymbol method)
+            {
+                continue;
+            }
+
+            var containingType = method.ContainingType?.ToDisplayString();
+            var operation = (containingType, method.Name) switch
+            {
+                ("System.Net.Http.HttpClient", "Send") => "HttpClient.Send",
+                ("System.IO.StreamReader", "ReadToEnd") => "StreamReader.ReadToEnd",
+                ("System.Threading.WaitHandle", "WaitOne") => "WaitHandle.WaitOne",
+                ("System.Threading.Tasks.Task", "Wait") => "Task.Wait",
+                _ => null
+            };
+            if (operation == null &&
+                method.Name == "GetResult" &&
+                method.ContainingNamespace?.ToDisplayString() == "System.Runtime.CompilerServices" &&
+                method.ContainingType?.Name == "TaskAwaiter")
+            {
+                operation = "TaskAwaiter.GetResult";
+            }
+            if (operation != null)
+            {
+                violations.Add(operation);
+            }
+        }
+
+        return violations.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static CompilationUnitSyntax Parse(string source)
+    {
+        return CSharpSyntaxTree
+            .ParseText(source, CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Preview))
+            .GetCompilationUnitRoot();
+    }
+
+    private static bool StartsWithNamespace(string? value, string namespacePrefix)
+    {
+        return value != null &&
+               (value.Equals(namespacePrefix, StringComparison.Ordinal) ||
+                value.StartsWith($"{namespacePrefix}.", StringComparison.Ordinal));
+    }
+
+    private static ImmutableArray<MetadataReference> CreatePlatformReferences()
+    {
+        var trustedAssemblies = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrWhiteSpace(trustedAssemblies))
+        {
+            throw new InvalidOperationException("Trusted platform assemblies are unavailable.");
+        }
+
+        return trustedAssemblies
+            .Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries)
+            .Select(path => (MetadataReference)MetadataReference.CreateFromFile(path))
+            .ToImmutableArray();
+    }
+}
+
+internal sealed record CSharpTypeDeclaration(string Name, string FullName);

--- a/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
+++ b/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
@@ -1,22 +1,8 @@
-using System.Text.RegularExpressions;
-
 namespace DownKyi.Architecture.Tests;
 
 public sealed class ModuleBoundaryBaselineTests
 {
     private static readonly string RepositoryRoot = FindRepositoryRoot();
-    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(2);
-    private static readonly Regex NamespaceDeclarationRegex = new(
-        @"^[ \t]*namespace[ \t]+([A-Za-z_][\w\.]*)[ \t]*[;{]",
-        RegexOptions.CultureInvariant | RegexOptions.Multiline | RegexOptions.NonBacktracking,
-        RegexTimeout);
-    private static readonly Regex TypeDeclarationRegex = new(
-        @"^[ \t]*(?:(?:public|internal|protected|private|file)[ \t]+)?" +
-        @"(?:(?:sealed|abstract|static|partial)[ \t]+)*" +
-        @"(?:class|record(?:[ \t]+(?:class|struct))?|struct|interface|enum)[ \t]+" +
-        @"([A-Za-z_][\w]*)",
-        RegexOptions.CultureInvariant | RegexOptions.NonBacktracking,
-        RegexTimeout);
 
     private static readonly Dictionary<string, HashSet<string>> KnownDuplicateSimpleNames =
         new(StringComparer.Ordinal)
@@ -50,6 +36,12 @@ public sealed class ModuleBoundaryBaselineTests
     private static readonly HashSet<string> KnownFileTypeMismatches = new(StringComparer.Ordinal);
 
     private static readonly Dictionary<string, int> KnownOversizedFiles = new(StringComparer.Ordinal);
+
+    private static readonly HashSet<string> KnownPresentationBoundContracts = new(StringComparer.Ordinal)
+    {
+        "src/DownKyi.Desktop/Services/Download/DownloadManagerCoordinator.cs",
+        "src/DownKyi.Desktop/Services/Migration/LegacyUpgradeCoordinator.cs"
+    };
 
     [Fact]
     public void CoreHasNoUiOrQrRenderingDependencies()
@@ -116,17 +108,19 @@ public sealed class ModuleBoundaryBaselineTests
     }
 
     [Fact]
-    public void ServiceContractsCannotAddPresentationDependencies()
+    public void PresentationBoundServiceContractsCannotGrowBeyondTheKnownBaseline()
     {
         var servicesRoot = Path.Combine(RepositoryRoot, "src", "DownKyi.Desktop", "Services");
         var actual = Directory
-            .EnumerateFiles(servicesRoot, "I*.cs", SearchOption.AllDirectories)
+            .EnumerateFiles(servicesRoot, "*.cs", SearchOption.AllDirectories)
             .Where(path => !IsBuildOutput(path))
-            .Where(path => File.ReadAllText(path).Contains("DownKyi.ViewModels", StringComparison.Ordinal))
+            .Where(path => CSharpSourceInspector.DeclaresInterfaceWithNamespaceDependency(
+                File.ReadAllText(path),
+                "DownKyi.ViewModels"))
             .Select(Relative)
             .ToArray();
 
-        Assert.Empty(actual);
+        AssertSubset(actual, KnownPresentationBoundContracts, "presentation-bound service contract");
     }
 
     [Fact]
@@ -212,15 +206,107 @@ public sealed class ModuleBoundaryBaselineTests
     }
 
     [Fact]
-    public void TypeDeclarationScanUsesLineScopedNonBacktrackingMatching()
+    public void RoslynDeclarationScanCannotBeBypassedByModifiersOrMalformedInput()
     {
-        var adversarialLine =
-            $"{new string(' ', 100_000)}{string.Concat(Enumerable.Repeat("partial ", 20_000))}not-a-type";
-        var source = $"{adversarialLine}{Environment.NewLine}public sealed class ExpectedType";
+        var source = $$"""
+            namespace Adversarial;
+
+            {{new string('/', 100_000)}}
+            public readonly record struct StableValue;
+            public ref struct StackBuffer { }
+            file record HiddenOwner;
+            internal interface Contract { }
+            """;
 
         var declarations = ReadDeclaredTypeNames(source);
 
-        Assert.Equal(["ExpectedType"], declarations);
+        Assert.Equal(
+            ["StableValue", "StackBuffer", "HiddenOwner", "Contract"],
+            declarations);
+    }
+
+    [Fact]
+    public void ServiceContractScanCannotBeBypassedByFileName()
+    {
+        const string source = """
+            using DownKyi.ViewModels;
+            namespace DownKyi.Services;
+            internal interface DownloadContract
+            {
+                ViewModelBase Create();
+            }
+            """;
+
+        Assert.True(CSharpSourceInspector.DeclaresInterfaceWithNamespaceDependency(
+            source,
+            "DownKyi.ViewModels"));
+    }
+
+    [Fact]
+    public void SynchronousHttpScanCannotBeBypassedByReceiverName()
+    {
+        const string source = """
+            using System.IO;
+            using System.Net.Http;
+            using System.Threading;
+            internal sealed class Probe
+            {
+                private static string Read(HttpClient transport, StreamReader payload, WaitHandle signal)
+                {
+                    using var response = transport.Send(new HttpRequestMessage());
+                    signal.WaitOne();
+                    return payload.ReadToEnd();
+                }
+            }
+            """;
+
+        Assert.Equal(
+            ["HttpClient.Send", "StreamReader.ReadToEnd", "WaitHandle.WaitOne"],
+            CSharpSourceInspector.FindSynchronousRuntimeOperations(source));
+    }
+
+    [Fact]
+    public void StaticHttpClientScanCannotBeBypassedByNullableTypeOrFieldName()
+    {
+        const string source = """
+            internal sealed class BilibiliHttpClient;
+            internal sealed class Probe
+            {
+                private static BilibiliHttpClient? transportRuntime;
+            }
+            """;
+
+        Assert.Equal(
+            ["static BilibiliHttpClient field"],
+            CSharpSourceInspector.FindSynchronousRuntimeOperations(source));
+    }
+
+    [Fact]
+    public void ProductionInventoryIncludesRootLevelSourcesButExcludesTestTrees()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"downkyi-architecture-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "src"));
+            Directory.CreateDirectory(Path.Combine(root, "tests"));
+            File.WriteAllText(Path.Combine(root, "RootOwner.cs"), "internal class RootOwner { }");
+            File.WriteAllText(Path.Combine(root, "src", "SourceOwner.cs"), "internal class SourceOwner { }");
+            File.WriteAllText(Path.Combine(root, "tests", "TestOnly.cs"), "internal class TestOnly { }");
+
+            var actual = EnumerateProductionFiles(root, "*.cs")
+                .Select(path => Path.GetRelativePath(root, path).Replace('\\', '/'))
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(["RootOwner.cs", "src/SourceOwner.cs"], actual);
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
     }
 
     [Fact]
@@ -332,21 +418,11 @@ public sealed class ModuleBoundaryBaselineTests
             Path.Combine(RepositoryRoot, "DownKyi.Core", "BiliApi"),
             Path.Combine(RepositoryRoot, "src", "DownKyi.Infrastructure", "Bilibili")
         };
-        var markers = new[]
-        {
-            "static BilibiliHttpClient? _client",
-            "_httpClient.Send(",
-            "reader.ReadToEnd()",
-            "WaitHandle.WaitOne"
-        };
         var actual = apiRoots
             .SelectMany(root => Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
-            .Where(path =>
-            {
-                var source = File.ReadAllText(path);
-                return markers.Any(marker => source.Contains(marker, StringComparison.Ordinal));
-            })
-            .Select(Relative)
+            .SelectMany(path => CSharpSourceInspector
+                .FindSynchronousRuntimeOperations(File.ReadAllText(path))
+                .Select(operation => $"{Relative(path)} -> {operation}"))
             .ToArray();
 
         Assert.Empty(actual);
@@ -395,16 +471,9 @@ public sealed class ModuleBoundaryBaselineTests
         return EnumerateProductionFiles("*.cs")
             .SelectMany(path =>
             {
-                var source = File.ReadAllText(path);
-                var namespaceMatch = NamespaceDeclarationRegex.Match(source);
-                if (!namespaceMatch.Success)
-                {
-                    return [];
-                }
-
-                var namespaceName = namespaceMatch.Groups[1].Value;
-                return ReadDeclaredTypeNames(source)
-                    .Select(name => new TypeDeclaration(name, $"{namespaceName}.{name}", Relative(path)))
+                return CSharpSourceInspector
+                    .ReadTypeDeclarations(File.ReadAllText(path))
+                    .Select(item => new TypeDeclaration(item.Name, item.FullName, Relative(path)))
                     .ToArray();
             })
             .ToArray();
@@ -412,31 +481,31 @@ public sealed class ModuleBoundaryBaselineTests
 
     private static string[] ReadDeclaredTypeNames(string source)
     {
-        var names = new List<string>();
-        var knownNames = new HashSet<string>(StringComparer.Ordinal);
-        using var reader = new StringReader(source);
-        while (reader.ReadLine() is { } line)
-        {
-            var match = TypeDeclarationRegex.Match(line);
-            if (match.Success && knownNames.Add(match.Groups[1].Value))
-            {
-                names.Add(match.Groups[1].Value);
-            }
-        }
-
-        return names.ToArray();
+        return CSharpSourceInspector
+            .ReadTypeDeclarations(source)
+            .Select(item => item.Name)
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
     }
 
     private static IEnumerable<string> EnumerateProductionFiles(string pattern)
     {
-        return new[]
+        return EnumerateProductionFiles(RepositoryRoot, pattern);
+    }
+
+    private static IEnumerable<string> EnumerateProductionFiles(string repositoryRoot, string pattern)
+    {
+        var rootFiles = Directory.EnumerateFiles(repositoryRoot, pattern, SearchOption.TopDirectoryOnly);
+        var sourceFiles = new[]
             {
-                Path.Combine(RepositoryRoot, "DownKyi"),
-                Path.Combine(RepositoryRoot, "DownKyi.Core"),
-                Path.Combine(RepositoryRoot, "src")
+                Path.Combine(repositoryRoot, "DownKyi"),
+                Path.Combine(repositoryRoot, "DownKyi.Core"),
+                Path.Combine(repositoryRoot, "src")
             }
+            .Where(Directory.Exists)
             .SelectMany(root => Directory.EnumerateFiles(root, pattern, SearchOption.AllDirectories))
-            .Where(path => !IsBuildOutput(path));
+            .Where(path => !IsBuildOutput(repositoryRoot, path));
+        return rootFiles.Concat(sourceFiles).Distinct(StringComparer.OrdinalIgnoreCase);
     }
 
     private static void AssertSubset(
@@ -456,7 +525,12 @@ public sealed class ModuleBoundaryBaselineTests
 
     private static bool IsBuildOutput(string path)
     {
-        var relative = Path.GetRelativePath(RepositoryRoot, path);
+        return IsBuildOutput(RepositoryRoot, path);
+    }
+
+    private static bool IsBuildOutput(string repositoryRoot, string path)
+    {
+        var relative = Path.GetRelativePath(repositoryRoot, path);
         var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
         return segments.Contains("bin", StringComparer.OrdinalIgnoreCase) ||
                segments.Contains("obj", StringComparer.OrdinalIgnoreCase);

--- a/tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
@@ -1,0 +1,332 @@
+using System.Text.Json;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class ReviewInvariantCorpusTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string CorpusPath = Path.Combine(
+        RepositoryRoot,
+        "docs",
+        "testing",
+        "review-invariant-corpus.json");
+    private static readonly string[] RequiredPrInvariantIds =
+    [
+        "cancellation-semantics",
+        "runtime-ownership",
+        "file-and-output-ownership",
+        "failure-classification",
+        "ffmpeg-concurrency-budget",
+        "json-contract-presence",
+        "request-origin-and-credential-contracts",
+        "architecture-rule-self-defense",
+        "cross-platform-backend-contract",
+        "ui-async-state-and-dialogs",
+        "host-process-and-log-lifecycle",
+        "semantic-version-contract"
+    ];
+    private static readonly string[] RequiredMainRehearsalEvidenceIds =
+    [
+        "assembly-lifecycle-stress",
+        "real-binary-transfer-security"
+    ];
+
+    [Fact]
+    public void CorpusReferencesExistingDeterministicTestClasses()
+    {
+        var corpus = LoadCorpus(CorpusPath);
+        var knownClasses = ReadKnownTestClasses();
+
+        var errors = ValidateCorpus(corpus.PrInvariants, knownClasses);
+
+        Assert.Equal(1, corpus.SchemaVersion);
+        Assert.Empty(errors);
+        Assert.Empty(ValidateEvidence(corpus.MainRehearsalEvidence));
+        Assert.Empty(RequiredPrInvariantIds.Except(
+            corpus.PrInvariants.Select(invariant => invariant.Id),
+            StringComparer.Ordinal));
+        Assert.Empty(RequiredMainRehearsalEvidenceIds.Except(
+            corpus.MainRehearsalEvidence.Select(evidence => evidence.Id),
+            StringComparer.Ordinal));
+        Assert.Equal(
+            [
+                "tests/DownKyi.Application.Tests/DownKyi.Application.Tests.csproj",
+                "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+                "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj",
+                "tests/DownKyi.Desktop.Tests/DownKyi.Desktop.Tests.csproj",
+                "tests/DownKyi.Domain.Tests/DownKyi.Domain.Tests.csproj",
+                "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj",
+                "tests/DownKyi.Tests/DownKyi.Tests.csproj"
+            ],
+            corpus.PrInvariants
+                .SelectMany(invariant => invariant.TestClasses)
+                .Select(test => test.Project)
+                .Distinct(StringComparer.Ordinal)
+                .Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void CorpusValidatorFailsClosedForMissingDuplicateOrUnknownCoverage()
+    {
+        var knownClasses = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "Example.Tests.ValidInvariantTests"
+        };
+        var valid = new ReviewInvariantDefinition(
+            "valid",
+            ["PR #1"],
+            "Guards one root cause.",
+            [new ReviewInvariantTestClass("tests/Example.Tests/Example.Tests.csproj", "Example.Tests.ValidInvariantTests")]);
+        Assert.Empty(ValidateCorpus([valid], knownClasses, _ => true));
+
+        var errors = ValidateCorpus(
+            [
+                valid,
+                valid,
+                new ReviewInvariantDefinition(
+                    "empty",
+                    [],
+                    string.Empty,
+                    []),
+                new ReviewInvariantDefinition(
+                    "unknown",
+                    ["PR #2"],
+                    "Unknown test must fail.",
+                    [new ReviewInvariantTestClass("missing.csproj", "Example.Tests.MissingTests")])
+            ],
+            knownClasses,
+            _ => false);
+
+        Assert.Contains(errors, error => error.Contains("duplicate invariant id", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("historical root", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("guard text", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("test class", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("test project", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void HeavyEvidenceValidatorFailsClosedForMissingProfilesOrWorkflow()
+    {
+        var valid = new ReviewInvariantEvidenceDefinition(
+            "lifecycle",
+            ["PR #1"],
+            ".github/workflows/quality.yml",
+            ["Main", "Rehearsal"],
+            "Runs repeated lifecycle checks.");
+        Assert.Empty(ValidateEvidence([valid], _ => true));
+
+        var errors = ValidateEvidence(
+            [
+                valid,
+                valid,
+                new ReviewInvariantEvidenceDefinition(
+                    "missing",
+                    [],
+                    "missing.yml",
+                    ["PR"],
+                    string.Empty)
+            ],
+            _ => false);
+
+        Assert.Contains(errors, error => error.Contains("duplicate evidence id", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("historical root", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("guard text", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("workflow", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("Main profile", StringComparison.Ordinal));
+        Assert.Contains(errors, error => error.Contains("Rehearsal profile", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void StrictCiRunsCorpusAndRetainsHeavyMainRehearsalProfiles()
+    {
+        var quality = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            ".github",
+            "workflows",
+            "quality.yml"));
+        var release = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            ".github",
+            "workflows",
+            "build.yml"));
+
+        Assert.Contains("test-review-invariants.ps1", quality, StringComparison.Ordinal);
+        Assert.Contains("windows-latest", quality, StringComparison.Ordinal);
+        Assert.Contains("ubuntu-latest", quality, StringComparison.Ordinal);
+        Assert.Contains("macos-latest", quality, StringComparison.Ordinal);
+        Assert.Contains("\"Main\"", quality, StringComparison.Ordinal);
+        Assert.Contains("-Profile Rehearsal", release, StringComparison.Ordinal);
+    }
+
+    private static ReviewInvariantCorpus LoadCorpus(string path)
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(path));
+        var root = document.RootElement;
+        var invariants = root
+            .GetProperty("prInvariants")
+            .EnumerateArray()
+            .Select(element => new ReviewInvariantDefinition(
+                element.GetProperty("id").GetString() ?? string.Empty,
+                element.GetProperty("historicalRoots")
+                    .EnumerateArray()
+                    .Select(item => item.GetString() ?? string.Empty)
+                    .ToArray(),
+                element.GetProperty("guards").GetString() ?? string.Empty,
+                element.GetProperty("testClasses")
+                    .EnumerateArray()
+                    .Select(item => new ReviewInvariantTestClass(
+                        item.GetProperty("project").GetString() ?? string.Empty,
+                        item.GetProperty("class").GetString() ?? string.Empty))
+                    .ToArray()))
+            .ToArray();
+        var evidence = root
+            .GetProperty("mainRehearsalEvidence")
+            .EnumerateArray()
+            .Select(element => new ReviewInvariantEvidenceDefinition(
+                element.GetProperty("id").GetString() ?? string.Empty,
+                element.GetProperty("historicalRoots")
+                    .EnumerateArray()
+                    .Select(item => item.GetString() ?? string.Empty)
+                    .ToArray(),
+                element.GetProperty("workflow").GetString() ?? string.Empty,
+                element.GetProperty("profiles")
+                    .EnumerateArray()
+                    .Select(item => item.GetString() ?? string.Empty)
+                    .ToArray(),
+                element.GetProperty("guards").GetString() ?? string.Empty))
+            .ToArray();
+        return new ReviewInvariantCorpus(
+            root.GetProperty("schemaVersion").GetInt32(),
+            invariants,
+            evidence);
+    }
+
+    private static string[] ValidateCorpus(
+        IReadOnlyList<ReviewInvariantDefinition> invariants,
+        HashSet<string> knownClasses,
+        Func<string, bool>? projectExists = null)
+    {
+        projectExists ??= project => File.Exists(Path.Combine(RepositoryRoot, project));
+        var errors = new List<string>();
+        errors.AddRange(invariants
+            .GroupBy(invariant => invariant.Id, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => $"duplicate invariant id: {group.Key}"));
+
+        foreach (var invariant in invariants)
+        {
+            if (invariant.HistoricalRoots.Count == 0)
+            {
+                errors.Add($"{invariant.Id}: missing historical root");
+            }
+            if (string.IsNullOrWhiteSpace(invariant.Guards))
+            {
+                errors.Add($"{invariant.Id}: missing guard text");
+            }
+            if (invariant.TestClasses.Count == 0)
+            {
+                errors.Add($"{invariant.Id}: missing test class");
+            }
+
+            foreach (var test in invariant.TestClasses)
+            {
+                if (!projectExists(test.Project))
+                {
+                    errors.Add($"{invariant.Id}: missing test project {test.Project}");
+                }
+                if (!knownClasses.Contains(test.Class))
+                {
+                    errors.Add($"{invariant.Id}: unknown test class {test.Class}");
+                }
+            }
+        }
+
+        return errors.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static string[] ValidateEvidence(
+        IReadOnlyList<ReviewInvariantEvidenceDefinition> evidence,
+        Func<string, bool>? workflowExists = null)
+    {
+        workflowExists ??= workflow => File.Exists(Path.Combine(RepositoryRoot, workflow));
+        var errors = evidence
+            .GroupBy(item => item.Id, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => $"duplicate evidence id: {group.Key}")
+            .ToList();
+
+        foreach (var item in evidence)
+        {
+            if (item.HistoricalRoots.Count == 0)
+            {
+                errors.Add($"{item.Id}: missing historical root");
+            }
+            if (string.IsNullOrWhiteSpace(item.Guards))
+            {
+                errors.Add($"{item.Id}: missing guard text");
+            }
+            if (!workflowExists(item.Workflow))
+            {
+                errors.Add($"{item.Id}: missing workflow {item.Workflow}");
+            }
+            if (!item.Profiles.Contains("Main", StringComparer.Ordinal))
+            {
+                errors.Add($"{item.Id}: missing Main profile");
+            }
+            if (!item.Profiles.Contains("Rehearsal", StringComparer.Ordinal))
+            {
+                errors.Add($"{item.Id}: missing Rehearsal profile");
+            }
+        }
+
+        return errors.Order(StringComparer.Ordinal).ToArray();
+    }
+
+    private static HashSet<string> ReadKnownTestClasses()
+    {
+        return Directory
+            .EnumerateFiles(Path.Combine(RepositoryRoot, "tests"), "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains(
+                $"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}",
+                StringComparison.OrdinalIgnoreCase))
+            .SelectMany(path => CSharpSourceInspector.ReadTypeDeclarations(File.ReadAllText(path)))
+            .Select(declaration => declaration.FullName)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the DownKyi repository root.");
+    }
+
+    private sealed record ReviewInvariantCorpus(
+        int SchemaVersion,
+        IReadOnlyList<ReviewInvariantDefinition> PrInvariants,
+        IReadOnlyList<ReviewInvariantEvidenceDefinition> MainRehearsalEvidence);
+
+    private sealed record ReviewInvariantDefinition(
+        string Id,
+        IReadOnlyList<string> HistoricalRoots,
+        string Guards,
+        IReadOnlyList<ReviewInvariantTestClass> TestClasses);
+
+    private sealed record ReviewInvariantTestClass(string Project, string Class);
+
+    private sealed record ReviewInvariantEvidenceDefinition(
+        string Id,
+        IReadOnlyList<string> HistoricalRoots,
+        string Workflow,
+        IReadOnlyList<string> Profiles,
+        string Guards);
+}

--- a/tests/DownKyi.Core.Tests/SemanticVersionPolicyTests.cs
+++ b/tests/DownKyi.Core.Tests/SemanticVersionPolicyTests.cs
@@ -1,0 +1,58 @@
+using DownKyi.Core.Versioning;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class SemanticVersionPolicyTests
+{
+    [Theory]
+    [InlineData("v1.2.3", "1.2.3")]
+    [InlineData("1.2.3-beta.1", "1.2.3-beta.1")]
+    [InlineData("1.2.3-beta.1+build.9", "1.2.3-beta.1")]
+    public void DisplayNormalizationPreservesPrereleaseAndHidesBuildMetadata(
+        string input,
+        string expected)
+    {
+        Assert.Equal(expected, SemanticVersionPolicy.NormalizeForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("1.2", false, "")]
+    [InlineData("1.02.3", false, "")]
+    [InlineData("not-a-version", false, "")]
+    [InlineData("v1.2.3-rc.1+sha.abc", true, "1.2.3-rc.1+sha.abc")]
+    public void IdentityNormalizationRequiresSemverAndPreservesBuildMetadata(
+        string input,
+        bool expectedSuccess,
+        string expected)
+    {
+        var success = SemanticVersionPolicy.TryNormalizeIdentity(input, out var normalized);
+
+        Assert.Equal(expectedSuccess, success);
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData("1.0.0-alpha.1", "1.0.0-alpha", true)]
+    [InlineData("1.0.0-beta", "1.0.0-alpha.9", true)]
+    [InlineData("1.0.0", "1.0.0-rc.1", true)]
+    [InlineData("1.0.0-rc.1", "1.0.0", false)]
+    [InlineData("1.0.0+new", "1.0.0+old", false)]
+    public void NewerComparisonFollowsSemverPrecedence(
+        string candidate,
+        string current,
+        bool expected)
+    {
+        Assert.Equal(expected, SemanticVersionPolicy.IsNewer(candidate, current));
+    }
+
+    [Fact]
+    public void SkipEquivalenceIgnoresBuildMetadataButNotPrerelease()
+    {
+        Assert.True(SemanticVersionPolicy.HasSamePrecedence(
+            "v1.2.3-beta.1+build.1",
+            "1.2.3-beta.1+build.2"));
+        Assert.False(SemanticVersionPolicy.HasSamePrecedence(
+            "1.2.3-beta.1",
+            "1.2.3"));
+    }
+}

--- a/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
+++ b/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
@@ -9,6 +9,30 @@ namespace DownKyi.Core.Tests;
 public sealed class SettingsStoreTests
 {
     [Fact]
+    public void SkipVersionAcceptsPrereleaseAndBuildMetadata()
+    {
+        var directory = CreateTestDirectory();
+        try
+        {
+            using var store = new SettingsStore(Path.Combine(directory, "settings.json"));
+
+            var updated = store.Update(settings => settings with
+            {
+                About = settings.About with
+                {
+                    SkipVersionOnLaunch = "v1.2.3-beta.1+build.9"
+                }
+            });
+
+            Assert.Equal("1.2.3-beta.1+build.9", updated.About.SkipVersionOnLaunch);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
     public void CustomAriaAcceptsTheDefaultEmptyRpcSecretWithoutBootstrapFailure()
     {
         var directory = CreateTestDirectory();

--- a/tests/DownKyi.Tests/ManualUpdateDialogContractTests.cs
+++ b/tests/DownKyi.Tests/ManualUpdateDialogContractTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using DownKyi.Application.Desktop;
+using DownKyi.Application.Diagnostics;
+using DownKyi.Models;
+using DownKyi.Services;
+using DownKyi.ViewModels.Dialogs;
+using DownKyi.ViewModels.Settings;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DownKyi.Tests;
+
+public sealed class ManualUpdateDialogContractTests
+{
+    [Fact]
+    public async Task ManualUpdateSuppliesExplicitNonSkippableDialogContract()
+    {
+        using var settings = new TestSettingsStore();
+        var dialogs = new RecordingDialogService();
+        var interactions = new TestDesktopInteractionContext(dialogs: dialogs);
+        using var handler = new ReleaseHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.github.test/")
+        };
+        using var viewModel = new ViewAboutViewModel(
+            interactions,
+            settings.Store,
+            new StubLogService(),
+            new StubPlatformLauncher(),
+            new VersionCheckerService(httpClient, "owner", "repo", "1.0.0"),
+            NullLogger<ViewAboutViewModel>.Instance);
+
+        viewModel.CheckUpdateCommand.Execute(null);
+        var request = await dialogs.Request.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(AppDialog.NewVersionAvailable, request.Dialog);
+        var parameters = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(
+            request.Parameters);
+        Assert.IsType<GitHubRelease>(parameters["release"]);
+        Assert.False(Assert.IsType<bool>(parameters["enableSkipVersion"]));
+    }
+
+    private sealed class RecordingDialogService : IAppDialogService
+    {
+        public TaskCompletionSource<AppDialogRequest> Request { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<AppDialogResult> ShowAsync(
+            AppDialogRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Request.TrySetResult(request);
+            return Task.FromResult(new AppDialogResult(
+                AppDialogOutcome.Canceled,
+                new Dictionary<string, object?>()));
+        }
+    }
+
+    private sealed class ReleaseHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"tag_name\":\"v2.0.0\"}")
+            });
+        }
+    }
+
+    private sealed class StubLogService : IApplicationLogService
+    {
+        public string LogDirectory => string.Empty;
+
+        public IReadOnlyList<ApplicationLogRecord> GetRecentEvents() => [];
+
+        public ApplicationLogMetrics GetMetrics() =>
+            new(0, 0, 0, 0, 0, 0, 0, 0, null);
+
+        public Task FlushAsync(CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<string> ExportDiagnosticLogAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(string.Empty);
+    }
+
+    private sealed class StubPlatformLauncher : IPlatformLauncher
+    {
+        public Task<bool> OpenFileAsync(
+            string path,
+            CancellationToken cancellationToken = default) => Task.FromResult(false);
+
+        public Task<bool> OpenFolderAsync(
+            string path,
+            CancellationToken cancellationToken = default) => Task.FromResult(false);
+
+        public Task<bool> OpenUriAsync(
+            Uri uri,
+            CancellationToken cancellationToken = default) => Task.FromResult(false);
+    }
+}

--- a/tests/DownKyi.Tests/TestDesktopInteractionContext.cs
+++ b/tests/DownKyi.Tests/TestDesktopInteractionContext.cs
@@ -4,16 +4,19 @@ namespace DownKyi.Tests;
 
 internal sealed class TestDesktopInteractionContext : IDesktopInteractionContext
 {
-    public TestDesktopInteractionContext(IAppNavigationService? navigation = null)
+    public TestDesktopInteractionContext(
+        IAppNavigationService? navigation = null,
+        IAppDialogService? dialogs = null)
     {
         Navigation = navigation ?? new TestNavigationService();
+        Dialogs = dialogs ?? new TestDialogService();
     }
 
     public IUserNotificationService Notifications { get; } = new TestNotificationService();
 
     public IAppNavigationService Navigation { get; }
 
-    public IAppDialogService Dialogs { get; } = new TestDialogService();
+    public IAppDialogService Dialogs { get; }
 
     private sealed class TestNotificationService : IUserNotificationService
     {

--- a/tests/DownKyi.Tests/VersionCheckerServiceTests.cs
+++ b/tests/DownKyi.Tests/VersionCheckerServiceTests.cs
@@ -32,10 +32,10 @@ public class VersionCheckerServiceTests
 
     [Theory]
     [InlineData("v1.0.32", "1.0.32")]
-    [InlineData("1.0.32-debug", "1.0.32")]
+    [InlineData("1.0.32-debug", "1.0.32-debug")]
     [InlineData("1.0.32+abcdef", "1.0.32")]
-    [InlineData("v1.0.32-beta.1", "1.0.32")]
-    public void NormalizeVersionNameReturnsComparableSemverCore(string input, string expected)
+    [InlineData("v1.0.32-beta.1", "1.0.32-beta.1")]
+    public void NormalizeVersionNamePreservesSemverReleaseIdentity(string input, string expected)
     {
         Assert.Equal(expected, AppInfo.NormalizeVersionName(input));
     }
@@ -70,6 +70,23 @@ public class VersionCheckerServiceTests
         Assert.True(service.IsNewVersionAvailable("v99.0.0"));
     }
 
+    [Theory]
+    [InlineData("1.1.1-beta.2", "1.1.1-beta.1", true)]
+    [InlineData("1.1.1", "1.1.1-rc.1", true)]
+    [InlineData("1.1.1-rc.1", "1.1.1", false)]
+    [InlineData("1.1.1+build.2", "1.1.1+build.1", false)]
+    public void VersionAvailabilityUsesFullSemverPrecedence(
+        string latest,
+        string current,
+        bool expected)
+    {
+        using var handler = new StubHandler("{}");
+        using var httpClient = CreateHttpClient(handler);
+        var service = new VersionCheckerService(httpClient, "owner", "repo", current);
+
+        Assert.Equal(expected, service.IsNewVersionAvailable(latest));
+    }
+
     [Fact]
     public async Task LatestReleaseCheckPreservesPreCanceledRequest()
     {
@@ -99,6 +116,26 @@ public class VersionCheckerServiceTests
 
         Assert.Equal("v2.0.0-beta.1", release?.TagName);
         Assert.Equal("https://api.github.test/repos/owner/repo/releases", handler.RequestUri?.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task SkippedPrereleaseIgnoresEquivalentBuildAndReturnsNextRelease()
+    {
+        using var handler = new StubHandler("""
+            [
+              {"tag_name":"v2.0.0-beta.1+build.2"},
+              {"tag_name":"v2.0.0-beta.2"}
+            ]
+            """);
+        using var httpClient = CreateHttpClient(handler);
+        var service = new VersionCheckerService(httpClient, "owner", "repo", "1.0.0");
+
+        var release = await service.GetLatestReleaseAsync(
+            true,
+            "2.0.0-beta.1+build.1",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("v2.0.0-beta.2", release?.TagName);
     }
 
     private static HttpClient CreateHttpClient(HttpMessageHandler handler)


### PR DESCRIPTION
## Summary

- add a machine-readable, root-cause review invariant corpus and run its deterministic failure/contract coverage on Windows, Linux, and macOS PR CI
- replace receiver/file-name-sensitive C# architecture checks with Roslyn inspection plus adversarial self-tests
- preserve the existing SQLite durable output reservation owner by reusing its admission/store regressions instead of adding a mutable registry or cache
- fix the still-live SemVer prerelease/build/skip contract and the manual update dialog parameter defect found during the overlap audit
- document the review-to-invariant rule in AGENTS.md, testing policy, the knowledge graph, and formal Verification

## Root cause

Historical reviewer findings were stored in individual tests and conversations, while CI had no fail-closed index proving that representative guards still existed or ran. Several architecture scans could also be bypassed by a receiver, filename, modifier, or source-location change. The overlap audit additionally confirmed two current update-flow defects rather than adding duplicate tests for already-fixed download/runtime behavior.

## Validation

- strict Release build: 0 warnings, 0 errors
- review invariant gate: 12 invariants, 7 projects, 309 tests
- full solution: 884 passed, 0 failed, 1 local real-binary test skipped
- module boundary audit: 0 violations
- lifecycle ownership: 493 matches, 0 violations
- assembly lifecycle: 7 assemblies, 213 phases, 0 failures
- format, Gitleaks 8.30.1, Actionlint, release-version contract, vulnerable/deprecated package audits, and git diff --check passed

## Scope

This PR is stacked on #127. It does not change download path ownership or introduce a path registry/cache. DownloadTaskAdmissionService remains the sole coordinator and the Domain/SQLite transaction plus unique index remain the reservation truth.