### PR TITLE
fix(downloads): publish outputs without overwriting foreign files

### DIFF
--- a/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
+++ b/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DownKyi.Services.Download;
+
+internal interface IAtomicOutputPublisher
+{
+    Task<AtomicOutputPublishResult> PublishAsync(
+        string destinationPath,
+        Func<string, CancellationToken, Task> writeTemporaryAsync,
+        CancellationToken cancellationToken);
+}
+
+internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
+{
+    private const int MaximumTemporaryPathAttempts = 8;
+    private readonly Action<string>? _beforePublish;
+
+    public AtomicOutputPublisher()
+    {
+    }
+
+    internal AtomicOutputPublisher(Action<string> beforePublish)
+    {
+        _beforePublish = beforePublish ?? throw new ArgumentNullException(nameof(beforePublish));
+    }
+
+    public async Task<AtomicOutputPublishResult> PublishAsync(
+        string destinationPath,
+        Func<string, CancellationToken, Task> writeTemporaryAsync,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+        ArgumentNullException.ThrowIfNull(writeTemporaryAsync);
+        var temporaryPath = CreateTemporaryFile(destinationPath);
+        try
+        {
+            await writeTemporaryAsync(temporaryPath, cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            _beforePublish?.Invoke(destinationPath);
+            try
+            {
+                File.Move(temporaryPath, destinationPath, overwrite: false);
+            }
+            catch (IOException exception) when (File.Exists(destinationPath))
+            {
+                return AtomicOutputPublishResult.DestinationCollision(exception);
+            }
+
+            return AtomicOutputPublishResult.Published();
+        }
+        finally
+        {
+            DeleteTemporaryFile(temporaryPath);
+        }
+    }
+
+    private static string CreateTemporaryFile(string destinationPath)
+    {
+        var fullDestinationPath = Path.GetFullPath(destinationPath);
+        var directory = Path.GetDirectoryName(fullDestinationPath)
+            ?? throw new IOException("The output destination has no directory.");
+        var name = Path.GetFileNameWithoutExtension(fullDestinationPath);
+        var extension = Path.GetExtension(fullDestinationPath);
+        for (var attempt = 0; attempt < MaximumTemporaryPathAttempts; attempt++)
+        {
+            var temporaryPath = Path.Combine(
+                directory,
+                $".{name}-{Guid.NewGuid():N}.downkyi-tmp{extension}");
+            try
+            {
+                using var stream = new FileStream(
+                    temporaryPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None);
+                return temporaryPath;
+            }
+            catch (IOException) when (attempt < MaximumTemporaryPathAttempts - 1)
+            {
+            }
+        }
+
+        throw new IOException("A unique temporary output file could not be created.");
+    }
+
+    private static void DeleteTemporaryFile(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}
+
+internal sealed record AtomicOutputPublishResult(
+    bool Succeeded,
+    bool IsDestinationCollision,
+    IOException? Error)
+{
+    public static AtomicOutputPublishResult Published() => new(true, false, null);
+
+    public static AtomicOutputPublishResult DestinationCollision(IOException error) =>
+        new(false, true, error);
+}

--- a/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
+++ b/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
@@ -80,6 +80,7 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
             }
             catch (IOException) when (attempt < MaximumTemporaryPathAttempts - 1)
             {
+                continue;
             }
         }
 
@@ -94,9 +95,11 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
         }
         catch (IOException)
         {
+            return;
         }
         catch (UnauthorizedAccessException)
         {
+            return;
         }
     }
 }

