### PR TITLE
fix(downloads): add atomic batch admission

### DIFF
--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -5,7 +5,7 @@ using DownKyi.Domain.Results;
 
 namespace DownKyi.Application.Downloads;
 
-public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationService, IDisposable
+public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationService, IDownloadTaskAtomicBatchApplicationService, IDisposable
 {
     private const int MaximumUpdateAttempts = 2;
     private readonly IDownloadTaskStore _store;
@@ -22,6 +22,41 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
     }
 
     public event EventHandler<DownloadTaskChangedEventArgs>? TaskChanged;
+
+    public async Task<OperationResult> AddManyAtomicAsync(
+        IReadOnlyList<DownloadTask> tasks,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tasks);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (tasks.Count == 0)
+        {
+            return OperationResult.Success();
+        }
+
+        foreach (var task in tasks)
+        {
+            ArgumentNullException.ThrowIfNull(task);
+        }
+
+        if (_store is not IDownloadTaskAtomicBatchStore batchStore)
+        {
+            throw new NotSupportedException("The configured download task store does not support atomic batch insertion.");
+        }
+
+        var result = await batchStore.AddManyAtomicAsync(tasks, cancellationToken).ConfigureAwait(false);
+        if (!result.IsSuccess)
+        {
+            return result;
+        }
+
+        foreach (var task in tasks)
+        {
+            Publish(task, DownloadTaskChangeKind.Added);
+        }
+
+        return OperationResult.Success();
+    }
 
     public async Task<OperationResult<DownloadTask>> AddAsync(
         DownloadTask task,
@@ -52,6 +87,12 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         return _store.GetUnfinishedAsync(cancellationToken);
+    }
+
+    public Task<IReadOnlyList<string>> GetActiveOutputPathsAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.GetActiveOutputPathsAsync(cancellationToken);
     }
 
     public Task<bool> IsOutputPathReservedAsync(

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -17,6 +17,12 @@ public interface IDownloadTaskApplicationService
 
     Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken);
 
