### PR TITLE
fix(updates): enforce semantic version contracts

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
     <PackageVersion Include="NLog" Version="6.1.4" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="NuGet.Versioning" Version="7.6.0" />
     <PackageVersion Include="QRCoder" Version="1.8.0" />
     <PackageVersion Include="SQLite3MC.PCLRaw.bundle" Version="2.3.6" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />

--- a/DownKyi.Core/DownKyi.Core.csproj
+++ b/DownKyi.Core/DownKyi.Core.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="Microsoft.Data.Sqlite.Core"/>
         <PackageReference Include="Microsoft.Extensions.Logging"/>
         <PackageReference Include="Newtonsoft.Json"/>
+        <PackageReference Include="NuGet.Versioning"/>
         <PackageReference Include="SQLite3MC.PCLRaw.bundle"/>
     </ItemGroup>
 

--- a/DownKyi.Core/Settings/ApplicationSettings.cs
+++ b/DownKyi.Core/Settings/ApplicationSettings.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using DownKyi.Core.Aria2cNet.Server;
 using DownKyi.Core.FileName;
+using DownKyi.Core.Versioning;
 
 namespace DownKyi.Core.Settings;
 
@@ -266,8 +267,10 @@ internal static class ApplicationSettingsValidator
         {
             IsReceiveBetaVersion = AllowValue(settings.About.IsReceiveBetaVersion, AllowStatus.No, "About.IsReceiveBetaVersion", corrections),
             AutoUpdateWhenLaunch = AllowValue(settings.About.AutoUpdateWhenLaunch, AllowStatus.No, "About.AutoUpdateWhenLaunch", corrections),
-            SkipVersionOnLaunch = Version.TryParse(settings.About.SkipVersionOnLaunch, out _)
-                ? settings.About.SkipVersionOnLaunch
+            SkipVersionOnLaunch = SemanticVersionPolicy.TryNormalizeIdentity(
+                settings.About.SkipVersionOnLaunch,
+                out var normalizedSkipVersion)
+                ? normalizedSkipVersion
                 : string.Empty
         };
         var user = settings.User with

--- a/DownKyi.Core/Settings/SettingsManager.About.cs
+++ b/DownKyi.Core/Settings/SettingsManager.About.cs
@@ -1,3 +1,5 @@
+using DownKyi.Core.Versioning;
+
 namespace DownKyi.Core.Settings;
 
 public sealed partial class SettingsManager