--- a/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Publication.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Publication.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Xml;
+using DownKyi.Application.Bilibili;
+using DownKyi.Core.Danmaku2Ass;
+using DownKyi.Domain.Results;
+using DownKyi.Models;
+
+namespace DownKyi.Services.Download;
+
+internal sealed partial class DownloadArtifactWriter
+{
+    private Task<AtomicOutputPublishResult> PublishCoverAsync(
+        string fileName,
+        string coverUrl,
+        CancellationToken cancellationToken)
+    {
+        return _outputPublisher.PublishAsync(
+            fileName,
+            (temporaryPath, token) => _client.DownloadFileAsync(
+                new BilibiliHttpRequest(coverUrl),
+                temporaryPath,
+                token),
+            cancellationToken);
+    }
+
+    private Task<AtomicOutputPublishResult> PublishDanmakuAsync(
+        string assFile,
+        BilibiliDanmakuConverter converter,
+        DownloadBase downloadBase,
+        Config subtitleConfig,
+        CancellationToken cancellationToken)
+    {
+        return _outputPublisher.PublishAsync(
+            assFile,
+            (temporaryPath, token) => converter.CreateAsync(
+                _client,
+                downloadBase.Avid,
+                downloadBase.Cid,
+                subtitleConfig,
+                temporaryPath,
+                token),
+            cancellationToken);
+    }
+
+    private Task<AtomicOutputPublishResult> PublishSubtitleAsync(
+        string srtFile,
+        string content,
+        CancellationToken cancellationToken)
+    {
+        return _outputPublisher.PublishAsync(
+            srtFile,
+            (temporaryPath, token) => File.WriteAllTextAsync(temporaryPath, content, token),
+            cancellationToken);
+    }
+
+    private Task<AtomicOutputPublishResult> PublishDefaultSubtitleAsync(
+        string defaultSubtitleFile,
+        string sourceSubtitleFile,
+        CancellationToken cancellationToken)
+    {
+        return _outputPublisher.PublishAsync(
+            defaultSubtitleFile,
+            (temporaryPath, _) =>
+            {
+                File.Copy(sourceSubtitleFile, temporaryPath, overwrite: true);
+                return Task.CompletedTask;
+            },
+            cancellationToken);
+    }
+
+    private Task<AtomicOutputPublishResult> PublishNfoAsync(
+        string nfoFile,
+        MovieMetadata metadata,
+        CancellationToken cancellationToken)
+    {
+        return _outputPublisher.PublishAsync(
+            nfoFile,
+            async (temporaryPath, _) =>
+            {
+                var writer = CreateNfoWriter(temporaryPath);
+                try
+                {
+                    WriteMovieMetadata(writer, metadata);
+                    await writer.FlushAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    await writer.DisposeAsync().ConfigureAwait(false);
+                }
+            },
+            cancellationToken);
+    }
+
+    private static OperationResult<DownloadArtifactWriteResult> OutputCollisionFailure()
+    {
+        return ArtifactFailure(
+            "download.output.destination-collision",
+            "The output destination is already occupied by another file.");
+    }
+
+    private static void WriteMovieMetadata(XmlWriter writer, MovieMetadata metadata)
+    {
+        writer.WriteStartDocument();
+        writer.WriteStartElement("movie");
+        writer.WriteElementString("title", metadata.Title);
+        writer.WriteElementString("plot", metadata.Plot);
+        writer.WriteElementString("year", metadata.Year);
+
+        foreach (var genre in metadata.Genres)
+        {
+            writer.WriteElementString("genre", genre);
+        }
+
+        foreach (var tag in metadata.Tags)
+        {
+            writer.WriteElementString("tag", tag);
+        }
+
+        foreach (var actor in metadata.Actors)
+        {
+            writer.WriteStartElement("actor");
+            writer.WriteElementString("name", actor.Name);
+            writer.WriteElementString("role", actor.Role);
+            writer.WriteEndElement();
+        }
+
+        if (metadata.BilibiliId != null)
+        {
+            writer.WriteStartElement("uniqueid");
+            writer.WriteAttributeString("type", metadata.BilibiliId.Type);
+            writer.WriteString(metadata.BilibiliId.Value);
+            writer.WriteEndElement();
+        }
+
+        writer.WriteElementString("premiered", metadata.Premiered);
+        foreach (var rating in metadata.Ratings)
+        {
+            writer.WriteStartElement("rating");
+            writer.WriteAttributeString("name", rating.Name);
+            writer.WriteAttributeString("max", rating.Max.ToString(CultureInfo.InvariantCulture));
+            writer.WriteAttributeString("default", rating.IsDefault ? "true" : "false");
+            writer.WriteString(rating.Value.ToString(CultureInfo.InvariantCulture));
+            writer.WriteEndElement();
+        }
+
+        writer.WriteEndElement();
+        writer.WriteEndDocument();
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.cs
@@ -77,13 +77,7 @@ internal sealed partial class DownloadArtifactWriter
                 transferKey,
                 fileName,
                 cancellationToken).ConfigureAwait(false);
-            var publish = await _outputPublisher.PublishAsync(
-                fileName,
-                (temporaryPath, token) => _client.DownloadFileAsync(
-                    new BilibiliHttpRequest(coverUrl),
-                    temporaryPath,
-                    token),
-                cancellationToken).ConfigureAwait(false);
+            var publish = await PublishCoverAsync(fileName, coverUrl, cancellationToken).ConfigureAwait(false);
             if (publish.IsDestinationCollision)
             {
                 return OutputCollisionFailure();
@@ -172,15 +166,11 @@ internal sealed partial class DownloadArtifactWriter
                 "danmaku",
                 assFile,
                 cancellationToken).ConfigureAwait(false);
-            var publish = await _outputPublisher.PublishAsync(
+            var publish = await PublishDanmakuAsync(
                 assFile,
-                (temporaryPath, token) => converter.CreateAsync(
-                    _client,
-                    downloadBase.Avid,
-                    downloadBase.Cid,
-                    subtitleConfig,
-                    temporaryPath,
-                    token),
+                converter,
+                downloadBase,
+                subtitleConfig,
                 cancellationToken).ConfigureAwait(false);
             if (publish.IsDestinationCollision)
             {
@@ -315,12 +305,9 @@ internal sealed partial class DownloadArtifactWriter
                     GetSubtitleTrackTransferKey(index),
                     srtFile,
                     cancellationToken).ConfigureAwait(false);
-                var publish = await _outputPublisher.PublishAsync(
+                var publish = await PublishSubtitleAsync(
                     srtFile,
-                    (temporaryPath, token) => File.WriteAllTextAsync(
-                        temporaryPath,
-                        subRip.SrtString,
-                        token),
+                    subRip.SrtString,
                     cancellationToken).ConfigureAwait(false);
                 if (publish.IsDestinationCollision)
                 {
@@ -360,13 +347,9 @@ internal sealed partial class DownloadArtifactWriter
                 DefaultSubtitleTransferKey,
                 defaultSubtitleFile,
                 cancellationToken).ConfigureAwait(false);
-            var publish = await _outputPublisher.PublishAsync(
+            var publish = await PublishDefaultSubtitleAsync(
                 defaultSubtitleFile,
-                (temporaryPath, _) =>
-                {
-                    File.Copy(srtFiles[0], temporaryPath, overwrite: true);
-                    return Task.CompletedTask;
-                },
+                srtFiles[0],
                 cancellationToken).ConfigureAwait(false);
             if (publish.IsDestinationCollision)
             {
@@ -417,23 +400,9 @@ internal sealed partial class DownloadArtifactWriter
                 "nfo",
                 nfoFile,
                 cancellationToken).ConfigureAwait(false);
-            var publish = await _outputPublisher.PublishAsync(
+            var publish = await PublishNfoAsync(
                 nfoFile,
-                async (temporaryPath, _) =>
-                {
-                    var writer = XmlWriter.Create(
-                        temporaryPath,
-                        new XmlWriterSettings { Async = true, Indent = true });
-                    try
-                    {
-                        WriteMovieMetadata(writer, downloading.Metadata);
-                        await writer.FlushAsync().ConfigureAwait(false);
-                    }
-                    finally
-                    {
-                        await writer.DisposeAsync().ConfigureAwait(false);
-                    }
-                },
+                downloading.Metadata,
                 cancellationToken).ConfigureAwait(false);
             if (publish.IsDestinationCollision)
             {
@@ -480,60 +449,9 @@ internal sealed partial class DownloadArtifactWriter
             OperationError.Unexpected(code, message));
     }
 
-    private static OperationResult<DownloadArtifactWriteResult> OutputCollisionFailure()
+    private static XmlWriter CreateNfoWriter(string path)
     {
-        return ArtifactFailure(
-            "download.output.destination-collision",
-            "The output destination is already occupied by another file.");
-    }
-
-    private static void WriteMovieMetadata(XmlWriter writer, MovieMetadata metadata)
-    {
-        writer.WriteStartDocument();
-        writer.WriteStartElement("movie");
-        writer.WriteElementString("title", metadata.Title);
-        writer.WriteElementString("plot", metadata.Plot);
-        writer.WriteElementString("year", metadata.Year);
-
-        foreach (var genre in metadata.Genres)
-        {
-            writer.WriteElementString("genre", genre);
-        }
-
-        foreach (var tag in metadata.Tags)
-        {
-            writer.WriteElementString("tag", tag);
-        }
-
-        foreach (var actor in metadata.Actors)
-        {
-            writer.WriteStartElement("actor");
-            writer.WriteElementString("name", actor.Name);
-            writer.WriteElementString("role", actor.Role);
-            writer.WriteEndElement();
-        }
-
-        if (metadata.BilibiliId != null)
-        {
-            writer.WriteStartElement("uniqueid");
-            writer.WriteAttributeString("type", metadata.BilibiliId.Type);
-            writer.WriteString(metadata.BilibiliId.Value);
-            writer.WriteEndElement();
-        }
-
-        writer.WriteElementString("premiered", metadata.Premiered);
-        foreach (var rating in metadata.Ratings)
-        {
-            writer.WriteStartElement("rating");
-            writer.WriteAttributeString("name", rating.Name);
-            writer.WriteAttributeString("max", rating.Max.ToString(CultureInfo.InvariantCulture));
-            writer.WriteAttributeString("default", rating.IsDefault ? "true" : "false");
-            writer.WriteString(rating.Value.ToString(CultureInfo.InvariantCulture));
-            writer.WriteEndElement();
-        }
-
-        writer.WriteEndElement();
-        writer.WriteEndDocument();
+        return XmlWriter.Create(path, new XmlWriterSettings { Async = true, Indent = true });
     }
 
     private static string GetDanmakuLayoutAlgorithmValue(DanmakuLayoutAlgorithm algorithm)

--- a/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.cs
@@ -29,17 +29,20 @@ internal sealed partial class DownloadArtifactWriter
     private readonly DownloadTaskStateWriter _stateWriter;
     private readonly ILogger _logger;
     private readonly IBilibiliApiClient _client;
+    private readonly IAtomicOutputPublisher _outputPublisher;
 
     public DownloadArtifactWriter(
         IWbiKeyProvider wbiKeyProvider,
         DownloadTaskStateWriter stateWriter,
         ILogger logger,
-        IBilibiliApiClient client)
+        IBilibiliApiClient client,
+        IAtomicOutputPublisher? outputPublisher = null)
     {
         _wbiKeyProvider = wbiKeyProvider ?? throw new ArgumentNullException(nameof(wbiKeyProvider));
         _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _client = client ?? throw new ArgumentNullException(nameof(client));
+        _outputPublisher = outputPublisher ?? new AtomicOutputPublisher();
     }
 
     public async Task<OperationResult<DownloadArtifactWriteResult>> DownloadCoverAsync(
@@ -74,10 +77,17 @@ internal sealed partial class DownloadArtifactWriter
                 transferKey,
                 fileName,
                 cancellationToken).ConfigureAwait(false);
-            await _client.DownloadFileAsync(
-                new BilibiliHttpRequest(coverUrl),
+            var publish = await _outputPublisher.PublishAsync(
                 fileName,
+                (temporaryPath, token) => _client.DownloadFileAsync(
+                    new BilibiliHttpRequest(coverUrl),
+                    temporaryPath,
+                    token),
                 cancellationToken).ConfigureAwait(false);
+            if (publish.IsDestinationCollision)
+            {
+                return OutputCollisionFailure();
+            }
             var integrity = DownloadFileIntegrity.Check(fileName);
             if (!integrity.IsUsable)
             {
@@ -162,13 +172,20 @@ internal sealed partial class DownloadArtifactWriter
                 "danmaku",
                 assFile,
                 cancellationToken).ConfigureAwait(false);
-            await converter.CreateAsync(
-                _client,
-                downloadBase.Avid,
-                downloadBase.Cid,
-                subtitleConfig,
+            var publish = await _outputPublisher.PublishAsync(
                 assFile,
+                (temporaryPath, token) => converter.CreateAsync(
+                    _client,
+                    downloadBase.Avid,
+                    downloadBase.Cid,
+                    subtitleConfig,
+                    temporaryPath,
+                    token),
                 cancellationToken).ConfigureAwait(false);
+            if (publish.IsDestinationCollision)
+            {
+                return OutputCollisionFailure();
+            }
             var integrity = DownloadFileIntegrity.Check(assFile);
             if (!integrity.IsUsable)
             {
@@ -298,7 +315,17 @@ internal sealed partial class DownloadArtifactWriter
                     GetSubtitleTrackTransferKey(index),
                     srtFile,
                     cancellationToken).ConfigureAwait(false);
-                await File.WriteAllTextAsync(srtFile, subRip.SrtString, cancellationToken).ConfigureAwait(false);
+                var publish = await _outputPublisher.PublishAsync(
+                    srtFile,
+                    (temporaryPath, token) => File.WriteAllTextAsync(
+                        temporaryPath,
+                        subRip.SrtString,
+                        token),
+                    cancellationToken).ConfigureAwait(false);
+                if (publish.IsDestinationCollision)
+                {
+                    return OutputCollisionFailure();
+                }
                 var integrity = DownloadFileIntegrity.Check(srtFile);
                 if (!integrity.IsUsable)
                 {
@@ -333,7 +360,18 @@ internal sealed partial class DownloadArtifactWriter
                 DefaultSubtitleTransferKey,
                 defaultSubtitleFile,
                 cancellationToken).ConfigureAwait(false);
-            File.Copy(srtFiles[0], defaultSubtitleFile, true);
+            var publish = await _outputPublisher.PublishAsync(
+                defaultSubtitleFile,
+                (temporaryPath, _) =>
+                {
+                    File.Copy(srtFiles[0], temporaryPath, overwrite: true);
+                    return Task.CompletedTask;
+                },
+                cancellationToken).ConfigureAwait(false);
+            if (publish.IsDestinationCollision)
+            {
+                return OutputCollisionFailure();
+            }
             if (!DownloadFileIntegrity.Check(defaultSubtitleFile).IsUsable)
             {
                 return ArtifactFailure(
@@ -379,17 +417,27 @@ internal sealed partial class DownloadArtifactWriter
                 "nfo",
                 nfoFile,
                 cancellationToken).ConfigureAwait(false);
-            var writer = XmlWriter.Create(
+            var publish = await _outputPublisher.PublishAsync(
                 nfoFile,
-                new XmlWriterSettings { Async = true, Indent = true });
-            try
+                async (temporaryPath, _) =>
+                {
+                    var writer = XmlWriter.Create(
+                        temporaryPath,
+                        new XmlWriterSettings { Async = true, Indent = true });
+                    try
+                    {
+                        WriteMovieMetadata(writer, downloading.Metadata);
+                        await writer.FlushAsync().ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        await writer.DisposeAsync().ConfigureAwait(false);
+                    }
+                },
+                cancellationToken).ConfigureAwait(false);
+            if (publish.IsDestinationCollision)
             {
-                WriteMovieMetadata(writer, downloading.Metadata);
-                await writer.FlushAsync().ConfigureAwait(false);
-            }
-            finally
-            {
-                await writer.DisposeAsync().ConfigureAwait(false);
+                return OutputCollisionFailure();
             }
 
             if (!DownloadFileIntegrity.Check(nfoFile).IsUsable)
@@ -430,6 +478,13 @@ internal sealed partial class DownloadArtifactWriter
     {
         return OperationResult.Failure<DownloadArtifactWriteResult>(
             OperationError.Unexpected(code, message));
+    }
+
+    private static OperationResult<DownloadArtifactWriteResult> OutputCollisionFailure()
+    {
+        return ArtifactFailure(
+            "download.output.destination-collision",
+            "The output destination is already occupied by another file.");
     }
 
     private static void WriteMovieMetadata(XmlWriter writer, MovieMetadata metadata)

--- a/src/DownKyi.Desktop/Services/Download/MuxStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/MuxStage.cs
@@ -87,7 +87,7 @@ internal sealed class MuxStage : IDownloadPipelineStage
         return result.Succeeded
             ? DownloadStageResult.Success(Name)
             : DownloadStageResult.Failure(
-                GetFailureCode("download.mux.dash", invalidation),
+                GetFailureCode("download.mux.dash", result, invalidation),
                 "Audio and video streams could not be finalized.");
     }
 
@@ -129,7 +129,7 @@ internal sealed class MuxStage : IDownloadPipelineStage
             return mergeResult.Succeeded
                 ? DownloadStageResult.Success(Name)
                 : DownloadStageResult.Failure(
-                    GetFailureCode("download.mux.durl", singleInvalidation),
+                    GetFailureCode("download.mux.durl", mergeResult, singleInvalidation),
                     "The media segment could not be finalized.");
         }
 
@@ -164,7 +164,7 @@ internal sealed class MuxStage : IDownloadPipelineStage
         return result.Succeeded
             ? DownloadStageResult.Success(Name)
             : DownloadStageResult.Failure(
-                GetFailureCode("download.mux.concat", invalidation),
+                GetFailureCode("download.mux.concat", result, invalidation),
                 "Segmented media could not be concatenated.");
     }
 
@@ -236,8 +236,14 @@ internal sealed class MuxStage : IDownloadPipelineStage
 
     private static string GetFailureCode(
         string defaultCode,
+        FfmpegOperationResult operationResult,
         SourceInvalidationOutcome invalidation)
     {
+        if (operationResult.FailureKind == FfmpegOperationFailureKind.DestinationConflict)
+        {
+            return "download.output.destination-collision";
+        }
+
         return invalidation switch
         {
             SourceInvalidationOutcome.Invalidated => "download.mux.invalid-source",

--- a/tests/DownKyi.Core.Tests/FfmpegConcatRuntimeTests.cs
+++ b/tests/DownKyi.Core.Tests/FfmpegConcatRuntimeTests.cs
@@ -106,6 +106,33 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
     }
 
     [Fact]
+    public async Task ConcatLateDestinationConflictPreservesForeignOutputAndCleansPartial()
+    {
+        var segment = CreateSegment("late-segment.flv");
+        var output = Path.Combine(_testDirectory, "late-output.mp4");
+        byte[] foreignContent = [9, 8, 7];
+        var runner = new RecordingConcatRunner(() => File.WriteAllBytes(output, foreignContent));
+        var runtime = new FfmpegConcatRuntime(
+            runner,
+            new StubMediaValidator(isValid: true),
+            new AsyncConcurrencyGate(() => 1),
+            NullLogger<FfmpegConcatRuntime>.Instance);
+
+        var result = await runtime.ConcatAsync(
+            [new FfmpegConcatSegment(1, segment, TimeSpan.FromSeconds(5))],
+            output,
+            hardwareEncoder: null,
+            allowStreamCopy: false,
+            overwriteDestination: false,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(FfmpegOperationFailureKind.DestinationConflict, result.FailureKind);
+        Assert.Equal(foreignContent, await File.ReadAllBytesAsync(output, TestContext.Current.CancellationToken));
+        Assert.Empty(Directory.EnumerateFiles(_testDirectory, "*.partial.mp4"));
+    }
+
+    [Fact]
     public async Task ConcatValidationFailurePreservesExistingDestination()
     {
         var segment = CreateSegment("invalid.flv");
@@ -212,7 +239,7 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
         return path;
     }
 
-    private sealed class RecordingConcatRunner : IFfmpegProcessRunner
+    private sealed class RecordingConcatRunner(Action? afterOutputWritten = null) : IFfmpegProcessRunner
     {
         public List<FfmpegCommand> Commands { get; } = new();
 
@@ -236,6 +263,7 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
                 cancellationToken).ConfigureAwait(false);
             await File.WriteAllBytesAsync(command.Arguments[^1], [1, 2, 3], cancellationToken)
                 .ConfigureAwait(false);
+            afterOutputWritten?.Invoke();
             return new FfmpegProcessResult(true, 0, string.Empty, string.Empty, false);
         }
     }

--- a/tests/DownKyi.Core.Tests/FfmpegProcessorMergeTests.cs
+++ b/tests/DownKyi.Core.Tests/FfmpegProcessorMergeTests.cs
@@ -166,6 +166,33 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         Assert.Equal(
             originalDestination,
             await File.ReadAllBytesAsync(destination, TestContext.Current.CancellationToken));
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.partial.mp4"));
+    }
+
+    [Fact]
+    public async Task LateDestinationConflictPreservesForeignOutputAndCleansPartial()
+    {
+        var audio = CreateInput("late-destination-audio.m4s");
+        var video = CreateInput("late-destination-video.m4s");
+        var destination = Path.Combine(_directory, "late-destination.mp4");
+        byte[] foreignContent = [9, 8, 7];
+        var processor = new FfmpegProcessor(
+            _settings,
+            NullLoggerFactory.Instance,
+            new SuccessfulMergeRunner(() => File.WriteAllBytes(destination, foreignContent)));
+
+        var result = await processor.MergeMediaAsync(
+            _settings.Current.Video,
+            audio,
+            video,
+            destination,
+            overwriteDestination: false,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(FfmpegOperationFailureKind.DestinationConflict, result.FailureKind);
+        Assert.Equal(foreignContent, await File.ReadAllBytesAsync(destination, TestContext.Current.CancellationToken));
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.partial.mp4"));
     }
 
     [Fact]
@@ -344,7 +371,7 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         }
     }
 
-    private sealed class SuccessfulMergeRunner : IFfmpegProcessRunner
+    private sealed class SuccessfulMergeRunner(Action? afterOutputWritten = null) : IFfmpegProcessRunner
     {
         public int CallCount { get; private set; }
 
@@ -360,6 +387,7 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
                 command.Arguments[^1],
                 [1, 2, 3],
                 cancellationToken).ConfigureAwait(false);
+            afterOutputWritten?.Invoke();
             return new FfmpegProcessResult(true, 0, string.Empty, string.Empty, false);
         }
     }