+    async Task<IReadOnlyList<string>> GetActiveOutputPathsAsync(CancellationToken cancellationToken)
+    {
+        var tasks = await GetUnfinishedAsync(cancellationToken).ConfigureAwait(false);
+        return tasks.Select(static task => task.Output.BasePath).ToArray();
+    }
+
     Task<bool> IsOutputPathReservedAsync(
         string basePath,
         bool ignoreCase,

--- a/src/DownKyi.Application/Downloads/IDownloadTaskAtomicBatchApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskAtomicBatchApplicationService.cs
@@ -1,0 +1,12 @@
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+/// <summary>Optional capability for atomically adding download tasks.</summary>
+public interface IDownloadTaskAtomicBatchApplicationService
+{
+    Task<OperationResult> AddManyAtomicAsync(
+        IReadOnlyList<DownloadTask> tasks,
+        CancellationToken cancellationToken);
+}

--- a/src/DownKyi.Application/Downloads/IDownloadTaskAtomicBatchStore.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskAtomicBatchStore.cs
@@ -1,0 +1,12 @@
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+/// <summary>Optional store capability for one durable batch transaction.</summary>
+public interface IDownloadTaskAtomicBatchStore
+{
+    Task<OperationResult> AddManyAtomicAsync(
+        IReadOnlyList<DownloadTask> tasks,
+        CancellationToken cancellationToken);
+}

--- a/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
@@ -22,6 +22,9 @@ public interface IDownloadTaskStore
 
     Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<string>> GetActiveOutputPathsAsync(CancellationToken cancellationToken) =>
+        Task.FromResult<IReadOnlyList<string>>([]);
+
     Task<bool> IsOutputPathReservedAsync(
         string basePath,
         bool ignoreCase,

--- a/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
+++ b/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
@@ -12,6 +12,7 @@ using DownKyi.Core.Settings;
 using DownKyi.Presentation;
 using DownKyi.Services.Video;
 using DownKyi.Utils;
+using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.Services.Download;
@@ -206,68 +207,77 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
 
         var settings = _settingsStore.Current;
         var addedCount = 0;
-        foreach (var section in _videoSections)
+        const int admissionBatchSize = 64;
+        var admissionBatch = new List<DownloadingItem>(admissionBatchSize);
+        var admissionFlushFailed = false;
+
+        async Task FlushAdmissionBatchAsync(CancellationToken admissionCancellationToken)
         {
-            foreach (var page in section.VideoPages)
+            if (admissionBatch.Count == 0)
             {
-                if ((!isAll && !page.IsSelected) || page.PlayUrl == null)
-                {
-                    continue;
-                }
-
-                var retry = 0;
-                while (page.VideoQuality == null && retry < 5)
-                {
-                    var playUrl = await _videoInfoService
-                        .GetVideoStreamAsync(page, cancellationToken)
-                        .ConfigureAwait(false);
-                    VideoPagePlaybackMapper.ApplyPlayUrl(playUrl, page, settings);
-                    retry++;
-                }
-
-                if (page.VideoQuality == null)
-                {
-                    continue;
-                }
-
-                var videoQuality = page.VideoQuality;
-                if (await _duplicatePolicy
-                    .ShouldSkipAsync(
-                        page,
-                        videoQuality,
-                        settings.Basic.RepeatDownloadStrategy,
-                        cancellationToken)
-                    .ConfigureAwait(true))
-                {
-                    continue;
-                }
-
-                var downloadingItem = DownloadTaskDraftFactory.Create(
-                    directory,
-                    _videoInfoView,
-                    section,
-                    _videoSections.Count,
-                    page,
-                    videoQuality,
-                    settings,
-                    _downloadContent);
-                if (settings.Video.Content.GenerateMovieMetadata && _downloadContent.Video)
-                {
-                    downloadingItem.Metadata = await _metadataBuilder
-                        .BuildAsync(_videoInfoView, page, cancellationToken)
-                        .ConfigureAwait(true);
-                }
-
-                await _admission
-                    .AdmitAsync(
-                        downloadingItem,
-                        settings.Basic.RepeatFileAutoAddNumberSuffix,
-                        cancellationToken)
-                    .ConfigureAwait(true);
-                addedCount++;
+                return;
             }
+
+            var count = admissionBatch.Count;
+            admissionFlushFailed = true;
+            await _admission.AdmitManyAsync(
+                admissionBatch,
+                settings.Basic.RepeatFileAutoAddNumberSuffix,
+                admissionCancellationToken).ConfigureAwait(true);
+            admissionFlushFailed = false;
+            addedCount += count;
+            admissionBatch.Clear();
         }
 
+        try
+        {
+            foreach (var section in _videoSections)
+            {
+                foreach (var page in section.VideoPages)
+                {
+                    if ((!isAll && !page.IsSelected) || page.PlayUrl == null) continue;
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var retry = 0;
+                    while (page.VideoQuality == null && retry < 5)
+                    {
+                        var playUrl = await _videoInfoService.GetVideoStreamAsync(page, cancellationToken).ConfigureAwait(false);
+                        VideoPagePlaybackMapper.ApplyPlayUrl(playUrl, page, settings);
+                        retry++;
+                    }
+
+                    if (page.VideoQuality == null) continue;
+                    var videoQuality = page.VideoQuality;
+                    if (await _duplicatePolicy.ShouldSkipAsync(
+                        page, videoQuality, settings.Basic.RepeatDownloadStrategy, cancellationToken, admissionBatch).ConfigureAwait(true)) continue;
+
+                    var downloadingItem = DownloadTaskDraftFactory.Create(
+                        directory, _videoInfoView, section, _videoSections.Count, page, videoQuality, settings, _downloadContent);
+                    if (settings.Video.Content.GenerateMovieMetadata && _downloadContent.Video)
+                    {
+                        downloadingItem.Metadata = await _metadataBuilder.BuildAsync(_videoInfoView, page, cancellationToken).ConfigureAwait(true);
+                    }
+
+                    admissionBatch.Add(downloadingItem);
+                    if (admissionBatch.Count >= admissionBatchSize)
+                    {
+                        await FlushAdmissionBatchAsync(cancellationToken).ConfigureAwait(true);
+                    }
+                }
+            }
+        }
+        catch
+        {
+            // Pages fully prepared before later failure retain the prior partial-success behavior.
+            // Never retry a batch whose durable outcome is uncertain.
+            if (!admissionFlushFailed && admissionBatch.Count is > 0 and < admissionBatchSize)
+            {
+                await FlushAdmissionBatchAsync(CancellationToken.None).ConfigureAwait(true);
+            }
+
+            throw;
+        }
+
+        await FlushAdmissionBatchAsync(cancellationToken).ConfigureAwait(true);
         return addedCount;
     }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadDuplicatePolicy.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadDuplicatePolicy.cs
@@ -33,11 +33,24 @@ internal sealed class DownloadDuplicatePolicy
         VideoPage page,
         VideoQuality videoQuality,
         RepeatDownloadStrategy strategy,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        IReadOnlyList<DownloadingItem>? pendingDownloading = null)
     {
         ArgumentNullException.ThrowIfNull(page);
         ArgumentNullException.ThrowIfNull(videoQuality);
         cancellationToken.ThrowIfCancellationRequested();
+
+        if (pendingDownloading != null)
+        {
+            foreach (var item in pendingDownloading)
+            {
+                if (IsSameVideo(item, page, videoQuality))
+                {
+                    _notificationService.Show($"{page.Name}{DictionaryResource.GetString("TipAlreadyToAddDownloading")}");
+                    return true;
+                }
+            }
+        }
 
         foreach (var item in _downloadLists.Downloading)
         {

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
@@ -15,13 +15,16 @@ internal static class DownloadOutputPathResolver
         bool autoAddNumberSuffix,
         Func<string, CancellationToken, Task<bool>> isReservedAsync,
         CancellationToken cancellationToken,
-        StringComparer? comparer = null)
+        StringComparer? comparer = null,
+        int initialSuffix = 0,
+        IReadOnlySet<string>? occupiedPaths = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
         ArgumentNullException.ThrowIfNull(isReservedAsync);
         comparer ??= PlatformComparer;
-        var occupiedPaths = GetExistingBasePaths(basePath).ToHashSet(comparer);
-        for (var suffix = 0; ; suffix++)
+        ArgumentOutOfRangeException.ThrowIfNegative(initialSuffix);
+        occupiedPaths ??= GetExistingBasePaths(basePath).ToHashSet(comparer);
+        for (var suffix = initialSuffix; ; suffix++)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var candidate = suffix == 0 ? basePath : $"{basePath}({suffix})";
@@ -43,6 +46,29 @@ internal static class DownloadOutputPathResolver
         DownloadOutputPathKey.UsesCaseInsensitiveComparison
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
+
+    public static IReadOnlySet<string> CaptureExistingBasePaths(IEnumerable<string> basePaths, StringComparer? comparer = null)
+    {
+        ArgumentNullException.ThrowIfNull(basePaths);
+        comparer ??= PlatformComparer;
+        var directories = new HashSet<string>(comparer);
+        foreach (var basePath in basePaths)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
+            var directory = Path.GetDirectoryName(Normalize(basePath));
+            if (!string.IsNullOrEmpty(directory)) directories.Add(directory);
+        }
+
+        var occupied = new HashSet<string>(comparer);
+        foreach (var directory in directories)
+        {
+            if (!Directory.Exists(directory)) continue;
+            foreach (var file in Directory.EnumerateFiles(directory))
+                occupied.Add(Normalize(Path.Combine(directory, Path.GetFileNameWithoutExtension(file))));
+        }
+
+        return occupied;
+    }
 
     private static string[] GetExistingBasePaths(string basePath)
     {

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputReservationIndex.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputReservationIndex.cs
@@ -1,0 +1,147 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+
+namespace DownKyi.Services.Download;
+
+/// <summary>In-process logical suffix hint cache; SQLite remains authoritative.</summary>
+internal sealed class DownloadOutputReservationIndex : IDisposable
+{
+    private readonly IDownloadTaskApplicationService _tasks;
+    private readonly object _sync = new();
+    private readonly HashSet<string> _activeKeys = new(StringComparer.Ordinal);
+    private readonly Dictionary<DownloadTaskId, string> _taskKeys = [];
+    private readonly Dictionary<string, int> _nextSuffixByBase = new(StringComparer.Ordinal);
+    private readonly List<DownloadTaskChangedEventArgs> _pendingChanges = [];
+    private Task? _initializeTask;
+    private bool _initialized;
+    private bool _disposed;
+
+    public DownloadOutputReservationIndex(IDownloadTaskApplicationService tasks)
+    {
+        _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
+        _tasks.TaskChanged += OnTaskChanged;
+    }
+
+    public Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        Task task;
+        lock (_sync)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            _initializeTask ??= InitializeCoreAsync();
+            task = _initializeTask;
+        }
+
+        return task.WaitAsync(cancellationToken);
+    }
+
+    public int GetNextSuffix(string basePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
+        lock (_sync)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            if (!_initialized) throw new InvalidOperationException("Output reservation index is not initialized.");
+            var baseKey = CreateKey(basePath);
+            var suffix = _nextSuffixByBase.TryGetValue(baseKey, out var remembered) ? remembered : 0;
+            while (_activeKeys.Contains(CreateCandidateKey(basePath, suffix))) suffix = checked(suffix + 1);
+            _nextSuffixByBase[baseKey] = suffix;
+            return suffix;
+        }
+    }
+
+    public void Dispose()
+    {
+        lock (_sync)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            _activeKeys.Clear(); _taskKeys.Clear(); _nextSuffixByBase.Clear(); _pendingChanges.Clear();
+        }
+
+        _tasks.TaskChanged -= OnTaskChanged;
+    }
+
+    private async Task InitializeCoreAsync()
+    {
+        var paths = await _tasks.GetActiveOutputPathsAsync(CancellationToken.None).ConfigureAwait(false);
+        lock (_sync)
+        {
+            ObjectDisposedException.ThrowIf(_disposed, this);
+            foreach (var path in paths) _activeKeys.Add(CreateKey(path));
+            foreach (var change in _pendingChanges) ApplyChangeCore(change);
+            _pendingChanges.Clear();
+            _initialized = true;
+        }
+    }
+
+    private void OnTaskChanged(object? sender, DownloadTaskChangedEventArgs args)
+    {
+        lock (_sync)
+        {
+            if (_disposed) return;
+            if (!_initialized) { _pendingChanges.Add(args); return; }
+            ApplyChangeCore(args);
+        }
+    }
+
+    private void ApplyChangeCore(DownloadTaskChangedEventArgs args)
+    {
+        if (args.Kind == DownloadTaskChangeKind.HistoryCleared) return;
+        if (args.Kind == DownloadTaskChangeKind.Deleted || args.Snapshot?.Phase is DownloadPhase.Completed or DownloadPhase.Deleted)
+        {
+            ReleaseTaskCore(args.TaskId, args.Snapshot?.Output.BasePath);
+        }
+        else if (args.Snapshot != null)
+        {
+            TrackTaskCore(args.Snapshot);
+        }
+    }
+
+    private void TrackTaskCore(DownloadTask task)
+    {
+        var key = CreateKey(task.Output.BasePath);
+        if (_taskKeys.TryGetValue(task.Id, out var prior) && !string.Equals(prior, key, StringComparison.Ordinal))
+        {
+            _activeKeys.Remove(prior); LowerHintsForReleasedKeyCore(prior);
+        }
+
+        _taskKeys[task.Id] = key; _activeKeys.Add(key);
+    }
+
+    private void ReleaseTaskCore(DownloadTaskId taskId, string? snapshotPath)
+    {
+        if (_taskKeys.Remove(taskId, out var existing))
+        {
+            _activeKeys.Remove(existing); LowerHintsForReleasedKeyCore(existing); return;
+        }
+
+        if (!string.IsNullOrWhiteSpace(snapshotPath))
+        {
+            var key = CreateKey(snapshotPath); _activeKeys.Remove(key); LowerHintsForReleasedKeyCore(key);
+        }
+    }
+
+    private void LowerHintsForReleasedKeyCore(string releasedKey)
+    {
+        foreach (var baseKey in _nextSuffixByBase.Keys.ToArray())
+        {
+            if (TryGetSuffix(baseKey, releasedKey, out var suffix) && suffix < _nextSuffixByBase[baseKey]) _nextSuffixByBase[baseKey] = suffix;
+        }
+    }
+
+    private static bool TryGetSuffix(string baseKey, string candidateKey, out int suffix)
+    {
+        if (string.Equals(baseKey, candidateKey, StringComparison.Ordinal)) { suffix = 0; return true; }
+        var prefix = baseKey + "(";
+        if (!candidateKey.StartsWith(prefix, StringComparison.Ordinal) || !candidateKey.EndsWith(')')) { suffix = 0; return false; }
+        return int.TryParse(candidateKey[prefix.Length..^1], System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out suffix) && suffix > 0;
+    }
+
+    private static string CreateCandidateKey(string basePath, int suffix) => CreateKey(suffix == 0 ? basePath : $"{basePath}({suffix})");
+    private static string CreateKey(string path)
+    {
+        var key = DownloadOutputPathKey.NormalizeLogicalPath(path);
+        return DownloadOutputPathKey.UsesCaseInsensitiveComparison ? key.ToUpperInvariant() : key;
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Application.Downloads;
@@ -13,61 +16,149 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
     private readonly IDownloadTaskApplicationService _tasks;
     private readonly DownloadTaskProjectionStore _projections;
     private readonly IDownloadTaskQueue _taskQueue;
+    private readonly DownloadOutputReservationIndex _reservationIndex;
     private readonly SemaphoreSlim _admissionGate = new(1, 1);
     private bool _disposed;
 
-    public DownloadTaskAdmissionService(
-        DownloadListState downloadLists,
-        IDownloadTaskApplicationService tasks,
-        DownloadTaskProjectionStore projections,
-        IDownloadTaskQueue taskQueue)
+    public DownloadTaskAdmissionService(DownloadListState downloadLists, IDownloadTaskApplicationService tasks, DownloadTaskProjectionStore projections, IDownloadTaskQueue taskQueue)
     {
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
         _projections = projections ?? throw new ArgumentNullException(nameof(projections));
         _taskQueue = taskQueue ?? throw new ArgumentNullException(nameof(taskQueue));
+        _reservationIndex = new DownloadOutputReservationIndex(_tasks);
     }
 
-    public async Task AdmitAsync(
-        DownloadingItem item,
-        bool autoAddNumberSuffix,
-        CancellationToken cancellationToken)
+    public async Task AdmitAsync(DownloadingItem item, bool autoAddNumberSuffix, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(item);
         ObjectDisposedException.ThrowIf(_disposed, this);
         await _admissionGate.WaitAsync(cancellationToken).ConfigureAwait(true);
+        try { await AdmitCoreAsync(item, autoAddNumberSuffix, cancellationToken).ConfigureAwait(true); }
+        finally { _admissionGate.Release(); }
+    }
+
+    public async Task AdmitManyAsync(IReadOnlyList<DownloadingItem> items, bool autoAddNumberSuffix, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (items.Count == 0) return;
+        foreach (var item in items) ArgumentNullException.ThrowIfNull(item);
+
+        await _admissionGate.WaitAsync(cancellationToken).ConfigureAwait(true);
         try
         {
-            item.DownloadBase.FilePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
-                item.DownloadBase.FilePath,
-                autoAddNumberSuffix,
-                (candidate, token) => _tasks.IsOutputPathReservedAsync(
-                    candidate,
-                    DownloadOutputPathKey.UsesCaseInsensitiveComparison,
-                    token),
-                cancellationToken).ConfigureAwait(true);
+            if (items.Count == 1 || _tasks is not IDownloadTaskAtomicBatchApplicationService)
+            {
+                await AdmitSequentialCoreAsync(items, autoAddNumberSuffix, cancellationToken).ConfigureAwait(true);
+                return;
+            }
 
-            await _projections.AddDownloadingAsync(item, cancellationToken).ConfigureAwait(true);
+            await _reservationIndex.EnsureInitializedAsync(cancellationToken).ConfigureAwait(true);
+            var originalPaths = items.Select(static item => item.DownloadBase.FilePath).ToArray();
+            var occupiedPaths = DownloadOutputPathResolver.CaptureExistingBasePaths(originalPaths);
+            var comparer = DownloadOutputPathKey.UsesCaseInsensitiveComparison ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+            var plannedPaths = new HashSet<string>(comparer);
+            var nextSuffixes = new Dictionary<string, int>(comparer);
 
-            // Once persisted, admission must finish even if the originating UI operation is canceled.
-            _downloadLists.AddDownloading(item);
-            await _taskQueue.EnqueueAsync(
-                new DownloadTaskId(item.DownloadBase.Id),
-                CancellationToken.None).ConfigureAwait(true);
+            try
+            {
+                for (var index = 0; index < items.Count; index++)
+                {
+                    var requestedPath = originalPaths[index];
+                    var requestedKey = DownloadOutputPathKey.NormalizeLogicalPath(requestedPath);
+                    var suffix = autoAddNumberSuffix
+                        ? nextSuffixes.TryGetValue(requestedKey, out var next) ? next : _reservationIndex.GetNextSuffix(requestedPath)
+                        : 0;
+                    items[index].DownloadBase.FilePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+                        requestedPath, autoAddNumberSuffix,
+                        (candidate, _) => Task.FromResult(plannedPaths.Contains(DownloadOutputPathKey.NormalizeLogicalPath(candidate))),
+                        cancellationToken, initialSuffix: suffix, occupiedPaths: occupiedPaths).ConfigureAwait(true);
+                    var plannedKey = DownloadOutputPathKey.NormalizeLogicalPath(items[index].DownloadBase.FilePath);
+                    if (!plannedPaths.Add(plannedKey)) throw new InvalidOperationException("Batch admission produced a duplicate planned path.");
+                    if (autoAddNumberSuffix) nextSuffixes[requestedKey] = checked(GetResolvedSuffix(requestedPath, items[index].DownloadBase.FilePath) + 1);
+                }
+            }
+            catch (IOException)
+            {
+                RestoreOriginalPaths(items, originalPaths);
+                await AdmitSequentialCoreAsync(items, autoAddNumberSuffix, cancellationToken).ConfigureAwait(true);
+                return;
+            }
+            catch { RestoreOriginalPaths(items, originalPaths); throw; }
+
+            DownloadProjectionAddResult persisted;
+            try { persisted = await _projections.TryAddDownloadingManyAtomicAsync(items, cancellationToken).ConfigureAwait(true); }
+            catch { RestoreOriginalPaths(items, originalPaths); throw; }
+            if (!persisted.IsSuccess)
+            {
+                RestoreOriginalPaths(items, originalPaths);
+                await AdmitSequentialCoreAsync(items, autoAddNumberSuffix, cancellationToken).ConfigureAwait(true);
+                return;
+            }
+
+            var taskIds = new DownloadTaskId[items.Count];
+            for (var index = 0; index < items.Count; index++)
+            {
+                _downloadLists.AddDownloading(items[index]);
+                taskIds[index] = new DownloadTaskId(items[index].DownloadBase.Id);
+            }
+
+            await _taskQueue.EnqueueManyAsync(taskIds, CancellationToken.None).ConfigureAwait(true);
         }