@@ -68,11 +70,13 @@ public sealed partial class SettingsManager
 
     public bool SetSkipVersionOnLaunch(string skipVersionOnLaunch)
     {
-        if (Version.TryParse(skipVersionOnLaunch, out var _))
+        if (SemanticVersionPolicy.TryNormalizeIdentity(
+                skipVersionOnLaunch,
+                out var normalizedVersion))
         {
             return SetProperty(
                 _appSettings.About.SkipVersionOnLaunch,
-                skipVersionOnLaunch,
+                normalizedVersion,
                 v => _appSettings.About.SkipVersionOnLaunch = v);
         }
 
@@ -81,9 +85,11 @@ public sealed partial class SettingsManager
 
     public string GetSkipVersionOnLaunch()
     {
-        if (Version.TryParse(_appSettings.About.SkipVersionOnLaunch, out var _))
+        if (SemanticVersionPolicy.TryNormalizeIdentity(
+                _appSettings.About.SkipVersionOnLaunch,
+                out var normalizedVersion))
         {
-            return _appSettings.About.SkipVersionOnLaunch;
+            return normalizedVersion;
         }
         return string.Empty;
     }

--- a/DownKyi.Core/Versioning/SemanticVersionPolicy.cs
+++ b/DownKyi.Core/Versioning/SemanticVersionPolicy.cs
@@ -1,0 +1,90 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using NuGet.Versioning;
+
+namespace DownKyi.Core.Versioning;
+
+public static class SemanticVersionPolicy
+{
+    public static string NormalizeForDisplay(string? value)
+    {
+        return TryParse(value, out var version)
+            ? Format(version, includeMetadata: false)
+            : string.Empty;
+    }
+
+    public static bool TryNormalizeIdentity(string? value, out string normalized)
+    {
+        if (!TryParse(value, out var version))
+        {
+            normalized = string.Empty;
+            return false;
+        }
+
+        normalized = Format(version, includeMetadata: true);
+        return true;
+    }
+
+    public static bool IsNewer(string? candidate, string? current)
+    {
+        return TryParse(candidate, out var candidateVersion) &&
+               TryParse(current, out var currentVersion) &&
+               VersionComparer.VersionRelease.Compare(candidateVersion, currentVersion) > 0;
+    }
+
+    public static bool HasSamePrecedence(string? left, string? right)
+    {
+        return TryParse(left, out var leftVersion) &&
+               TryParse(right, out var rightVersion) &&
+               VersionComparer.VersionRelease.Equals(leftVersion, rightVersion);
+    }
+
+    internal static bool TryParse(
+        string? value,
+        [NotNullWhen(true)] out NuGetVersion? version)
+    {
+        version = null;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var candidate = value.Trim();
+        if (candidate.Length > 1 &&
+            (candidate[0] == 'v' || candidate[0] == 'V') &&
+            char.IsAsciiDigit(candidate[1]))
+        {
+            candidate = candidate[1..];
+        }
+
+        var coreEnd = candidate.IndexOfAny('-', '+');
+        var core = coreEnd < 0 ? candidate : candidate[..coreEnd];
+        var coreParts = core.Split('.');
+        if (coreParts.Length != 3 || coreParts.Any(part =>
+                part.Length == 0 ||
+                (part.Length > 1 && part[0] == '0') ||
+                !int.TryParse(part, NumberStyles.None, CultureInfo.InvariantCulture, out _)))
+        {
+            return false;
+        }
+
+        return NuGetVersion.TryParse(candidate, out version);
+    }
+
+    private static string Format(NuGetVersion version, bool includeMetadata)
+    {
+        var normalized = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{version.Major}.{version.Minor}.{version.Patch}");
+        if (!string.IsNullOrEmpty(version.Release))
+        {
+            normalized = $"{normalized}-{version.Release}";
+        }
+        if (includeMetadata && !string.IsNullOrEmpty(version.Metadata))
+        {
+            normalized = $"{normalized}+{version.Metadata}";
+        }
+
+        return normalized;
+    }
+}

--- a/src/DownKyi.Desktop/Models/AppInfo.cs
+++ b/src/DownKyi.Desktop/Models/AppInfo.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Globalization;
 using System.Reflection;
-using System.Text.RegularExpressions;
+using DownKyi.Core.Versioning;
 
 namespace DownKyi.Models;
 
@@ -25,13 +25,7 @@ internal class AppInfo
 
     public static string NormalizeVersionName(string? versionName)
     {
-        if (string.IsNullOrWhiteSpace(versionName))
-        {
-            return string.Empty;
-        }
-
-        var match = Regex.Match(versionName, @"v?(\d+\.\d+\.\d+)", RegexOptions.IgnoreCase);
-        return match.Success ? match.Groups[1].Value : string.Empty;
+        return SemanticVersionPolicy.NormalizeForDisplay(versionName);
     }
 
     public static int VersionNameToCode(string versionName)
@@ -39,21 +33,18 @@ internal class AppInfo
         var code = 0;
         var normalizedVersion = NormalizeVersionName(versionName);
 
-        var isMatch = Regex.IsMatch(normalizedVersion, @"^\d+\.\d+\.\d+$");
-        if (!isMatch)
+        var coreVersion = normalizedVersion.Split('-', 2)[0];
+        var parts = coreVersion.Split('.');
+        if (parts.Length != 3)
         {
             return 0;
         }
 
-        var parts = normalizedVersion.Split('.');
-        if (parts.Length == 3)
+        var i = 2;
+        foreach (var item in parts)
         {
-            var i = 2;
-            foreach (var item in parts)
-            {
-                code += int.Parse(item, CultureInfo.InvariantCulture) * (int)Math.Pow(100, i);
-                i--;
-            }
+            code += int.Parse(item, CultureInfo.InvariantCulture) * (int)Math.Pow(100, i);
+            i--;
         }
 
         return code;

--- a/src/DownKyi.Desktop/Services/VersionCheckerService.cs
+++ b/src/DownKyi.Desktop/Services/VersionCheckerService.cs
@@ -4,6 +4,7 @@ using System.Net.Http;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using DownKyi.Core.Versioning;
 using DownKyi.Models;
 
 namespace DownKyi.Services;
@@ -21,11 +22,20 @@ internal sealed class VersionCheckerService
     }
 
     internal VersionCheckerService(HttpClient httpClient, string repoOwner, string repoName)
