### PR TITLE
fix: restore VideoDetail manual command availability

### DIFF
--- a/src/DownKyi.Desktop/Commands/DownKyiAsyncDelegateCommand.cs
+++ b/src/DownKyi.Desktop/Commands/DownKyiAsyncDelegateCommand.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Input;
 using DownKyi.Application.Diagnostics;
@@ -14,7 +15,7 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
     private readonly Func<T, bool>? _canExecute;
     private readonly ILogger _logger;
     private readonly Func<bool>? _isCancellationExpected;
-    private bool _isExecuting;
+    private int _isExecuting;
 
     public event EventHandler? CanExecuteChanged;
 
@@ -34,19 +35,30 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
     {
         if (parameter is null && typeof(T) == typeof(object))
         {
-            return !_isExecuting && (_canExecute?.Invoke(default!) ?? true);
+            return Volatile.Read(ref _isExecuting) == 0 && (_canExecute?.Invoke(default!) ?? true);
         }
 
         if (parameter is not T typedParameter)
         {
             return false;
         }
-        return !_isExecuting && (_canExecute?.Invoke(typedParameter) ?? true);
+        return Volatile.Read(ref _isExecuting) == 0 && (_canExecute?.Invoke(typedParameter) ?? true);
     }
 
     public void Execute(object? parameter)
     {
+        if (!CanExecute(parameter)
+            || Interlocked.CompareExchange(ref _isExecuting, 1, 0) != 0)
+        {
+            return;
+        }
+
         _ = ExecuteAsync(parameter);
+    }
+
+    public void NotifyCanExecuteChanged()
+    {
+        OnCanExecuteChanged();
     }
 
     private async Task ExecuteAsync(object? parameter)
@@ -65,7 +77,6 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
             return;
         }
 
-        _isExecuting = true;
         OnCanExecuteChanged();
 
         try
@@ -86,7 +97,7 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
         }
         finally
         {
-            _isExecuting = false;
+            Volatile.Write(ref _isExecuting, 0);
             OnCanExecuteChanged();
         }
     }
@@ -97,7 +108,7 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
             ?? exception.CancellationToken.IsCancellationRequested;
     }
 
-    protected void OnCanExecuteChanged()
+    private void OnCanExecuteChanged()
     {
         CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }

--- a/src/DownKyi.Desktop/ViewModels/UiState/VideoDetailUiState.cs
+++ b/src/DownKyi.Desktop/ViewModels/UiState/VideoDetailUiState.cs
@@ -1,3 +1,4 @@
+using System;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DownKyi.Images;
 using DownKyi.Presentation;
@@ -14,6 +15,8 @@ internal enum VideoDetailDisplayState
 
 internal sealed partial class VideoDetailUiState : ObservableObject
 {
+    public event Action? IsBusyChanged;
+
     [ObservableProperty]
     private string? _inputText;
 
@@ -46,4 +49,12 @@ internal sealed partial class VideoDetailUiState : ObservableObject
     public bool IsContentVisible => DisplayState == VideoDetailDisplayState.Content;
 
     public bool IsEmptyVisible => DisplayState == VideoDetailDisplayState.Empty;
+
+    partial void OnDisplayStateChanged(VideoDetailDisplayState oldValue, VideoDetailDisplayState newValue)
+    {
+        if ((oldValue == VideoDetailDisplayState.Busy) != (newValue == VideoDetailDisplayState.Busy))
+        {
+            IsBusyChanged?.Invoke();
+        }
+    }
 }

--- a/src/DownKyi.Desktop/ViewModels/ViewVideoDetailViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewVideoDetailViewModel.cs
@@ -57,6 +57,7 @@ internal sealed class ViewVideoDetailViewModel : ViewModelBase
         ParseCommand = new DownKyiAsyncDelegateCommand<object>(ExecuteParseCommandAsync, _logger, _ => !UiState.IsBusy);
         ParseAllVideoCommand = new DownKyiAsyncDelegateCommand(ExecuteParseAllVideoCommandAsync, _logger, () => !UiState.IsBusy);
         AddToDownloadCommand = new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger, () => !UiState.IsBusy);
+        UiState.IsBusyChanged += OnIsBusyChanged;
     }
 
     public VideoDetailUiState UiState { get; } = new();
@@ -65,15 +66,23 @@ internal sealed class ViewVideoDetailViewModel : ViewModelBase
 
     public RelayCommand BackSpaceCommand { get; }
     public RelayCommand DownloadManagerCommand { get; }