-        finally
+        finally { _admissionGate.Release(); }
+    }
+
+    private async Task AdmitSequentialCoreAsync(IReadOnlyList<DownloadingItem> items, bool autoAddNumberSuffix, CancellationToken cancellationToken)
+    {
+        foreach (var item in items) await AdmitCoreAsync(item, autoAddNumberSuffix, cancellationToken).ConfigureAwait(true);
+    }
+
+    private async Task AdmitCoreAsync(DownloadingItem item, bool autoAddNumberSuffix, CancellationToken cancellationToken)
+    {
+        var requestedPath = item.DownloadBase.FilePath;
+        await _reservationIndex.EnsureInitializedAsync(cancellationToken).ConfigureAwait(true);
+        var suffix = autoAddNumberSuffix ? _reservationIndex.GetNextSuffix(requestedPath) : 0;
+        while (true)
         {
-            _admissionGate.Release();
+            item.DownloadBase.FilePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+                requestedPath, autoAddNumberSuffix,
+                (candidate, token) => _tasks.IsOutputPathReservedAsync(
+                    candidate, DownloadOutputPathKey.UsesCaseInsensitiveComparison, token),
+                cancellationToken, initialSuffix: suffix).ConfigureAwait(true);
+            var result = await _projections.TryAddDownloadingAsync(item, cancellationToken).ConfigureAwait(true);
+            if (result.IsSuccess) break;
+            if (!result.IsOutputPathConflict) throw new InvalidOperationException(result.ErrorMessage ?? "Download storage rejected admission.");
+            if (!autoAddNumberSuffix) throw new IOException("The selected output path is already in use.");
+            suffix = checked(GetResolvedSuffix(requestedPath, item.DownloadBase.FilePath) + 1);
         }
