### PR TITLE
fix(api): preserve Bangumi episode identity

### DIFF
--- a/DownKyi.Core/BiliApi/VideoStream/BangumiPlayUrlV2Contract.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/BangumiPlayUrlV2Contract.cs
@@ -18,6 +18,26 @@ internal static class BangumiPlayUrlV2Contract
             result.VideoInfo,
             "result.video_info",
             operationName);
+        if (payload.Durl == null)
+        {
+            throw MalformedPayload(operationName, "result.video_info.durl");
+        }
+
+        if (payload.Dash == null)
+        {
+            throw MalformedPayload(operationName, "result.video_info.dash");
+        }
+
+        if (payload.Dash.Video == null)
+        {
+            throw MalformedPayload(operationName, "result.video_info.dash.video");
+        }
+
+        if (payload.Dash.Audio == null)
+        {
+            throw MalformedPayload(operationName, "result.video_info.dash.audio");
+        }
+
         if (payload.Durl.Count == 0
             && payload.Dash.Video.Count == 0
             && payload.Dash.Audio.Count == 0)
@@ -28,5 +48,14 @@ internal static class BangumiPlayUrlV2Contract
         }
 
         return payload;
+    }
+
+    private static BilibiliApiResponseException MalformedPayload(
+        string operationName,
+        string fieldName)
+    {
+        return new BilibiliApiResponseException(
+            operationName,
+            $"{operationName} returned a malformed playback payload: '{fieldName}' was null.");
     }
 }

--- a/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.cs
@@ -133,10 +133,12 @@ public static partial class VideoStreamApi
         long avid,
         string bvid,
         long cid,
