### PR TITLE
fix(release): keep tag workflow dependency runnable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,9 +78,6 @@ jobs:
           filters: |
             external_assets:
               - 'script/assets/external-assets.json'
-      - name: Keep the release dependency chain runnable outside pull requests
-        if: github.event_name != 'pull_request'
-        run: echo 'Manifest diff detection is only required for pull requests.'
 
   external-assets-preflight:
     name: Production manifest preflight

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,18 +66,21 @@ jobs:
 
   detect-production-manifest-change:
     name: Detect production manifest change
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       external_assets: ${{ steps.filter.outputs.external_assets }}
     steps:
       - name: Detect external asset manifest changes in the PR diff
         id: filter
+        if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
         with:
           filters: |
             external_assets:
               - 'script/assets/external-assets.json'
+      - name: Keep the release dependency chain runnable outside pull requests
+        if: github.event_name != 'pull_request'
+        run: echo 'Manifest diff detection is only required for pull requests.'
 
   external-assets-preflight:
     name: Production manifest preflight

--- a/script/aria2.ps1
+++ b/script/aria2.ps1
@@ -2,6 +2,8 @@ param($arch)
 
 $ErrorActionPreference = "Stop"
 
+. (Join-Path $PSScriptRoot "download-external-asset.ps1")
+
 function Create-Dir($dir) {
     if (!(Test-Path -Path $dir)) {
         New-Item $dir -ItemType "directory" | Out-Null
@@ -35,7 +37,7 @@ $archive = Join-Path $downloadDir "aria2-$arch.zip"
 if (Test-Path -LiteralPath $archive) {
     Remove-Item -LiteralPath $archive -Force
 }
-Start-BitsTransfer -Source $asset.url -Destination $archive
+Invoke-ExternalAssetDownload -Uri $asset.url -Destination $archive
 Verify-Asset $archive $asset.sha256
 
 $destDir = Join-Path $binaryRoot "$rid\aria2"

--- a/script/download-external-asset.ps1
+++ b/script/download-external-asset.ps1
@@ -1,0 +1,52 @@
+function Invoke-ExternalAssetDownload {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Uri]$Uri,
+
+        [Parameter(Mandatory)]
+        [string]$Destination,
+
+        [ValidateRange(1, 10)]
+        [int]$MaximumAttempts = 3,
+
+        [ValidateRange(0, 60)]
+        [int]$RetryDelaySeconds = 2,
+
+        [scriptblock]$TransferOperation = {
+            param([Uri]$Source, [string]$Target)
+
+            Start-BitsTransfer -Source $Source.AbsoluteUri -Destination $Target
+        }
+    )
+
+    for ($attempt = 1; $attempt -le $MaximumAttempts; $attempt++) {
+        try {
+            if (Test-Path -LiteralPath $Destination) {
+                Remove-Item -LiteralPath $Destination -Force
+            }
+
+            & $TransferOperation $Uri $Destination
+
+            $download = Get-Item -LiteralPath $Destination -ErrorAction Stop
+            if ($download.Length -le 0) {
+                throw [InvalidDataException]::new('The downloaded external asset is empty.')
+            }
+
+            return
+        }
+        catch {
+            if (Test-Path -LiteralPath $Destination) {
+                Remove-Item -LiteralPath $Destination -Force
+            }
+
+            if ($attempt -eq $MaximumAttempts) {
+                throw
+            }
+
+            if ($RetryDelaySeconds -gt 0) {
+                Start-Sleep -Seconds $RetryDelaySeconds
+            }
+        }
+    }
+}

--- a/script/ffmpeg.ps1
+++ b/script/ffmpeg.ps1
@@ -2,6 +2,8 @@ param($arch)
 
 $ErrorActionPreference = "Stop"
 