+        : this(httpClient, repoOwner, repoName, new AppInfo().VersionName)
+    {
+    }
+
+    internal VersionCheckerService(
+        HttpClient httpClient,
+        string repoOwner,
+        string repoName,
+        string currentVersion)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         _repoOwner = repoOwner ?? throw new ArgumentNullException(nameof(repoOwner));
         _repoName = repoName ?? throw new ArgumentNullException(nameof(repoName));
-        _currentVersion = AppInfo.NormalizeVersionName(new AppInfo().VersionName);
+        _currentVersion = SemanticVersionPolicy.NormalizeForDisplay(currentVersion);
     }
 
     public async Task<GitHubRelease?> GetLatestReleaseAsync(
@@ -45,30 +55,27 @@ internal sealed class VersionCheckerService
             var releases = JsonSerializer.Deserialize(
                 responseJson,
                 GitHubJsonContext.Default.GitHubReleaseArray);
-            return string.IsNullOrEmpty(excludedVersion)
-                ? releases?.FirstOrDefault()
-                : releases?.FirstOrDefault(release =>
-                    release.TagName.TrimStart('v') != excludedVersion);
+            return releases?.FirstOrDefault(release => !IsExcluded(
+                release.TagName,
+                excludedVersion));
         }
 
         var latestRelease = JsonSerializer.Deserialize(
             responseJson,
             GitHubJsonContext.Default.GitHubRelease);
-        return string.IsNullOrEmpty(excludedVersion) ||
-               latestRelease?.TagName.TrimStart('v') != excludedVersion
+        return latestRelease != null && !IsExcluded(latestRelease.TagName, excludedVersion)
             ? latestRelease
             : null;
     }
 
     public bool IsNewVersionAvailable(string latestVersion)
     {
-        var latestReleaseVersion = AppInfo.NormalizeVersionName(latestVersion);
-        if (!Version.TryParse(_currentVersion, out var current) ||
-            !Version.TryParse(latestReleaseVersion, out var latest))
-        {
-            return false;
-        }
+        return SemanticVersionPolicy.IsNewer(latestVersion, _currentVersion);
+    }
 
-        return latest > current;
+    private static bool IsExcluded(string releaseVersion, string? excludedVersion)
+    {
+        return !string.IsNullOrWhiteSpace(excludedVersion) &&
+               SemanticVersionPolicy.HasSamePrecedence(releaseVersion, excludedVersion);
     }
 }

--- a/src/DownKyi.Desktop/ViewModels/Dialogs/NewVersionAvailableDialogViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Dialogs/NewVersionAvailableDialogViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using DownKyi.Application.Desktop;
 using DownKyi.Commands;
 using DownKyi.Core.Settings;
+using DownKyi.Core.Versioning;
 using DownKyi.Models;
 using Microsoft.Extensions.Logging;
 
@@ -94,7 +95,11 @@ namespace DownKyi.ViewModels.Dialogs
             EnableSkipVersionOnLaunch = GetRequiredParameter<bool>(request, "enableSkipVersion");
             MarkdownText = release.Body;
             TagName = release.TagName;
-            NewVersion = release.TagName.TrimStart('v');
+            NewVersion = SemanticVersionPolicy.TryNormalizeIdentity(
+                release.TagName,
+                out var normalizedVersion)
+                ? normalizedVersion
+                : string.Empty;
         }
     }
 }