--- a/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
+++ b/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
@@ -90,18 +90,24 @@ public sealed class DownloadArtifactStageTests
                 context.Execution,
                 TestContext.Current.CancellationToken).ConfigureAwait(true);
             Assert.False(result.IsSuccess);
+            if (failureMode == CoverFailureMode.IoAfterWrite)
+            {
+                Assert.Equal("download.artifact.cover.io", result.Error?.Code);
+            }
         }
 
         var task = await context.GetTaskAsync().ConfigureAwait(true);
         AssertPhysicalArtifactsAreDurablyOwned(context, task);
-        if (failureMode == CoverFailureMode.HttpBeforeWrite)
-        {
-            Assert.Empty(context.GetPhysicalArtifactFiles());
-        }
-        else
+        if (failureMode == CoverFailureMode.HtmlError)
         {
             Assert.Single(context.GetPhysicalArtifactFiles());
         }
+        else
+        {
+            Assert.Empty(context.GetPhysicalArtifactFiles());
+        }
+
+        Assert.Empty(context.GetTemporaryOutputFiles());
     }
 
     [Theory]
@@ -138,6 +144,7 @@ public sealed class DownloadArtifactStageTests
         var task = await context.GetTaskAsync().ConfigureAwait(true);
         AssertPhysicalArtifactsAreDurablyOwned(context, task);
         Assert.NotEmpty(context.GetPhysicalArtifactFiles());