+. (Join-Path $PSScriptRoot "download-external-asset.ps1")
+
 function Create-Dir($dir) {
     if (!(Test-Path -Path $dir)) {
         New-Item $dir -ItemType "directory" | Out-Null
@@ -36,7 +38,7 @@ $archive = Join-Path $downloadDir "ffmpeg-$arch.zip"
 if (Test-Path -LiteralPath $archive) {
     Remove-Item -LiteralPath $archive -Force
 }
-Start-BitsTransfer -Source $asset.url -Destination $archive
+Invoke-ExternalAssetDownload -Uri $asset.url -Destination $archive
 Verify-Asset $archive $asset.sha256
 
 $destDir = Join-Path $binaryRoot "$rid\ffmpeg"

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -28,6 +28,62 @@ public sealed class ReleaseWorkflowArchitectureTests
     }
 
     [Fact]
+    public void TagReleaseDependencyChainDoesNotStartFromASkippedPullRequestOnlyJob()
+    {
+        var workflow = File.ReadAllText(
+            Path.Combine(RepositoryRoot, ".github", "workflows", "build.yml"));
+
+        Assert.True(
+            HasRunnableManifestDetectionDependency(workflow),
+            "The manifest-detection dependency must succeed on tag/manual events instead of skipping the release chain.");
+    }
+
+    [Fact]
+    public void TagReleaseDependencyGuardRejectsJobLevelSkipsAndNonExecutableLookalikes()
+    {
+        const string validWorkflow = """
+            jobs:
+              detect-production-manifest-change:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: Detect pull request changes
+                    id: filter
+                    if: github.event_name == 'pull_request'
+                    uses: dorny/paths-filter@v3
+                  - name: Preserve non-pull-request dependency success
+                    if: github.event_name != 'pull_request'
+                    run: echo release-chain-ready
+            """;
+        string[] invalidMutations =
+        [
+            validWorkflow.Replace(
+                "    runs-on: ubuntu-latest",
+                "    if: github.event_name == 'pull_request'\n    runs-on: ubuntu-latest",
+                StringComparison.Ordinal),
+            validWorkflow.Replace(
+                "if: github.event_name != 'pull_request'",
+                "if: github.event_name == 'pull_request'",
+                StringComparison.Ordinal),
+            validWorkflow.Replace(
+                "run: echo release-chain-ready",
+                "run:",
+                StringComparison.Ordinal),
+            validWorkflow.Replace(
+                "uses: dorny/paths-filter@v3",
+                "run: echo not-a-diff-detector",
+                StringComparison.Ordinal),
+            validWorkflow.Replace(
+                "run: echo release-chain-ready",
+                "continue-on-error: true\n        run: echo release-chain-ready",
+                StringComparison.Ordinal)
+        ];
+
+        Assert.True(HasRunnableManifestDetectionDependency(validWorkflow));
+        Assert.All(invalidMutations, mutation =>
+            Assert.False(HasRunnableManifestDetectionDependency(mutation)));
+    }
+
+    [Fact]
     public void ReleaseTagMustMatchTheSingleVersionSource()
     {
         var validator = File.ReadAllText(
@@ -251,6 +307,146 @@ public sealed class ReleaseWorkflowArchitectureTests
     private static int CountOccurrences(string source, string value)
     {
         return source.Split(value, StringSplitOptions.None).Length - 1;
+    }
+
+    private static bool HasRunnableManifestDetectionDependency(string workflow)
+    {
+        var lines = workflow.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var job = GetYamlBlock(lines, "  detect-production-manifest-change:", 2);
+        if (job.Count == 0 || HasYamlKeyPrefix(job, 4, "if:"))
+        {
+            return false;
+        }
+
+        var stepsStart = job.FindIndex(line =>
+            GetIndent(line) == 4 && string.Equals(line.Trim(), "steps:", StringComparison.Ordinal));
+        if (stepsStart < 0)
+        {
+            return false;
+        }
+
+        var steps = GetYamlSequenceBlocks(job[(stepsStart + 1)..], 6);
+        var pullRequestDetector = steps.Any(step =>
+            HasExactIf(step, "github.event_name == 'pull_request'") &&
+            HasYamlKey(step, 8, "id: filter") &&
+            HasYamlValuePrefix(step, 8, "uses:", "dorny/paths-filter@") &&
+            !HasYamlKey(step, 8, "continue-on-error: true"));
+        var nonPullRequestSuccess = steps.Any(step =>
+            HasExactIf(step, "github.event_name != 'pull_request'") &&
+            HasExecutableRun(step) &&
+            !HasYamlKey(step, 8, "continue-on-error: true"));
+
+        return pullRequestDetector && nonPullRequestSuccess;
+    }
+
+    private static List<string> GetYamlBlock(
+        string[] lines,
+        string header,
+        int headerIndent)
+    {
+        var start = -1;
+        for (var index = 0; index < lines.Length; index++)
+        {
+            if (string.Equals(lines[index], header, StringComparison.Ordinal))
+            {
+                start = index;
+                break;
+            }
+        }
+
+        if (start < 0)
+        {
+            return [];
+        }
+
+        var result = new List<string>();
+        for (var index = start + 1; index < lines.Length; index++)
+        {
+            var line = lines[index];
+            if (!string.IsNullOrWhiteSpace(line) &&
+                !line.TrimStart().StartsWith('#') &&
+                GetIndent(line) <= headerIndent)
+            {
+                break;
+            }
+
+            result.Add(line);
+        }
+
+        return result;
+    }
+
+    private static List<List<string>> GetYamlSequenceBlocks(
+        IReadOnlyList<string> lines,
+        int itemIndent)
+    {
+        var result = new List<List<string>>();
+        List<string>? current = null;
+        foreach (var line in lines)
+        {
+            if (!string.IsNullOrWhiteSpace(line) && GetIndent(line) < itemIndent)
+            {
+                break;
+            }
+
+            if (GetIndent(line) == itemIndent && line.TrimStart().StartsWith("- ", StringComparison.Ordinal))
+            {
+                current = [];
+                result.Add(current);
+            }
+
+            current?.Add(line);
+        }
+
+        return result;
+    }
+
+    private static bool HasExactIf(IReadOnlyList<string> block, string expression)
+    {
+        return block.Any(line =>
+            GetIndent(line) == 8 &&
+            string.Equals(line.Trim(), $"if: {expression}", StringComparison.Ordinal));
+    }
+
+    private static bool HasExecutableRun(IReadOnlyList<string> block)
+    {
+        return block.Any(line =>
+        {
+            if (GetIndent(line) != 8 || !line.TrimStart().StartsWith("run:", StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            return !string.IsNullOrWhiteSpace(line.Trim()["run:".Length..]);
+        });
+    }
+
+    private static bool HasYamlKey(IReadOnlyList<string> block, int indent, string key)
+    {
+        return block.Any(line =>
+            GetIndent(line) == indent && string.Equals(line.Trim(), key, StringComparison.Ordinal));
+    }
+
+    private static bool HasYamlKeyPrefix(IReadOnlyList<string> block, int indent, string key)
+    {
+        return block.Any(line =>
+            GetIndent(line) == indent && line.Trim().StartsWith(key, StringComparison.Ordinal));
+    }
+
+    private static bool HasYamlValuePrefix(
+        IReadOnlyList<string> block,
+        int indent,
+        string key,
+        string valuePrefix)
+    {
+        return block.Any(line =>
+            GetIndent(line) == indent &&
+            line.Trim().StartsWith($"{key} {valuePrefix}", StringComparison.Ordinal));
+    }
+
+    private static int GetIndent(string line)
+    {
+        return line.Length - line.TrimStart().Length;
     }
 
     private static void AssertPinnedAsset(

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
+using System.Text;
 using System.Text.Json;
 using System.Xml.Linq;
 
@@ -50,9 +51,6 @@ public sealed class ReleaseWorkflowArchitectureTests
                     id: filter
                     if: github.event_name == 'pull_request'
                     uses: dorny/paths-filter@v3
-                  - name: Preserve non-pull-request dependency success
-                    if: github.event_name != 'pull_request'
-                    run: echo release-chain-ready
             """;
         string[] invalidMutations =
         [
@@ -61,21 +59,29 @@ public sealed class ReleaseWorkflowArchitectureTests
                 "    if: github.event_name == 'pull_request'\n    runs-on: ubuntu-latest",
                 StringComparison.Ordinal),
             validWorkflow.Replace(
-                "if: github.event_name != 'pull_request'",
                 "if: github.event_name == 'pull_request'",
-                StringComparison.Ordinal),
-            validWorkflow.Replace(
-                "run: echo release-chain-ready",
-                "run:",
+                "if: github.event_name != 'pull_request'",
                 StringComparison.Ordinal),
             validWorkflow.Replace(
                 "uses: dorny/paths-filter@v3",
                 "run: echo not-a-diff-detector",
                 StringComparison.Ordinal),
             validWorkflow.Replace(
-                "run: echo release-chain-ready",
-                "continue-on-error: true\n        run: echo release-chain-ready",
-                StringComparison.Ordinal)
+                "uses: dorny/paths-filter@v3",
+                "continue-on-error: true\n        uses: dorny/paths-filter@v3",
+                StringComparison.Ordinal),
+            validWorkflow + """
+                  - name: Failing non-PR transition
+                    if: github.event_name != 'pull_request'
+                    run: exit 1
+                """,
+            validWorkflow + """
+                  - name: Failing multiline non-PR transition
+                    if: github.event_name != 'pull_request'
+                    run: |
+                      echo starting
+                      exit 1
+                """
         ];
 
         Assert.True(HasRunnableManifestDetectionDependency(validWorkflow));
@@ -244,6 +250,111 @@ public sealed class ReleaseWorkflowArchitectureTests
     }
 
     [Fact]
+    public void WindowsExternalAssetInstallersUseTheSharedBoundedRetryOwner()
+    {
+        var aria2Installer = File.ReadAllText(Path.Combine(RepositoryRoot, "script", "aria2.ps1"));
+        var ffmpegInstaller = File.ReadAllText(Path.Combine(RepositoryRoot, "script", "ffmpeg.ps1"));
+
+        Assert.All(new[] { aria2Installer, ffmpegInstaller }, source =>
+        {
+            Assert.Contains("download-external-asset.ps1", source, StringComparison.Ordinal);
+            Assert.Contains("Invoke-ExternalAssetDownload", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("Start-BitsTransfer", source, StringComparison.Ordinal);
+        });
+    }
+
+    [Fact]
+    public void ExternalAssetDownloadRetriesTransientFailuresAndFailsClosed()
+    {
+        var helperPath = Path.Combine(RepositoryRoot, "script", "download-external-asset.ps1");
+        var command = $$"""
+            $ErrorActionPreference = 'Stop'
+            $ProgressPreference = 'SilentlyContinue'
+            . '{{helperPath.Replace("'", "''", StringComparison.Ordinal)}}'
+            $successPath = [IO.Path]::GetTempFileName()
+            $failurePath = [IO.Path]::GetTempFileName()
+            try {
+                $successAttempts = 0
+                Invoke-ExternalAssetDownload `
+                    -Uri 'https://example.invalid/immutable.zip' `
+                    -Destination $successPath `
+                    -MaximumAttempts 3 `
+                    -RetryDelaySeconds 0 `
+                    -TransferOperation {
+                        param($source, $destination)
+                        $script:successAttempts++
+                        if ($script:successAttempts -lt 3) {
+                            throw [IO.IOException]::new('injected transient transport failure')
+                        }
+                        [IO.File]::WriteAllText($destination, 'verified later by the manifest checksum')
+                    }
+                if ($successAttempts -ne 3 -or -not (Test-Path -LiteralPath $successPath)) {
+                    throw 'The bounded retry did not recover on the final allowed attempt.'
+                }
+
+                $failureAttempts = 0
+                $failedClosed = $false
+                try {
+                    Invoke-ExternalAssetDownload `
+                        -Uri 'https://example.invalid/immutable.zip' `
+                        -Destination $failurePath `
+                        -MaximumAttempts 3 `
+                        -RetryDelaySeconds 0 `
+                        -TransferOperation {
+                            param($source, $destination)
+                            $script:failureAttempts++
+                            [IO.File]::WriteAllText($destination, 'injected partial response')
+                            throw [IO.IOException]::new('injected persistent transport failure')
+                        }
+                }
+                catch [IO.IOException] {
+                    $failedClosed = $true
+                }
+                if (-not $failedClosed -or $failureAttempts -ne 3) {
+                    throw 'Retry exhaustion did not preserve the transport failure.'
+                }
+                if (Test-Path -LiteralPath $failurePath) {
+                    throw 'Retry exhaustion left an unverified partial asset behind.'
+                }
+            }
+            finally {
+                foreach ($path in @($successPath, $failurePath)) {
+                    if (Test-Path -LiteralPath $path) {
+                        Remove-Item -LiteralPath $path -Force
+                    }
+                }
+            }
+            exit 0
+            """;
+
+        var encodedCommand = Convert.ToBase64String(Encoding.Unicode.GetBytes(command));
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            ArgumentList =
+            {
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-EncodedCommand",
+                encodedCommand
+            },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        });
+        Assert.NotNull(process);
+        Assert.True(process.WaitForExit(30_000), "The external-asset retry regression timed out.");
+
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        Assert.True(
+            process.ExitCode == 0,
+            $"External-asset retry regression failed. stdout={standardOutput} stderr={standardError}");
+    }
+
+    [Fact]
     public void MacPackageBuildRestoresTheRequestedRuntimeBeforePublishing()
     {
         var workflow = File.ReadAllText(
@@ -331,12 +442,8 @@ public sealed class ReleaseWorkflowArchitectureTests
             HasYamlKey(step, 8, "id: filter") &&
             HasYamlValuePrefix(step, 8, "uses:", "dorny/paths-filter@") &&
             !HasYamlKey(step, 8, "continue-on-error: true"));
-        var nonPullRequestSuccess = steps.Any(step =>
-            HasExactIf(step, "github.event_name != 'pull_request'") &&
-            HasExecutableRun(step) &&
-            !HasYamlKey(step, 8, "continue-on-error: true"));
 
-        return pullRequestDetector && nonPullRequestSuccess;
+        return pullRequestDetector && steps.Count == 1;
     }
 
     private static List<string> GetYamlBlock(
@@ -406,19 +513,6 @@ public sealed class ReleaseWorkflowArchitectureTests
         return block.Any(line =>
             GetIndent(line) == 8 &&
             string.Equals(line.Trim(), $"if: {expression}", StringComparison.Ordinal));
-    }
-
-    private static bool HasExecutableRun(IReadOnlyList<string> block)
-    {
-        return block.Any(line =>
-        {
-            if (GetIndent(line) != 8 || !line.TrimStart().StartsWith("run:", StringComparison.Ordinal))
-            {
-                return false;
-            }
-
-            return !string.IsNullOrWhiteSpace(line.Trim()["run:".Length..]);
-        });
     }
 
     private static bool HasYamlKey(IReadOnlyList<string> block, int indent, string key)


### PR DESCRIPTION
## Summary

- keep detect-production-manifest-change runnable on tag and manual events instead of skipping the release dependency chain
- retain the pull-request-only manifest detector as the job's only step; reject extra failing non-PR transitions
- add bounded, fail-closed Windows transport retry shared by aria2 and FFmpeg immutable asset installers
- remove unverified partial files between attempts and preserve existing SHA-256 verification after transfer

## Root causes

The first 1.1.1 tag run, [31676471295](https://github.com/crazysmile-PhD/downkyicore/actions/runs/31676471295), reported workflow success while every release gate, package job, and publisher job was skipped. detect-production-manifest-change had a pull-request-only job condition; GitHub Actions propagated that skipped dependency through the tag release chain.

The first PR head (f062fd) then exposed a separate failure in [Strict PR CI run 31677601524](https://github.com/crazysmile-PhD/downkyicore/actions/runs/31677601524): Windows x86 Start-BitsTransfer was terminated abnormally before SHA validation. The pinned immutable asset subsequently returned HTTP 200, so this was a one-shot transport reliability gap, not stale identity. The shared downloader now retries at most three times, removes partial bytes between attempts, and still fails closed on exhaustion; manifest checksum verification remains outside and after the retry owner.

Review also showed an executable-looking un: cannot prove success (un: exit 1). The corrected dependency contract contains no synthetic non-PR shell step: the job is unconditional and its sole PR-only detector step is skipped on tags, so the job completes without an untrusted success command. Adversarial fixtures reject job-level skips, wrong conditions/actions, continue-on-error, xit 1, and failing multiline additions.

No product source or release asset manifest changes are included.

## Local verification for exact head $head

- strict Release build (AnalysisMode=All, warnings as errors): passed, 0 warnings/errors
- complete solution tests: 940 passed, 0 failed, 1 packaged-aria2 test skipped without the hosted trust-store fixture
- focused release workflow/bootstrap regressions: 13 passed
- review invariant corpus: 314 passed; all 5 injected file-ownership mutations rejected
- bounded transfer fault injection: transient failures recover on attempt 3; persistent failures preserve the exception and leave no partial file
- dotnet format --verify-no-changes: passed
- module boundary audit: passed
- ctionlint 1.7.12: passed
- vulnerable/deprecated package audits: no findings
- Gitleaks 8.30.1: 1,098 candidates, 0 findings
- git diff --check: passed

The local Windows x86 real-binary TLS run reached the OS LocalMachine Root certificate installation path and blocked in the native trust-store call, so it was stopped with a managed-stack capture; the hosted six-RID security matrix remains the authoritative runtime evidence.

## Release impact

The replacement 1.1.1 tag will not be created until this exact PR head passes required checks and is merged into main.