--- a/src/DownKyi.Desktop/ViewModels/Settings/ViewAboutViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Settings/ViewAboutViewModel.cs
@@ -152,7 +152,8 @@ internal class ViewAboutViewModel : ViewModelBase
                     AppDialog.NewVersionAvailable,
                     new Dictionary<string, object?>
                     {
-                        ["release"] = release
+                        ["release"] = release,
+                        ["enableSkipVersion"] = false
                     })).ConfigureAwait(true);
             }
             else

--- a/tests/DownKyi.Core.Tests/SemanticVersionPolicyTests.cs
+++ b/tests/DownKyi.Core.Tests/SemanticVersionPolicyTests.cs
@@ -1,0 +1,58 @@
+using DownKyi.Core.Versioning;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class SemanticVersionPolicyTests
+{
+    [Theory]
+    [InlineData("v1.2.3", "1.2.3")]
+    [InlineData("1.2.3-beta.1", "1.2.3-beta.1")]
+    [InlineData("1.2.3-beta.1+build.9", "1.2.3-beta.1")]
+    public void DisplayNormalizationPreservesPrereleaseAndHidesBuildMetadata(
+        string input,
+        string expected)
+    {
+        Assert.Equal(expected, SemanticVersionPolicy.NormalizeForDisplay(input));
+    }
+
+    [Theory]
+    [InlineData("1.2", false, "")]
+    [InlineData("1.02.3", false, "")]
+    [InlineData("not-a-version", false, "")]
+    [InlineData("v1.2.3-rc.1+sha.abc", true, "1.2.3-rc.1+sha.abc")]
+    public void IdentityNormalizationRequiresSemverAndPreservesBuildMetadata(
+        string input,
+        bool expectedSuccess,
+        string expected)
+    {
+        var success = SemanticVersionPolicy.TryNormalizeIdentity(input, out var normalized);
+
+        Assert.Equal(expectedSuccess, success);
+        Assert.Equal(expected, normalized);
+    }
+
+    [Theory]
+    [InlineData("1.0.0-alpha.1", "1.0.0-alpha", true)]
+    [InlineData("1.0.0-beta", "1.0.0-alpha.9", true)]
+    [InlineData("1.0.0", "1.0.0-rc.1", true)]
+    [InlineData("1.0.0-rc.1", "1.0.0", false)]
+    [InlineData("1.0.0+new", "1.0.0+old", false)]
+    public void NewerComparisonFollowsSemverPrecedence(
+        string candidate,
+        string current,
+        bool expected)
+    {
+        Assert.Equal(expected, SemanticVersionPolicy.IsNewer(candidate, current));
+    }
+
+    [Fact]
+    public void SkipEquivalenceIgnoresBuildMetadataButNotPrerelease()
+    {
+        Assert.True(SemanticVersionPolicy.HasSamePrecedence(
+            "v1.2.3-beta.1+build.1",
+            "1.2.3-beta.1+build.2"));
+        Assert.False(SemanticVersionPolicy.HasSamePrecedence(
+            "1.2.3-beta.1",
+            "1.2.3"));
+    }
+}