+
+        _downloadLists.AddDownloading(item);
+        await _taskQueue.EnqueueAsync(new DownloadTaskId(item.DownloadBase.Id), CancellationToken.None).ConfigureAwait(true);
+    }
+
+    private static void RestoreOriginalPaths(IReadOnlyList<DownloadingItem> items, string[] originalPaths)
+    {
+        for (var index = 0; index < items.Count; index++) items[index].DownloadBase.FilePath = originalPaths[index];
+    }
+
+    private static int GetResolvedSuffix(string basePath, string resolvedPath)
+    {
+        // This is logical planning. Create() is the physical SQLite identity.
+        var normalizedBase = DownloadOutputPathKey.NormalizeLogicalPath(basePath);
+        var normalizedResolved = DownloadOutputPathKey.NormalizeLogicalPath(resolvedPath);
+        var comparison = DownloadOutputPathKey.UsesCaseInsensitiveComparison ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        if (string.Equals(normalizedBase, normalizedResolved, comparison)) return 0;
+        var prefix = normalizedBase + "(";
+        if (normalizedResolved.StartsWith(prefix, comparison) && normalizedResolved.EndsWith(')') &&
+            int.TryParse(normalizedResolved[prefix.Length..^1], System.Globalization.NumberStyles.None, System.Globalization.CultureInfo.InvariantCulture, out var suffix) && suffix > 0) return suffix;
+        throw new InvalidOperationException($"Resolved output path '{resolvedPath}' is not a numeric suffix of '{normalizedBase}'.");
     }
 
     public void Dispose()
     {
-        if (_disposed)
-        {
-            return;
-        }
-
+        if (_disposed) return;
+        _reservationIndex.Dispose();
         _admissionGate.Dispose();
         _disposed = true;
         GC.SuppressFinalize(this);

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskProjectionStore.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskProjectionStore.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
 using DownKyi.ViewModels.DownloadManager;
 
 namespace DownKyi.Services.Download;
@@ -35,9 +36,20 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
         DownloadingItem? downloadingItem,
         CancellationToken cancellationToken = default)
     {
+        var result = await TryAddDownloadingAsync(downloadingItem, cancellationToken).ConfigureAwait(true);
+        if (!result.IsSuccess)
+        {
+            ThrowStoreFailure(result.ErrorMessage);
+        }
+    }
+
+    public async Task<DownloadProjectionAddResult> TryAddDownloadingAsync(
+        DownloadingItem? downloadingItem,
+        CancellationToken cancellationToken = default)
+    {
         if (downloadingItem?.DownloadBase == null)
         {
-            return;
+            return DownloadProjectionAddResult.Success();
         }
 
         var task = DownloadTaskProjectionMapper.CreateNewTask(downloadingItem, _clock.UtcNow);
@@ -45,18 +57,79 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
         var result = await _tasks.AddAsync(task, cancellationToken).ConfigureAwait(true);
         if (result.IsSuccess)
         {
-            return;
+            return DownloadProjectionAddResult.Success();
         }
 
         var existing = await _tasks.FindAsync(task.Id, cancellationToken).ConfigureAwait(true);
         if (existing != null)
         {
             Publish(existing);
-            return;
+            return DownloadProjectionAddResult.Success();
         }
 
         _downloadingProjections.TryRemove(task.Id, out _);
-        ThrowStoreFailure(result.Error?.Message);
+        return DownloadProjectionAddResult.Failure(
+            result.Error?.Code == "download.store.output_path_reserved",
+            result.Error?.Message);
+    }
+
+    public async Task<DownloadProjectionAddResult> TryAddDownloadingManyAtomicAsync(
+        IReadOnlyList<DownloadingItem> downloadingItems,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(downloadingItems);
+        if (downloadingItems.Count == 0)
+        {
+            return DownloadProjectionAddResult.Success();
+        }
+
+        if (_tasks is not IDownloadTaskAtomicBatchApplicationService batchTasks)
+        {
+            throw new NotSupportedException("The configured application service does not support atomic batch insertion.");
+        }
+
+        var tasks = new DownloadTask[downloadingItems.Count];
+        for (var index = 0; index < downloadingItems.Count; index++)
+        {
+            var item = downloadingItems[index];
+            ArgumentNullException.ThrowIfNull(item);
+            if (item.DownloadBase == null)
+            {
+                throw new ArgumentException("A downloading item has no DownloadBase.", nameof(downloadingItems));
+            }
+
+            var task = DownloadTaskProjectionMapper.CreateNewTask(item, _clock.UtcNow);
+            tasks[index] = task;
+            _downloadingProjections[task.Id] = item;
+        }
+
+        OperationResult result;
+        try
+        {
+            result = await batchTasks.AddManyAtomicAsync(tasks, cancellationToken).ConfigureAwait(true);
+        }
+        catch
+        {
+            foreach (var task in tasks)
+            {
+                _downloadingProjections.TryRemove(task.Id, out _);
+            }
+
+            throw;
+        }
+
+        if (result.IsSuccess)
+        {
+            return DownloadProjectionAddResult.Success();
+        }
+
+        foreach (var task in tasks)
+        {
+            _downloadingProjections.TryRemove(task.Id, out _);
+        }
+
+        return DownloadProjectionAddResult.Failure(
+            result.Error?.Code == "download.store.output_path_reserved", result.Error?.Message);
     }
 
     public async Task<IReadOnlyList<DownloadingItem>> GetDownloadingAsync(
@@ -265,6 +338,13 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
     {
         throw new InvalidOperationException(message ?? "Download storage operation failed.");
     }
+}
+
+internal sealed record DownloadProjectionAddResult(bool IsSuccess, bool IsOutputPathConflict, string? ErrorMessage)
+{
+    public static DownloadProjectionAddResult Success() => new(true, false, null);
+    public static DownloadProjectionAddResult Failure(bool isOutputPathConflict, string? errorMessage) =>
+        new(false, isOutputPathConflict, errorMessage);
 }
 
 internal sealed record DownloadTaskProjectionStartupState(

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
@@ -104,6 +104,64 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
         }
     }
 
