### PR TITLE
test: enforce root-cause review remediation

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -67,6 +67,14 @@ jobs:
           -c Release
           --no-restore
           --no-build
+      - name: Run review invariant failure corpus
+        shell: pwsh
+        run: >
+          ./script/test-review-invariants.ps1
+          -Configuration Release
+          -NoRestore
+          -NoBuild
+          -ResultsDirectory ./TestResults/review-invariants
       - name: Test
         shell: pwsh
         run: >
@@ -80,7 +88,9 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: test-results-${{ matrix.os }}
-          path: TestResults/*.trx
+          path: |
+            TestResults/*.trx
+            TestResults/review-invariants/*.trx
           if-no-files-found: ignore
 
   aria2-tls-security:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,15 @@
 4. 涉及 Bilibili API、WBI、JSON envelope 或登入契約時，先閱讀並同步更新 `docs/operations/bilibili-api-audit.md`。
 5. 涉及建置、依賴、外部 binary、分析器或發版時，再閱讀 `docs/maintenance.md` 與 `docs/operations/verification-and-rollback.md`。
 6. 新增、刪除、移動或重新導向模組責任的 PR，必須同步更新知識圖譜、架構文件與即時計畫。
+7. 收到 PR/GitHub/Codex/CI review finding 時，先閱讀 `docs/testing/review-invariant-policy.md` 與 `docs/testing/review-invariant-corpus.json`。Finding 只是症狀證據，不是 patch instruction；修改前必須找出 violated invariant、完整 failure path、同族 sibling paths，以及最早丟失語意或做錯 state transition 的 boundary。
+
+## Review Remediation Gate
+
+- Result model、failure taxonomy、sentinel、cleanup、commit boundary、ownership 或 transaction boundary若是根因，必須修正 shared abstraction/owner；禁止只在 reviewer 指出的 caller 疊加 `if`、catch 或另一個模糊 sentinel。
+- Regression 由 invariant 或外部 protocol contract 推導。Retry、cleanup、classification、lifecycle、persistence 與 state-machine finding 必須建立或更新 failure/transition matrix，不得一個 comment 配一個近似 test。
+- 同一 PR 後續 review 若再次出現相同 failure family，視為前次未修到 root cause。立即停止 local patch，重新審查 typed result、shared abstraction、state machine、commit boundary、ownership 與 transaction，直到同族入口由一個共同 invariant 封閉。
+- 深入調查可以擴大分析範圍，但不能自動擴大目前 PR 的修改範圍。只有與目前 violated invariant 同一 root cause、且封閉同一 failure family 所必要的 sibling paths 才能進入目前 PR；不同 invariant、不同產品問題或順帶發現的缺陷只記錄 finding，移入 backlog 或 separate PR。
+- 相同根因只保留一條永久 invariant；deterministic failure/contract 放 PR CI，重型 race/stress/systematic 證據留在 Main/rehearsal；architecture/static gate 本身必須有 adversarial fixture。
 
 ## 專案概況
 
@@ -200,6 +209,10 @@ dotnet build .\DownKyi.sln `
   -p:CodeAnalysisTreatWarningsAsErrors=true
 
 pwsh .\script\test-solution.ps1 -Configuration Release -NoRestore -NoBuild
+pwsh .\script\test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
 pwsh .\script\audit-lifecycle-ownership.ps1 `
   -OutputDirectory .\artifacts\assembly-lifecycle\ownership
 pwsh .\script\test-assembly-lifecycle.ps1 `

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2,7 +2,7 @@
 
 Status: maintained architecture index
 Schema version: 1.0
-Last reviewed: 2026-08-01
+Last reviewed: 2026-08-09
 
 This document is the first file an AI agent should read before changing DownKyi. Its goal is to preserve stable knowledge about project structure, ownership boundaries, and call relationships so agents do not rediscover the same code paths from scratch.
 
@@ -145,6 +145,7 @@ flowchart TD
     Benchmarks["test.performance-baseline\nBenchmarkCases + runner"]
     SystemBenchmarks["test.system-performance\nisolated system scenarios"]
     CI["workflow.strict-pr-ci\n.github/workflows/quality.yml"]
+    ReviewInvariants["test.review-invariant-corpus\nroot-cause failure corpus"]
     AriaTlsCI["workflow.aria2-tls-security\nsix RID real-binary gate"]
     Release["workflow.release-packaging\n.github/workflows/build.yml"]
     Nightly["workflow.system-baselines\nnightly cross-platform reports"]
@@ -179,6 +180,8 @@ flowchart TD
     SystemBenchmarks -->|measures| FFmpeg
     Nightly -->|runs| SystemBenchmarks
     CI -->|runs PR and main profiles| LifecycleGate
+    CI -->|runs deterministic corpus| ReviewInvariants
+    ReviewInvariants -->|guards| Tests
     Release -->|runs rehearsal profile| LifecycleGate
     LifecycleOwners -->|governs| LifecycleGate
     LifecycleGate -->|guards| Tests
@@ -2434,7 +2437,9 @@ paths:
   - .github/workflows/quality.yml
   - .github/workflows/build.yml
   - script/test-solution.ps1
-responsibility: Blocks PRs that break formatting, restore, Release build, warnings-as-errors, unit tests, or vulnerable package policy.
+  - script/test-review-invariants.ps1
+  - docs/testing/review-invariant-corpus.json
+responsibility: Blocks PRs that break formatting, restore, Release build, warnings-as-errors, unit tests, root-cause review invariants, or vulnerable package policy.
 inbound:
   - github.pull_request
 outbound:
@@ -2451,11 +2456,16 @@ contracts:
   - Every test project writes a distinct assembly-named TRX; no solution-level logger filename may overwrite earlier project evidence.
   - Windows PR and main jobs must run the Assembly Lifecycle Stability Gate and upload its reports even when a phase fails.
   - Every PR runs the six-RID real-binary aria2 TLS security matrix; a unit-test-only pass cannot replace it.
+  - A review finding is symptom evidence, not a patch instruction. Remediation identifies the violated invariant, traces the complete failure path and sibling callers, and fixes the earliest shared semantic or transition boundary.
+  - A repeated failure family in the same PR blocks further local patches and requires a typed-result, state-machine, commit-boundary, ownership or transaction review.
+  - Investigation may widen analysis, but only sibling paths sharing the same root cause and required to close the same failure family may widen the current PR diff; unrelated findings move to backlog or a separate PR.
+  - The review corpus references only contracts present on its target branch and fails unless every declared class actually executes on Windows, Linux and macOS.
 hazards:
   - Turning every historical analyzer suggestion into PR failure makes unrelated PRs impossible.
   - Broad NoWarn, global suppressions, nullable disable, or analyzer exclusions hide new defects.
   - Restoring one parallel solution-level `dotnet test` command can reintroduce Windows foreground-thread timeouts and TRX overwrite.
 tests:
+  - test.review-invariant-corpus
   - github.actions
 ```
 
@@ -3290,6 +3300,19 @@ test.assembly-lifecycle-architecture:
     - formal Verification cannot omit the ownership audit, five-iteration local gate or Rehearsal report
     - Desktop main-loop teardown awaits async App and Host disposal
     - every declared lifecycle owner documents start, stop, teardown, paths and allowed mechanisms
+
+test.review-invariant-corpus:
+  paths:
+    - docs/testing/review-invariant-policy.md
+    - docs/testing/review-invariant-corpus.json
+    - script/test-review-invariants.ps1
+    - tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
+  guards:
+    - review findings trigger violated-invariant, full failure-path, sibling-path and earliest-boundary analysis before production edits
+    - repeated failure families in one PR stop local patches and escalate to shared typed-result, state, ownership or transaction remediation
+    - scope containment keeps unrelated invariants and incidental product defects out of the active PR
+    - deterministic PR coverage resolves to existing classes across all seven test projects and proves each class executed
+    - Main/rehearsal retains lifecycle stress and real-binary transfer evidence
 
 test.infrastructure-clock:
   paths:

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -2,6 +2,8 @@
 
 目前即時狀態位於 `../refactoring-live-plan.md`。v1.1.1 的安全修補順序、
 範圍、驗證與回滾位於 `v1.1.1-security-patch.md`。
+Root-cause review remediation policy baseline 的獨立範圍與驗證位於
+`root-cause-review-policy-baseline.md`。
 
 每個 work item 必須包含：
 

--- a/docs/exec-plans/root-cause-review-policy-baseline.md
+++ b/docs/exec-plans/root-cause-review-policy-baseline.md
@@ -41,7 +41,7 @@ gate directly on `main` before further #120 or #127 remediation.
 
 ## Local Verification
 
-Verified on Windows x64 against `origin/main` at `a03ab647a9965b8b95f57369fb9784f58484d5bb`:
+Verified on Windows x64 against `origin/main` at `c4d00b3296922844826343e5ba82085364ebba32`:
 
 - Strict Release build: 0 warnings, 0 errors.
 - Review invariant corpus: 9 invariants, 7 projects, 239 tests passed.

--- a/docs/exec-plans/root-cause-review-policy-baseline.md
+++ b/docs/exec-plans/root-cause-review-policy-baseline.md
@@ -1,0 +1,61 @@
+# Root-Cause Review Policy Baseline
+
+Status: local verification complete; exact-head CI pending
+
+## Goal
+
+Land the Root-Cause Review Remediation rule and its minimal executable invariant
+gate directly on `main` before further #120 or #127 remediation.
+
+## In Scope
+
+- Agent and testing policy for invariant identification, full failure-path and
+  sibling-path analysis, information-preserving typed results, commit boundaries
+  and repeated-review escalation.
+- A main-compatible machine-readable corpus that references only tests already
+  present on `main`.
+- A deterministic runner that proves every declared test class actually ran.
+- Cross-platform PR CI invocation, architecture contract checks, knowledge graph
+  and formal Verification commands.
+- A scope-containment contract: analysis may find adjacent defects, but this PR
+  changes only the policy baseline and its necessary executable gate.
+
+## Out Of Scope
+
+- SemVer, update-dialog or other product fixes found while constructing the
+  corpus. These are the concrete #129 example of findings that require a
+  separate product PR rather than scope expansion of the policy PR.
+- Any #120 or #127 review remediation, thread resolution, GitHub comment or PR
+  merge.
+- Claims that #125 output reservation or #127 FFmpeg failure taxonomy already
+  exist on `main`.
+
+## Completion
+
+1. Strict Release build and all seven test projects pass.
+2. Review corpus executes every declared class on Windows, Linux and macOS.
+3. Format, module, secret, workflow, package and lifecycle gates pass.
+4. The policy PR is based directly on `main`, contains no product behavior, and
+   exact-head GitHub checks are green.
+5. Only after this baseline merges may work resume on #120 and then #127.
+
+## Local Verification
+
+Verified on Windows x64 against `origin/main` at `a03ab647a9965b8b95f57369fb9784f58484d5bb`:
+
+- Strict Release build: 0 warnings, 0 errors.
+- Review invariant corpus: 9 invariants, 7 projects, 239 tests passed.
+- Full solution: 806 passed, 1 existing real-binary test skipped, 0 failed.
+- Architecture gate: 229 passed, 0 failed.
+- Assembly lifecycle: 7 assemblies, 213 phase results, 0 failures.
+- Lifecycle ownership: 477 matches, 0 violations.
+- Format, module boundary, workflow lint, package vulnerability/deprecation,
+  Gitleaks and `git diff --check`: passed.
+
+The final diff contains policy, documentation, CI workflow, test and script
+changes only. It contains no application production-code changes.
+
+## Rollback
+
+Revert the policy commit range. No user settings, SQLite data, downloads,
+resume state or external protocol behavior changes in this PR.

--- a/docs/operations/verification-and-rollback.md
+++ b/docs/operations/verification-and-rollback.md
@@ -31,6 +31,10 @@ dotnet build ./DownKyi.sln `
   -p:CodeAnalysisTreatWarningsAsErrors=true `
   -p:UseSharedCompilation=false
 
+pwsh ./script/test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
 pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild
 pwsh ./script/audit-lifecycle-ownership.ps1 `
   -OutputDirectory ./artifacts/assembly-lifecycle/ownership
@@ -53,6 +57,11 @@ pwsh ./script/scan-secrets.ps1
 ```
 
 `scan-secrets.ps1` 使用 Gitleaks 掃描目前 tracked 與尚未追蹤、但未被 `.gitignore` 排除的候選提交檔。固定驗證版本為 Gitleaks `8.30.1`；Windows x64 release zip 必須先依官方 `gitleaks_8.30.1_checksums.txt` 驗證 SHA-256，再解壓到 `.tools/gitleaks/bin/`。`.gitleaks.toml` 只允許公開 WBI 測試 fixture 與精確的 Avalonia brush resource 行，不得加入整個目錄或一般測試檔的寬鬆排除。
+
+`test-review-invariants.ps1` 是 root-cause failure corpus gate。它必須證明
+每個 manifest class 實際執行，不得只用總測試數推測 coverage。Corpus 只
+記錄 target branch 已存在的契約；未合併 PR 的設計不能提前寫成 stable
+invariant。
 
 Lifecycle ownership audit 與 5 次全 test-assembly gate 是同一套嚴格
 Verification 的必要步驟，不是選用診斷工具。每個 assembly 必須通過

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -94,6 +94,8 @@ dotnet build ./DownKyi.sln -c Release --no-restore --no-incremental `
   -p:EnableNETAnalyzers=true -p:AnalysisMode=All `
   -p:EnforceCodeStyleInBuild=true -p:TreatWarningsAsErrors=true `
   -p:CodeAnalysisTreatWarningsAsErrors=true -p:UseSharedCompilation=false
+pwsh ./script/test-review-invariants.ps1 `
+  -Configuration Release -NoRestore -NoBuild
 pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild
 pwsh ./script/audit-lifecycle-ownership.ps1 `
   -OutputDirectory ./artifacts/assembly-lifecycle/ownership

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -15,7 +15,21 @@
 - `module-boundary-ratchets.md`
 - `assembly-lifecycle-stability.md`
 - `assembly-lifecycle-owners.json`
+- `review-invariant-policy.md`
+- `review-invariant-corpus.json`
 - `../maintenance.md`
 - `../operations/verification-and-rollback.md`
 
 測試不得讀取使用者真實 settings、cookie、下載 DB 或 aria2 session。網路 contract tests 使用 fixture 或 loopback server。
+
+Reviewer/Codex finding 必須先依 `review-invariant-policy.md` 做 root-cause
+investigation，再按根因合併成永久 invariant。PR CI 執行 deterministic
+failure/contract coverage；重型 race、process、GC、real-binary 與系統性
+平台證據保留在 Main/rehearsal。
+
+```powershell
+pwsh ./script/test-review-invariants.ps1 `
+  -Configuration Release `
+  -NoRestore `
+  -NoBuild
+```

--- a/docs/testing/review-invariant-corpus.json
+++ b/docs/testing/review-invariant-corpus.json
@@ -1,0 +1,115 @@
+{
+  "schemaVersion": 1,
+  "prInvariants": [
+    {
+      "id": "cancellation-semantics",
+      "historicalRoots": ["PR #85 F057", "PR #91", "PR #120"],
+      "guards": "Caller cancellation, pause, shutdown and timeout retain distinct outcomes and do not become retry or generic failure.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Domain.Tests/DownKyi.Domain.Tests.csproj", "class": "DownKyi.Domain.Tests.DownloadTaskStateMachineTests" },
+        { "project": "tests/DownKyi.Application.Tests/DownKyi.Application.Tests.csproj", "class": "DownKyi.Application.Tests.ApplicationCancellationTests" },
+        { "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj", "class": "DownKyi.Infrastructure.Tests.BilibiliHttpTransportTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadRetryPolicyTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadShutdownCoordinatorTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.AsyncDelegateCommandTests" }
+      ]
+    },
+    {
+      "id": "runtime-ownership",
+      "historicalRoots": ["PR #85 F049", "PR #94", "PR #113", "PR #122"],
+      "guards": "Scopes, GIDs, processes, flush barriers and operation identities remain owned until asynchronous cleanup completes.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Application.Tests/DownKyi.Application.Tests.csproj", "class": "DownKyi.Application.Tests.DownloadTaskApplicationServiceTests" },
+        { "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj", "class": "DownKyi.Infrastructure.Tests.ApplicationLogProviderTests" },
+        { "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj", "class": "DownKyi.Core.Tests.AriaServerProcessTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadOrchestratorTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.AriaRuntimeClientRegistryTests" }
+      ]
+    },
+    {
+      "id": "output-cleanup-ownership",
+      "historicalRoots": ["PR #85", "PR #120"],
+      "guards": "Task rows, resume state, generated files and sidecars are changed through their existing owners; cancellation preserves recoverable state.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj", "class": "DownKyi.Infrastructure.Tests.SqliteDownloadTaskStoreTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadTaskFileServiceTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadTaskProjectionStoreResumeTests" }
+      ]
+    },
+    {
+      "id": "json-contract-presence",
+      "historicalRoots": ["PR #85 F060-F061", "PR #120"],
+      "guards": "Missing, null, empty, malformed and valid JSON remain distinct; optional envelopes cannot invent success payloads.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj", "class": "DownKyi.Core.Tests.JsonEnvelopePresenceTests" },
+        { "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj", "class": "DownKyi.Core.Tests.PlayUrlEnvelopeContractTests" },
+        { "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj", "class": "DownKyi.Core.Tests.BiliApiModelContractTests" }
+      ]
+    },
+    {
+      "id": "request-origin-and-credential-contracts",
+      "historicalRoots": ["PR #85 F065-F066", "PR #91", "PR #122"],
+      "guards": "Endpoint parameters, cookie handling, required headers and redirect/origin security remain explicit and credential-safe.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj", "class": "DownKyi.Core.Tests.PlayUrlEnvelopeContractTests" },
+        { "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj", "class": "DownKyi.Core.Tests.AriaClientSecurityTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.AriaSecurityTests" }
+      ]
+    },
+    {
+      "id": "architecture-rule-self-defense",
+      "historicalRoots": ["PR #85 F052-F055", "PR #98", "PR #104"],
+      "guards": "Architecture, policy and corpus gates fail closed when required entries, workflows or evidence disappear.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj", "class": "DownKyi.Architecture.Tests.AgentEnvironmentArchitectureTests" },
+        { "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj", "class": "DownKyi.Architecture.Tests.ReviewInvariantCorpusTests" }
+      ]
+    },
+    {
+      "id": "cross-platform-backend-contract",
+      "historicalRoots": ["PR #122"],
+      "guards": "Selectable transfer backends apply the same retry and credential-safe transport outcomes across supported operating systems.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadRetryPolicyTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.AriaSecurityTests" }
+      ]
+    },
+    {
+      "id": "ui-async-state",
+      "historicalRoots": ["PR #85 F056-F059", "PR #120"],
+      "guards": "Newer UI operations reject stale data while selection and asynchronous command state remain coherent.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Desktop.Tests/DownKyi.Desktop.Tests.csproj", "class": "DownKyi.Desktop.Tests.UiSmokeTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.VideoDetailWorkflowCoordinatorTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.VideoSelectionStateTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.AsyncDelegateCommandTests" }
+      ]
+    },
+    {
+      "id": "host-process-and-log-lifecycle",
+      "historicalRoots": ["PR #94", "PR #113", "PR #120", "PR #122"],
+      "guards": "Host, process and logging owners dispose, exit and persist deterministically; accepted work is not reported completed before durable flush.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Desktop.Tests/DownKyi.Desktop.Tests.csproj", "class": "DownKyi.Desktop.Tests.UiSmokeTests" },
+        { "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj", "class": "DownKyi.Infrastructure.Tests.ApplicationLogProviderTests" },
+        { "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj", "class": "DownKyi.Architecture.Tests.AssemblyLifecycleArchitectureTests" }
+      ]
+    }
+  ],
+  "mainRehearsalEvidence": [
+    {
+      "id": "assembly-lifecycle-stress",
+      "historicalRoots": ["PR #113"],
+      "workflow": ".github/workflows/quality.yml",
+      "profiles": ["Main", "Rehearsal"],
+      "guards": "Repeated assembly load, discovery, execution, teardown and process exit with timeout forensics."
+    },
+    {
+      "id": "real-binary-transfer-security",
+      "historicalRoots": ["PR #122"],
+      "workflow": ".github/workflows/quality.yml",
+      "profiles": ["PR", "Main", "Rehearsal"],
+      "guards": "Six-RID aria2 TLS, redirect, Range and credential behavior against packaged binaries."
+    }
+  ]
+}

--- a/docs/testing/review-invariant-policy.md
+++ b/docs/testing/review-invariant-policy.md
@@ -1,0 +1,119 @@
+# Review Invariant Policy
+
+## Purpose
+
+A review finding is evidence of a symptom, not a complete patch specification.
+Before production code changes, the agent must identify the violated invariant,
+trace the whole failure path, search sibling entry points and locate the first
+boundary that lost information or made an invalid state transition.
+
+## Required Workflow
+
+1. **Identify the violated invariant.** Name the system contract, protocol,
+   ownership rule, state transition or lifecycle invariant. A source line is
+   evidence, not the invariant.
+2. **Trace the complete failure path.** Follow the input or external event into
+   classification, retry, cleanup, persistence, physical files, finalization
+   and the observable UI outcome. Locate the earliest incorrect boundary.
+3. **Search sibling paths.** Inspect callers of the same result, helper, owner,
+   exception mapper, sentinel, cleanup path, retry path and state mutation. A
+   failure family must be closed across all entry points.
+4. **Classify local versus systemic.** A local patch is permitted only with
+   evidence that no sibling path shares the defect. Weak result models,
+   incomplete failure taxonomy, ambiguous sentinels, non-atomic transitions,
+   duplicate owners and missing commit boundaries require a shared-owner fix.
+5. **Preserve information.** Failure kinds needed for retry, cleanup,
+   persistence or user outcome cannot collapse into `bool`, `null`, an empty
+   collection, generic exception, exit code or free-form text. Use typed results
+   or discriminated state and do not infer semantics from side effects.
+6. **Delay irreversible effects.** Source deletion, resume-identity removal,
+   completed-key invalidation, destination overwrite and completed publication
+   happen only after final required validation. Filesystem, backend and durable
+   Domain state need an explicit commit order and failure recovery.
+
+Before adding code, search current production modules and tests. Reuse or extend
+the existing owner; never create a parallel registry, limiter, validator, retry
+policy or lifecycle owner. Findings with one root cause share one invariant even
+when they came from different review comments.
+
+## Scope Containment
+
+Investigation may widen the analysis surface, but it does not automatically
+widen the current PR's modification scope. A sibling path belongs in the
+current PR only when it shares the same root cause and is necessary to close the
+same failure family.
+
+A different invariant, product issue or incidental defect is recorded as a
+finding and moved to the backlog or a separate PR. It must not be bundled merely
+because it was discovered during the investigation. The root-cause requirement
+expands evidence gathering; it does not authorize unrelated product changes.
+
+## Prohibited Remediation
+
+Do not close a finding by adding one condition to the reported `if`, catching
+only the reported exception, inventing another sentinel, or encoding current
+implementation behavior as an architecture contract. Do not add only the
+reported example without searching its failure family. Green CI proves the
+recorded checks passed; it does not prove an unexamined semantic contract.
+
+Cleanup failure cannot be followed by durable invalidation, and destructive
+effects cannot run before the workflow commit boundary.
+
+## Failure And Transition Matrix
+
+Classification, retry, cleanup, lifecycle, persistence and state-machine fixes
+must create or update a matrix derived from the invariant. Applicable rows must
+separate at least:
+
+- invalid or corrupt input;
+- missing input;
+- inaccessible input or destination;
+- dependency, runtime or process failure;
+- timeout or transport failure;
+- destination conflict;
+- cleanup failure;
+- caller cancellation, pause and shutdown.
+
+For each row define the expected physical source, partial/sidecar, completed
+key, backend/resume identity, destination output, retry eligibility and durable
+task state. A new failure kind must fit the matrix instead of falling into a
+generic fallback that callers reinterpret.
+
+Tests derive from the invariant or external protocol, not from the
+implementation just written. Deterministic failure injection, contract tests
+and architecture self-tests run in PR CI. Repeated race, stress, GC, process,
+real-binary and systematic platform checks stay in Main or release rehearsal
+unless an existing security policy already requires PR coverage.
+
+## External Protocol Evidence
+
+For Bilibili API, protobuf, HTTP, FFmpeg, aria2, SQLite and other external
+contracts, one successful or failed fixture is insufficient. Termination,
+absence, empty result and failure remain distinct. Confirm assumptions against
+the repository protocol definition, official behavior, a sanitized real fixture
+or another primary source before promoting them to stable architecture. Mark
+insufficient evidence as an assumption or unresolved contract.
+
+## Repeated-Review Escalation
+
+If a later review round on the same PR exposes the same failure family, the
+previous remediation did not close the root cause. Stop local patches. Reopen
+the shared abstraction, typed result, state machine, commit boundary, ownership
+or transaction analysis and replace the patch chain with one systemic invariant
+and failure/transition matrix.
+
+## Executable Corpus
+
+`review-invariant-corpus.json` maps root-cause invariants to representative test
+classes already present on the target branch. It must not claim a contract that
+exists only on an unmerged PR. `test-review-invariants.ps1` fails unless every
+declared class actually executes and passes.
+
+## Completion Rule
+
+A finding is complete only when the violated invariant and earliest incorrect
+boundary are documented, sibling paths are searched, the fix lives in the
+smallest correct shared owner, the invariant-derived regression or matrix is
+green, and architecture/knowledge/plan documents match executable behavior. No
+new undocumented sentinel, failure interpretation or destructive lifecycle rule
+may remain.

--- a/script/test-review-invariants.ps1
+++ b/script/test-review-invariants.ps1
@@ -1,0 +1,121 @@
+[CmdletBinding()]
+param(
+    [ValidateSet("Debug", "Release")]
+    [string]$Configuration = "Release",
+
+    [switch]$NoRestore,
+
+    [switch]$NoBuild,
+
+    [string]$ResultsDirectory = "artifacts/review-invariants"
+)
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$manifestPath = Join-Path $repositoryRoot "docs/testing/review-invariant-corpus.json"
+$resultRoot = [IO.Path]::GetFullPath((Join-Path $repositoryRoot $ResultsDirectory))
+
+if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
+    throw "Review invariant corpus is missing: $manifestPath"
+}
+
+$manifest = Get-Content -LiteralPath $manifestPath -Raw | ConvertFrom-Json
+if ($manifest.schemaVersion -ne 1) {
+    throw "Unsupported review invariant corpus schema: $($manifest.schemaVersion)"
+}
+
+$invariants = @($manifest.prInvariants)
+if ($invariants.Count -eq 0) {
+    throw "The PR review invariant corpus is empty."
+}
+
+$duplicateIds = @(
+    $invariants |
+        Group-Object id |
+        Where-Object Count -gt 1 |
+        Select-Object -ExpandProperty Name
+)
+if ($duplicateIds.Count -gt 0) {
+    throw "Duplicate review invariant ids: $($duplicateIds -join ', ')"
+}
+
+$testClasses = @(
+    foreach ($invariant in $invariants) {
+        if ([string]::IsNullOrWhiteSpace($invariant.id) -or
+            [string]::IsNullOrWhiteSpace($invariant.guards) -or
+            @($invariant.historicalRoots).Count -eq 0 -or
+            @($invariant.testClasses).Count -eq 0) {
+            throw "Review invariant '$($invariant.id)' has an incomplete contract."
+        }
+
+        foreach ($testClass in @($invariant.testClasses)) {
+            if ([string]::IsNullOrWhiteSpace($testClass.project) -or
+                [string]::IsNullOrWhiteSpace($testClass.class)) {
+                throw "Review invariant '$($invariant.id)' contains an incomplete test reference."
+            }
+            $testClass
+        }
+    }
+)
+
+New-Item -ItemType Directory -Path $resultRoot -Force | Out-Null
+$projectGroups = @($testClasses | Group-Object project | Sort-Object Name)
+$totalPassed = 0
+
+foreach ($projectGroup in $projectGroups) {
+    $projectPath = Join-Path $repositoryRoot $projectGroup.Name
+    if (-not (Test-Path -LiteralPath $projectPath -PathType Leaf)) {
+        throw "Review invariant test project is missing: $($projectGroup.Name)"
+    }
+
+    $classNames = @($projectGroup.Group.class | Sort-Object -Unique)
+    $filter = ($classNames | ForEach-Object { "FullyQualifiedName~$_" }) -join "|"
+    $safeName = [IO.Path]::GetFileNameWithoutExtension($projectPath)
+    $trxName = "$safeName.trx"
+    $arguments = @(
+        "test",
+        $projectPath,
+        "-c", $Configuration,
+        "--filter", $filter,
+        "--logger", "trx;LogFileName=$trxName",
+        "--results-directory", $resultRoot
+    )
+    if ($NoRestore) {
+        $arguments += "--no-restore"
+    }
+    if ($NoBuild) {
+        $arguments += "--no-build"
+    }
+
+    Write-Host "Running review invariants in $($projectGroup.Name)"
+    & dotnet @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "Review invariant tests failed for $($projectGroup.Name)."
+    }
+
+    $trxPath = Join-Path $resultRoot $trxName
+    if (-not (Test-Path -LiteralPath $trxPath -PathType Leaf)) {
+        throw "Review invariant test report is missing: $trxPath"
+    }
+
+    [xml]$trx = Get-Content -LiteralPath $trxPath -Raw
+    $counters = $trx.TestRun.ResultSummary.Counters
+    $failed = [int]$counters.failed
+    $notExecuted = [int]$counters.notExecuted
+    $passed = [int]$counters.passed
+    $executedClasses = @(
+        $trx.TestRun.TestDefinitions.UnitTest.TestMethod |
+            ForEach-Object { [string]$_.className } |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+            Sort-Object -Unique
+    )
+    $missingClasses = @($classNames | Where-Object { $_ -notin $executedClasses })
+
+    if ($failed -ne 0 -or $notExecuted -ne 0 -or $missingClasses.Count -ne 0) {
+        throw "Review invariant coverage was incomplete for $($projectGroup.Name): passed=$passed failed=$failed notExecuted=$notExecuted missingClasses=$($missingClasses -join ',')."
+    }
+
+    $totalPassed += $passed
+}
+
+Write-Host "Review invariant gate passed: $($invariants.Count) root-cause invariants, $($projectGroups.Count) test projects, $totalPassed tests."

--- a/tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class ReviewInvariantCorpusTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string CorpusPath = Path.Combine(
+        RepositoryRoot,
+        "docs",
+        "testing",
+        "review-invariant-corpus.json");
+
+    [Fact]
+    public void CorpusAndPolicyRemainFailClosed()
+    {
+        using var document = JsonDocument.Parse(File.ReadAllText(CorpusPath));
+        var root = document.RootElement;
+        var invariants = root.GetProperty("prInvariants").EnumerateArray().ToArray();
+        var evidence = root.GetProperty("mainRehearsalEvidence").EnumerateArray().ToArray();
+
+        Assert.Equal(1, root.GetProperty("schemaVersion").GetInt32());
+        Assert.NotEmpty(invariants);
+        Assert.Equal(
+            invariants.Length,
+            invariants.Select(item => item.GetProperty("id").GetString()).Distinct(StringComparer.Ordinal).Count());
+
+        foreach (var invariant in invariants)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(invariant.GetProperty("id").GetString()));
+            Assert.False(string.IsNullOrWhiteSpace(invariant.GetProperty("guards").GetString()));
+            Assert.NotEmpty(invariant.GetProperty("historicalRoots").EnumerateArray());
+            var tests = invariant.GetProperty("testClasses").EnumerateArray().ToArray();
+            Assert.NotEmpty(tests);
+            foreach (var test in tests)
+            {
+                var project = test.GetProperty("project").GetString();
+                Assert.False(string.IsNullOrWhiteSpace(test.GetProperty("class").GetString()));
+                Assert.True(File.Exists(Path.Combine(RepositoryRoot, project!)), project);
+            }
+        }
+
+        Assert.Contains(evidence, item =>
+            item.GetProperty("profiles").EnumerateArray().Any(profile =>
+                profile.GetString() == "Main") &&
+            item.GetProperty("profiles").EnumerateArray().Any(profile =>
+                profile.GetString() == "Rehearsal"));
+
+        var policy = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "docs",
+            "testing",
+            "review-invariant-policy.md"));
+        Assert.Contains("Identify the violated invariant", policy, StringComparison.Ordinal);
+        Assert.Contains("Search sibling paths", policy, StringComparison.Ordinal);
+        Assert.Contains("Failure And Transition Matrix", policy, StringComparison.Ordinal);
+        Assert.Contains("Repeated-Review Escalation", policy, StringComparison.Ordinal);
+        Assert.Contains("Scope Containment", policy, StringComparison.Ordinal);
+        Assert.Contains("does not automatically", policy, StringComparison.Ordinal);
+
+        var agents = File.ReadAllText(Path.Combine(RepositoryRoot, "AGENTS.md"));
+        Assert.Contains("Review Remediation Gate", agents, StringComparison.Ordinal);
+        Assert.Contains("停止 local patch", agents, StringComparison.Ordinal);
+        Assert.Contains("不能自動擴大目前 PR 的修改範圍", agents, StringComparison.Ordinal);
+        Assert.Contains("backlog 或 separate PR", agents, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void StrictCiRunsCorpusOnEverySupportedOperatingSystem()
+    {
+        var quality = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            ".github",
+            "workflows",
+            "quality.yml"));
+        var release = File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            ".github",
+            "workflows",
+            "build.yml"));
+
+        Assert.Contains("test-review-invariants.ps1", quality, StringComparison.Ordinal);
+        Assert.Contains("windows-latest", quality, StringComparison.Ordinal);
+        Assert.Contains("ubuntu-latest", quality, StringComparison.Ordinal);
+        Assert.Contains("macos-latest", quality, StringComparison.Ordinal);
+        Assert.Contains("\"Main\"", quality, StringComparison.Ordinal);
+        Assert.Contains("-Profile Rehearsal", release, StringComparison.Ordinal);
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the DownKyi repository root.");
+    }
+}


### PR DESCRIPTION
## Summary

- define root-cause review remediation and repeated-review escalation rules
- add scope containment so investigation cannot silently widen a PR diff
- add a main-compatible invariant corpus and fail-closed runner
- run the deterministic corpus on Windows, Linux, and macOS PR/main CI
- document the formal verification and knowledge-graph contracts

This policy PR is based directly on `main`. It contains no SemVer, manual update dialog, #120, #125, or #127 product behavior.

## Verification

- strict Release build: 0 warnings, 0 errors
- review invariant corpus: 9 invariants, 7 projects, 239 passed
- full solution: 806 passed, 1 existing real-binary skip, 0 failed
- architecture: 229 passed
- assembly lifecycle: 7 assemblies, 213 phases, 0 failures
- lifecycle ownership: 477 matches, 0 violations
- format, module boundary, actionlint, package audit, Gitleaks, and diff check: passed