-    public ICommand InputCommand { get; }
+    public DownKyiAsyncDelegateCommand InputCommand { get; }
     public ICommand InputSearchCommand { get; }
     public ICommand CopyCoverUrlCommand { get; }
     public RelayCommand UpperCommand { get; }
     public RelayCommand SelectAllCommand { get; }
     public RelayCommand ClearSelectionCommand { get; }
-    public ICommand ParseCommand { get; }
-    public ICommand ParseAllVideoCommand { get; }
-    public ICommand AddToDownloadCommand { get; }
+    public DownKyiAsyncDelegateCommand<object> ParseCommand { get; }
+    public DownKyiAsyncDelegateCommand ParseAllVideoCommand { get; }
+    public DownKyiAsyncDelegateCommand AddToDownloadCommand { get; }
+
+    private void OnIsBusyChanged()
+    {
+        InputCommand.NotifyCanExecuteChanged();
+        ParseCommand.NotifyCanExecuteChanged();
+        ParseAllVideoCommand.NotifyCanExecuteChanged();
+        AddToDownloadCommand.NotifyCanExecuteChanged();
+    }
 
     protected internal override void ExecuteBackSpace()
     {
@@ -407,6 +416,7 @@ internal sealed class ViewVideoDetailViewModel : ViewModelBase
     {
         if (disposing && !IsDisposed)
         {
+            UiState.IsBusyChanged -= OnIsBusyChanged;
             _workflow.Dispose();
         }
 

--- a/tests/DownKyi.Desktop.Tests/VideoDetailCommandStateTests.cs
+++ b/tests/DownKyi.Desktop.Tests/VideoDetailCommandStateTests.cs
@@ -1,0 +1,502 @@
+using System.Collections.Generic;
+using System.Threading;
+using Avalonia.Controls;
+using Avalonia.VisualTree;
+using DownKyi.Application.Desktop;
+using DownKyi.Commands;
+using DownKyi.Core.Settings;
+using DownKyi.Services.Video;
+using DownKyi.ViewModels;
+using DownKyi.ViewModels.UiState;
+using DownKyi.Views;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DownKyi.Desktop.Tests;
+
+public sealed class VideoDetailCommandStateTests
+{
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void BusyRecoveryInvalidatesEveryBusyDependentCommand()
+    {
+        DesktopTestResources.EnsureProductThemeResources();
+        var settingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-video-detail-command-{Guid.NewGuid():N}.json");
+        using var settings = new SettingsStore(settingsPath);
+        using var workflow = new VideoDetailWorkflowCoordinatorStub();
+        using var viewModel = new ViewVideoDetailViewModel(
+            new DesktopInteractionContextStub(),
+            new ClipboardServiceStub(),
+            settings,
+            workflow,
+            new VideoDetailDownloadCoordinatorStub(),
+            NullLogger<ViewVideoDetailViewModel>.Instance);
+        var commands = new[]
+        {
+            viewModel.InputCommand,
+            viewModel.ParseCommand,
+            viewModel.ParseAllVideoCommand,
+            viewModel.AddToDownloadCommand
+        };
+        var invalidationCounts = commands.ToDictionary(command => command, _ => 0);
+        foreach (var command in commands)
+        {
+            command.CanExecuteChanged += (_, _) => invalidationCounts[command]++;
+        }
+
+        foreach (var recoveryState in new[]
+        {
+            VideoDetailDisplayState.Content,
+            VideoDetailDisplayState.Idle,
+            VideoDetailDisplayState.Empty
+        })
+        {
+            viewModel.UiState.DisplayState = VideoDetailDisplayState.Busy;
+
+            Assert.All(commands, command => Assert.False(command.CanExecute(null)));
+
+            viewModel.UiState.DisplayState = recoveryState;
+
+            Assert.False(viewModel.UiState.IsBusy);
+            Assert.All(commands, command => Assert.True(command.CanExecute(null)));
+        }
+
+        Assert.All(commands, command => Assert.Equal(6, invalidationCounts[command]));
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public void BusyToContentUpdatesAvaloniaActionButtons()
+    {
+        DesktopTestResources.EnsureProductThemeResources();
+        var settingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-video-detail-buttons-{Guid.NewGuid():N}.json");
+        using var settings = new SettingsStore(settingsPath);
+        using var workflow = new VideoDetailWorkflowCoordinatorStub();
+        using var viewModel = new ViewVideoDetailViewModel(
+            new DesktopInteractionContextStub(),
+            new ClipboardServiceStub(),
+            settings,
+            workflow,
+            new VideoDetailDownloadCoordinatorStub(),
+            NullLogger<ViewVideoDetailViewModel>.Instance);
+        var view = new VideoDetailActionsView { DataContext = viewModel };
+        var window = new Window { Content = view };
+
+        try
+        {
+            window.Show();
+            window.UpdateLayout();
+            var buttons = view
+                .GetVisualDescendants()
+                .OfType<Button>()
+                .Where(button => ReferenceEquals(button.Command, viewModel.ParseAllVideoCommand)
+                    || ReferenceEquals(button.Command, viewModel.AddToDownloadCommand))
+                .ToArray();
+            Assert.Equal(2, buttons.Length);
+
+            viewModel.UiState.DisplayState = VideoDetailDisplayState.Busy;
+            window.UpdateLayout();
+            Assert.All(buttons, button => Assert.False(button.IsEffectivelyEnabled));
+
+            viewModel.UiState.DisplayState = VideoDetailDisplayState.Content;
+            window.UpdateLayout();
+            Assert.All(buttons, button => Assert.True(button.IsEffectivelyEnabled));
+        }
+        finally
+        {
+            window.Close();
+        }
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public async Task ManualParseRecoveryEnablesAndDispatchesSelectedDownload()
+    {
+        DesktopTestResources.EnsureProductThemeResources();
+        var settingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-video-detail-manual-{Guid.NewGuid():N}.json");
+        using var settings = new SettingsStore(settingsPath);
+        settings.Update(current => current with
+        {
+            Basic = current.Basic with { ParseScope = ParseScope.All }
+        });
+        using var workflow = new VideoDetailWorkflowCoordinatorStub();
+        var downloadCoordinator = new VideoDetailDownloadCoordinatorStub();
+        using var viewModel = new ViewVideoDetailViewModel(
+            new DesktopInteractionContextStub(),
+            new ClipboardServiceStub(),
+            settings,
+            workflow,
+            downloadCoordinator,
+            NullLogger<ViewVideoDetailViewModel>.Instance);
+        var page = new DownKyi.Presentation.VideoPage
+        {
+            Bvid = "BV1G1421D7mL",
+            IsSelected = true
+        };
+        var section = new DownKyi.Presentation.VideoSection
+        {
+            IsSelected = true,
+            VideoPages = new List<DownKyi.Presentation.VideoPage> { page }
+        };
+        viewModel.UiState.VideoInfoView = new DownKyi.Presentation.VideoInfoView();
+        viewModel.VideoSections.Add(section);
+        viewModel.UiState.DisplayState = VideoDetailDisplayState.Content;
+
+        viewModel.ParseAllVideoCommand.Execute(null);
+        await workflow.PageStreamsStarted.Task
+            .WaitAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.True(viewModel.UiState.IsBusy);
+        Assert.False(viewModel.AddToDownloadCommand.CanExecute(null));
+        var downloadEnabled = WaitUntilExecutable(viewModel.AddToDownloadCommand);
+
+        workflow.ReleasePageStreams();
+        await downloadEnabled.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.Equal(VideoDetailDisplayState.Content, viewModel.UiState.DisplayState);
+        Assert.True(viewModel.AddToDownloadCommand.CanExecute(null));
+
+        viewModel.AddToDownloadCommand.Execute(null);
+        await downloadCoordinator.AddRequested.Task
+            .WaitAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.False(downloadCoordinator.LastIsAll);
+        Assert.Same(viewModel.UiState.VideoInfoView, downloadCoordinator.LastVideoInfo);
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public async Task AutoParseCompletionReEnablesSelectedDownload()
+    {
+        DesktopTestResources.EnsureProductThemeResources();
+        var settingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-video-detail-auto-{Guid.NewGuid():N}.json");
+        using var settings = new SettingsStore(settingsPath);
+        settings.Update(current => current with
+        {
+            Basic = current.Basic with
+            {
+                IsAutoParseVideo = AllowStatus.Yes,
+                ParseScope = ParseScope.All
+            }
+        });
+        var page = new DownKyi.Presentation.VideoPage
+        {
+            Bvid = "BV1G1421D7mL",
+            IsSelected = true
+        };
+        var section = new DownKyi.Presentation.VideoSection
+        {
+            IsSelected = true,
+            VideoPages = new List<DownKyi.Presentation.VideoPage> { page }
+        };
+        using var workflow = new VideoDetailWorkflowCoordinatorStub
+        {
+            DetailResult = new VideoDetailParseResult(
+                new DownKyi.Presentation.VideoInfoView(),
+                new[] { section })
+        };
+        using var viewModel = new ViewVideoDetailViewModel(
+            new DesktopInteractionContextStub(),
+            new ClipboardServiceStub(),
+            settings,
+            workflow,
+            new VideoDetailDownloadCoordinatorStub(),
+            NullLogger<ViewVideoDetailViewModel>.Instance);
+        viewModel.UiState.InputText = "https://www.bilibili.com/video/BV1G1421D7mL";
+
+        viewModel.InputCommand.Execute(null);
+        await workflow.PageStreamsStarted.Task
+            .WaitAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.True(viewModel.UiState.IsBusy);
+        Assert.False(viewModel.AddToDownloadCommand.CanExecute(null));
+        var downloadEnabled = WaitUntilExecutable(viewModel.AddToDownloadCommand);
+
+        workflow.ReleasePageStreams();
+        await downloadEnabled.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.Equal(VideoDetailDisplayState.Content, viewModel.UiState.DisplayState);
+        Assert.True(viewModel.ParseAllVideoCommand.CanExecute(null));
+        Assert.True(viewModel.AddToDownloadCommand.CanExecute(null));
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public Task FailedInputLeavesBusyAndReEnablesCommands()
+    {
+        return AssertInputRecoveryAsync(
+            new InvalidOperationException("detail failed"),
+            VideoDetailDisplayState.Empty);
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
+    public Task CanceledInputLeavesBusyAndReEnablesCommands()
+    {
+        return AssertInputRecoveryAsync(
+            new OperationCanceledException(),
+            VideoDetailDisplayState.Idle);
+    }
+
+    private static async Task AssertInputRecoveryAsync(
+        Exception operationException,
+        VideoDetailDisplayState expectedState)
+    {
+        DesktopTestResources.EnsureProductThemeResources();
+        var settingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-video-detail-recovery-{Guid.NewGuid():N}.json");
+        using var settings = new SettingsStore(settingsPath);
+        using var workflow = new VideoDetailWorkflowCoordinatorStub
+        {
+            DetailException = operationException
+        };
+        using var viewModel = new ViewVideoDetailViewModel(
+            new DesktopInteractionContextStub(),
+            new ClipboardServiceStub(),
+            settings,
+            workflow,
+            new VideoDetailDownloadCoordinatorStub(),
+            NullLogger<ViewVideoDetailViewModel>.Instance);
+        var completion = WaitUntilExecutableAfterDisabled(viewModel.InputCommand);
+        viewModel.UiState.InputText = "https://www.bilibili.com/video/BV1G1421D7mL";
+
+        viewModel.InputCommand.Execute(null);
+        await completion.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.Equal(expectedState, viewModel.UiState.DisplayState);
+        Assert.False(viewModel.UiState.IsBusy);
+        Assert.True(viewModel.InputCommand.CanExecute(null));
+        Assert.True(viewModel.ParseCommand.CanExecute(null));
+        Assert.True(viewModel.ParseAllVideoCommand.CanExecute(null));
+        Assert.True(viewModel.AddToDownloadCommand.CanExecute(null));
+    }
+
+    private static Task WaitUntilExecutable(DownKyiAsyncDelegateCommand command)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        EventHandler? handler = null;
+        handler = (_, _) =>
+        {
+            if (!command.CanExecute(null))
+            {
+                return;
+            }
+
+            command.CanExecuteChanged -= handler;
+            completion.TrySetResult();
+        };
+        command.CanExecuteChanged += handler;
+        return completion.Task;
+    }
+
+    private static Task WaitUntilExecutableAfterDisabled(DownKyiAsyncDelegateCommand command)
+    {
+        var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var disabledObserved = false;
+        EventHandler? handler = null;
+        handler = (_, _) =>
+        {
+            if (!command.CanExecute(null))
+            {
+                disabledObserved = true;
+                return;
+            }
+
+            if (!disabledObserved)
+            {
+                return;
+            }
+
+            command.CanExecuteChanged -= handler;
+            completion.TrySetResult();
+        };
+        command.CanExecuteChanged += handler;
+        return completion.Task;
+    }
+
+    private sealed class DesktopInteractionContextStub : IDesktopInteractionContext
+    {
+        public IUserNotificationService Notifications { get; } = new NotificationServiceStub();
+
+        public IAppNavigationService Navigation { get; } = new NavigationServiceStub();
+
+        public IAppDialogService Dialogs { get; } = new DialogServiceStub();
+    }
+
+    private sealed class ClipboardServiceStub : IClipboardService
+    {
+        public Task SetTextAsync(string text, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class VideoDetailWorkflowCoordinatorStub : IVideoDetailWorkflowCoordinator
+    {
+        private readonly TaskCompletionSource _releasePageStreams =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _version;
+
+        public string CurrentInput { get; private set; } = string.Empty;
+
+        public VideoDetailParseResult DetailResult { get; init; } = VideoDetailParseResult.Empty;
+
+        public Exception? DetailException { get; init; }
+
+        public TaskCompletionSource PageStreamsStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public VideoDetailOperation StartOperation()
+        {
+            return new VideoDetailOperation(Interlocked.Increment(ref _version), CancellationToken.None);
+        }
+
+        public bool IsCurrent(VideoDetailOperation operation)
+        {
+            return operation.Version == Volatile.Read(ref _version);
+        }
+
+        public void Cancel()
+        {
+        }
+
+        public void Reset()
+        {
+        }
+
+        public string SetInput(string requestedInput)
+        {
+            CurrentInput = requestedInput;
+            return CurrentInput;
+        }
+
+        public void ApplySearch(string? searchText)
+        {
+        }
+
+        public Task<VideoDetailParseResult> LoadDetailAsync(VideoDetailOperation operation)
+        {
+            if (DetailException != null)
+            {
+                return Task.FromException<VideoDetailParseResult>(DetailException);
+            }
+
+            return Task.FromResult(DetailResult);
+        }
+
+        public Task<VideoStreamParseResult?> LoadPageStreamAsync(
+            DownKyi.Presentation.VideoPage page,
+            VideoDetailOperation operation)
+        {
+            throw new NotSupportedException();
+        }
+
+        public async Task<IReadOnlyList<VideoStreamParseResult>> LoadPageStreamsAsync(
+            IEnumerable<DownKyi.Presentation.VideoSection> sections,
+            ParseScope parseScope,
+            VideoDetailOperation operation)
+        {
+            var pages = sections.SelectMany(section => section.VideoPages).ToArray();
+            PageStreamsStarted.TrySetResult();
+            await _releasePageStreams.Task.ConfigureAwait(true);
+            return pages.Select(page => new VideoStreamParseResult(page, null)).ToArray();
+        }
+
+        public void ReleasePageStreams()
+        {
+            _releasePageStreams.TrySetResult();
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class VideoDetailDownloadCoordinatorStub : IVideoDetailDownloadCoordinator
+    {
+        public TaskCompletionSource AddRequested { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool LastIsAll { get; private set; }
+
+        public DownKyi.Presentation.VideoInfoView? LastVideoInfo { get; private set; }
+
+        public Task<int?> AddAsync(
+            string input,
+            DownKyi.Presentation.VideoInfoView videoInfoView,
+            IList<DownKyi.Presentation.VideoSection> videoSections,
+            bool isAll,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            LastIsAll = isAll;
+            LastVideoInfo = videoInfoView;
+            AddRequested.TrySetResult();
+            return Task.FromResult<int?>(1);
+        }
+    }
+
+    private sealed class NotificationServiceStub : IUserNotificationService
+    {
+        public event EventHandler<UserNotificationEventArgs>? NotificationRaised;
+
+        public void Show(string message)
+        {
+            NotificationRaised?.Invoke(this, new UserNotificationEventArgs(message));
+        }
+    }
+
+    private sealed class DialogServiceStub : IAppDialogService
+    {
+        public Task<AppDialogResult> ShowAsync(
+            AppDialogRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            throw new NotSupportedException();
+        }
+    }
+
+    private sealed class NavigationServiceStub : IAppNavigationService
+    {
+        public event EventHandler<AppNavigationChangedEventArgs>? NavigationChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public void Navigate(AppNavigationRequest request)
+        {
+        }
+
+        public void NavigateRegion(
+            AppNavigationRegion region,
+            AppRoute route,
+            IReadOnlyDictionary<string, object?>? parameters = null)
+        {
+        }
+
+        public void ClearRegion(AppNavigationRegion region)
+        {
+        }
+
+        public bool CanGoBack(AppNavigationRegion region)
+        {
+            return false;
+        }
+
+        public void GoBack(AppNavigationRegion region)
+        {
+        }
+
+        public object? GetActiveView(AppNavigationRegion region)
+        {
+            return null;
+        }
+    }
+}

--- a/tests/DownKyi.Tests/AsyncDelegateCommandTests.cs
+++ b/tests/DownKyi.Tests/AsyncDelegateCommandTests.cs
@@ -62,6 +62,56 @@ public sealed class AsyncDelegateCommandTests
         Assert.IsType<OperationCanceledException>(entry.Exception);
     }
 
+    [Fact]
+    public void ExternalDependencyInvalidationRaisesCanExecuteChanged()
+    {
+        var isEnabled = false;
+        var command = new DownKyiAsyncDelegateCommand(
+            () => Task.CompletedTask,
+            new RecordingLogger(),
+            () => isEnabled);
+        var invalidationCount = 0;
+        command.CanExecuteChanged += (_, _) => invalidationCount++;
+
+        Assert.False(command.CanExecute(null));
+
+        isEnabled = true;
+        command.NotifyCanExecuteChanged();
+
+        Assert.Equal(1, invalidationCount);
+        Assert.True(command.CanExecute(null));
+    }
+
+    [Fact]
+    public async Task ExternalInvalidationDoesNotPermitConcurrentExecution()
+    {
+        var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var executionCount = 0;
+        var command = new DownKyiAsyncDelegateCommand(
+            async () =>
+            {
+                Interlocked.Increment(ref executionCount);
+                started.TrySetResult();
+                await release.Task.ConfigureAwait(true);
+            },
+            new RecordingLogger());
+        var completion = ObserveCompletion(command);
+
+        command.Execute(null);
+        await started.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        command.NotifyCanExecuteChanged();
+        Assert.False(command.CanExecute(null));
+        command.Execute(null);
+        Assert.Equal(1, Volatile.Read(ref executionCount));
+
+        release.TrySetResult();
+        await completion.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+        Assert.True(command.CanExecute(null));
+        Assert.Equal(1, Volatile.Read(ref executionCount));
+    }
+
     private static Task ObserveCompletion(DownKyiAsyncDelegateCommand command)
     {
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);


### PR DESCRIPTION
## Summary

- notify all VideoDetail commands when the external `UiState.IsBusy` dependency changes
- preserve command-local execution locking with an atomic claim so external invalidation cannot permit concurrent execution
- add deterministic ViewModel, real Avalonia binding, manual parse, auto-parse, failure, cancellation, and double-execution regressions

## Root cause

`DisplayState` correctly moved from `Busy` to `Content`, `Idle`, or `Empty`, but `DownKyiAsyncDelegateCommand` only raised `CanExecuteChanged` for its own execution lifecycle. Avalonia therefore retained the disabled state for commands whose external `CanExecute` dependency was `UiState.IsBusy`.

Auto-parse bypassed the command and called the parse workflow directly, so parsing succeeded while the manual parse and selected-download buttons remained stale.

## Scope

Only VideoDetail command enablement and the existing async command's execution invariant are changed. No Bilibili API, PlayUrl, WBI, aria2, download persistence, admission, selection, or styling behavior is modified.

## Verification

- strict Release build with `AnalysisMode=All` and warnings as errors: 0 warnings, 0 errors
- full solution: 7 test projects; 948 passed, 1 environment-dependent packaged-aria2 TLS test skipped
- review invariant gate: 11 invariants, 316 tests, adversarial mutation rejected
- assembly lifecycle: 7 assemblies, 213 phase results, 0 failures
- lifecycle ownership: 512 matches, 0 violations
- format, module boundaries, Actionlint, vulnerable/deprecated package audits, Gitleaks (1,069 candidates), and `git diff --check`: passed
- isolated real UI: manual parse populated duration/audio/video quality; selected-download dialog opened; confirmed task appeared in the download queue

## Provenance

Commit `f850621` introduced the current `UiState.IsBusy` dependency during the Desktop-boundary refactor. The missing external invalidation mechanism predates that refactor and is visible in the earliest traceable rewritten-history baseline, where the equivalent command predicate depended on `LoadingVisibility` without a matching notification.