+    public async Task EnqueueManyAsync(
+        IReadOnlyList<DownloadTaskId> taskIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(taskIds);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (taskIds.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var taskId in taskIds)
+        {
+            ArgumentNullException.ThrowIfNull(taskId);
+        }
+
+        IDownloadRuntime? runtime;
+        lock (_sync)
+        {
+            runtime = _runtime;
+            if (runtime == null)
+            {
+                foreach (var taskId in taskIds)
+                {
+                    _pending.Add(taskId);
+                }
+
+                return;
+            }
+        }
+
+        var index = 0;
+        try
+        {
+            for (; index < taskIds.Count; index++)
+            {
+                await runtime.EnqueueAsync(taskIds[index], cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch
+        {
+            lock (_sync)
+            {
+                if (ReferenceEquals(_runtime, runtime))
+                {
+                    _runtime = null;
+                }
+
+                for (var pendingIndex = index; pendingIndex < taskIds.Count; pendingIndex++)
+                {
+                    _pending.Add(taskIds[pendingIndex]);
+                }
+            }
+
+            throw;
+        }
+    }
+
     public Task<bool> CancelAsync(DownloadTaskId taskId)
     {
         ArgumentNullException.ThrowIfNull(taskId);

--- a/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
+++ b/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Domain.Downloads;
@@ -8,6 +9,18 @@ namespace DownKyi.Services.Download;
 internal interface IDownloadTaskQueue
 {
     Task EnqueueAsync(DownloadTaskId taskId, CancellationToken cancellationToken = default);
+
+    async Task EnqueueManyAsync(
+        IReadOnlyList<DownloadTaskId> taskIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(taskIds);
+        foreach (var taskId in taskIds)
+        {
+            ArgumentNullException.ThrowIfNull(taskId);
+            await EnqueueAsync(taskId, cancellationToken).ConfigureAwait(false);
+        }
+    }
 
     Task<bool> CancelAsync(DownloadTaskId taskId);
 }

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.OutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.OutputReservations.cs
@@ -75,6 +75,87 @@ public sealed partial class SqliteDownloadTaskStore
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<OperationResult> AddManyAtomicAsync(
+        IReadOnlyList<DownloadTask> tasks,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(tasks);
+        if (tasks.Count == 0)
+        {
+            return OperationResult.Success();
+        }
+
+        foreach (var task in tasks)
+        {
+            ArgumentNullException.ThrowIfNull(task);
+            if (task.Phase == DownloadPhase.Deleted)
+            {
+                throw new ArgumentException("A deleted task cannot be inserted.", nameof(tasks));
+            }
+        }
+
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var transaction = BeginImmediateTransaction(connection);
+        var currentTaskId = tasks[0].Id;
+        try
+        {
+            foreach (var task in tasks)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                currentTaskId = task.Id;
+                if (task.Phase != DownloadPhase.Completed &&
+                    await IsOutputPathReservedCoreAsync(
+                        connection, transaction, task.Output.BasePath,
+                        DownloadOutputPathKey.UsesCaseInsensitiveComparison, cancellationToken).ConfigureAwait(false))
+                {
+                    await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                    return OutputPathConflict();
+                }
+
+                await DownloadTaskSqlWriter.InsertBaseAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
+                await DownloadTaskSqlWriter.WriteStateRowAsync(connection, transaction, task, cancellationToken).ConfigureAwait(false);
+            }
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            return OperationResult.Success();
+        }
+        catch (SqliteException exception) when (exception.SqliteErrorCode == 19)
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            return exception.Message.Contains("output_reservation_key", StringComparison.OrdinalIgnoreCase)
+                ? OutputPathConflict()
+                : Conflict(currentTaskId, "already exists");
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    public async Task<IReadOnlyList<string>> GetActiveOutputPathsAsync(CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT db.file_path FROM download_base db
+            INNER JOIN downloading dl ON dl.id = db.id
+            WHERE NOT EXISTS (SELECT 1 FROM download_quarantine q
+                WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+            ORDER BY db.id
+            """;
+        var paths = new List<string>();
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            paths.Add(reader.GetString(0));
+        }
+
+        return paths;
+    }
+
     private static async Task<bool> IsOutputPathReservedCoreAsync(
         SqliteConnection connection,
         SqliteTransaction? transaction,

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Infrastructure.Downloads;
 
-public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
+public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDownloadTaskAtomicBatchStore, IDisposable
 {
     private const int MaximumHistoryPageSize = 500;
     private static readonly Action<ILogger, int, Exception?> LogOrphanCleanup = LoggerMessage.Define<int>(

--- a/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
@@ -194,6 +194,29 @@ public sealed class DownloadTaskApplicationServiceTests
     }
 
     [Fact]
+    public async Task AtomicBatchPublishesAddedOnlyAfterTheStoreSucceeds()
+    {
+        var store = new RecordingStore { AtomicSucceeds = false };
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+        var events = 0;
+        service.TaskChanged += (_, args) =>
+        {
+            Assert.True(store.AtomicPersisted);
+            Assert.Equal(DownloadTaskChangeKind.Added, args.Kind);
+            events++;
+        };
+
+        var rejected = await service.AddManyAtomicAsync([CreateTask()], TestContext.Current.CancellationToken);
+        Assert.False(rejected.IsSuccess);
+        Assert.Equal(0, events);
+
+        store.AtomicSucceeds = true;
+        var admitted = await service.AddManyAtomicAsync([CreateTask()], TestContext.Current.CancellationToken);
+        Assert.True(admitted.IsSuccess);
+        Assert.Equal(1, events);
+    }
+
+    [Fact]
     public async Task InvalidCommandDoesNotPersistOrPublishAReplacementSnapshot()
     {
         var store = new RecordingStore();
@@ -249,13 +272,17 @@ public sealed class DownloadTaskApplicationServiceTests
         }
     }
 
-    private sealed class RecordingStore : IDownloadTaskStore
+    private sealed class RecordingStore : IDownloadTaskStore, IDownloadTaskAtomicBatchStore
     {
         private readonly Lock _sync = new();
 
         public DownloadTask? Current { get; private set; }
 
         public List<long> ExpectedVersions { get; } = [];
+
+        public bool AtomicSucceeds { get; set; } = true;
+
+        public bool AtomicPersisted { get; private set; }
 
         public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
@@ -275,6 +302,21 @@ public sealed class DownloadTaskApplicationServiceTests
                 Current = task;
                 return Task.FromResult(OperationResult.Success());
             }
+        }
+
+        public Task<OperationResult> AddManyAtomicAsync(
+            IReadOnlyList<DownloadTask> tasks,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!AtomicSucceeds)
+            {
+                return Task.FromResult(OperationResult.Failure(new OperationError(
+                    "download.store.output_path_reserved", "Reserved.", OperationErrorKind.Conflict)));
+            }
+
+            AtomicPersisted = true;
+            return Task.FromResult(OperationResult.Success());
         }
 
         public Task<OperationResult> UpdateAsync(

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -492,6 +492,69 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task AtomicBatchRollsBackAllRowsWhenAReservationCollides()
+    {
+        using var store = CreateStore();
+        var path = Path.Combine(_directory, "atomic-collision");
+        var first = CreateQueuedTask("atomic-first", path);
+        var second = CreateQueuedTask("atomic-second", path);
+
+        var result = await store.AddManyAtomicAsync(
+            [first, second], TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.store.output_path_reserved", result.Error?.Code);
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task AtomicBatchJunctionAliasRollsBackBothTasks()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var realDirectory = Path.Combine(_directory, "atomic-junction-real");
+        var aliasDirectory = Path.Combine(_directory, "atomic-junction-alias");
+        Directory.CreateDirectory(realDirectory);
+        await CreateDirectoryJunctionAsync(aliasDirectory, realDirectory, TestContext.Current.CancellationToken);
+        try
+        {
+            using var store = CreateStore();
+            var result = await store.AddManyAtomicAsync(
+                [
+                    CreateQueuedTask("atomic-junction-real", Path.Combine(realDirectory, "output")),
+                    CreateQueuedTask("atomic-junction-alias", Path.Combine(aliasDirectory, "output"))
+                ],
+                TestContext.Current.CancellationToken);
+
+            Assert.False(result.IsSuccess);
+            Assert.Equal("download.store.output_path_reserved", result.Error?.Code);
+            Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            if (Directory.Exists(aliasDirectory)) Directory.Delete(aliasDirectory);
+        }
+    }
+
+    [Fact]
+    public async Task CanceledAtomicBatchLeavesNoRows()
+    {
+        using var store = CreateStore();
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            store.AddManyAtomicAsync(
+                [CreateQueuedTask("atomic-cancel", Path.Combine(_directory, "atomic-cancel"))],
+                cancellation.Token));
+
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
     public async Task ConcurrentAddsAtomicallyClaimOneOutputPath()
     {
         var outputPath = Path.Combine(_directory, "shared-output");

--- a/tests/DownKyi.Tests/DownloadBatchAdmissionTests.cs
+++ b/tests/DownKyi.Tests/DownloadBatchAdmissionTests.cs
@@ -30,8 +30,8 @@ public sealed class DownloadBatchAdmissionTests
         Assert.Equal(output, first.DownloadBase.FilePath);
         Assert.Equal(output, second.DownloadBase.FilePath);
         Assert.Equal(["suffix-off-first"], store.AddedTaskIds);
-        Assert.Equal(1, lists.Downloading.Count);
-        Assert.Equal(1, queue.Enqueued.Count);
+        Assert.Single(lists.Downloading);
+        Assert.Single(queue.Enqueued);
         Assert.Equal(0, store.AtomicCalls);
     }
 
@@ -120,8 +120,14 @@ public sealed class DownloadBatchAdmissionTests
     {
         DownloadBase = new DownloadBase
         {
-            Id = id, Avid = cid, Bvid = $"BV-{id}", Cid = cid, FilePath = path, Name = id,
-            Resolution = new DownKyi.Core.BiliApi.BiliUtils.Quality { Id = 80, Name = "1080P" }, VideoCodecName = "AVC"
+            Id = id,
+            Avid = cid,
+            Bvid = $"BV-{id}",
+            Cid = cid,
+            FilePath = path,
+            Name = id,
+            Resolution = new DownKyi.Core.BiliApi.BiliUtils.Quality { Id = 80, Name = "1080P" },
+            VideoCodecName = "AVC"
         },
         Downloading = new Downloading
         {

--- a/tests/DownKyi.Tests/DownloadBatchAdmissionTests.cs
+++ b/tests/DownKyi.Tests/DownloadBatchAdmissionTests.cs
@@ -1,0 +1,183 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+using DownKyi.Infrastructure.Downloads;
+using DownKyi.Infrastructure.Time;
+using DownKyi.Models;
+using DownKyi.Services.Download;
+using DownKyi.ViewModels.DownloadManager;
+
+namespace DownKyi.Tests;
+
+public sealed class DownloadBatchAdmissionTests
+{
+    [Fact]
+    public async Task SameBaseNameBatchWithSuffixOffPreservesSequentialPartialSuccess()
+    {
+        var store = new ScriptedAtomicStore();
+        using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+        using var projections = new DownloadTaskProjectionStore(tasks, new SystemClock());
+        var lists = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        using var admission = new DownloadTaskAdmissionService(lists, tasks, projections, queue);
+        var output = Path.Combine(Path.GetTempPath(), "batch-suffix-off", Guid.NewGuid().ToString("N"));
+        var first = CreateItem("suffix-off-first", output, 1);
+        var second = CreateItem("suffix-off-second", output, 2);
+
+        await Assert.ThrowsAsync<IOException>(() => admission.AdmitManyAsync(
+            [first, second], false, TestContext.Current.CancellationToken));
+
+        Assert.Equal(output, first.DownloadBase.FilePath);
+        Assert.Equal(output, second.DownloadBase.FilePath);
+        Assert.Equal(["suffix-off-first"], store.AddedTaskIds);
+        Assert.Equal(1, lists.Downloading.Count);
+        Assert.Equal(1, queue.Enqueued.Count);
+        Assert.Equal(0, store.AtomicCalls);
+    }
+
+    [Fact]
+    public async Task KnownAtomicRollbackRestoresLogicalPathsBeforeSequentialReplay()
+    {
+        var store = new ScriptedAtomicStore
+        {
+            AtomicResult = OperationResult.Failure(new OperationError(
+                "download.store.output_path_reserved", "Reserved.", OperationErrorKind.Conflict))
+        };
+        using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+        using var projections = new DownloadTaskProjectionStore(tasks, new SystemClock());
+        var lists = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        using var admission = new DownloadTaskAdmissionService(lists, tasks, projections, queue);
+        var output = Path.Combine(Path.GetTempPath(), "batch-fallback", Guid.NewGuid().ToString("N"));
+        var first = CreateItem("fallback-first", output, 1);
+        var second = CreateItem("fallback-second", output, 2);
+
+        await admission.AdmitManyAsync([first, second], true, TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, store.AtomicCalls);
+        Assert.Empty(store.AtomicPersistedTaskIds);
+        Assert.Equal([output, output + "(1)"], store.ReservationProbes);
+        Assert.Equal(["fallback-first", "fallback-second"], store.AddedTaskIds);
+        Assert.Equal(2, lists.Downloading.Count);
+        Assert.Equal(2, queue.Enqueued.Count);
+    }
+
+    [Fact]
+    public async Task CancellationAfterAtomicCommitCompletesAllListAndQueueWork()
+    {
+        using var cancellation = new CancellationTokenSource();
+        var store = new ScriptedAtomicStore { AfterAtomicCommitAsync = cancellation.CancelAsync };
+        using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+        using var projections = new DownloadTaskProjectionStore(tasks, new SystemClock());
+        var lists = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        using var admission = new DownloadTaskAdmissionService(lists, tasks, projections, queue);
+        var output = Path.Combine(Path.GetTempPath(), "batch-post-commit", Guid.NewGuid().ToString("N"));
+
+        await admission.AdmitManyAsync(
+            [CreateItem("post-commit-first", output, 1), CreateItem("post-commit-second", output, 2)],
+            true,
+            cancellation.Token);
+
+        Assert.True(cancellation.IsCancellationRequested);
+        Assert.Equal(2, store.AtomicPersistedTaskIds.Count);
+        Assert.Equal(2, lists.Downloading.Count);
+        Assert.Equal(2, queue.Enqueued.Count);
+    }
+    [Fact]
+    public async Task SameBaseNameBatchGetsDistinctReservationsAndQueuesBoth()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "downkyi-batch-admission-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        try
+        {
+            using var store = new SqliteDownloadTaskStore(new SqliteDownloadTaskStoreOptions(Path.Combine(root, "downloads.db")), new SystemClock());
+            using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+            using var projections = new DownloadTaskProjectionStore(tasks, new SystemClock());
+            var lists = new DownloadListState();
+            var queue = new RecordingDownloadTaskQueue();
+            using var admission = new DownloadTaskAdmissionService(lists, tasks, projections, queue);
+            var output = Path.Combine(root, "same-output");
+            var first = CreateItem("batch-1", output, 1);
+            var second = CreateItem("batch-2", output, 2);
+
+            await admission.AdmitManyAsync([first, second], true, TestContext.Current.CancellationToken);
+
+            Assert.Equal(output, first.DownloadBase.FilePath);
+            Assert.Equal(output + "(1)", second.DownloadBase.FilePath);
+            Assert.Equal(2, (await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken)).Count);
+            Assert.Equal(2, lists.Downloading.Count);
+            Assert.Equal(2, queue.Enqueued.Count);
+        }
+        finally
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            if (Directory.Exists(root)) Directory.Delete(root, true);
+        }
+    }
+
+    private static DownloadingItem CreateItem(string id, string path, long cid) => new()
+    {
+        DownloadBase = new DownloadBase
+        {
+            Id = id, Avid = cid, Bvid = $"BV-{id}", Cid = cid, FilePath = path, Name = id,
+            Resolution = new DownKyi.Core.BiliApi.BiliUtils.Quality { Id = 80, Name = "1080P" }, VideoCodecName = "AVC"
+        },
+        Downloading = new Downloading
+        {
+            DownloadStatus = DownloadStatus.NotStarted,
+            PlayStreamType = DownKyi.Core.BiliApi.VideoStream.PlayStreamType.Video
+        },
+        PlayUrl = new DownKyi.Core.BiliApi.VideoStream.Models.PlayUrl()
+    };
+
+    private sealed class ScriptedAtomicStore : IDownloadTaskStore, IDownloadTaskAtomicBatchStore
+    {
+        private readonly Dictionary<string, DownloadTask> _active = [];
+
+        public OperationResult AtomicResult { get; init; } = OperationResult.Success();
+        public Func<Task>? AfterAtomicCommitAsync { get; init; }
+        public int AtomicCalls { get; private set; }
+        public List<string> AtomicPersistedTaskIds { get; } = [];
+        public List<string> AddedTaskIds { get; } = [];
+        public List<string> ReservationProbes { get; } = [];
+
+        public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public Task<OperationResult> UpdateAsync(DownloadTask task, long expectedVersion, CancellationToken cancellationToken) => Task.FromResult(OperationResult.Success());
+        public Task<OperationResult> UpdateProgressAsync(DownloadProgressWrite progressWrite, CancellationToken cancellationToken) => Task.FromResult(OperationResult.Success());
+        public Task<DownloadTask?> FindAsync(DownloadTaskId taskId, CancellationToken cancellationToken) => Task.FromResult(_active.GetValueOrDefault(taskId.Value));
+        public Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<DownloadTask>>(_active.Values.ToArray());
+        public Task<IReadOnlyList<string>> GetActiveOutputPathsAsync(CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<string>>(_active.Values.Select(static task => task.Output.BasePath).ToArray());
+        public Task<DownloadHistoryPage> GetHistoryPageAsync(DownloadHistoryCursor? cursor, int pageSize, CancellationToken cancellationToken) => Task.FromResult(new DownloadHistoryPage([], null));
+        public Task<OperationResult> DeleteAsync(DownloadTaskId taskId, CancellationToken cancellationToken) => Task.FromResult(OperationResult.Success());
+        public Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken) => Task.FromResult(OperationResult.Success());
+        public Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(CancellationToken cancellationToken) => Task.FromResult<IReadOnlyList<QuarantinedDownloadRecord>>([]);
+
+        public Task<bool> IsOutputPathReservedAsync(string basePath, bool ignoreCase, CancellationToken cancellationToken)
+        {
+            ReservationProbes.Add(basePath);
+            return Task.FromResult(_active.Values.Any(task => string.Equals(task.Output.BasePath, basePath, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        public Task<OperationResult> AddAsync(DownloadTask task, CancellationToken cancellationToken)
+        {
+            AddedTaskIds.Add(task.Id.Value);
+            _active.Add(task.Id.Value, task);
+            return Task.FromResult(OperationResult.Success());
+        }
+
+        public async Task<OperationResult> AddManyAtomicAsync(IReadOnlyList<DownloadTask> tasks, CancellationToken cancellationToken)
+        {
+            AtomicCalls++;
+            if (!AtomicResult.IsSuccess) return AtomicResult;
+            foreach (var task in tasks)
+            {
+                _active.Add(task.Id.Value, task);
+                AtomicPersistedTaskIds.Add(task.Id.Value);
+            }
+
+            if (AfterAtomicCommitAsync != null) await AfterAtomicCommitAsync().ConfigureAwait(false);
+            return OperationResult.Success();
+        }
+    }
+}

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -132,6 +132,107 @@ public sealed class VideoTagLoadingTests : IDisposable
     }
 
     [Fact]
+    public async Task AddToDownloadAdmitsSixtyFourPreparedPagesInOneAtomicBatch()
+    {
+        using var context = CreateContext(generateMetadata: false);
+        context.PreparePages(CreatePages(64));
+
+        var added = await context.Service.AddToDownload(_directory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(64, added);
+        Assert.Equal([64], context.Store.AtomicBatchSizes);
+        Assert.Equal(64, context.ListState.Downloading.Count);
+        Assert.Equal(64, context.Queue.Enqueued.Count);
+    }
+
+    [Fact]
+    public async Task AddToDownloadFinishesCommittedBatchAfterCallerCancellation()
+    {
+        using var context = CreateContext(generateMetadata: false);
+        using var operation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        context.Store.AfterAtomicBatchAsync = operation.CancelAsync;
+        context.PreparePages(CreatePages(64));
+
+        var added = await context.Service.AddToDownload(_directory, cancellationToken: operation.Token);
+
+        Assert.True(operation.IsCancellationRequested);
+        Assert.Equal(64, added);
+        Assert.Equal([64], context.Store.AtomicBatchSizes);
+        Assert.Equal(64, context.ListState.Downloading.Count);
+        Assert.Equal(64, context.Queue.Enqueued.Count);
+    }
+
+    [Fact]
+    public async Task AddToDownloadDoesNotReplayAnUncertainAdmissionBatch()
+    {
+        using var context = CreateContext(generateMetadata: false);
+        context.Store.AtomicException = new InvalidOperationException("indeterminate batch result");
+        context.PreparePages(CreatePages(64));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            context.Service.AddToDownload(_directory, cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal([64], context.Store.AtomicBatchSizes);
+        Assert.Equal(0, context.Store.AddCount);
+        Assert.Empty(context.ListState.Downloading);
+        Assert.Empty(context.Queue.Enqueued);
+    }
+
+    [Fact]
+    public async Task CancellationDuringLaterPreparationRetainsPreparedTrailingBatch()
+    {
+        using var context = CreateContext(generateMetadata: true);
+        using var operation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        var pages = CreatePages(66);
+        pages[^1].LoadTagsAsync = async _ =>
+        {
+            await operation.CancelAsync().ConfigureAwait(false);
+            operation.Token.ThrowIfCancellationRequested();
+            return Array.Empty<string>();
+        };
+        context.PreparePages(pages);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            context.Service.AddToDownload(_directory, cancellationToken: operation.Token));
+
+        Assert.Equal([64], context.Store.AtomicBatchSizes);
+        Assert.Equal(65, context.Store.AddCount);
+        Assert.Equal(65, context.ListState.Downloading.Count);
+        Assert.Equal(65, context.Queue.Enqueued.Count);
+    }
+
+    [Fact]
+    public async Task AddToDownloadAdmitsPreparedTrailingPageAfterFullBatch()
+    {
+        using var context = CreateContext(generateMetadata: true);
+        context.PreparePages(CreatePages(65));
+
+        var added = await context.Service.AddToDownload(_directory, cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.Equal(65, added);
+        Assert.Equal([64], context.Store.AtomicBatchSizes);
+        Assert.Equal(65, context.Store.AddCount);
+    }
+
+    [Fact]
+    public async Task LaterPreparationFailureRecoversAlreadyPreparedTrailingItem()
+    {
+        using var context = CreateContext(generateMetadata: true);
+        var pages = CreatePages(66);
+        pages[^1].LoadTagsAsync = _ => Task.FromException<IReadOnlyList<string>>(
+            new OperationCanceledException("later preparation failed"));
+        context.PreparePages(pages);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            context.Service.AddToDownload(_directory, cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal([64], context.Store.AtomicBatchSizes);
+        Assert.Equal(65, context.Store.AddCount);
+        Assert.Equal(65, context.ListState.Downloading.Count);
+        Assert.Equal(65, context.Queue.Enqueued.Count);
+    }
+
+    [Fact]
     public async Task TagNetworkFailureDoesNotBlockDownloadTaskCreation()
     {
         using var context = CreateContext(generateMetadata: true);
@@ -238,6 +339,19 @@ public sealed class VideoTagLoadingTests : IDisposable
         };
     }
 
+    private static VideoPage[] CreatePages(int count) => Enumerable.Range(0, count)
+        .Select(index =>
+        {
+            var page = CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([]));
+            page.Avid = index + 1;
+            page.Bvid = $"BV1batch{index:D3}";
+            page.Cid = index + 1;
+            page.Name = $"page-{index:D3}";
+            page.Order = index + 1;
+            return page;
+        })
+        .ToArray();
+
     public void Dispose()
     {
         if (Directory.Exists(_directory))
@@ -310,6 +424,11 @@ public sealed class VideoTagLoadingTests : IDisposable
 
         public void Prepare(VideoPage page)
         {
+            PreparePages([page]);
+        }
+
+        public void PreparePages(IReadOnlyList<VideoPage> pages)
+        {
             Service.GetVideo(
                 new VideoInfoView
                 {
@@ -323,7 +442,7 @@ public sealed class VideoTagLoadingTests : IDisposable
                         Id = 1,
                         IsSelected = true,
                         Title = "section",
-                        VideoPages = [page]
+                        VideoPages = pages.ToList()
                     }
                 ]);
         }
@@ -353,11 +472,17 @@ public sealed class VideoTagLoadingTests : IDisposable
         }
     }
 
-    private sealed class RecordingDownloadTaskStore : IDownloadTaskStore
+    private sealed class RecordingDownloadTaskStore : IDownloadTaskStore, IDownloadTaskAtomicBatchStore
     {
         public int AddCount { get; private set; }
 
         public Func<Task>? AfterAddAsync { get; set; }
+
+        public Func<Task>? AfterAtomicBatchAsync { get; set; }
+
+        public Exception? AtomicException { get; set; }
+
+        public List<int> AtomicBatchSizes { get; } = [];
 
         public async Task<OperationResult> AddAsync(
             DownloadTask task,
@@ -368,6 +493,26 @@ public sealed class VideoTagLoadingTests : IDisposable
             if (AfterAddAsync != null)
             {
                 await AfterAddAsync().ConfigureAwait(false);
+            }
+
+            return OperationResult.Success();
+        }
+
+        public async Task<OperationResult> AddManyAtomicAsync(
+            IReadOnlyList<DownloadTask> tasks,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AtomicBatchSizes.Add(tasks.Count);
+            if (AtomicException != null)
+            {
+                throw AtomicException;
+            }
+
+            AddCount += tasks.Count;
+            if (AfterAtomicBatchAsync != null)
+            {
+                await AfterAtomicBatchAsync().ConfigureAwait(false);
             }
 
             return OperationResult.Success();


### PR DESCRIPTION
## Summary

Add atomic batch admission on top of the physical output-identity work from PR #178.

- add atomic application/store batch capabilities
- persist batches inside one immediate SQLite transaction
- keep physical output reservation identity authoritative in SQLite
- add logical-only reservation/suffix acceleration for batch planning
- preserve sequential fallback semantics after known rolled-back batch conflicts
- complete projection/list/queue work only after durable persistence
- batch AddToDownload admissions in bounded groups of 64 while preserving partial-success semantics

## Ownership boundary

PR #178 remains authoritative for durable physical output identity.

This PR does not replace SQLite ownership with an in-memory registry. `DownloadOutputReservationIndex` is an acceleration structure for logical suffix planning only; physical collisions are still arbitrated by the current SQLite reservation path, including legacy NULL-key fallback.

## Atomic semantics

- one immediate SQLite transaction owns the whole batch
- reservation/uniqueness conflicts roll back the entire atomic batch
- cancellation/errors before commit roll back with `CancellationToken.None`
- `TaskChanged` Added events are published only after durable commit
- list/queue completion happens after persistence; post-commit queue completion is not interrupted by caller cancellation
- known rolled-back atomic conflicts may replay through verified sequential admission semantics
- uncertain persistence failures are not blindly replayed

## Verification

Exact head: `fa7e6418afa8d862f9a5ac016ebe9da7a9f1a80f`

- Strict PR CI #188: passed
- CodeQL #193: passed
- strict Release build with warnings/analyzers as errors: passed, 0 warnings/errors
- format verification: passed
- focused `VideoTagLoadingTests`: 14 passed
- focused `DownloadBatchAdmissionTests`: 4 passed
- focused atomic SQLite tests: 3 passed
- earlier focused SQLite suite: 23 passed
- application-service tests: 7 passed
- admission/batch tests: 11 passed
- `git diff --check`: passed
- forbidden PR3/TOCTOU/performance scope scan: clean
- remote committed diff: 2 commits, 19 files, mergeable against `output-ownership-integration`

## Scope exclusions

Not included:

- #177 TOCTOU / late filesystem collision handling
- disk-claim / foreign-file race probes
- physical-output late collision checks
- suffix/performance probes
- unrelated architecture refactoring

This PR is intentionally kept as the PR2 batch-admission layer before the later TOCTOU work.