+        Assert.Empty(context.GetTemporaryOutputFiles());
         if (kind == ArtifactKind.Subtitle)
         {
             Assert.Contains(DownloadArtifactWriter.DefaultSubtitleTransferKey, task.Plan.TransferFiles.Keys);
@@ -236,7 +243,8 @@ public sealed class DownloadArtifactStageTests
             TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         Assert.True(first.IsSuccess, first.Error?.Message);
-        Assert.True(second.IsSuccess, second.Error?.Message);
+        Assert.False(second.IsSuccess);
+        Assert.Equal("download.output.destination-collision", second.Error?.Code);
         var task = await context.GetTaskAsync().ConfigureAwait(true);
         AssertPhysicalArtifactsAreDurablyOwned(context, task);
         Assert.Contains(
@@ -396,6 +404,79 @@ public sealed class DownloadArtifactStageTests
         Assert.True(run.Result.IsSuccess);
         Assert.True(finalized);
         Assert.True(File.Exists(context.Execution.CoverFile));
+    }
+
+    [Theory]
+    [InlineData(nameof(ArtifactKind.MainCover))]
+    [InlineData(nameof(ArtifactKind.Subtitle))]
+    [InlineData(nameof(ArtifactKind.Danmaku))]
+    [InlineData(nameof(ArtifactKind.Nfo))]
+    public async Task LateDestinationCollisionPreservesForeignArtifactAndCleansTemporaryFile(
+        string kindName)
+    {
+        var kind = Enum.Parse<ArtifactKind>(kindName);
+        string? foreignPath = null;
+        var publisher = new AtomicOutputPublisher(path =>
+        {
+            foreignPath = path;
+            File.WriteAllText(path, "foreign artifact");
+        });
+        var client = CreateSuccessfulArtifactClient(kind);
+        using var context = await ArtifactTestContext.CreateAsync(
+            client,
+            cover: kind == ArtifactKind.MainCover,
+            subtitle: kind == ArtifactKind.Subtitle,
+            danmaku: kind == ArtifactKind.Danmaku,
+            generateMetadata: kind == ArtifactKind.Nfo,
+            outputPublisher: publisher).ConfigureAwait(true);
+        if (kind == ArtifactKind.MainCover)
+        {
+            context.Downloading.DownloadBase.CoverUrl = "https://example.test/cover.jpg";
+        }
+
+        var result = await context.Stage.ExecuteAsync(
+            context.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.output.destination-collision", result.Error?.Code);
+        var path = Assert.IsType<string>(foreignPath);
+        Assert.Equal("foreign artifact", await File.ReadAllTextAsync(
+            path,
+            TestContext.Current.CancellationToken).ConfigureAwait(true));
+        Assert.Empty(context.GetTemporaryOutputFiles());
+    }
+
+    [Fact]
+    public async Task DefaultSubtitleLateDestinationCollisionPreservesForeignFileAndCleansTemporaryFile()
+    {
+        string? foreignPath = null;
+        var publisher = new AtomicOutputPublisher(path =>
+        {
+            if (!string.Equals(Path.GetFileName(path), "output.srt", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            foreignPath = path;
+            File.WriteAllText(path, "foreign subtitle");
+        });
+        using var context = await ArtifactTestContext.CreateAsync(
+            CreateSuccessfulArtifactClient(ArtifactKind.Subtitle),
+            subtitle: true,
+            outputPublisher: publisher).ConfigureAwait(true);
+
+        var result = await context.Stage.ExecuteAsync(
+            context.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.output.destination-collision", result.Error?.Code);
+        var path = Assert.IsType<string>(foreignPath);
+        Assert.Equal("foreign subtitle", await File.ReadAllTextAsync(
+            path,
+            TestContext.Current.CancellationToken).ConfigureAwait(true));
+        Assert.Empty(context.GetTemporaryOutputFiles());
     }
 
     private static StringComparer PathComparer =>
@@ -614,13 +695,21 @@ public sealed class DownloadArtifactStageTests
                 .ToArray();
         }
 
+        public string[] GetTemporaryOutputFiles()
+        {
+            return Directory.EnumerateFiles(_directory, "*.downkyi-tmp*", SearchOption.AllDirectories)
+                .Select(Path.GetFullPath)
+                .ToArray();
+        }
+
         public static async Task<ArtifactTestContext> CreateAsync(
             TestBilibiliApiClient client,
             bool cover = false,
             bool subtitle = false,
             bool danmaku = false,
             bool generateMetadata = false,
-            bool useMissingOutputDirectory = false)
+            bool useMissingOutputDirectory = false,
+            IAtomicOutputPublisher? outputPublisher = null)
         {
             var directory = Path.Combine(
                 Path.GetTempPath(),
@@ -697,7 +786,8 @@ public sealed class DownloadArtifactStageTests
                 new TestWbiKeyProvider(),
                 stateWriter,
                 NullLogger<DownloadArtifactWriter>.Instance,
-                client);
+                client,
+                outputPublisher);
             var execution = new DownloadExecutionContext(
                 taskId,
                 downloading,

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionCrossInstanceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionCrossInstanceTests.cs
@@ -1,0 +1,275 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Core.BiliApi.VideoStream.Models;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+using DownKyi.Infrastructure.Downloads;
+using DownKyi.Infrastructure.Time;
+using DownKyi.Models;
+using DownKyi.Services.Download;
+using DownKyi.ViewModels.DownloadManager;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Tests;
+
+public sealed class DownloadTaskAdmissionCrossInstanceTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "downkyi-cross-instance-admission",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task AutoSuffixOnRetriesAfterIndependentDurableReservationConflict()
+    {
+        using var session = await AdmissionSession.CreateAsync(_directory).ConfigureAwait(true);
+        var requestedPath = Path.Combine(_directory, "same-output");
+
+        var first = CreateItem("first", requestedPath);
+        var second = CreateItem("second", requestedPath);
+
+        await Task.WhenAll(
+            session.First.AdmitAsync(first, autoAddNumberSuffix: true, TestContext.Current.CancellationToken),
+            session.Second.AdmitAsync(second, autoAddNumberSuffix: true, TestContext.Current.CancellationToken))
+            .ConfigureAwait(true);
+
+        Assert.Equal(
+            [Path.GetFullPath(requestedPath), Path.GetFullPath(requestedPath) + "(1)"],
+            new[] { first.DownloadBase.FilePath, second.DownloadBase.FilePath }
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray());
+    }
+
+    [Fact]
+    public async Task AutoSuffixOffAllowsExactlyOneIndependentDurableReservationOwner()
+    {
+        using var session = await AdmissionSession.CreateAsync(_directory).ConfigureAwait(true);
+        var requestedPath = Path.Combine(_directory, "same-output");
+
+        var first = CreateItem("first", requestedPath);
+        var second = CreateItem("second", requestedPath);
+
+        var results = await Task.WhenAll(
+            CaptureIOExceptionAsync(() => session.First.AdmitAsync(first, autoAddNumberSuffix: false, TestContext.Current.CancellationToken)),
+            CaptureIOExceptionAsync(() => session.Second.AdmitAsync(second, autoAddNumberSuffix: false, TestContext.Current.CancellationToken)))
+            .ConfigureAwait(true);
+
+        Assert.Single(results, result => result == null);
+        Assert.Single(results, result => result is IOException);
+        var unfinished = await session.Tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+        Assert.Single(unfinished);
+        Assert.Equal(Path.GetFullPath(requestedPath), unfinished[0].Output.BasePath);
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+
+        GC.SuppressFinalize(this);
+    }
+
+    private static async Task<IOException?> CaptureIOExceptionAsync(Func<Task> operation)
+    {
+        try
+        {
+            await operation().ConfigureAwait(true);
+            return null;
+        }
+        catch (IOException exception)
+        {
+            return exception;
+        }
+    }
+
+    private static DownloadingItem CreateItem(string id, string basePath)
+    {
+        return new DownloadingItem
+        {
+            DownloadBase = new DownloadBase
+            {
+                Id = id,
+                Bvid = $"BV-{id}",
+                MainTitle = id,
+                Name = id,
+                FilePath = basePath
+            },
+            Downloading = new Downloading
+            {
+                Id = id,
+                DownloadStatus = DownloadStatus.WaitForDownload
+            },
+            PlayUrl = new PlayUrl()
+        };
+    }
+
+    private sealed class AdmissionSession : IDisposable
+    {
+        private readonly SqliteDownloadTaskStore _firstStore;
+        private readonly SqliteDownloadTaskStore _secondStore;
+        private readonly DownloadTaskProjectionStore _firstProjections;
+        private readonly DownloadTaskProjectionStore _secondProjections;
+        private readonly DownloadTaskAdmissionService _firstAdmission;
+        private readonly DownloadTaskAdmissionService _secondAdmission;
+
+        private AdmissionSession(
+            SqliteDownloadTaskStore firstStore,
+            SqliteDownloadTaskStore secondStore,
+            DownloadTaskApplicationService firstTasks,
+            DownloadTaskApplicationService secondTasks,
+            DownloadTaskProjectionStore firstProjections,
+            DownloadTaskProjectionStore secondProjections,
+            DownloadTaskAdmissionService firstAdmission,
+            DownloadTaskAdmissionService secondAdmission)
+        {
+            _firstStore = firstStore;
+            _secondStore = secondStore;
+            First = firstAdmission;
+            Second = secondAdmission;
+            Tasks = firstTasks;
+            _firstProjections = firstProjections;
+            _secondProjections = secondProjections;
+            _firstAdmission = firstAdmission;
+            _secondAdmission = secondAdmission;
+            FirstTasks = firstTasks;
+            SecondTasks = secondTasks;
+        }
+
+        public DownloadTaskAdmissionService First { get; }
+
+        public DownloadTaskAdmissionService Second { get; }
+
+        public DownloadTaskApplicationService Tasks { get; }
+
+        private DownloadTaskApplicationService FirstTasks { get; }
+
+        private DownloadTaskApplicationService SecondTasks { get; }
+
+        public static async Task<AdmissionSession> CreateAsync(string directory)
+        {
+            Directory.CreateDirectory(directory);
+            var databasePath = Path.Combine(directory, "download.db");
+            var firstStore = new SqliteDownloadTaskStore(
+                new SqliteDownloadTaskStoreOptions(databasePath), new SystemClock());
+            var secondStore = new SqliteDownloadTaskStore(
+                new SqliteDownloadTaskStoreOptions(databasePath), new SystemClock());
+            var addGate = new ConcurrentAddGate();
+            var firstTasks = new DownloadTaskApplicationService(
+                new SynchronizedAddStore(firstStore, addGate), new SystemClock());
+            var secondTasks = new DownloadTaskApplicationService(
+                new SynchronizedAddStore(secondStore, addGate), new SystemClock());
+            var firstProjections = new DownloadTaskProjectionStore(firstTasks, new SystemClock());
+            var secondProjections = new DownloadTaskProjectionStore(secondTasks, new SystemClock());
+            var firstAdmission = new DownloadTaskAdmissionService(
+                new DownloadListState(), firstTasks, firstProjections, new RecordingDownloadTaskQueue());
+            var secondAdmission = new DownloadTaskAdmissionService(
+                new DownloadListState(), secondTasks, secondProjections, new RecordingDownloadTaskQueue());
+            await firstStore.InitializeAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+            await secondStore.InitializeAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+            return new AdmissionSession(
+                firstStore, secondStore, firstTasks, secondTasks, firstProjections, secondProjections,
+                firstAdmission, secondAdmission);
+        }
+
+        public void Dispose()
+        {
+            _firstAdmission.Dispose();
+            _secondAdmission.Dispose();
+            _firstProjections.Dispose();
+            _secondProjections.Dispose();
+            FirstTasks.Dispose();
+            SecondTasks.Dispose();
+            _firstStore.Dispose();
+            _secondStore.Dispose();
+        }
+    }
+
+    private sealed class ConcurrentAddGate
+    {
+        private readonly TaskCompletionSource _bothAddsReached = new(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        private int _arrivals;
+
+        public Task WaitForFirstPairAsync(CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _arrivals) == 2)
+            {
+                _bothAddsReached.TrySetResult();
+            }
+
+            return _bothAddsReached.Task.WaitAsync(cancellationToken);
+        }
+    }
+
+    private sealed class SynchronizedAddStore(IDownloadTaskStore inner, ConcurrentAddGate addGate)
+        : IDownloadTaskStore
+    {
+        private int _addCalls;
+
+        public Task InitializeAsync(CancellationToken cancellationToken) =>
+            inner.InitializeAsync(cancellationToken);
+
+        public async Task<OperationResult> AddAsync(
+            DownloadTask task,
+            CancellationToken cancellationToken)
+        {
+            if (Interlocked.Increment(ref _addCalls) <= 1)
+            {
+                await addGate.WaitForFirstPairAsync(cancellationToken).ConfigureAwait(false);
+            }
+
+            return await inner.AddAsync(task, cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task<OperationResult> UpdateAsync(
+            DownloadTask task,
+            long expectedVersion,
+            CancellationToken cancellationToken) =>
+            inner.UpdateAsync(task, expectedVersion, cancellationToken);
+
+        public Task<OperationResult> UpdateProgressAsync(
+            DownloadProgressWrite progressWrite,
+            CancellationToken cancellationToken) =>
+            inner.UpdateProgressAsync(progressWrite, cancellationToken);
+
+        public Task<DownloadTask?> FindAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken) =>
+            inner.FindAsync(taskId, cancellationToken);
+
+        public Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(
+            CancellationToken cancellationToken) =>
+            inner.GetUnfinishedAsync(cancellationToken);
+
+        public Task<IReadOnlyList<string>> GetActiveOutputPathsAsync(
+            CancellationToken cancellationToken) =>
+            inner.GetActiveOutputPathsAsync(cancellationToken);
+
+        public Task<bool> IsOutputPathReservedAsync(
+            string basePath,
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            inner.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
+
+        public Task<DownloadHistoryPage> GetHistoryPageAsync(
+            DownloadHistoryCursor? cursor,
+            int pageSize,
+            CancellationToken cancellationToken) =>
+            inner.GetHistoryPageAsync(cursor, pageSize, cancellationToken);
+
+        public Task<OperationResult> DeleteAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken) =>
+            inner.DeleteAsync(taskId, cancellationToken);
+
+        public Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken) =>
+            inner.ClearHistoryAsync(cancellationToken);
+
+        public Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
+            CancellationToken cancellationToken) =>
+            inner.GetQuarantinedRecordsAsync(cancellationToken);
+    }
+}

--- a/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
+++ b/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
@@ -16,6 +16,43 @@ namespace DownKyi.Tests;
 public sealed class MuxFailureRecoveryTests
 {
     [Fact]
+    public async Task DashDestinationCollisionIsReportedAsAnOutputCollision()
+    {
+        var test = await MuxTestContext.CreateAsync().ConfigureAwait(true);
+        await using var testLifetime = test.ConfigureAwait(true);
+        var stage = test.CreateStage(FfmpegOperationResult.Failure(
+            "destination exists",
+            FfmpegOperationFailureKind.DestinationConflict));
+
+        var result = await stage.ExecuteAsync(
+            test.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.output.destination-collision", result.Error?.Code);
+        Assert.True(File.Exists(test.AudioFile));
+        Assert.True(File.Exists(test.VideoFile));
+    }
+
+    [Fact]
+    public async Task DurlDestinationCollisionIsReportedAsAnOutputCollision()
+    {
+        var test = await MuxTestContext.CreateAsync().ConfigureAwait(true);
+        await using var testLifetime = test.ConfigureAwait(true);
+        await test.AddDurlSourcesAsync().ConfigureAwait(true);
+        var stage = test.CreateStage(FfmpegOperationResult.Failure(
+            "destination exists",
+            FfmpegOperationFailureKind.DestinationConflict));
+
+        var result = await stage.ExecuteAsync(
+            test.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.output.destination-collision", result.Error?.Code);
+    }
+
+    [Fact]
     public async Task InvalidAudioRevokesOnlyAudioCacheAndKeepsValidVideo()
     {
         var test = await MuxTestContext.CreateAsync().ConfigureAwait(true);


### PR DESCRIPTION
## Summary

Close the PR3 late-filesystem-collision gap from #177 by moving filesystem ownership to the actual final-publication boundary instead of pretending admission-time filesystem checks are atomic.

- add a same-directory atomic output publisher using exclusive temp creation and non-overwrite final move
- migrate direct artifact writers for NFO, danmaku, subtitles, default subtitle, and covers
- preserve existing safe DASH/DURL mux publication behavior while surfacing destination collisions distinctly
- add deterministic cross-instance admission tests proving suffix-on retry and suffix-off fail-closed behavior
- keep PR1 physical reservation identity and PR2 atomic batch semantics unchanged

## Ownership boundary

SQLite remains authoritative for DownKyi-vs-DownKyi durable reservation only.

Filesystem ownership is established only when a task-owned temporary output is successfully published to the final destination with non-overwrite semantics.

The new publication protocol is:

1. create a unique sibling temporary path with exclusive `CreateNew` semantics
2. write only to that temporary path
3. publish with non-overwrite move
4. on destination collision, preserve the foreign destination and delete only the task-owned temporary file
5. fail closed with `download.output.destination-collision`

No admission-time `File.Exists` check is used as ownership authorization.

## Artifact coverage

Migrated:
- NFO
- danmaku
- language subtitles
- default subtitle
- covers

Already safe and retained:
- DASH mux
- DURL mux

## Verification

Exact head: `2678c9a3302ccb8cd79e0f9fd903042d3d6405a3`

- semantic audit: READY TO COMMIT; no P0/P1/P2 findings
- focused desktop tests: 36 passed
- FFmpeg tests: 14 passed
- SQLite tests: 24 passed
- strict solution build: 0 warnings / 0 errors
- `dotnet format --verify-no-changes`: passed
- `git diff --check HEAD^..HEAD`: passed
- remote committed diff: 1 commit, 8 files, ahead 1 / behind 0 from `output-ownership-integration`
- deterministic coverage includes artifact late collisions, DASH/DURL publish collisions, writer/cancellation cleanup, successful temp cleanup, non-collision IO classification, and independent-store suffix ON/OFF behavior

## Scope exclusions / PR4 boundary

This PR intentionally does **not** solve cleanup provenance.

A file successfully published by DownKyi can later be replaced by another actor. Filename-derived cleanup still cannot prove that a later same-name file is task-owned. That remaining #177 data-loss risk is deferred to PR4, which will add authoritative artifact provenance and cleanup authorization.

Not included:
- artifact provenance tables/records
- `DownloadTaskFileService` cleanup-authorization redesign
- manager deletion ownership changes
- SQLite reservation identity/schema changes
- PR2 atomic batch changes
- suffix-performance/scaling work

This PR therefore establishes: **DownKyi will not overwrite a foreign file during final publication.** PR4 will establish: **DownKyi will not later delete a file unless ownership is proven.**