--- a/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
+++ b/tests/DownKyi.Core.Tests/SettingsStoreTests.cs
@@ -9,6 +9,30 @@ namespace DownKyi.Core.Tests;
 public sealed class SettingsStoreTests
 {
     [Fact]
+    public void SkipVersionAcceptsPrereleaseAndBuildMetadata()
+    {
+        var directory = CreateTestDirectory();
+        try
+        {
+            using var store = new SettingsStore(Path.Combine(directory, "settings.json"));
+
+            var updated = store.Update(settings => settings with
+            {
+                About = settings.About with
+                {
+                    SkipVersionOnLaunch = "v1.2.3-beta.1+build.9"
+                }
+            });
+
+            Assert.Equal("1.2.3-beta.1+build.9", updated.About.SkipVersionOnLaunch);
+        }
+        finally
+        {
+            DeleteDirectory(directory);
+        }
+    }
+
+    [Fact]
     public void CustomAriaAcceptsTheDefaultEmptyRpcSecretWithoutBootstrapFailure()
     {
         var directory = CreateTestDirectory();

--- a/tests/DownKyi.Tests/ManualUpdateDialogContractTests.cs
+++ b/tests/DownKyi.Tests/ManualUpdateDialogContractTests.cs
@@ -1,0 +1,107 @@
+using System.Net;
+using DownKyi.Application.Desktop;
+using DownKyi.Application.Diagnostics;
+using DownKyi.Models;
+using DownKyi.Services;
+using DownKyi.ViewModels.Dialogs;
+using DownKyi.ViewModels.Settings;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DownKyi.Tests;
+
+public sealed class ManualUpdateDialogContractTests
+{
+    [Fact]
+    public async Task ManualUpdateSuppliesExplicitNonSkippableDialogContract()
+    {
+        using var settings = new TestSettingsStore();
+        var dialogs = new RecordingDialogService();
+        var interactions = new TestDesktopInteractionContext(dialogs: dialogs);
+        using var handler = new ReleaseHandler();
+        using var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new Uri("https://api.github.test/")
+        };
+        using var viewModel = new ViewAboutViewModel(
+            interactions,
+            settings.Store,
+            new StubLogService(),
+            new StubPlatformLauncher(),
+            new VersionCheckerService(httpClient, "owner", "repo", "1.0.0"),
+            NullLogger<ViewAboutViewModel>.Instance);
+
+        viewModel.CheckUpdateCommand.Execute(null);
+        var request = await dialogs.Request.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(AppDialog.NewVersionAvailable, request.Dialog);
+        var parameters = Assert.IsAssignableFrom<IReadOnlyDictionary<string, object?>>(
+            request.Parameters);
+        Assert.IsType<GitHubRelease>(parameters["release"]);
+        Assert.False(Assert.IsType<bool>(parameters["enableSkipVersion"]));
+    }
+
+    private sealed class RecordingDialogService : IAppDialogService
+    {
+        public TaskCompletionSource<AppDialogRequest> Request { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task<AppDialogResult> ShowAsync(
+            AppDialogRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Request.TrySetResult(request);
+            return Task.FromResult(new AppDialogResult(
+                AppDialogOutcome.Canceled,
+                new Dictionary<string, object?>()));
+        }
+    }
+
+    private sealed class ReleaseHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"tag_name\":\"v2.0.0\"}")
+            });
+        }
+    }
+
+    private sealed class StubLogService : IApplicationLogService
+    {
+        public string LogDirectory => string.Empty;
+
+        public IReadOnlyList<ApplicationLogRecord> GetRecentEvents() => [];
+
+        public ApplicationLogMetrics GetMetrics() =>
+            new(0, 0, 0, 0, 0, 0, 0, 0, null);
+
+        public Task FlushAsync(CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<string> ExportDiagnosticLogAsync(
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult(string.Empty);
+    }
+
+    private sealed class StubPlatformLauncher : IPlatformLauncher
+    {
+        public Task<bool> OpenFileAsync(
+            string path,
+            CancellationToken cancellationToken = default) => Task.FromResult(false);
+
+        public Task<bool> OpenFolderAsync(
+            string path,
+            CancellationToken cancellationToken = default) => Task.FromResult(false);
+
+        public Task<bool> OpenUriAsync(
+            Uri uri,
+            CancellationToken cancellationToken = default) => Task.FromResult(false);
+    }
+}

--- a/tests/DownKyi.Tests/TestDesktopInteractionContext.cs
+++ b/tests/DownKyi.Tests/TestDesktopInteractionContext.cs
@@ -4,16 +4,19 @@ namespace DownKyi.Tests;
 
 internal sealed class TestDesktopInteractionContext : IDesktopInteractionContext
 {
-    public TestDesktopInteractionContext(IAppNavigationService? navigation = null)
+    public TestDesktopInteractionContext(
+        IAppNavigationService? navigation = null,
+        IAppDialogService? dialogs = null)
     {
         Navigation = navigation ?? new TestNavigationService();
+        Dialogs = dialogs ?? new TestDialogService();
     }
 
     public IUserNotificationService Notifications { get; } = new TestNotificationService();
 
     public IAppNavigationService Navigation { get; }
 
-    public IAppDialogService Dialogs { get; } = new TestDialogService();
+    public IAppDialogService Dialogs { get; }
 
     private sealed class TestNotificationService : IUserNotificationService
     {

--- a/tests/DownKyi.Tests/VersionCheckerServiceTests.cs
+++ b/tests/DownKyi.Tests/VersionCheckerServiceTests.cs
@@ -32,10 +32,10 @@ public class VersionCheckerServiceTests
 
     [Theory]
     [InlineData("v1.0.32", "1.0.32")]
-    [InlineData("1.0.32-debug", "1.0.32")]
+    [InlineData("1.0.32-debug", "1.0.32-debug")]
     [InlineData("1.0.32+abcdef", "1.0.32")]
-    [InlineData("v1.0.32-beta.1", "1.0.32")]
-    public void NormalizeVersionNameReturnsComparableSemverCore(string input, string expected)
+    [InlineData("v1.0.32-beta.1", "1.0.32-beta.1")]
+    public void NormalizeVersionNamePreservesSemverReleaseIdentity(string input, string expected)
     {
         Assert.Equal(expected, AppInfo.NormalizeVersionName(input));
     }
@@ -70,6 +70,23 @@ public class VersionCheckerServiceTests
         Assert.True(service.IsNewVersionAvailable("v99.0.0"));
     }
 
+    [Theory]
+    [InlineData("1.1.1-beta.2", "1.1.1-beta.1", true)]
+    [InlineData("1.1.1", "1.1.1-rc.1", true)]
+    [InlineData("1.1.1-rc.1", "1.1.1", false)]
+    [InlineData("1.1.1+build.2", "1.1.1+build.1", false)]
+    public void VersionAvailabilityUsesFullSemverPrecedence(
+        string latest,
+        string current,
+        bool expected)
+    {
+        using var handler = new StubHandler("{}");
+        using var httpClient = CreateHttpClient(handler);
+        var service = new VersionCheckerService(httpClient, "owner", "repo", current);
+
+        Assert.Equal(expected, service.IsNewVersionAvailable(latest));
+    }
+
     [Fact]
     public async Task LatestReleaseCheckPreservesPreCanceledRequest()
     {
@@ -99,6 +116,26 @@ public class VersionCheckerServiceTests
 
         Assert.Equal("v2.0.0-beta.1", release?.TagName);
         Assert.Equal("https://api.github.test/repos/owner/repo/releases", handler.RequestUri?.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task SkippedPrereleaseIgnoresEquivalentBuildAndReturnsNextRelease()
+    {
+        using var handler = new StubHandler("""
+            [
+              {"tag_name":"v2.0.0-beta.1+build.2"},
+              {"tag_name":"v2.0.0-beta.2"}
+            ]
+            """);
+        using var httpClient = CreateHttpClient(handler);
+        var service = new VersionCheckerService(httpClient, "owner", "repo", "1.0.0");
+
+        var release = await service.GetLatestReleaseAsync(
+            true,
+            "2.0.0-beta.1+build.1",
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal("v2.0.0-beta.2", release?.TagName);
     }
 
     private static HttpClient CreateHttpClient(HttpMessageHandler handler)


### PR DESCRIPTION
## Summary

- centralize SemVer parsing and precedence for release comparison, display normalization, and skipped-version identity
- preserve prerelease semantics while ignoring build metadata for precedence comparisons
- make the manual update dialog pass its explicit non-skippable contract

## Scope containment

This product fix was split from #129 after the root-cause review policy established that investigation may widen analysis but must not automatically widen a PR's modification scope. The policy and invariant CI gate landed separately in #130. This PR contains no review-policy or CI-corpus changes.

## Validation

- strict Release build: 0 warnings, 0 errors
- full solution: 826 passed, 1 existing real-binary skip, 0 failed across 7 test projects
- Architecture Tests: 229 passed
- dotnet format --verify-no-changes: passed
- git diff --check: passed