+        long episodeId,
         int quality = 125,
         CancellationToken cancellationToken = default)
     {
-        var baseUrl = $"https://api.bilibili.com/pgc/player/web/v2/playurl?cid={cid}&qn={quality}&fourk=1&fnver=0&fnval=4048";
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(episodeId);
+        var baseUrl = $"https://api.bilibili.com/pgc/player/web/v2/playurl?cid={cid}&ep_id={episodeId}&qn={quality}&fourk=1&fnver=0&fnval=4048";
         string url;
         if (bvid != null)
         {

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -1628,6 +1628,8 @@ contracts:
   - Publication search uses `x/space/wbi/arc/search` and retains `data.page.count`; favorite search uses `x/v3/fav/resource/list` and retains `data.has_more`.
   - Anonymous navigation alone may accept API code `-101` because `/x/web-interface/nav` still supplies public WBI metadata; the exception cannot spread to other endpoints.
   - Ordinary playback selects `data`, bangumi v2 playback selects `result.video_info`, and cheese playback selects `data`.
+  - Bangumi v2 playback requires a positive `ep_id`; page parsing and persisted download playback must preserve the episode identity to the HTTP request boundary.
+  - Bangumi v2 DURL and DASH are alternative playback formats. Explicit null playback fields and all-empty playback collections are typed failures; an absent alternative does not invalidate a non-empty format.
   - Every fixed endpoint literal in Core must appear in the API audit with status, evidence, alternative and deterministic coverage.
 hazards:
   - Bilibili schema changes must fail at this boundary rather than deserialize into a plausible empty success object.
@@ -3036,10 +3038,13 @@ test.bilibili-api-contract-audit:
     - tests/DownKyi.Core.Tests/PlayUrlEnvelopeContractTests.cs
     - tests/DownKyi.Core.Tests/BiliApi/JsonSamples/user-navigation-anonymous.json
     - tests/DownKyi.Core.Tests/BiliApi/JsonSamples/playurl-bangumi-v2-result.json
+    - tests/DownKyi.Tests/BangumiEpisodeIdentityTests.cs
     - tests/DownKyi.Architecture.Tests/BilibiliApiInventoryArchitectureTests.cs
   guards:
     - anonymous navigation preserves public WBI metadata while nonzero API codes remain rejected everywhere else
-    - bangumi v2 requires a non-empty `result.video_info` payload
+    - bangumi v2 requires a positive `ep_id` and a non-empty `result.video_info` payload
+    - page playback and persisted download playback preserve the same bangumi episode identity in the actual request URI
+    - explicit null DURL/DASH fields and all-empty playback collections fail with typed diagnostics while DURL-only and DASH-only payloads remain valid
     - optional `data` and `result` envelopes cannot invent payloads with default initializers
     - every hard-coded Core endpoint is listed in the maintained API audit
     - anonymous and authenticated probes have separate explicit-consent paths

--- a/docs/operations/bilibili-api-audit.md
+++ b/docs/operations/bilibili-api-audit.md
@@ -56,7 +56,7 @@ Dynamic media dependencies are not fixed API endpoints: subtitle JSON addresses 
 |---|---|---|---|---|
 | `api.bilibili.com/pgc/review/user` | `BangumiInfo.BangumiMediaInfo`; media-to-season resolution | GET, `result` | `current`; YT/community implementations retain the media/season route | Keep. Optional `result` remains nullable and required by the caller. |
 | `api.bilibili.com/pgc/view/web/season` | `BangumiInfo.BangumiSeasonInfo`; season/episode metadata | GET, `result` | `current`; LIVE code 0 for multiple public episodes; YT agrees | Keep. Public episode fixtures cover field selection. |
-| `api.bilibili.com/pgc/player/web/v2/playurl` | `VideoStreamApi.GetBangumiPlayUrl`; bangumi streams | GET, `result.video_info`; auth/region rules vary | `fixed`; LIVE code 0 for ep 21495, 50188 and 678060; YT and NEMO use v2 | Replaced legacy v1 runtime URL. New nullable `BangumiPlayUrlV2Origin` contract rejects missing/empty `result.video_info`; v1 fixture remains only as wire compatibility coverage. |
+| `api.bilibili.com/pgc/player/web/v2/playurl` | `VideoStreamApi.GetBangumiPlayUrlAsync`; bangumi streams | GET, positive `ep_id` required, `result.video_info`; auth/region rules vary | `fixed`; LIVE code 0 for ep 21495, 50188 and 678060; YT and NEMO use v2 | Replaced legacy v1 runtime URL. Page parsing and persisted download playback both preserve the episode identity. The contract rejects missing `result.video_info`, explicit null playback fields and an empty DURL/DASH result; DURL and DASH remain alternative valid formats. |
 | `api.bilibili.com/pugv/view/web/season` | `CheeseInfo.CheeseViewInfo`; course metadata | GET, `data`; access varies | `current`; LIVE endpoint responds; NEMO/fixtures agree | Keep. Required `data` failure is typed. |
 | `api.bilibili.com/pugv/view/web/ep/list` | `CheeseInfo.CheeseEpisodeList`; course pages | GET, `data` | `current`; LIVE endpoint responds; NEMO agrees | Keep. Pagination remains explicit. |
 | `api.bilibili.com/pugv/player/web/playurl` | `VideoStreamApi.GetCheesePlayUrl`; course streams | GET, `data`, `ep_id` required | `current`; LIVE endpoint responds; YT uses the same route | Keep. `PlayUrlEnvelopeContractTests.CheeseEndpointUsesDataEnvelope` fixes the endpoint contract. |
@@ -120,7 +120,7 @@ The machine-readable artifact is [`bilibili-authenticated-api-audit.json`](bilib
 ## Confirmed Changes
 
 1. Anonymous navigation now accepts only API code `-101` at the `/nav` contract, then requires `data`. This repairs WBI bootstrap for public videos without weakening global API error handling.
-2. Bangumi playback now uses `/pgc/player/web/v2/playurl` and explicitly selects `result.video_info`. The v2 DTO does not create default payloads.
+2. Bangumi playback uses `/pgc/player/web/v2/playurl`, requires a positive `ep_id`, and explicitly selects `result.video_info`. Both page playback and persisted download playback carry the episode identity. The v2 DTO does not create a default envelope payload; explicit null playback fields and an all-empty DURL/DASH result fail with typed diagnostics while either non-empty format remains valid by itself.
 3. The audit records the retired channel family, invalid nickname query, legacy danmaku path, and watch-later ambiguity without speculative remapping.
 4. `BilibiliApiInventoryArchitectureTests` fails when a fixed Core endpoint is not present in this document or when the `/nav` nonzero-code exception spreads to another source file.
 5. `script/audit-bilibili-api.ps1 -ConfirmLive` reproduces the anonymous subset and outputs only sanitized diagnostics. It is an operator tool, not a CI test.
@@ -131,7 +131,13 @@ The machine-readable artifact is [`bilibili-authenticated-api-audit.json`](bilib
 - `UserNavigationContractTests.AnonymousNavigationResponsePreservesPublicWbiMetadata`
 - `UserNavigationContractTests.AnonymousCodeRemainsRejectedOutsideTheNavigationContract`
 - `PlayUrlEnvelopeContractTests.BangumiEndpointUsesResultVideoInfoEnvelope`
+- `PlayUrlEnvelopeContractTests.BangumiEndpointRejectsInvalidEpisodeIdBeforeRequest`
 - `PlayUrlEnvelopeContractTests.BangumiV2MissingVideoInfoThrowsTypedContractFailure`
+- `PlayUrlEnvelopeContractTests.BangumiV2NullPlaybackFieldThrowsTypedMalformedFailure`
+- `PlayUrlEnvelopeContractTests.BangumiV2EmptyPlaybackCollectionsThrowTypedEmptyFailure`
+- `PlayUrlEnvelopeContractTests.BangumiV2DashOnlyPayloadRemainsValid`
+- `BangumiEpisodeIdentityTests.InfoServicePassesPageEpisodeIdToPlaybackRequest`
+- `BangumiEpisodeIdentityTests.DownloadResolverPassesPersistedEpisodeIdToPlaybackRequest`
 - existing `PlayUrlEnvelopeContractTests` for ordinary video and cheese
 - existing `BvFixtureContractTests` for `BV1U7V66FEiK`
 - `BilibiliApiInventoryArchitectureTests.EveryHardCodedBilibiliApiEndpointIsRecordedInTheAudit`

--- a/docs/refactoring-live-plan.md
+++ b/docs/refactoring-live-plan.md
@@ -2,10 +2,9 @@
 
 Status: active
 Last updated: 2026-08-11
-Current work item: v1.1.1 item 2, PR #120 review remediation
-Current remote branch: `perf/watch-later-list-virtualization`
-Current remote head: `c9fb114c2039c2f7d970c75f60fbef07971de3d6`
-Current base: `origin/main` at `912949735733c986bcfeefaa4300a5fdb25c907e`
+Current work item: v1.1.1 item 3, Bangumi episode identity and playback contract
+Current working branch: `fix/bangumi-ep-id-contract`
+Current base: `origin/main` at `6e1e1d79b9aa10c06f534a94a845b4707d9766ba`
 
 This file contains only unfinished, blocked or integration-pending work. Accepted
 design and completed history belong in `ARCHITECTURE.md`, `docs/design-docs/`,
@@ -14,32 +13,34 @@ in `docs/exec-plans/v1.1.1-security-patch.md`.
 
 ## Current Item
 
-### v1.1.1 Item 2: PR #120 Root-Cause Review Remediation
+### v1.1.1 Item 3: Bangumi Episode Identity And Playback Contract
 
-- [ ] Reconcile the remote PR head with the already verified local remediation
-      commits without force-push or unrelated product changes.
-- [ ] Preserve append-only artifact ownership so a failed required artifact
-      cannot publish completion or leave an unowned file.
-- [ ] Bound segmented danmaku termination and distinguish normal absence from
-      protocol/transport failure.
-- [ ] Preserve borderless dialog hit testing, migration close/cancel semantics
-      and startup-dialog ownership.
-- [ ] Run the invariant corpus, strict Release build, all seven test projects,
-      architecture/lifecycle checks, format, secrets, workflow and package
-      gates on one exact head.
-- [ ] Reply to and resolve only the review threads proven complete by that exact
-      head. Keep PR #120 open until its required checks are green.
+- [x] Require a positive `ep_id` before the Bangumi v2 playback request and
+      preserve it through page parsing and persisted download playback.
+- [x] Keep DURL and DASH as alternative valid formats while rejecting missing
+      envelopes, explicit null playback fields and all-empty playback results
+      with typed diagnostics.
+- [x] Cover the actual request URI, invalid-ID no-request behavior, malformed
+      response matrix and both production callers with deterministic tests.
+- [x] Synchronize the Bilibili API audit and AI knowledge graph.
+- [x] Pass strict Release, invariant corpus, all seven test projects,
+      architecture/lifecycle, format, module, workflow, package, secret and diff
+      gates locally.
+- [ ] Push one exact head, open the current-architecture replacement for stale
+      PR #85, and obtain all required remote checks. Close #85 only after the
+      replacement is merged.
 
 ## Next Items
 
-These remain deliberately unstarted until the current item is complete:
+These remain deliberately unstarted until the current item is integrated:
 
-1. Bangumi `ep_id` propagation and playback response contract, reimplemented on
-   current `main` rather than merging the stale PR #85 base.
-2. Remaining v1.1.1 P1, merge-blocking or core runtime review debt, including
+1. Remaining v1.1.1 P1, merge-blocking or core runtime review debt, including
    the open dialog/output-path/mux/source-transition stack after its dependency
    graph is reconciled with current `main`.
-3. Final release rehearsal, package validation and v1.1.1 publication.
+   This includes the pre-existing `DownKyi.Tests` SQLite pool-disposal race
+   observed once during item 3 verification; an isolated rerun and the next full
+   run passed, which does not prove that separate lifecycle root cause fixed.
+2. Final release rehearsal, package validation and v1.1.1 publication.
 
 ## Deferred After v1.1.1
 

--- a/src/DownKyi.Desktop/Services/BangumiInfoService.cs
+++ b/src/DownKyi.Desktop/Services/BangumiInfoService.cs
@@ -302,6 +302,7 @@ internal class BangumiInfoService : IInfoService
             page.Avid,
             page.Bvid,
             page.Cid,
+            page.EpisodeId,
             cancellationToken: cancellationToken);
     }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadPlaybackResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadPlaybackResolver.cs
@@ -61,6 +61,7 @@ internal sealed class DownloadPlaybackResolver
                 downloading.DownloadBase.Avid,
                 downloading.DownloadBase.Bvid,
                 downloading.DownloadBase.Cid,
+                downloading.DownloadBase.EpisodeId,
                 cancellationToken: cancellationToken),
             PlayStreamType.Cheese => _client.GetCheesePlayUrlAsync(
                 downloading.DownloadBase.Avid,

--- a/tests/DownKyi.Core.Tests/PlayUrlEnvelopeContractTests.cs
+++ b/tests/DownKyi.Core.Tests/PlayUrlEnvelopeContractTests.cs
@@ -1,3 +1,4 @@
+using DownKyi.Application.Bilibili;
 using DownKyi.Core.BiliApi;
 using DownKyi.Core.BiliApi.Sign;
 using DownKyi.Core.BiliApi.VideoStream;
@@ -105,15 +106,50 @@ public sealed class PlayUrlEnvelopeContractTests
     [Fact]
     public async Task BangumiEndpointUsesResultVideoInfoEnvelope()
     {
-        var client = CreateClient("playurl-bangumi-v2-result.json");
+        BilibiliHttpRequest? capturedRequest = null;
+        var client = CreateClient(
+            "playurl-bangumi-v2-result.json",
+            request => capturedRequest = request);
 
         var payload = await client.GetBangumiPlayUrlAsync(
             1,
             "BV1fixture",
             2,
+            3489,
             cancellationToken: TestContext.Current.CancellationToken);
 
         Assert.Equal(1, Assert.Single(payload?.Durl ?? []).Order);
+        var request = Assert.IsType<BilibiliHttpRequest>(capturedRequest);
+        var requestUri = new Uri(request.RequestAddress);
+        Assert.Equal("/pgc/player/web/v2/playurl", requestUri.AbsolutePath);
+        Assert.Contains("cid=2", requestUri.Query, StringComparison.Ordinal);
+        Assert.Contains("ep_id=3489", requestUri.Query, StringComparison.Ordinal);
+        Assert.Contains("qn=125", requestUri.Query, StringComparison.Ordinal);
+        Assert.Contains("fourk=1", requestUri.Query, StringComparison.Ordinal);
+        Assert.Contains("fnver=0", requestUri.Query, StringComparison.Ordinal);
+        Assert.Contains("fnval=4048", requestUri.Query, StringComparison.Ordinal);
+        Assert.Contains("bvid=BV1fixture", requestUri.Query, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(0L)]
+    [InlineData(-1L)]
+    public async Task BangumiEndpointRejectsInvalidEpisodeIdBeforeRequest(long episodeId)
+    {
+        var requestCount = 0;
+        var client = CreateClient(
+            "playurl-bangumi-v2-result.json",
+            _ => requestCount++);
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            client.GetBangumiPlayUrlAsync(
+                1,
+                "BV1fixture",
+                2,
+                episodeId,
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, requestCount);
     }
 
     [Fact]
@@ -129,6 +165,65 @@ public sealed class PlayUrlEnvelopeContractTests
 
         Assert.Equal("bangumi-v2", exception.Operation);
         Assert.Contains("result.video_info", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedBangumiPlaybackPayloads))]
+    public async Task BangumiV2NullPlaybackFieldThrowsTypedMalformedFailure(
+        string fieldName,
+        string responseBody)
+    {
+        var client = CreateClientFromBody(responseBody);
+
+        var exception = await Assert.ThrowsAsync<BilibiliApiResponseException>(() =>
+            client.GetBangumiPlayUrlAsync(
+                1,
+                "BV1fixture",
+                2,
+                3489,
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(nameof(VideoStreamApi.GetBangumiPlayUrlAsync), exception.Operation);
+        Assert.Contains("malformed playback payload", exception.Message, StringComparison.Ordinal);
+        Assert.Contains(fieldName, exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BangumiV2EmptyPlaybackCollectionsThrowTypedEmptyFailure()
+    {
+        var client = CreateClientFromBody(
+            """
+            {"code":0,"message":"success","result":{"video_info":{"durl":[],"dash":{"video":[],"audio":[]}}}}
+            """);
+
+        var exception = await Assert.ThrowsAsync<BilibiliApiResponseException>(() =>
+            client.GetBangumiPlayUrlAsync(
+                1,
+                "BV1fixture",
+                2,
+                3489,
+                cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Contains("empty 'result.video_info'", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task BangumiV2DashOnlyPayloadRemainsValid()
+    {
+        var client = CreateClientFromBody(
+            """
+            {"code":0,"message":"success","result":{"video_info":{"dash":{"video":[{"id":80}],"audio":[{"id":30280}]}}}}
+            """);
+
+        var payload = await client.GetBangumiPlayUrlAsync(
+            1,
+            "BV1fixture",
+            2,
+            3489,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(80, Assert.Single(payload?.Dash.Video ?? []).Id);
+        Assert.Equal(30280, Assert.Single(payload?.Dash.Audio ?? []).Id);
     }
 
     [Fact]
@@ -170,11 +265,48 @@ public sealed class PlayUrlEnvelopeContractTests
                ?? throw new InvalidDataException($"Sample '{name}' did not deserialize.");
     }
 
-    private static StubBilibiliApiClient CreateClient(string sampleName)
+    public static TheoryData<string, string> MalformedBangumiPlaybackPayloads => new()
+    {
+        {
+            "result.video_info.durl",
+            """
+            {"code":0,"message":"success","result":{"video_info":{"durl":null,"dash":{"video":[{}],"audio":[{}]}}}}
+            """
+        },
+        {
+            "result.video_info.dash",
+            """
+            {"code":0,"message":"success","result":{"video_info":{"durl":[{}],"dash":null}}}
+            """
+        },
+        {
+            "result.video_info.dash.video",
+            """
+            {"code":0,"message":"success","result":{"video_info":{"durl":[],"dash":{"video":null,"audio":[{}]}}}}
+            """
+        },
+        {
+            "result.video_info.dash.audio",
+            """
+            {"code":0,"message":"success","result":{"video_info":{"durl":[],"dash":{"video":[{}],"audio":null}}}}
+            """
+        }
+    };
+
+    private static StubBilibiliApiClient CreateClient(
+        string sampleName,
+        Action<BilibiliHttpRequest>? observeRequest = null)
     {
         var body = File.ReadAllText(Path.Combine(SampleDirectory, sampleName));
-        return new StubBilibiliApiClient((_, _) => Task.FromResult(body));
+        return new StubBilibiliApiClient((request, _) =>
+        {
+            observeRequest?.Invoke(request);
+            return Task.FromResult(body);
+        });
     }
+
+    private static StubBilibiliApiClient CreateClientFromBody(string body) =>
+        new((_, _) => Task.FromResult(body));
 
     private static string FindRepositoryRoot()
     {

--- a/tests/DownKyi.Tests/BangumiEpisodeIdentityTests.cs
+++ b/tests/DownKyi.Tests/BangumiEpisodeIdentityTests.cs
@@ -1,0 +1,110 @@
+using DownKyi.Application.Bilibili;
+using DownKyi.Core.BiliApi.VideoStream;
+using DownKyi.Core.Settings;
+using DownKyi.Domain.Downloads;
+using DownKyi.Models;
+using DownKyi.Presentation;
+using DownKyi.Services;
+using DownKyi.Services.Download;
+using DownKyi.ViewModels.DownloadManager;
+
+namespace DownKyi.Tests;
+
+public sealed class BangumiEpisodeIdentityTests
+{
+    private const long EpisodeId = 3489;
+    private const string PlaybackResponse =
+        "{\"code\":0,\"message\":\"success\",\"result\":{\"video_info\":{\"durl\":[{\"order\":1}]}}}";
+
+    [Fact]
+    public async Task InfoServicePassesPageEpisodeIdToPlaybackRequest()
+    {
+        using var settings = new TestSettingsStore();
+        BilibiliHttpRequest? capturedRequest = null;
+        var client = CreateClient(request => capturedRequest = request);
+        var service = new BangumiInfoService(settings.Store, client);
+        var page = new VideoPage
+        {
+            Avid = 1,
+            Bvid = "BV1fixture",
+            Cid = 2,
+            EpisodeId = EpisodeId
+        };
+
+        await service.GetVideoStreamAsync(
+            page,
+            TestContext.Current.CancellationToken);
+
+        AssertEpisodeId(capturedRequest);
+    }
+
+    [Fact]
+    public async Task DownloadResolverPassesPersistedEpisodeIdToPlaybackRequest()
+    {
+        using var settings = new TestSettingsStore();
+        BilibiliHttpRequest? capturedRequest = null;
+        var client = CreateClient(request => capturedRequest = request);
+        var resolver = new DownloadPlaybackResolver(
+            new TestWbiKeyProvider(),
+            TimeProvider.System,
+            client);
+        var context = CreateBangumiContext(settings.Store.Current);
+
+        await resolver.ResolveAsync(
+            context,
+            TestContext.Current.CancellationToken);
+
+        AssertEpisodeId(capturedRequest);
+    }
+
+    private static TestBilibiliApiClient CreateClient(Action<BilibiliHttpRequest> observeRequest)
+    {
+        return new TestBilibiliApiClient
+        {
+            GetStringAsyncHandler = (request, _) =>
+            {
+                observeRequest(request);
+                return Task.FromResult(PlaybackResponse);
+            }
+        };
+    }
+
+    private static DownloadExecutionContext CreateBangumiContext(ApplicationSettings settings)
+    {
+        var taskId = new DownloadTaskId("bangumi-episode-identity");
+        var downloadBase = new DownloadBase
+        {
+            Id = taskId.Value,
+            Avid = 1,
+            Bvid = "BV1fixture",
+            Cid = 2,
+            EpisodeId = EpisodeId,
+            FilePath = Path.Combine(Path.GetTempPath(), "downkyi-bangumi-episode-identity")
+        };
+        var downloading = new DownloadingItem
+        {
+            DownloadBase = downloadBase,
+            Downloading = new Downloading
+            {
+                Id = taskId.Value,
+                DownloadBase = downloadBase,
+                DownloadStatus = DownloadStatus.Downloading,
+                PlayStreamType = PlayStreamType.Bangumi
+            }
+        };
+
+        return new DownloadExecutionContext(
+            taskId,
+            downloading,
+            settings,
+            static (_, cancellationToken) => cancellationToken.ThrowIfCancellationRequested());
+    }
+
+    private static void AssertEpisodeId(BilibiliHttpRequest? capturedRequest)
+    {
+        var request = Assert.IsType<BilibiliHttpRequest>(capturedRequest);
+        var requestUri = new Uri(request.RequestAddress);
+        Assert.Equal("/pgc/player/web/v2/playurl", requestUri.AbsolutePath);
+        Assert.Contains($"ep_id={EpisodeId}", requestUri.Query, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Summary

- require a positive Bangumi `ep_id` before issuing the v2 playback request
- preserve episode identity through page playback and persisted download playback
- reject missing, explicitly null, or all-empty playback payloads with typed diagnostics while keeping DURL and DASH as alternative valid formats
- update deterministic contract/caller coverage and the maintained API audit/knowledge graph

## Root cause

The current v2 endpoint adapter did not accept `ep_id`, so both production callers lost the episode identity before the HTTP boundary. Its payload selector also dereferenced nested playback fields after deserialization without classifying explicit JSON nulls, allowing `NullReferenceException` instead of a typed API contract failure.

This replacement is implemented on current typed-navigation/Microsoft DI architecture and supersedes the valid intent of #85 without merging its stale architecture.

## Verification

- strict .NET 10 Release build with `AnalysisMode=All` and warnings as errors: 0 warnings, 0 errors
- review invariant corpus: 9 invariants, 7 projects, 247 tests
- full solution: 7 projects passed; 816 passed, 1 existing real-binary test skipped
- assembly lifecycle: 7 assemblies, 213 phases, 0 failures
- lifecycle ownership: 478 matches, 0 violations
- format, module boundary, actionlint, vulnerable/deprecated package audits, Gitleaks 8.30.1, and diff checks passed

One pre-existing `DownKyi.Tests` SQLite pool-disposal race appeared once during verification. The isolated test and two subsequent complete solution runs passed. It is tracked as separate v1.1.1 release-stability work and is not hidden or patched in this API-focused PR.

## Compatibility

No settings, SQLite schema, download record, resume identity, file format, or navigation behavior changes. Existing persisted `EpisodeId` data is now used by Bangumi playback as intended.