### PR TITLE
WIP: add authoritative output artifact provenance

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -196,6 +196,8 @@ FinalizeStage
 
 下載來源、續傳 sidecar 與 completed transfer key 在所有必要 stage 通過前都屬於可重試狀態。FFmpeg 只能發布已驗證輸出，不得刪除輸入；只有 `FinalizeStage` 成功提交 Domain `Completed` 後，才能透過既有 `DownloadTaskFileService` 清理該任務的精確來源與 sidecar。Artifact、mux、validation、取消或 SQLite completion 失敗都必須保留這些 retry checkpoint。
 
+Atomic artifact、FFmpeg merge 與 concat 在交給 producer 前，必須以仍開啟的 creation handle claim temporary object identity。Producer 完成後，只有 pathname 仍解析到同一 object 才能產生 final provenance；publication move 前必須重新觀察 cancellation。Temporary cleanup 僅由 identity-bound claim 授權，final output cleanup 則需要 persisted identity、length 與 hash；兩者不可互換。Windows native cleanup 必須在同一 live handle 上完成 evidence validation 與 destructive syscall，pathname normalization 或存在性檢查都不能取代 object ownership。
+
 下載重試只有一個預算 owner：
 
 ```text

--- a/DownKyi.Core/FFmpeg/FfmpegConcatRuntime.cs
+++ b/DownKyi.Core/FFmpeg/FfmpegConcatRuntime.cs
@@ -1,4 +1,5 @@
 using DownKyi.Application.Diagnostics;
+using DownKyi.Application.Downloads;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.Core.FFmpeg;
@@ -78,7 +79,8 @@ public sealed record FfmpegOperationResult
         string? failureReason,
         TimeSpan duration,
         FfmpegOperationFailureKind failureKind,
-        IReadOnlyList<FfmpegInputFailure> inputFailures)
+        IReadOnlyList<FfmpegInputFailure> inputFailures,
+        OutputArtifactPublicationEvidence? publicationEvidence = null)
     {
         ArgumentNullException.ThrowIfNull(inputFailures);
         if (succeeded != (failureKind == FfmpegOperationFailureKind.None))
@@ -88,11 +90,19 @@ public sealed record FfmpegOperationResult
                 nameof(failureKind));
         }
 
+        if (!succeeded && publicationEvidence is not null)
+        {
+            throw new ArgumentException(
+                "Failed FFmpeg operations cannot expose publication evidence.",
+                nameof(publicationEvidence));
+        }
+
         Succeeded = succeeded;
         OutputPath = outputPath;
         FailureReason = failureReason;
         Duration = duration;
         FailureKind = failureKind;
+        PublicationEvidence = publicationEvidence;
         InputFailures = inputFailures.ToArray();
         InvalidInputPaths = InputFailures
             .Where(failure => failure.CanInvalidate)
@@ -110,6 +120,14 @@ public sealed record FfmpegOperationResult
     public TimeSpan Duration { get; }
 
     public FfmpegOperationFailureKind FailureKind { get; }
+
+    /// <summary>
+    /// Evidence captured from the temporary media output and verified against
+    /// the object at its final path after publication. It is null when either
+    /// step was unavailable or did not succeed; callers must not infer
+    /// ownership from the output path.
+    /// </summary>
+    public OutputArtifactPublicationEvidence? PublicationEvidence { get; }
 
     public IReadOnlyList<FfmpegInputFailure> InputFailures { get; }
 
@@ -195,6 +213,7 @@ internal sealed class FfmpegConcatRuntime
         bool allowStreamCopy,
         bool overwriteDestination,
         Action<string>? progress = null,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(segments);
@@ -278,14 +297,34 @@ internal sealed class FfmpegConcatRuntime
                             continue;
                         }
 
+                        OutputArtifactPublicationEvidence? publicationEvidence = null;
+                        if (outputArtifactOwnershipProvider is not null)
+                        {
+                            var capture = await outputArtifactOwnershipProvider
+                                .CapturePublicationEvidenceAsync(temporaryOutput, cancellationToken)
+                                .ConfigureAwait(false);
+                            publicationEvidence = capture.Succeeded ? capture.Evidence : null;
+                        }
+
                         File.Move(temporaryOutput, outputFile, overwrite: overwriteDestination);
+                        if (publicationEvidence is not null
+                            && !await VerifyPublishedIdentityAsync(
+                                    outputArtifactOwnershipProvider,
+                                    outputFile,
+                                    publicationEvidence)
+                                .ConfigureAwait(false))
+                        {
+                            publicationEvidence = null;
+                        }
+
                         return new FfmpegOperationResult(
                             true,
                             outputFile,
                             null,
                             validation.Duration,
                             FfmpegOperationFailureKind.None,
-                            []);
+                            [],
+                            publicationEvidence);
                     }
                     finally
                     {
@@ -348,6 +387,35 @@ internal sealed class FfmpegConcatRuntime
             : result.StandardError.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).LastOrDefault() ?? "unknown";
         _logger.LogInformationMessage(
             $"FFmpeg operation completed. operation={command.Operation}; exitCode={result.ExitCode}; timedOut={result.TimedOut}; error={error}");
+    }
+
+    private static async Task<bool> VerifyPublishedIdentityAsync(
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider,
+        string outputFile,
+        OutputArtifactPublicationEvidence publicationEvidence)
+    {
+        if (outputArtifactOwnershipProvider is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            return await outputArtifactOwnershipProvider
+                .VerifyPublishedObjectIdentityAsync(
+                    outputFile,
+                    publicationEvidence,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidOperationException
+                                         or ArgumentException
+                                         or NotSupportedException)
+        {
+            return false;
+        }
     }
 
     private void DeleteFile(string file)

--- a/DownKyi.Core/FFmpeg/FfmpegConcatRuntime.cs
+++ b/DownKyi.Core/FFmpeg/FfmpegConcatRuntime.cs
@@ -193,17 +193,20 @@ internal sealed class FfmpegConcatRuntime
     private readonly IFfmpegMediaValidator _mediaValidator;
     private readonly IFfmpegProcessRunner _processRunner;
     private readonly ILogger<FfmpegConcatRuntime> _logger;
+    private readonly IOutputArtifactOwnershipProvider? _outputArtifactOwnershipProvider;
 
     public FfmpegConcatRuntime(
         IFfmpegProcessRunner processRunner,
         IFfmpegMediaValidator mediaValidator,
         AsyncConcurrencyGate concurrencyGate,
-        ILogger<FfmpegConcatRuntime> logger)
+        ILogger<FfmpegConcatRuntime> logger,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null)
     {
         _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
         _mediaValidator = mediaValidator ?? throw new ArgumentNullException(nameof(mediaValidator));
         _concurrencyGate = concurrencyGate ?? throw new ArgumentNullException(nameof(concurrencyGate));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _outputArtifactOwnershipProvider = outputArtifactOwnershipProvider;
     }
 
     public async Task<FfmpegOperationResult> ConcatAsync(
@@ -218,6 +221,8 @@ internal sealed class FfmpegConcatRuntime
     {
         ArgumentNullException.ThrowIfNull(segments);
         ArgumentException.ThrowIfNullOrWhiteSpace(outputFile);
+        var ownershipProvider = outputArtifactOwnershipProvider
+            ?? _outputArtifactOwnershipProvider;
         if (segments.Count == 0)
         {
             return FfmpegOperationResult.Failure(
@@ -263,8 +268,12 @@ internal sealed class FfmpegConcatRuntime
                     var temporaryOutput = Path.Combine(
                         outputDirectory,
                         $".{Path.GetFileNameWithoutExtension(outputFile)}-{Guid.NewGuid():N}.partial.mp4");
+                    FfmpegTemporaryOutput? temporaryOwnership = null;
                     try
                     {
+                        temporaryOwnership = FfmpegTemporaryOutput.Create(
+                            temporaryOutput,
+                            ownershipProvider);
                         progress?.Invoke($"FFmpeg {strategy}");
                         var command = FfmpegCommandFactory.BuildConcat(
                             listFile,
@@ -298,18 +307,23 @@ internal sealed class FfmpegConcatRuntime
                         }
 
                         OutputArtifactPublicationEvidence? publicationEvidence = null;
-                        if (outputArtifactOwnershipProvider is not null)
+                        if (ownershipProvider is not null
+                            && temporaryOwnership?.Claim is { } temporaryClaim)
                         {
-                            var capture = await outputArtifactOwnershipProvider
-                                .CapturePublicationEvidenceAsync(temporaryOutput, cancellationToken)
+                            var capture = await ownershipProvider
+                                .CapturePublicationEvidenceAsync(
+                                    temporaryOutput,
+                                    temporaryClaim,
+                                    cancellationToken)
                                 .ConfigureAwait(false);
                             publicationEvidence = capture.Succeeded ? capture.Evidence : null;
                         }
 
+                        cancellationToken.ThrowIfCancellationRequested();
                         File.Move(temporaryOutput, outputFile, overwrite: overwriteDestination);
                         if (publicationEvidence is not null
                             && !await VerifyPublishedIdentityAsync(
-                                    outputArtifactOwnershipProvider,
+                                    ownershipProvider,
                                     outputFile,
                                     publicationEvidence)
                                 .ConfigureAwait(false))
@@ -328,7 +342,12 @@ internal sealed class FfmpegConcatRuntime
                     }
                     finally
                     {
-                        DeleteFile(temporaryOutput);
+                        if (temporaryOwnership is not null)
+                        {
+                            await temporaryOwnership
+                                .DeleteIfOwnedAsync(ownershipProvider)
+                                .ConfigureAwait(false);
+                        }
                     }
                 }
             }

--- a/DownKyi.Core/FFmpeg/FfmpegProcessor.PublicationEvidence.cs
+++ b/DownKyi.Core/FFmpeg/FfmpegProcessor.PublicationEvidence.cs
@@ -4,6 +4,23 @@ namespace DownKyi.Core.FFmpeg;
 
 public sealed partial class FfmpegProcessor
 {
+    private async Task<bool> RunToFileSucceededAsync(
+        Func<string, FfmpegCommand> commandFactory,
+        string destination,
+        bool overwriteDestination,
+        Action<string>? action,
+        CancellationToken cancellationToken)
+    {
+        var result = await RunToFileAsync(
+            commandFactory,
+            destination,
+            overwriteDestination,
+            action: action,
+            outputArtifactOwnershipProvider: null,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+        return result.Succeeded;
+    }
+
     private static async Task<bool> VerifyPublishedIdentityAsync(
         IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider,
         string destination,

--- a/DownKyi.Core/FFmpeg/FfmpegProcessor.PublicationEvidence.cs
+++ b/DownKyi.Core/FFmpeg/FfmpegProcessor.PublicationEvidence.cs
@@ -1,0 +1,37 @@
+using DownKyi.Application.Downloads;
+
+namespace DownKyi.Core.FFmpeg;
+
+public sealed partial class FfmpegProcessor
+{
+    private static async Task<bool> VerifyPublishedIdentityAsync(
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider,
+        string destination,
+        OutputArtifactPublicationEvidence publicationEvidence)
+    {
+        if (outputArtifactOwnershipProvider is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            // Once the move succeeded, absence of verification deliberately
+            // produces an untracked output instead of changing publish success.
+            return await outputArtifactOwnershipProvider
+                .VerifyPublishedObjectIdentityAsync(
+                    destination,
+                    publicationEvidence,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidOperationException
+                                         or ArgumentException
+                                         or NotSupportedException)
+        {
+            return false;
+        }
+    }
+}

--- a/DownKyi.Core/FFmpeg/FfmpegProcessor.cs
+++ b/DownKyi.Core/FFmpeg/FfmpegProcessor.cs
@@ -1,4 +1,5 @@
 using DownKyi.Application.Diagnostics;
+using DownKyi.Application.Downloads;
 using DownKyi.Core.Settings;
 using Microsoft.Extensions.Logging;
 
@@ -14,6 +15,24 @@ public interface IFfmpegMediaMuxer
         Action<string>? action = null,
         CancellationToken cancellationToken = default);
 
+    Task<FfmpegOperationResult> ConcatDurlVideosWithEvidenceAsync(
+        VideoApplicationSettings videoSettings,
+        IReadOnlyList<FfmpegConcatSegment> segments,
+        string outputVideo,
+        bool overwriteDestination,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null,
+        Action<string>? action = null,
+        CancellationToken cancellationToken = default)
+    {
+        return ConcatDurlVideosAsync(
+            videoSettings,
+            segments,
+            outputVideo,
+            overwriteDestination,
+            action,
+            cancellationToken);
+    }
+
     Task<FfmpegOperationResult> MergeMediaAsync(
         VideoApplicationSettings videoSettings,
         string? audio,
@@ -21,9 +40,27 @@ public interface IFfmpegMediaMuxer
         string destination,
         bool overwriteDestination,
         CancellationToken cancellationToken = default);
+
+    Task<FfmpegOperationResult> MergeMediaWithEvidenceAsync(
+        VideoApplicationSettings videoSettings,
+        string? audio,
+        string? video,
+        string destination,
+        bool overwriteDestination,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null,
+        CancellationToken cancellationToken = default)
+    {
+        return MergeMediaAsync(
+            videoSettings,
+            audio,
+            video,
+            destination,
+            overwriteDestination,
+            cancellationToken);
+    }
 }
 
-public sealed class FfmpegProcessor : IFfmpegMediaMuxer
+public sealed partial class FfmpegProcessor : IFfmpegMediaMuxer
 {
     private static readonly TimeSpan OperationTimeout = TimeSpan.FromHours(2);
     private readonly AsyncConcurrencyGate _operationGate;
@@ -59,11 +96,30 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
             loggerFactory.CreateLogger<FfmpegConcatRuntime>());
     }
 
-    public async Task<FfmpegOperationResult> ConcatDurlVideosAsync(
+    public Task<FfmpegOperationResult> ConcatDurlVideosAsync(
         VideoApplicationSettings videoSettings,
         IReadOnlyList<FfmpegConcatSegment> segments,
         string outputVideo,
         bool overwriteDestination,
+        Action<string>? action = null,
+        CancellationToken cancellationToken = default)
+    {
+        return ConcatDurlVideosWithEvidenceAsync(
+            videoSettings,
+            segments,
+            outputVideo,
+            overwriteDestination,
+            outputArtifactOwnershipProvider: null,
+            action: action,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<FfmpegOperationResult> ConcatDurlVideosWithEvidenceAsync(
+        VideoApplicationSettings videoSettings,
+        IReadOnlyList<FfmpegConcatSegment> segments,
+        string outputVideo,
+        bool overwriteDestination,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null,
         Action<string>? action = null,
         CancellationToken cancellationToken = default)
     {
@@ -78,8 +134,9 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
                 encoder,
                 allowStreamCopy: false,
                 overwriteDestination,
-                action,
-                cancellationToken)
+                progress: action,
+                outputArtifactOwnershipProvider: outputArtifactOwnershipProvider,
+                cancellationToken: cancellationToken)
             .ConfigureAwait(false);
     }
 
@@ -101,12 +158,31 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
         return result.Succeeded;
     }
 
-    public async Task<FfmpegOperationResult> MergeMediaAsync(
+    public Task<FfmpegOperationResult> MergeMediaAsync(
         VideoApplicationSettings videoSettings,
         string? audio,
         string? video,
         string destination,
         bool overwriteDestination,
+        CancellationToken cancellationToken = default)
+    {
+        return MergeMediaWithEvidenceAsync(
+            videoSettings,
+            audio,
+            video,
+            destination,
+            overwriteDestination,
+            outputArtifactOwnershipProvider: null,
+            cancellationToken: cancellationToken);
+    }
+
+    public async Task<FfmpegOperationResult> MergeMediaWithEvidenceAsync(
+        VideoApplicationSettings videoSettings,
+        string? audio,
+        string? video,
+        string destination,
+        bool overwriteDestination,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null,
         CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(videoSettings);
@@ -145,7 +221,8 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
             destination,
             overwriteDestination,
             action: null,
-            cancellationToken).ConfigureAwait(false);
+            outputArtifactOwnershipProvider: outputArtifactOwnershipProvider,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
         if (outputResult.Succeeded)
         {
             return new FfmpegOperationResult(
@@ -154,7 +231,8 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
                 null,
                 TimeSpan.Zero,
                 FfmpegOperationFailureKind.None,
-                []);
+                [],
+                outputResult.PublicationEvidence);
         }
 
         if (outputResult.FailureKind != FfmpegOperationFailureKind.ProcessFailure)
@@ -274,8 +352,9 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
             commandFactory,
             destination,
             overwriteDestination,
-            action,
-            cancellationToken).ConfigureAwait(false);
+            action: action,
+            outputArtifactOwnershipProvider: null,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
         return result.Succeeded;
     }
 
@@ -284,6 +363,7 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
         string destination,
         bool overwriteDestination,
         Action<string>? action,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(commandFactory);
@@ -315,8 +395,27 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
                 return FfmpegOutputResult.Failure(FfmpegOperationFailureKind.OutputInvalid);
             }
 
+            OutputArtifactPublicationEvidence? publicationEvidence = null;
+            if (outputArtifactOwnershipProvider is not null)
+            {
+                var capture = await outputArtifactOwnershipProvider
+                    .CapturePublicationEvidenceAsync(temporaryOutput, cancellationToken)
+                    .ConfigureAwait(false);
+                publicationEvidence = capture.Succeeded ? capture.Evidence : null;
+            }
+
             File.Move(temporaryOutput, destination, overwrite: overwriteDestination);
-            return FfmpegOutputResult.Success();
+            if (publicationEvidence is not null
+                && !await VerifyPublishedIdentityAsync(
+                        outputArtifactOwnershipProvider,
+                        destination,
+                        publicationEvidence)
+                    .ConfigureAwait(false))
+            {
+                publicationEvidence = null;
+            }
+
+            return FfmpegOutputResult.Success(publicationEvidence);
         }
         catch (IOException e)
         {
@@ -376,12 +475,14 @@ public sealed class FfmpegProcessor : IFfmpegMediaMuxer
 
     private sealed record FfmpegOutputResult(
         bool Succeeded,
-        FfmpegOperationFailureKind FailureKind)
+        FfmpegOperationFailureKind FailureKind,
+        OutputArtifactPublicationEvidence? PublicationEvidence)
     {
-        public static FfmpegOutputResult Success() =>
-            new(true, FfmpegOperationFailureKind.None);
+        public static FfmpegOutputResult Success(
+            OutputArtifactPublicationEvidence? publicationEvidence) =>
+            new(true, FfmpegOperationFailureKind.None, publicationEvidence);
 
         public static FfmpegOutputResult Failure(FfmpegOperationFailureKind failureKind) =>
-            new(false, failureKind);
+            new(false, failureKind, null);
     }
 }

--- a/DownKyi.Core/FFmpeg/FfmpegProcessor.cs
+++ b/DownKyi.Core/FFmpeg/FfmpegProcessor.cs
@@ -69,22 +69,32 @@ public sealed partial class FfmpegProcessor : IFfmpegMediaMuxer
     private readonly ISettingsStore _settingsStore;
     private readonly ILogger<FfmpegProcessor> _logger;
     private readonly FfmpegHardwareEncoderDetector _hardwareEncoderDetector;
+    private readonly IOutputArtifactOwnershipProvider? _outputArtifactOwnershipProvider;
 
-    public FfmpegProcessor(ISettingsStore settingsStore, ILoggerFactory loggerFactory)
-        : this(settingsStore, loggerFactory, new FfmpegProcessRunner())
+    public FfmpegProcessor(
+        ISettingsStore settingsStore,
+        ILoggerFactory loggerFactory,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null)
+        : this(
+            settingsStore,
+            loggerFactory,
+            new FfmpegProcessRunner(),
+            outputArtifactOwnershipProvider)
     {
     }
 
     internal FfmpegProcessor(
         ISettingsStore settingsStore,
         ILoggerFactory loggerFactory,
-        IFfmpegProcessRunner processRunner)
+        IFfmpegProcessRunner processRunner,
+        IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null)
     {
         ArgumentNullException.ThrowIfNull(settingsStore);
         ArgumentNullException.ThrowIfNull(loggerFactory);
         _settingsStore = settingsStore;
         _logger = loggerFactory.CreateLogger<FfmpegProcessor>();
         _processRunner = processRunner ?? throw new ArgumentNullException(nameof(processRunner));
+        _outputArtifactOwnershipProvider = outputArtifactOwnershipProvider;
         _hardwareEncoderDetector = new FfmpegHardwareEncoderDetector(
             loggerFactory.CreateLogger<FfmpegHardwareEncoderDetector>());
         _operationGate = new AsyncConcurrencyGate(
@@ -93,7 +103,8 @@ public sealed partial class FfmpegProcessor : IFfmpegMediaMuxer
             _processRunner,
             new FfmpegMediaValidator(_processRunner),
             _operationGate,
-            loggerFactory.CreateLogger<FfmpegConcatRuntime>());
+            loggerFactory.CreateLogger<FfmpegConcatRuntime>(),
+            outputArtifactOwnershipProvider);
     }
 
     public Task<FfmpegOperationResult> ConcatDurlVideosAsync(
@@ -341,23 +352,6 @@ public sealed partial class FfmpegProcessor : IFfmpegMediaMuxer
         }
     }
 
-    private async Task<bool> RunToFileSucceededAsync(
-        Func<string, FfmpegCommand> commandFactory,
-        string destination,
-        bool overwriteDestination,
-        Action<string>? action,
-        CancellationToken cancellationToken)
-    {
-        var result = await RunToFileAsync(
-            commandFactory,
-            destination,
-            overwriteDestination,
-            action: action,
-            outputArtifactOwnershipProvider: null,
-            cancellationToken: cancellationToken).ConfigureAwait(false);
-        return result.Succeeded;
-    }
-
     private async Task<FfmpegOutputResult> RunToFileAsync(
         Func<string, FfmpegCommand> commandFactory,
         string destination,
@@ -369,13 +363,19 @@ public sealed partial class FfmpegProcessor : IFfmpegMediaMuxer
         ArgumentNullException.ThrowIfNull(commandFactory);
         ArgumentException.ThrowIfNullOrWhiteSpace(destination);
         var extension = Path.GetExtension(destination);
-        var temporaryOutput = Path.Combine(
+        var temporaryPath = Path.Combine(
             Path.GetDirectoryName(Path.GetFullPath(destination))!,
             $".{Path.GetFileNameWithoutExtension(destination)}-{Guid.NewGuid():N}.partial{extension}");
+        FfmpegTemporaryOutput? temporaryOutput = null;
+        var ownershipProvider = outputArtifactOwnershipProvider
+            ?? _outputArtifactOwnershipProvider;
         try
         {
             using var slot = await _operationGate.EnterAsync(cancellationToken).ConfigureAwait(false);
-            var command = commandFactory(temporaryOutput);
+            temporaryOutput = FfmpegTemporaryOutput.Create(
+                temporaryPath,
+                ownershipProvider);
+            var command = commandFactory(temporaryPath);
             var result = await _processRunner
                 .RunAsync(command, OperationTimeout, cancellationToken)
                 .ConfigureAwait(false);
@@ -390,24 +390,29 @@ public sealed partial class FfmpegProcessor : IFfmpegMediaMuxer
                             : FfmpegOperationFailureKind.ProcessFailure);
             }
 
-            if (!File.Exists(temporaryOutput) || new FileInfo(temporaryOutput).Length == 0)
+            if (!File.Exists(temporaryPath) || new FileInfo(temporaryPath).Length == 0)
             {
                 return FfmpegOutputResult.Failure(FfmpegOperationFailureKind.OutputInvalid);
             }
 
             OutputArtifactPublicationEvidence? publicationEvidence = null;
-            if (outputArtifactOwnershipProvider is not null)
+            if (ownershipProvider is not null
+                && temporaryOutput?.Claim is { } temporaryClaim)
             {
-                var capture = await outputArtifactOwnershipProvider
-                    .CapturePublicationEvidenceAsync(temporaryOutput, cancellationToken)
+                var capture = await ownershipProvider
+                    .CapturePublicationEvidenceAsync(
+                        temporaryPath,
+                        temporaryClaim,
+                        cancellationToken)
                     .ConfigureAwait(false);
                 publicationEvidence = capture.Succeeded ? capture.Evidence : null;
             }
 
-            File.Move(temporaryOutput, destination, overwrite: overwriteDestination);
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Move(temporaryPath, destination, overwrite: overwriteDestination);
             if (publicationEvidence is not null
                 && !await VerifyPublishedIdentityAsync(
-                        outputArtifactOwnershipProvider,
+                        ownershipProvider,
                         destination,
                         publicationEvidence)
                     .ConfigureAwait(false))
@@ -433,7 +438,12 @@ public sealed partial class FfmpegProcessor : IFfmpegMediaMuxer
         }
         finally
         {
-            DeleteFile(temporaryOutput);
+            if (temporaryOutput is not null)
+            {
+                await temporaryOutput
+                    .DeleteIfOwnedAsync(ownershipProvider)
+                    .ConfigureAwait(false);
+            }
         }
     }
 

--- a/DownKyi.Core/FFmpeg/FfmpegTemporaryOutput.cs
+++ b/DownKyi.Core/FFmpeg/FfmpegTemporaryOutput.cs
@@ -1,0 +1,64 @@
+using DownKyi.Application.Downloads;
+
+namespace DownKyi.Core.FFmpeg;
+
+internal sealed record FfmpegTemporaryOutput(
+    string Path,
+    OutputArtifactTemporaryClaim? Claim)
+{
+    public static FfmpegTemporaryOutput Create(
+        string path,
+        IOutputArtifactOwnershipProvider? ownershipProvider)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        using var stream = new FileStream(
+            path,
+            FileMode.CreateNew,
+            FileAccess.ReadWrite,
+            FileShare.None);
+        if (ownershipProvider is null)
+        {
+            return new FfmpegTemporaryOutput(path, null);
+        }
+
+        try
+        {
+            var claim = ownershipProvider.ClaimTemporaryObject(stream.SafeFileHandle);
+            return new FfmpegTemporaryOutput(
+                path,
+                claim.Succeeded ? claim.Claim : null);
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidOperationException
+                                         or ArgumentException
+                                         or NotSupportedException)
+        {
+            return new FfmpegTemporaryOutput(path, null);
+        }
+    }
+
+    public async Task DeleteIfOwnedAsync(
+        IOutputArtifactOwnershipProvider? ownershipProvider)
+    {
+        if (ownershipProvider is null || Claim is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await ownershipProvider
+                .DeleteTemporaryIfOwnedAsync(Path, Claim, CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidOperationException
+                                         or ArgumentException
+                                         or NotSupportedException)
+        {
+            return;
+        }
+    }
+}

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -1980,6 +1980,10 @@ paths:
   - src/DownKyi.Desktop/Services/Download/DownloadOutputRecorder.cs
   - src/DownKyi.Desktop/Services/Download/DownloadTaskFileService.cs
   - src/DownKyi.Desktop/Services/Download/DownloadFileIntegrity.cs
+  - src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
+  - src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactOwnershipProvider.cs
+  - src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.cs
+  - src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.TemporaryOwnership.cs
   - src/DownKyi.Desktop/Services/Download/DownloadDiagnosticLogger.cs
   - src/DownKyi.Desktop/Services/Download/DownloadShutdownCoordinator.cs
 responsibility: Admits committed task IDs directly, selects one transfer backend, dispatches bounded workers, orders typed download stages, centrally budgets transfer retries, writes auxiliary artifacts and task state through dedicated owners, verifies integrity, and projects completed tasks.
@@ -2031,6 +2035,8 @@ contracts:
   - `DownloadArtifactWriter` owns cover, subtitle, danmaku, and NFO generation; its typed result distinguishes created output, source-not-available, HTTP/parse/conversion/write/permission failure, invalid or zero-byte output, and cancellation. `DownloadTaskStateWriter` is a typed Application-command adapter and never accepts a UI task model.
   - `DownloadPipeline` creates one context and orders `ResolvePlaybackStage`, `DownloadMediaStage`, `DownloadArtifactsStage`, `MuxStage`, `ValidateStage`, and `FinalizeStage`; the first typed failure stops later stages, so requested artifact failure cannot produce completed history.
   - Download mux and DURL concat finalize through same-directory temporary files with `overwriteDestination: false`. A pre-existing destination fails the stage without deleting the foreign file or the valid source streams.
+  - Atomic artifact, FFmpeg merge, and concat outputs claim temporary object identity from the live creation handle before producer execution. Post-producer provenance requires the pathname to resolve to that claimed object, and cancellation is checked immediately before the publication move.
+  - Temporary cleanup is identity-bound and content-independent; final cleanup requires persisted identity, length, and hash. Windows validates and marks deletion through the same live handle, so a pathname replacement cannot transfer deletion authority to a foreign object.
   - `DownloadMediaStage` carries each persisted transfer key beside its audio, video or DURL file into `MuxStage`. Mux failure may revoke only paths listed by the typed FFmpeg invalid-input result; it reuses `DownloadTransferFileCleanup` and `DownloadTaskApplicationService.InvalidateCompletedFileAsync` instead of owning a parallel reset path.
   - Completed-key invalidation clears the task's backend identity in the same durable Application mutation. Confirmed invalid input removes its file and `.aria2` / `.download` sidecars; infrastructure-only mux failure preserves source files, completed keys and resume identity for retry.
   - `DownloadExecutionContext` captures one immutable settings snapshot and accepts the current operation token at each active check; it cannot retain a short-lived command token.

--- a/docs/testing/review-invariant-corpus.json
+++ b/docs/testing/review-invariant-corpus.json
@@ -31,13 +31,14 @@
     },
     {
       "id": "output-cleanup-ownership",
-      "historicalRoots": ["PR #85", "PR #120"],
-      "guards": "Task rows, transfer inputs, resume state, generated files and sidecars are changed through their existing owners; retry checkpoints survive every pre-commit failure and transfer inputs are cleaned only after durable completion.",
+      "historicalRoots": ["PR #85", "PR #120", "Issue #177"],
+      "guards": "Task rows, transfer inputs, resume state, generated files and sidecars are changed through their existing owners; retry checkpoints survive every pre-commit failure, transfer inputs are cleaned only after durable completion, and external objects cannot acquire publication or deletion authority through pathname replacement.",
       "testClasses": [
         { "project": "tests/DownKyi.Infrastructure.Tests/DownKyi.Infrastructure.Tests.csproj", "class": "DownKyi.Infrastructure.Tests.SqliteDownloadTaskStoreTests" },
         { "project": "tests/DownKyi.Core.Tests/DownKyi.Core.Tests.csproj", "class": "DownKyi.Core.Tests.FfmpegCommitBoundaryTests" },
         { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadTaskFileServiceTests" },
         { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadArtifactStageTests" },
+        { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.OutputArtifactOwnershipAdversarialTests" },
         { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadPipelineCommitBoundaryTests" },
         { "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj", "class": "DownKyi.Tests.DownloadTaskProjectionStoreResumeTests" }
       ],

--- a/src/DownKyi.Application/Downloads/DownloadOutputArtifactProvenance.cs
+++ b/src/DownKyi.Application/Downloads/DownloadOutputArtifactProvenance.cs
@@ -1,0 +1,103 @@
+using DownKyi.Domain.Downloads;
+
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// Durable evidence that one final output artifact was successfully published
+/// for a download task.
+/// </summary>
+/// <remarks>
+/// This is deliberately separate from planned or completed transfer files.
+/// It is deletion authority only when the filesystem ownership provider can
+/// validate every persisted evidence field against the currently opened file.
+/// </remarks>
+public sealed record DownloadOutputArtifactProvenance
+{
+    public DownloadOutputArtifactProvenance(
+        DownloadTaskId taskId,
+        string artifactKey,
+        string artifactKind,
+        string canonicalPath,
+        OutputArtifactPublicationEvidence publicationEvidence,
+        DateTimeOffset publishedAtUtc)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(canonicalPath);
+        ArgumentNullException.ThrowIfNull(publicationEvidence);
+        ArgumentOutOfRangeException.ThrowIfNegative(publicationEvidence.ByteLength);
+        if (!IsCanonicalSha256(publicationEvidence.Sha256))
+        {
+            throw new ArgumentException(
+                "Final-output provenance requires a lowercase hexadecimal SHA-256 digest.",
+                nameof(publicationEvidence));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicationEvidence.IdentityProvider);
+        ArgumentException.ThrowIfNullOrWhiteSpace(publicationEvidence.FilesystemIdentity);
+        if (publishedAtUtc.Offset != TimeSpan.Zero)
+        {
+            throw new ArgumentException(
+                "Final-output provenance timestamps must be UTC.",
+                nameof(publishedAtUtc));
+        }
+
+        TaskId = taskId;
+        ArtifactKey = artifactKey;
+        ArtifactKind = artifactKind;
+        CanonicalPath = canonicalPath;
+        ByteLength = publicationEvidence.ByteLength;
+        Sha256 = publicationEvidence.Sha256;
+        IdentityProvider = publicationEvidence.IdentityProvider;
+        FilesystemIdentity = publicationEvidence.FilesystemIdentity;
+        PublishedAtUtc = publishedAtUtc;
+    }
+
+    public DownloadTaskId TaskId { get; }
+
+    /// <summary>Stable logical identity, unique within a task.</summary>
+    public string ArtifactKey { get; }
+
+    /// <summary>Diagnostic artifact classification; it is not deletion authority.</summary>
+    public string ArtifactKind { get; }
+
+    /// <summary>
+    /// Normalized absolute final-output path used to open the candidate.
+    /// The application service normalizes it before the first durable write;
+    /// restored values are preserved verbatim.
+    /// </summary>
+    public string CanonicalPath { get; }
+
+    public long ByteLength { get; }
+
+    /// <summary>Canonical lowercase hexadecimal SHA-256 digest.</summary>
+    public string Sha256 { get; }
+
+    /// <summary>Provider-owned identity format identifier.</summary>
+    public string IdentityProvider { get; }
+
+    /// <summary>Provider-owned opaque durable filesystem identity.</summary>
+    public string FilesystemIdentity { get; }
+
+    public DateTimeOffset PublishedAtUtc { get; }
+
+    private static bool IsCanonicalSha256(string? value)
+    {
+        if (value is null || value.Length != 64)
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if ((character < '0' || character > '9') &&
+                (character < 'a' || character > 'f'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/DownKyi.Application/Downloads/DownloadOutputArtifactProvenanceApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadOutputArtifactProvenanceApplicationService.cs
@@ -1,0 +1,53 @@
+using DownKyi.Application.Time;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+public sealed class DownloadOutputArtifactProvenanceApplicationService
+    : IDownloadOutputArtifactProvenanceApplicationService
+{
+    private readonly IDownloadOutputArtifactProvenanceStore _store;
+    private readonly IClock _clock;
+
+    public DownloadOutputArtifactProvenanceApplicationService(
+        IDownloadOutputArtifactProvenanceStore store,
+        IClock clock)
+    {
+        ArgumentNullException.ThrowIfNull(store);
+        ArgumentNullException.ThrowIfNull(clock);
+        _store = store;
+        _clock = clock;
+    }
+
+    public Task<OperationResult> RecordPublishedAsync(
+        DownloadTaskId taskId,
+        string artifactKey,
+        string artifactKind,
+        string canonicalPath,
+        OutputArtifactPublicationEvidence publicationEvidence,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(canonicalPath);
+        ArgumentNullException.ThrowIfNull(publicationEvidence);
+        var provenance = new DownloadOutputArtifactProvenance(
+            taskId,
+            artifactKey,
+            artifactKind,
+            Path.GetFullPath(canonicalPath),
+            publicationEvidence,
+            _clock.UtcNow);
+        return _store.RecordPublishedAsync(provenance, cancellationToken);
+    }
+
+    public Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        return _store.GetPublishedAsync(taskId, cancellationToken);
+    }
+}

--- a/src/DownKyi.Application/Downloads/IDownloadOutputArtifactProvenanceApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadOutputArtifactProvenanceApplicationService.cs
@@ -1,0 +1,22 @@
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// Application boundary for recording and loading final-output provenance.
+/// </summary>
+public interface IDownloadOutputArtifactProvenanceApplicationService
+{
+    Task<OperationResult> RecordPublishedAsync(
+        DownloadTaskId taskId,
+        string artifactKey,
+        string artifactKind,
+        string canonicalPath,
+        OutputArtifactPublicationEvidence publicationEvidence,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+}

--- a/src/DownKyi.Application/Downloads/IDownloadOutputArtifactProvenanceStore.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadOutputArtifactProvenanceStore.cs
@@ -1,0 +1,22 @@
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// Durable storage for final-output publication evidence.
+/// </summary>
+/// <remarks>
+/// Implementations must not infer rows from task paths or transfer-file state.
+/// A missing row is intentionally distinct from a failed read.
+/// </remarks>
+public interface IDownloadOutputArtifactProvenanceStore
+{
+    Task<OperationResult> RecordPublishedAsync(
+        DownloadOutputArtifactProvenance provenance,
+        CancellationToken cancellationToken);
+
+    Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken);
+}

--- a/src/DownKyi.Application/Downloads/IOutputArtifactOwnershipProvider.cs
+++ b/src/DownKyi.Application/Downloads/IOutputArtifactOwnershipProvider.cs
@@ -1,0 +1,49 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// Captures opaque filesystem evidence for a temporary output and removes a
+/// published output only when the same filesystem object still matches its
+/// persisted evidence.
+/// </summary>
+/// <remarks>
+/// The <see cref="OutputArtifactPublicationEvidence.FilesystemIdentity"/> value
+/// is provider-owned and opaque. Consumers may persist it, but must not
+/// interpret, synthesize, or compare it themselves.
+/// </remarks>
+public interface IOutputArtifactOwnershipProvider
+{
+    /// <summary>
+    /// Captures evidence from the temporary file before it is atomically
+    /// published to its final path.
+    /// </summary>
+    Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+        string temporaryPath,
+        CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Verifies, without re-hashing, that the object at a final path is still
+    /// the captured object after its atomic publication move. False is
+    /// fail-closed and must not authorize provenance persistence.
+    /// </summary>
+    Task<bool> VerifyPublishedObjectIdentityAsync(
+        string destinationPath,
+        OutputArtifactPublicationEvidence evidence,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+        ArgumentNullException.ThrowIfNull(evidence);
+        return Task.FromResult(false);
+    }
+
+    /// <summary>
+    /// Deletes <paramref name="candidatePath"/> only when it remains the
+    /// filesystem object described by <paramref name="provenance"/>.
+    /// </summary>
+    Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+        string candidatePath,
+        DownloadOutputArtifactProvenance provenance,
+        CancellationToken cancellationToken);
+}

--- a/src/DownKyi.Application/Downloads/IOutputArtifactOwnershipProvider.cs
+++ b/src/DownKyi.Application/Downloads/IOutputArtifactOwnershipProvider.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
 
 namespace DownKyi.Application.Downloads;
 
@@ -13,15 +14,81 @@ namespace DownKyi.Application.Downloads;
 /// is provider-owned and opaque. Consumers may persist it, but must not
 /// interpret, synthesize, or compare it themselves.
 /// </remarks>
+public abstract record OutputArtifactTemporaryClaim;
+
+public enum OutputArtifactTemporaryClaimStatus
+{
+    Claimed,
+    Unsupported,
+    Failed
+}
+
+public sealed record OutputArtifactTemporaryClaimResult(
+    OutputArtifactTemporaryClaimStatus Status,
+    OutputArtifactTemporaryClaim? Claim)
+{
+    public bool Succeeded =>
+        Status == OutputArtifactTemporaryClaimStatus.Claimed && Claim is not null;
+
+    public static OutputArtifactTemporaryClaimResult Claimed(
+        OutputArtifactTemporaryClaim claim)
+    {
+        ArgumentNullException.ThrowIfNull(claim);
+        return new OutputArtifactTemporaryClaimResult(
+            OutputArtifactTemporaryClaimStatus.Claimed,
+            claim);
+    }
+
+    public static OutputArtifactTemporaryClaimResult Unsupported() =>
+        new(OutputArtifactTemporaryClaimStatus.Unsupported, null);
+
+    public static OutputArtifactTemporaryClaimResult Failed() =>
+        new(OutputArtifactTemporaryClaimStatus.Failed, null);
+}
+
 public interface IOutputArtifactOwnershipProvider
 {
     /// <summary>
-    /// Captures evidence from the temporary file before it is atomically
-    /// published to its final path.
+    /// Claims the exact temporary object while its creation handle is still
+    /// open. The returned capability is provider-owned and opaque.
+    /// </summary>
+    OutputArtifactTemporaryClaimResult ClaimTemporaryObject(
+        SafeFileHandle temporaryHandle)
+    {
+        ArgumentNullException.ThrowIfNull(temporaryHandle);
+        return OutputArtifactTemporaryClaimResult.Unsupported();
+    }
+
+    /// <summary>
+    /// Captures final provenance evidence only when the temporary pathname
+    /// still resolves to the previously claimed object.
     /// </summary>
     Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
         string temporaryPath,
-        CancellationToken cancellationToken);
+        OutputArtifactTemporaryClaim temporaryClaim,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(temporaryPath);
+        ArgumentNullException.ThrowIfNull(temporaryClaim);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
+    }
+
+    /// <summary>
+    /// Deletes a temporary pathname only when it still resolves to the
+    /// previously claimed object. Content changes made by the producer are
+    /// deliberately irrelevant to temporary cleanup authority.
+    /// </summary>
+    Task<OutputArtifactSafeDeleteResult> DeleteTemporaryIfOwnedAsync(
+        string temporaryPath,
+        OutputArtifactTemporaryClaim temporaryClaim,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(temporaryPath);
+        ArgumentNullException.ThrowIfNull(temporaryClaim);
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(OutputArtifactSafeDeleteResult.Unsupported());
+    }
 
     /// <summary>
     /// Verifies, without re-hashing, that the object at a final path is still

--- a/src/DownKyi.Application/Downloads/OutputArtifactEvidenceCaptureResult.cs
+++ b/src/DownKyi.Application/Downloads/OutputArtifactEvidenceCaptureResult.cs
@@ -1,0 +1,43 @@
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// The outcome of attempting to capture publication evidence.
+/// </summary>
+public enum OutputArtifactEvidenceCaptureStatus
+{
+    Captured,
+    Missing,
+    Unsupported,
+    Failed
+}
+
+/// <summary>
+/// The evidence-capture result. Only <see cref="OutputArtifactEvidenceCaptureStatus.Captured"/>
+/// with non-null <see cref="Evidence"/> may authorize durable provenance.
+/// </summary>
+public sealed record OutputArtifactEvidenceCaptureResult(
+    OutputArtifactEvidenceCaptureStatus Status,
+    OutputArtifactPublicationEvidence? Evidence)
+{
+    public bool Succeeded =>
+        Status == OutputArtifactEvidenceCaptureStatus.Captured
+        && Evidence is not null;
+
+    public static OutputArtifactEvidenceCaptureResult Captured(
+        OutputArtifactPublicationEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        return new OutputArtifactEvidenceCaptureResult(
+            OutputArtifactEvidenceCaptureStatus.Captured,
+            evidence);
+    }
+
+    public static OutputArtifactEvidenceCaptureResult Missing() =>
+        new(OutputArtifactEvidenceCaptureStatus.Missing, null);
+
+    public static OutputArtifactEvidenceCaptureResult Unsupported() =>
+        new(OutputArtifactEvidenceCaptureStatus.Unsupported, null);
+
+    public static OutputArtifactEvidenceCaptureResult Failed() =>
+        new(OutputArtifactEvidenceCaptureStatus.Failed, null);
+}

--- a/src/DownKyi.Application/Downloads/OutputArtifactPublicationEvidence.cs
+++ b/src/DownKyi.Application/Downloads/OutputArtifactPublicationEvidence.cs
@@ -1,0 +1,12 @@
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// Immutable evidence captured from one opened temporary output file before
+/// publication. The filesystem identity is deliberately opaque outside its
+/// originating provider.
+/// </summary>
+public sealed record OutputArtifactPublicationEvidence(
+    long ByteLength,
+    string Sha256,
+    string IdentityProvider,
+    string FilesystemIdentity);

--- a/src/DownKyi.Application/Downloads/OutputArtifactSafeDeleteResult.cs
+++ b/src/DownKyi.Application/Downloads/OutputArtifactSafeDeleteResult.cs
@@ -1,0 +1,45 @@
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// The fail-closed outcome of an ownership-validated output deletion attempt.
+/// </summary>
+public enum OutputArtifactSafeDeleteStatus
+{
+    Deleted,
+    Missing,
+    Replaced,
+    Modified,
+    Unsupported,
+    Unproven,
+    Failed
+}
+
+/// <summary>
+/// The outcome of an ownership-validated deletion attempt.
+/// </summary>
+public sealed record OutputArtifactSafeDeleteResult(
+    OutputArtifactSafeDeleteStatus Status)
+{
+    public bool Deleted => Status == OutputArtifactSafeDeleteStatus.Deleted;
+
+    public static OutputArtifactSafeDeleteResult DeletedResult() =>
+        new(OutputArtifactSafeDeleteStatus.Deleted);
+
+    public static OutputArtifactSafeDeleteResult Missing() =>
+        new(OutputArtifactSafeDeleteStatus.Missing);
+
+    public static OutputArtifactSafeDeleteResult Replaced() =>
+        new(OutputArtifactSafeDeleteStatus.Replaced);
+
+    public static OutputArtifactSafeDeleteResult Modified() =>
+        new(OutputArtifactSafeDeleteStatus.Modified);
+
+    public static OutputArtifactSafeDeleteResult Unsupported() =>
+        new(OutputArtifactSafeDeleteStatus.Unsupported);
+
+    public static OutputArtifactSafeDeleteResult Unproven() =>
+        new(OutputArtifactSafeDeleteStatus.Unproven);
+
+    public static OutputArtifactSafeDeleteResult Failed() =>
+        new(OutputArtifactSafeDeleteStatus.Failed);
+}

--- a/src/DownKyi.Desktop/Composition/DesktopComposition.cs
+++ b/src/DownKyi.Desktop/Composition/DesktopComposition.cs
@@ -91,8 +91,16 @@ internal static class DesktopComposition
         });
         services.AddSingleton<IWbiKeyProvider, WbiKeyProvider>();
         services.AddSingleton<FfmpegProcessor>();
-        services.AddSingleton<IDownloadTaskStore, SqliteDownloadTaskStore>();
+        services.AddSingleton<SqliteDownloadTaskStore>();
+        services.AddSingleton<IDownloadTaskStore>(provider =>
+            provider.GetRequiredService<SqliteDownloadTaskStore>());
+        services.AddSingleton<IDownloadOutputArtifactProvenanceStore>(provider =>
+            provider.GetRequiredService<SqliteDownloadTaskStore>());
         services.AddSingleton<IDownloadTaskApplicationService, DownloadTaskApplicationService>();
+        services.AddSingleton<IDownloadOutputArtifactProvenanceApplicationService,
+            DownloadOutputArtifactProvenanceApplicationService>();
+        services.AddSingleton<IOutputArtifactOwnershipProvider,
+            WindowsOutputArtifactOwnershipProvider>();
         services.AddSingleton<DownloadTaskProjectionStore>();
         services.AddSingleton<DownloadTaskStateWriter>();
         services.AddSingleton<DownloadTaskQueueGateway>();

--- a/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
+++ b/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using DownKyi.Application.Downloads;
 
 namespace DownKyi.Services.Download;
 
@@ -17,14 +18,30 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
 {
     private const int MaximumTemporaryPathAttempts = 8;
     private readonly Action<string>? _beforePublish;
+    private readonly IOutputArtifactOwnershipProvider? _ownershipProvider;
 
     public AtomicOutputPublisher()
     {
     }
 
+    public AtomicOutputPublisher(IOutputArtifactOwnershipProvider ownershipProvider)
+    {
+        _ownershipProvider = ownershipProvider
+            ?? throw new ArgumentNullException(nameof(ownershipProvider));
+    }
+
     internal AtomicOutputPublisher(Action<string> beforePublish)
     {
         _beforePublish = beforePublish ?? throw new ArgumentNullException(nameof(beforePublish));
+    }
+
+    internal AtomicOutputPublisher(
+        Action<string> beforePublish,
+        IOutputArtifactOwnershipProvider ownershipProvider)
+    {
+        _beforePublish = beforePublish ?? throw new ArgumentNullException(nameof(beforePublish));
+        _ownershipProvider = ownershipProvider
+            ?? throw new ArgumentNullException(nameof(ownershipProvider));
     }
 
     public async Task<AtomicOutputPublishResult> PublishAsync(
@@ -39,6 +56,15 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
         {
             await writeTemporaryAsync(temporaryPath, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
+            OutputArtifactPublicationEvidence? publicationEvidence = null;
+            if (_ownershipProvider != null)
+            {
+                var captured = await _ownershipProvider
+                    .CapturePublicationEvidenceAsync(temporaryPath, cancellationToken)
+                    .ConfigureAwait(false);
+                publicationEvidence = captured.Succeeded ? captured.Evidence : null;
+            }
+
             _beforePublish?.Invoke(destinationPath);
             try
             {
@@ -49,7 +75,19 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
                 return AtomicOutputPublishResult.DestinationCollision(exception);
             }
 
-            return AtomicOutputPublishResult.Published();
+            if (publicationEvidence is not null
+                && !await VerifyPublishedIdentityAsync(
+                        destinationPath,
+                        publicationEvidence)
+                    .ConfigureAwait(false))
+            {
+                // The final name no longer resolves to the object whose hash
+                // was captured before the move. The file remains published,
+                // but it must stay untracked and therefore undeletable.
+                publicationEvidence = null;
+            }
+
+            return AtomicOutputPublishResult.Published(publicationEvidence);
         }
         finally
         {
@@ -87,6 +125,37 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
         throw new IOException("A unique temporary output file could not be created.");
     }
 
+    private async Task<bool> VerifyPublishedIdentityAsync(
+        string destinationPath,
+        OutputArtifactPublicationEvidence publicationEvidence)
+    {
+        if (_ownershipProvider is null)
+        {
+            return false;
+        }
+
+        try
+        {
+            // Publication is irreversible at this point. Do not let a later
+            // cancellation change its success outcome; absent verification is
+            // represented by null evidence and an untracked output.
+            return await _ownershipProvider
+                .VerifyPublishedObjectIdentityAsync(
+                    destinationPath,
+                    publicationEvidence,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidOperationException
+                                         or ArgumentException
+                                         or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
     private static void DeleteTemporaryFile(string path)
     {
         try
@@ -107,10 +176,13 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
 internal sealed record AtomicOutputPublishResult(
     bool Succeeded,
     bool IsDestinationCollision,
-    IOException? Error)
+    IOException? Error,
+    OutputArtifactPublicationEvidence? PublicationEvidence)
 {
-    public static AtomicOutputPublishResult Published() => new(true, false, null);
+    public static AtomicOutputPublishResult Published(
+        OutputArtifactPublicationEvidence? publicationEvidence = null) =>
+        new(true, false, null, publicationEvidence);
 
     public static AtomicOutputPublishResult DestinationCollision(IOException error) =>
-        new(false, true, error);
+        new(false, true, error, null);
 }

--- a/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
+++ b/src/DownKyi.Desktop/Services/Download/AtomicOutputPublisher.cs
@@ -21,6 +21,7 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
     private readonly IOutputArtifactOwnershipProvider? _ownershipProvider;
 
     public AtomicOutputPublisher()
+        : this(new WindowsOutputArtifactOwnershipProvider())
     {
     }
 
@@ -31,8 +32,8 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
     }
 
     internal AtomicOutputPublisher(Action<string> beforePublish)
+        : this(beforePublish, new WindowsOutputArtifactOwnershipProvider())
     {
-        _beforePublish = beforePublish ?? throw new ArgumentNullException(nameof(beforePublish));
     }
 
     internal AtomicOutputPublisher(
@@ -51,16 +52,19 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
         ArgumentNullException.ThrowIfNull(writeTemporaryAsync);
-        var temporaryPath = CreateTemporaryFile(destinationPath);
+        var temporary = CreateTemporaryFile(destinationPath);
         try
         {
-            await writeTemporaryAsync(temporaryPath, cancellationToken).ConfigureAwait(false);
+            await writeTemporaryAsync(temporary.Path, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
             OutputArtifactPublicationEvidence? publicationEvidence = null;
-            if (_ownershipProvider != null)
+            if (_ownershipProvider != null && temporary.Claim is not null)
             {
                 var captured = await _ownershipProvider
-                    .CapturePublicationEvidenceAsync(temporaryPath, cancellationToken)
+                    .CapturePublicationEvidenceAsync(
+                        temporary.Path,
+                        temporary.Claim,
+                        cancellationToken)
                     .ConfigureAwait(false);
                 publicationEvidence = captured.Succeeded ? captured.Evidence : null;
             }
@@ -68,7 +72,8 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
             _beforePublish?.Invoke(destinationPath);
             try
             {
-                File.Move(temporaryPath, destinationPath, overwrite: false);
+                cancellationToken.ThrowIfCancellationRequested();
+                File.Move(temporary.Path, destinationPath, overwrite: false);
             }
             catch (IOException exception) when (File.Exists(destinationPath))
             {
@@ -91,11 +96,11 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
         }
         finally
         {
-            DeleteTemporaryFile(temporaryPath);
+            await DeleteTemporaryIfOwnedAsync(temporary).ConfigureAwait(false);
         }
     }
 
-    private static string CreateTemporaryFile(string destinationPath)
+    private TemporaryOutput CreateTemporaryFile(string destinationPath)
     {
         var fullDestinationPath = Path.GetFullPath(destinationPath);
         var directory = Path.GetDirectoryName(fullDestinationPath)
@@ -112,9 +117,12 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
                 using var stream = new FileStream(
                     temporaryPath,
                     FileMode.CreateNew,
-                    FileAccess.Write,
+                    FileAccess.ReadWrite,
                     FileShare.None);
-                return temporaryPath;
+                var claim = _ownershipProvider?.ClaimTemporaryObject(stream.SafeFileHandle);
+                return new TemporaryOutput(
+                    temporaryPath,
+                    claim is { Succeeded: true } ? claim.Claim : null);
             }
             catch (IOException) when (attempt < MaximumTemporaryPathAttempts - 1)
             {
@@ -123,6 +131,32 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
         }
 
         throw new IOException("A unique temporary output file could not be created.");
+    }
+
+    private async Task DeleteTemporaryIfOwnedAsync(TemporaryOutput temporary)
+    {
+        if (_ownershipProvider is null || temporary.Claim is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _ownershipProvider
+                .DeleteTemporaryIfOwnedAsync(
+                    temporary.Path,
+                    temporary.Claim,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidOperationException
+                                         or ArgumentException
+                                         or NotSupportedException)
+        {
+            return;
+        }
     }
 
     private async Task<bool> VerifyPublishedIdentityAsync(
@@ -156,21 +190,9 @@ internal sealed class AtomicOutputPublisher : IAtomicOutputPublisher
         }
     }
 
-    private static void DeleteTemporaryFile(string path)
-    {
-        try
-        {
-            File.Delete(path);
-        }
-        catch (IOException)
-        {
-            return;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return;
-        }
-    }
+    private sealed record TemporaryOutput(
+        string Path,
+        OutputArtifactTemporaryClaim? Claim);
 }
 
 internal sealed record AtomicOutputPublishResult(

--- a/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Ownership.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Ownership.cs
@@ -7,6 +7,11 @@ internal sealed partial class DownloadArtifactWriter
     internal const string MainCoverTransferKey = "cover";
     internal const string PageCoverTransferKey = "page-cover";
     internal const string DefaultSubtitleTransferKey = "subtitle";
+    internal const string CoverArtifactKind = "cover";
+    internal const string PageCoverArtifactKind = "page-cover";
+    internal const string DanmakuArtifactKind = "danmaku";
+    internal const string SubtitleArtifactKind = "subtitle";
+    internal const string NfoArtifactKind = "nfo";
 
     internal static string GetSubtitleTrackTransferKey(int index)
     {

--- a/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Provenance.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Provenance.cs
@@ -38,4 +38,3 @@ internal sealed partial class DownloadArtifactWriter
             : CoverArtifactKind;
     }
 }
-

--- a/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Provenance.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.Provenance.cs
@@ -1,0 +1,41 @@
+using System.Threading.Tasks;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Services.Download;
+
+internal sealed partial class DownloadArtifactWriter
+{
+    private static OperationResult<DownloadArtifactWriteResult> ArtifactFailure(
+        string code,
+        string message)
+    {
+        return OperationResult.Failure<DownloadArtifactWriteResult>(
+            OperationError.Unexpected(code, message));
+    }
+
+    private Task RecordPublishedArtifactAsync(
+        DownloadTaskId taskId,
+        string artifactKey,
+        string artifactKind,
+        string canonicalPath,
+        AtomicOutputPublishResult publication)
+    {
+        return _provenanceRecorder == null
+            ? Task.CompletedTask
+            : _provenanceRecorder.RecordAfterPublishAsync(
+                taskId,
+                artifactKey,
+                artifactKind,
+                canonicalPath,
+                publication.PublicationEvidence);
+    }
+
+    private static string GetCoverArtifactKind(string transferKey)
+    {
+        return transferKey == PageCoverTransferKey
+            ? PageCoverArtifactKind
+            : CoverArtifactKind;
+    }
+}
+

--- a/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadArtifactWriter.cs
@@ -30,19 +30,22 @@ internal sealed partial class DownloadArtifactWriter
     private readonly ILogger _logger;
     private readonly IBilibiliApiClient _client;
     private readonly IAtomicOutputPublisher _outputPublisher;
+    private readonly DownloadOutputArtifactProvenanceRecorder? _provenanceRecorder;
 
     public DownloadArtifactWriter(
         IWbiKeyProvider wbiKeyProvider,
         DownloadTaskStateWriter stateWriter,
         ILogger logger,
         IBilibiliApiClient client,
-        IAtomicOutputPublisher? outputPublisher = null)
+        IAtomicOutputPublisher? outputPublisher = null,
+        DownloadOutputArtifactProvenanceRecorder? provenanceRecorder = null)
     {
         _wbiKeyProvider = wbiKeyProvider ?? throw new ArgumentNullException(nameof(wbiKeyProvider));
         _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _client = client ?? throw new ArgumentNullException(nameof(client));
         _outputPublisher = outputPublisher ?? new AtomicOutputPublisher();
+        _provenanceRecorder = provenanceRecorder;
     }
 
     public async Task<OperationResult<DownloadArtifactWriteResult>> DownloadCoverAsync(
@@ -90,6 +93,12 @@ internal sealed partial class DownloadArtifactWriter
                     "The requested cover output is missing or invalid.");
             }
 
+            await RecordPublishedArtifactAsync(
+                taskId,
+                transferKey,
+                GetCoverArtifactKind(transferKey),
+                fileName,
+                publish).ConfigureAwait(false);
             return OperationResult.Success(DownloadArtifactWriteResult.Created(fileName));
         }
         catch (OperationCanceledException)
@@ -184,6 +193,12 @@ internal sealed partial class DownloadArtifactWriter
                     "The requested danmaku output is missing or invalid.");
             }
 
+            await RecordPublishedArtifactAsync(
+                taskId,
+                "danmaku",
+                DanmakuArtifactKind,
+                assFile,
+                publish).ConfigureAwait(false);
             return OperationResult.Success(DownloadArtifactWriteResult.Created(assFile));
         }
         catch (OperationCanceledException)
@@ -321,6 +336,12 @@ internal sealed partial class DownloadArtifactWriter
                         "A requested subtitle output is missing or invalid.");
                 }
 
+                await RecordPublishedArtifactAsync(
+                    taskId,
+                    GetSubtitleTrackTransferKey(index),
+                    SubtitleArtifactKind,
+                    srtFile,
+                    publish).ConfigureAwait(false);
                 srtFiles.Add(srtFile);
             }
             catch (IOException e)
@@ -362,6 +383,12 @@ internal sealed partial class DownloadArtifactWriter
                     "The default subtitle output is missing or invalid.");
             }
 
+            await RecordPublishedArtifactAsync(
+                taskId,
+                DefaultSubtitleTransferKey,
+                SubtitleArtifactKind,
+                defaultSubtitleFile,
+                publish).ConfigureAwait(false);
             srtFiles.Add(defaultSubtitleFile);
         }
         catch (IOException e)
@@ -416,6 +443,12 @@ internal sealed partial class DownloadArtifactWriter
                     "The requested metadata output is missing or invalid.");
             }
 
+            await RecordPublishedArtifactAsync(
+                new DownloadTaskId(downloading.DownloadBase.Id),
+                "nfo",
+                NfoArtifactKind,
+                nfoFile,
+                publish).ConfigureAwait(false);
             return OperationResult.Success(DownloadArtifactWriteResult.Created(nfoFile));
         }
         catch (IOException e)
@@ -439,14 +472,6 @@ internal sealed partial class DownloadArtifactWriter
                 "download.artifact.nfo.xml",
                 "The requested metadata file could not be generated.");
         }
-    }
-
-    private static OperationResult<DownloadArtifactWriteResult> ArtifactFailure(
-        string code,
-        string message)
-    {
-        return OperationResult.Failure<DownloadArtifactWriteResult>(
-            OperationError.Unexpected(code, message));
     }
 
     private static XmlWriter CreateNfoWriter(string path)

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputArtifactCleanupResult.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputArtifactCleanupResult.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DownKyi.Services.Download;
+
+/// <summary>
+/// The outcome for one final-output cleanup candidate. A preserved result is
+/// intentionally not a cleanup failure: the caller may remove the task after
+/// recording that DownKyi did not have deletion authority for the file.
+/// </summary>
+internal enum DownloadOutputArtifactCleanupStatus
+{
+    Deleted,
+    Missing,
+    PreservedUnproven,
+    PreservedModified,
+    PreservedReplaced,
+    PreservedUnsupported,
+    Failed
+}
+
+internal sealed record DownloadOutputArtifactCleanupEntry(
+    string? ArtifactKey,
+    string Path,
+    DownloadOutputArtifactCleanupStatus Status);
+
+internal sealed record DownloadOutputArtifactCleanupResult(
+    IReadOnlyList<DownloadOutputArtifactCleanupEntry> Entries)
+{
+    public int DeletedCount => Entries.Count(entry =>
+        entry.Status == DownloadOutputArtifactCleanupStatus.Deleted);
+
+    public int MissingCount => Entries.Count(entry =>
+        entry.Status == DownloadOutputArtifactCleanupStatus.Missing);
+
+    public int PreservedCount => Entries.Count(entry => entry.Status is
+        DownloadOutputArtifactCleanupStatus.PreservedUnproven or
+        DownloadOutputArtifactCleanupStatus.PreservedModified or
+        DownloadOutputArtifactCleanupStatus.PreservedReplaced or
+        DownloadOutputArtifactCleanupStatus.PreservedUnsupported);
+
+    public int FailedCount => Entries.Count(entry =>
+        entry.Status == DownloadOutputArtifactCleanupStatus.Failed);
+
+    public bool Succeeded => FailedCount == 0;
+}

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputArtifactProvenanceRecorder.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputArtifactProvenanceRecorder.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DownKyi.Application.Diagnostics;
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using Microsoft.Extensions.Logging;
+
+namespace DownKyi.Services.Download;
+
+/// <summary>
+/// Persists final-output provenance after a non-overwriting publication has
+/// succeeded. Failure to persist intentionally leaves the output untracked:
+/// cleanup must preserve it rather than attempting rollback deletion.
+/// </summary>
+internal sealed class DownloadOutputArtifactProvenanceRecorder
+{
+    private readonly IDownloadOutputArtifactProvenanceApplicationService _provenance;
+    private readonly ILogger _logger;
+
+    public DownloadOutputArtifactProvenanceRecorder(
+        IDownloadOutputArtifactProvenanceApplicationService provenance,
+        ILogger logger)
+    {
+        _provenance = provenance ?? throw new ArgumentNullException(nameof(provenance));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task RecordAfterPublishAsync(
+        DownloadTaskId taskId,
+        string artifactKey,
+        string artifactKind,
+        string canonicalPath,
+        OutputArtifactPublicationEvidence? evidence)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactKey);
+        ArgumentException.ThrowIfNullOrWhiteSpace(artifactKind);
+        ArgumentException.ThrowIfNullOrWhiteSpace(canonicalPath);
+
+        if (evidence == null)
+        {
+            _logger.LogWarningMessage(
+                "Final output published without ownership evidence; automatic cleanup will preserve it.");
+            return;
+        }
+
+        try
+        {
+            // Publication has already crossed its irreversible filesystem
+            // boundary. Persist independently of cancellation; a failure is
+            // deliberately represented as untracked output, never rollback.
+            var result = await _provenance.RecordPublishedAsync(
+                    taskId,
+                    artifactKey,
+                    artifactKind,
+                    canonicalPath,
+                    evidence,
+                    CancellationToken.None)
+                .ConfigureAwait(false);
+            if (!result.IsSuccess)
+            {
+                _logger.LogWarningMessage(
+                    "Final output provenance could not be persisted; automatic cleanup will preserve it.");
+            }
+        }
+        catch (Exception exception) when (exception is IOException
+                                         or UnauthorizedAccessException
+                                         or InvalidOperationException
+                                         or ArgumentException
+                                         or NotSupportedException
+                                         or Microsoft.Data.Sqlite.SqliteException)
+        {
+            _logger.LogErrorMessage(
+                "Final output provenance persistence failed; automatic cleanup will preserve it.",
+                exception);
+        }
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/DownloadRuntimeFactory.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadRuntimeFactory.cs
@@ -26,6 +26,8 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
     private readonly DownloadTaskProjectionStore _projectionStore;
     private readonly DownloadTaskStateWriter _stateWriter;
     private readonly IDownloadTaskApplicationService _tasks;
+    private readonly IDownloadOutputArtifactProvenanceApplicationService _outputProvenance;
+    private readonly IOutputArtifactOwnershipProvider _artifactOwnershipProvider;
     private readonly IUserNotificationService _notificationService;
     private readonly DownloadDiagnosticLogger _diagnosticLogger;
     private readonly FfmpegProcessor _ffmpegProcessor;
@@ -41,6 +43,8 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
         DownloadTaskProjectionStore projectionStore,
         DownloadTaskStateWriter stateWriter,
         IDownloadTaskApplicationService tasks,
+        IDownloadOutputArtifactProvenanceApplicationService outputProvenance,
+        IOutputArtifactOwnershipProvider artifactOwnershipProvider,
         IUserNotificationService notificationService,
         IUiDispatcher uiDispatcher,
         ISettingsStore settingsStore,
@@ -58,6 +62,10 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
             ?? throw new ArgumentNullException(nameof(projectionStore));
         _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
+        _outputProvenance = outputProvenance
+            ?? throw new ArgumentNullException(nameof(outputProvenance));
+        _artifactOwnershipProvider = artifactOwnershipProvider
+            ?? throw new ArgumentNullException(nameof(artifactOwnershipProvider));
         _notificationService = notificationService ?? throw new ArgumentNullException(nameof(notificationService));
         _uiDispatcher = uiDispatcher ?? throw new ArgumentNullException(nameof(uiDispatcher));
         _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
@@ -106,7 +114,11 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
             _wbiKeyProvider,
             _stateWriter,
             _loggerFactory.CreateLogger<DownloadArtifactWriter>(),
-            _client);
+            _client,
+            new AtomicOutputPublisher(_artifactOwnershipProvider),
+            new DownloadOutputArtifactProvenanceRecorder(
+                _outputProvenance,
+                _loggerFactory.CreateLogger<DownloadOutputArtifactProvenanceRecorder>()));
         var shutdownRecovery = new DownloadTaskShutdownRecovery(
             _tasks,
             _stateWriter);
@@ -144,7 +156,11 @@ internal sealed class DownloadRuntimeFactory : IDownloadRuntimeFactory
                 presenter,
                 _ffmpegProcessor,
                 _stateWriter,
-                _loggerFactory.CreateLogger<MuxStage>()),
+                _loggerFactory.CreateLogger<MuxStage>(),
+                _artifactOwnershipProvider,
+                new DownloadOutputArtifactProvenanceRecorder(
+                    _outputProvenance,
+                    _loggerFactory.CreateLogger<DownloadOutputArtifactProvenanceRecorder>())),
             new ValidateStage(),
             new FinalizeStage(
                 _projectionStore,

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskFileService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskFileService.cs
@@ -6,6 +6,8 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Application.Diagnostics;
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
 using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
 
@@ -19,14 +21,20 @@ internal sealed class DownloadTaskFileService
     private static readonly string[] TempExtensions = { "", ".aria2", ".download" };
     private readonly AriaRuntimeClientRegistry _ariaClientRegistry;
     private readonly ILogger<DownloadTaskFileService> _logger;
+    private readonly IDownloadOutputArtifactProvenanceApplicationService? _outputProvenance;
+    private readonly IOutputArtifactOwnershipProvider? _artifactOwnershipProvider;
 
     public DownloadTaskFileService(
         AriaRuntimeClientRegistry ariaClientRegistry,
-        ILogger<DownloadTaskFileService> logger)
+        ILogger<DownloadTaskFileService> logger,
+        IDownloadOutputArtifactProvenanceApplicationService? outputProvenance = null,
+        IOutputArtifactOwnershipProvider? artifactOwnershipProvider = null)
     {
         _ariaClientRegistry = ariaClientRegistry
             ?? throw new ArgumentNullException(nameof(ariaClientRegistry));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _outputProvenance = outputProvenance;
+        _artifactOwnershipProvider = artifactOwnershipProvider;
     }
 
     public async Task CancelActiveDownloadAsync(DownloadingItem downloading)
@@ -74,12 +82,87 @@ internal sealed class DownloadTaskFileService
         }
     }
 
-    public Task<DownloadFileDeletionResult> DeleteGeneratedFilesAsync(
+    public async Task<DownloadOutputArtifactCleanupResult> DeleteGeneratedFilesAsync(
         DownloadingItem downloading,
         CancellationToken cancellationToken = default)
     {
-        var files = GetGeneratedFiles(downloading);
-        return DeleteFilesAsync(files, cancellationToken);
+        ArgumentNullException.ThrowIfNull(downloading);
+        cancellationToken.ThrowIfCancellationRequested();
+        var discovered = GetGeneratedFiles(downloading);
+        var taskId = new DownloadTaskId(downloading.DownloadBase.Id);
+        if (_outputProvenance == null || _artifactOwnershipProvider == null)
+        {
+            return CreateUnprovenDiscoveryResult(discovered);
+        }
+
+        var loaded = await _outputProvenance
+            .GetPublishedAsync(taskId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!loaded.TryGetValue(out var provenance))
+        {
+            _logger.LogWarningMessage(
+                "Final output provenance could not be loaded; automatic cleanup will preserve discovered files.");
+            return CreateFailedDiscoveryResult(discovered);
+        }
+
+        var entries = new List<DownloadOutputArtifactCleanupEntry>();
+        var provenPaths = OperatingSystem.IsWindows()
+            ? new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(StringComparer.Ordinal);
+        foreach (var artifact in provenance)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            provenPaths.Add(artifact.CanonicalPath);
+            OutputArtifactSafeDeleteResult deletion;
+            try
+            {
+                deletion = await _artifactOwnershipProvider
+                    .DeleteIfOwnedAsync(
+                        artifact.CanonicalPath,
+                        artifact,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (IOException exception)
+            {
+                _logger.LogErrorMessage("Final output ownership deletion failed.", exception);
+                deletion = OutputArtifactSafeDeleteResult.Failed();
+            }
+            catch (UnauthorizedAccessException exception)
+            {
+                _logger.LogErrorMessage("Final output ownership deletion was denied.", exception);
+                deletion = OutputArtifactSafeDeleteResult.Failed();
+            }
+
+            var status = MapSafeDeleteStatus(deletion.Status);
+            entries.Add(new DownloadOutputArtifactCleanupEntry(
+                artifact.ArtifactKey,
+                artifact.CanonicalPath,
+                status));
+            if (status is not DownloadOutputArtifactCleanupStatus.Deleted and
+                not DownloadOutputArtifactCleanupStatus.Missing)
+            {
+                _logger.LogWarningMessage(
+                    $"Final output cleanup preserved an artifact. key={artifact.ArtifactKey}; outcome={status}.");
+            }
+        }
+
+        foreach (var candidate in discovered)
+        {
+            if (provenPaths.Contains(candidate) || !File.Exists(candidate))
+            {
+                continue;
+            }
+
+            entries.Add(new DownloadOutputArtifactCleanupEntry(
+                ArtifactKey: null,
+                candidate,
+                DownloadOutputArtifactCleanupStatus.PreservedUnproven));
+            _logger.LogWarningMessage(
+                "Final-output cleanup preserved a discovered file without provenance.");
+        }
+
+        return new DownloadOutputArtifactCleanupResult(entries);
     }
 
     internal Task<DownloadFileDeletionResult> DeleteFilesAsync(
@@ -273,6 +356,52 @@ internal sealed class DownloadTaskFileService
         }
 
         return false;
+    }
+
+    private static DownloadOutputArtifactCleanupResult CreateUnprovenDiscoveryResult(
+        IEnumerable<string> discovered)
+    {
+        return new DownloadOutputArtifactCleanupResult(
+            discovered
+                .Where(File.Exists)
+                .Select(path => new DownloadOutputArtifactCleanupEntry(
+                    ArtifactKey: null,
+                    path,
+                    DownloadOutputArtifactCleanupStatus.PreservedUnproven))
+                .ToArray());
+    }
+
+    private static DownloadOutputArtifactCleanupResult CreateFailedDiscoveryResult(
+        IEnumerable<string> discovered)
+    {
+        var entries = discovered
+            .Where(File.Exists)
+            .Select(path => new DownloadOutputArtifactCleanupEntry(
+                ArtifactKey: null,
+                path,
+                DownloadOutputArtifactCleanupStatus.PreservedUnproven))
+            .ToList();
+        entries.Add(new DownloadOutputArtifactCleanupEntry(
+            ArtifactKey: null,
+            Path: string.Empty,
+            DownloadOutputArtifactCleanupStatus.Failed));
+        return new DownloadOutputArtifactCleanupResult(entries);
+    }
+
+    private static DownloadOutputArtifactCleanupStatus MapSafeDeleteStatus(
+        OutputArtifactSafeDeleteStatus status)
+    {
+        return status switch
+        {
+            OutputArtifactSafeDeleteStatus.Deleted => DownloadOutputArtifactCleanupStatus.Deleted,
+            OutputArtifactSafeDeleteStatus.Missing => DownloadOutputArtifactCleanupStatus.Missing,
+            OutputArtifactSafeDeleteStatus.Replaced => DownloadOutputArtifactCleanupStatus.PreservedReplaced,
+            OutputArtifactSafeDeleteStatus.Modified => DownloadOutputArtifactCleanupStatus.PreservedModified,
+            OutputArtifactSafeDeleteStatus.Unsupported => DownloadOutputArtifactCleanupStatus.PreservedUnsupported,
+            OutputArtifactSafeDeleteStatus.Unproven => DownloadOutputArtifactCleanupStatus.PreservedUnproven,
+            OutputArtifactSafeDeleteStatus.Failed => DownloadOutputArtifactCleanupStatus.Failed,
+            _ => DownloadOutputArtifactCleanupStatus.Failed
+        };
     }
 }
 

--- a/src/DownKyi.Desktop/Services/Download/MuxStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/MuxStage.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using DownKyi.Application.Downloads;
 using DownKyi.Core.FFmpeg;
 using DownKyi.Core.Settings;
 using DownKyi.Domain.Results;
@@ -16,17 +17,23 @@ internal sealed class MuxStage : IDownloadPipelineStage
     private readonly IFfmpegMediaMuxer _ffmpegProcessor;
     private readonly DownloadTaskStateWriter _stateWriter;
     private readonly ILogger<MuxStage> _logger;
+    private readonly IOutputArtifactOwnershipProvider? _artifactOwnershipProvider;
+    private readonly DownloadOutputArtifactProvenanceRecorder? _provenanceRecorder;
 
     public MuxStage(
         DownloadActivityPresenter presenter,
         IFfmpegMediaMuxer ffmpegProcessor,
         DownloadTaskStateWriter stateWriter,
-        ILogger<MuxStage> logger)
+        ILogger<MuxStage> logger,
+        IOutputArtifactOwnershipProvider? artifactOwnershipProvider = null,
+        DownloadOutputArtifactProvenanceRecorder? provenanceRecorder = null)
     {
         _presenter = presenter ?? throw new ArgumentNullException(nameof(presenter));
         _ffmpegProcessor = ffmpegProcessor ?? throw new ArgumentNullException(nameof(ffmpegProcessor));
         _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _artifactOwnershipProvider = artifactOwnershipProvider;
+        _provenanceRecorder = provenanceRecorder;
     }
 
     public string Name => nameof(MuxStage);
@@ -64,13 +71,22 @@ internal sealed class MuxStage : IDownloadPipelineStage
         await _presenter.ShowMuxingAsync(context, cancellationToken).ConfigureAwait(true);
         var downloading = context.Downloading;
         var finalFile = GetDashOutputPath(context);
-        var result = await _ffmpegProcessor.MergeMediaAsync(
+        var result = await _ffmpegProcessor.MergeMediaWithEvidenceAsync(
             context.Settings.Video,
             context.AudioFile,
             context.VideoFile,
             finalFile,
             overwriteDestination: false,
-            cancellationToken).ConfigureAwait(true);
+            outputArtifactOwnershipProvider: _artifactOwnershipProvider,
+            cancellationToken: cancellationToken).ConfigureAwait(true);
+        if (result.Succeeded)
+        {
+            await RecordPublishedMediaAsync(
+                context,
+                artifactKind: "dash-media",
+                finalFile,
+                result).ConfigureAwait(true);
+        }
         var invalidation = result.Succeeded
             ? SourceInvalidationOutcome.None
             : await InvalidateSourcesAsync(
@@ -106,13 +122,22 @@ internal sealed class MuxStage : IDownloadPipelineStage
         {
             await _presenter.ShowMuxingAsync(context, cancellationToken).ConfigureAwait(true);
             var finalFile = $"{context.Downloading.DownloadBase.FilePath}.mp4";
-            var mergeResult = await _ffmpegProcessor.MergeMediaAsync(
+            var mergeResult = await _ffmpegProcessor.MergeMediaWithEvidenceAsync(
                 context.Settings.Video,
                 audio: null,
                 video: context.DurlDownloads[0].FilePath,
                 destination: finalFile,
                 overwriteDestination: false,
-                cancellationToken).ConfigureAwait(true);
+                outputArtifactOwnershipProvider: _artifactOwnershipProvider,
+                cancellationToken: cancellationToken).ConfigureAwait(true);
+            if (mergeResult.Succeeded)
+            {
+                await RecordPublishedMediaAsync(
+                    context,
+                    artifactKind: "durl-media",
+                    finalFile,
+                    mergeResult).ConfigureAwait(true);
+            }
             var singleInvalidation = mergeResult.Succeeded
                 ? SourceInvalidationOutcome.None
                 : await InvalidateSourcesAsync(
@@ -142,12 +167,21 @@ internal sealed class MuxStage : IDownloadPipelineStage
                 download.FilePath,
                 TimeSpan.FromMilliseconds(download.Durl.Length)))
             .ToArray();
-        var result = await _ffmpegProcessor.ConcatDurlVideosAsync(
+        var result = await _ffmpegProcessor.ConcatDurlVideosWithEvidenceAsync(
             context.Settings.Video,
             segments,
             outputPath,
             overwriteDestination: false,
+            outputArtifactOwnershipProvider: _artifactOwnershipProvider,
             cancellationToken: cancellationToken).ConfigureAwait(true);
+        if (result.Succeeded)
+        {
+            await RecordPublishedMediaAsync(
+                context,
+                artifactKind: "durl-media",
+                outputPath,
+                result).ConfigureAwait(true);
+        }
         var invalidation = result.Succeeded
             ? SourceInvalidationOutcome.None
             : await InvalidateSourcesAsync(
@@ -232,6 +266,22 @@ internal sealed class MuxStage : IDownloadPipelineStage
         return cleanupFailed
             ? SourceInvalidationOutcome.CleanupFailed
             : SourceInvalidationOutcome.Invalidated;
+    }
+
+    private Task RecordPublishedMediaAsync(
+        DownloadExecutionContext context,
+        string artifactKind,
+        string finalFile,
+        FfmpegOperationResult result)
+    {
+        return _provenanceRecorder == null
+            ? Task.CompletedTask
+            : _provenanceRecorder.RecordAfterPublishAsync(
+                context.TaskId,
+                artifactKey: "media",
+                artifactKind,
+                finalFile,
+                result.PublicationEvidence);
     }
 
     private static string GetFailureCode(

--- a/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.Interop.cs
+++ b/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.Interop.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace DownKyi.Services.Download;
+
+internal sealed partial class WindowsOutputArtifactNativeFileSystem
+{
+    private enum OutputArtifactNativeOpenStatus
+    {
+        Opened,
+        Missing,
+        Unsupported,
+        Failed
+    }
+
+    private enum FileInformationByHandleClass
+    {
+        FileBasicInformation = 0,
+        FileDispositionInformation = 4,
+        FileIdInformation = 18
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileDispositionInformation
+    {
+        public byte DeleteFile;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileBasicInformation
+    {
+        public long CreationTime;
+        public long LastAccessTime;
+        public long LastWriteTime;
+        public long ChangeTime;
+        public uint FileAttributes;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileIdInformation
+    {
+        public ulong VolumeSerialNumber;
+        public ulong FileIdLow;
+        public ulong FileIdHigh;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct FileLockOverlapped
+    {
+        public IntPtr Internal;
+        public IntPtr InternalHigh;
+        public uint Offset;
+        public uint OffsetHigh;
+        public IntPtr EventHandle;
+    }
+
+    private static class WindowsOutputArtifactNativeMethods
+    {
+        [DllImport(
+            "kernel32.dll",
+            EntryPoint = "CreateFileW",
+            SetLastError = true,
+            CharSet = CharSet.Unicode)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        internal static extern SafeFileHandle CreateFile(
+            string fileName,
+            uint desiredAccess,
+            uint shareMode,
+            IntPtr securityAttributes,
+            int creationDisposition,
+            uint flagsAndAttributes,
+            IntPtr templateFile);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetFileInformationByHandleEx(
+            SafeFileHandle file,
+            FileInformationByHandleClass fileInformationClass,
+            out FileIdInformation fileInformation,
+            uint bufferSize);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetFileInformationByHandleEx(
+            SafeFileHandle file,
+            FileInformationByHandleClass fileInformationClass,
+            out FileBasicInformation fileInformation,
+            uint bufferSize);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool SetFileInformationByHandle(
+            SafeFileHandle file,
+            FileInformationByHandleClass fileInformationClass,
+            in FileDispositionInformation fileInformation,
+            uint bufferSize);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool GetFileSizeEx(
+            SafeFileHandle file,
+            out long fileSize);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool LockFileEx(
+            SafeFileHandle file,
+            uint flags,
+            uint reserved,
+            uint numberOfBytesToLockLow,
+            uint numberOfBytesToLockHigh,
+            ref FileLockOverlapped overlapped);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        internal static extern bool UnlockFileEx(
+            SafeFileHandle file,
+            uint reserved,
+            uint numberOfBytesToUnlockLow,
+            uint numberOfBytesToUnlockHigh,
+            ref FileLockOverlapped overlapped);
+    }
+}
+
+

--- a/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.Interop.cs
+++ b/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.Interop.cs
@@ -128,5 +128,3 @@ internal sealed partial class WindowsOutputArtifactNativeFileSystem
             ref FileLockOverlapped overlapped);
     }
 }
-
-

--- a/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.TemporaryOwnership.cs
+++ b/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.TemporaryOwnership.cs
@@ -1,0 +1,131 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+
+namespace DownKyi.Services.Download;
+
+internal sealed partial class WindowsOutputArtifactNativeFileSystem
+{
+    private readonly Action<SafeFileHandle>? _beforeDelete;
+    private readonly uint _shareMode;
+
+    internal WindowsOutputArtifactNativeFileSystem()
+    {
+    }
+
+    internal WindowsOutputArtifactNativeFileSystem(Action<SafeFileHandle> beforeDelete)
+    {
+        _beforeDelete = beforeDelete ?? throw new ArgumentNullException(nameof(beforeDelete));
+        _shareMode = FileShareRead | FileShareWrite | FileShareDelete;
+    }
+
+    public OutputArtifactNativeIdentityCaptureResult CaptureIdentity(
+        SafeFileHandle handle)
+    {
+        ArgumentNullException.ThrowIfNull(handle);
+        if (!OperatingSystem.IsWindows())
+        {
+            return OutputArtifactNativeIdentityCaptureResult.Unsupported();
+        }
+
+        if (handle.IsClosed || handle.IsInvalid)
+        {
+            return OutputArtifactNativeIdentityCaptureResult.Failed();
+        }
+
+        try
+        {
+            return OutputArtifactNativeIdentityCaptureResult.Captured(GetFileId(handle));
+        }
+        catch (IOException)
+        {
+            return OutputArtifactNativeIdentityCaptureResult.Failed();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return OutputArtifactNativeIdentityCaptureResult.Failed();
+        }
+        catch (NotSupportedException)
+        {
+            return OutputArtifactNativeIdentityCaptureResult.Failed();
+        }
+    }
+
+    public Task<OutputArtifactNativeSafeDeleteResult> DeleteIfIdentityMatchesAsync(
+        string path,
+        string expectedFilesystemIdentity,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentException.ThrowIfNullOrWhiteSpace(expectedFilesystemIdentity);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!OperatingSystem.IsWindows())
+        {
+            return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Unsupported());
+        }
+
+        SafeFileHandle? handle = null;
+        try
+        {
+            var status = TryOpen(path, includeDeleteAccess: true, out handle);
+            if (status == OutputArtifactNativeOpenStatus.Missing)
+            {
+                return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Missing());
+            }
+
+            if (status == OutputArtifactNativeOpenStatus.Unsupported)
+            {
+                return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Unsupported());
+            }
+
+            if (status != OutputArtifactNativeOpenStatus.Opened || handle is null)
+            {
+                return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Failed());
+            }
+
+            if (!TryAcquireExclusiveWholeFileLock(handle, out var lockState))
+            {
+                return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Failed());
+            }
+
+            try
+            {
+                if (!string.Equals(
+                        GetFileId(handle),
+                        expectedFilesystemIdentity,
+                        StringComparison.Ordinal))
+                {
+                    return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Replaced());
+                }
+
+                _beforeDelete?.Invoke(handle);
+                return Task.FromResult(
+                    MarkOpenedFileForDeletion(handle)
+                        ? OutputArtifactNativeSafeDeleteResult.Deleted()
+                        : OutputArtifactNativeSafeDeleteResult.Failed());
+            }
+            catch (IOException)
+            {
+                return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Failed());
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Failed());
+            }
+            catch (NotSupportedException)
+            {
+                return Task.FromResult(OutputArtifactNativeSafeDeleteResult.Failed());
+            }
+            finally
+            {
+                ReleaseWholeFileLock(handle, ref lockState);
+            }
+        }
+        finally
+        {
+            handle?.Dispose();
+        }
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.cs
+++ b/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.cs
@@ -1,0 +1,448 @@
+using System;
+using System.Buffers;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32.SafeHandles;
+
+namespace DownKyi.Services.Download;
+
+internal sealed partial class WindowsOutputArtifactNativeFileSystem
+    : IOutputArtifactNativeFileSystem
+{
+    private const uint GenericRead = 0x80000000;
+    private const uint Delete = 0x00010000;
+    private const uint FileAttributeNormal = 0x00000080;
+    private const uint FileAttributeReparsePoint = 0x00000400;
+    private const uint FileFlagOverlapped = 0x40000000;
+    private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint LockFileFailImmediately = 0x00000001;
+    private const uint LockFileExclusiveLock = 0x00000002;
+    private const int ErrorFileNotFound = 2;
+    private const int ErrorPathNotFound = 3;
+    private const int OpenExisting = 3;
+
+    public bool IsSupported => OperatingSystem.IsWindows();
+
+    public async Task<OutputArtifactNativeCaptureResult> CaptureEvidenceAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return OutputArtifactNativeCaptureResult.Unsupported();
+        }
+
+        SafeFileHandle? handle = null;
+        try
+        {
+            var status = TryOpen(path, includeDeleteAccess: false, out handle);
+            if (status == OutputArtifactNativeOpenStatus.Missing)
+            {
+                return OutputArtifactNativeCaptureResult.Missing();
+            }
+
+            if (status == OutputArtifactNativeOpenStatus.Unsupported)
+            {
+                return OutputArtifactNativeCaptureResult.Unsupported();
+            }
+
+            if (status != OutputArtifactNativeOpenStatus.Opened || handle is null)
+            {
+                return OutputArtifactNativeCaptureResult.Failed();
+            }
+
+            if (!TryAcquireExclusiveWholeFileLock(handle, out var lockState))
+            {
+                return OutputArtifactNativeCaptureResult.Failed();
+            }
+
+            try
+            {
+                var evidence = await ReadEvidenceAsync(handle, cancellationToken)
+                    .ConfigureAwait(false);
+                return OutputArtifactNativeCaptureResult.Captured(evidence);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (IOException)
+            {
+                return OutputArtifactNativeCaptureResult.Failed();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return OutputArtifactNativeCaptureResult.Failed();
+            }
+            catch (CryptographicException)
+            {
+                return OutputArtifactNativeCaptureResult.Failed();
+            }
+            catch (NotSupportedException)
+            {
+                return OutputArtifactNativeCaptureResult.Failed();
+            }
+            finally
+            {
+                ReleaseWholeFileLock(handle, ref lockState);
+            }
+        }
+        finally
+        {
+            handle?.Dispose();
+        }
+    }
+
+    public async Task<OutputArtifactNativeSafeDeleteResult> DeleteIfEvidenceMatchesAsync(
+        string path,
+        OutputArtifactNativeEvidence expectedEvidence,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(expectedEvidence);
+        if (!OperatingSystem.IsWindows())
+        {
+            return OutputArtifactNativeSafeDeleteResult.Unsupported();
+        }
+
+        SafeFileHandle? handle = null;
+        try
+        {
+            var status = TryOpen(path, includeDeleteAccess: true, out handle);
+            if (status == OutputArtifactNativeOpenStatus.Missing)
+            {
+                return OutputArtifactNativeSafeDeleteResult.Missing();
+            }
+
+            if (status == OutputArtifactNativeOpenStatus.Unsupported)
+            {
+                return OutputArtifactNativeSafeDeleteResult.Unsupported();
+            }
+
+            if (status != OutputArtifactNativeOpenStatus.Opened || handle is null)
+            {
+                return OutputArtifactNativeSafeDeleteResult.Failed();
+            }
+
+            if (!TryAcquireExclusiveWholeFileLock(handle, out var lockState))
+            {
+                return OutputArtifactNativeSafeDeleteResult.Failed();
+            }
+
+            try
+            {
+                var actualEvidence = await ReadEvidenceAsync(handle, cancellationToken)
+                    .ConfigureAwait(false);
+                if (!string.Equals(
+                        actualEvidence.FilesystemIdentity,
+                        expectedEvidence.FilesystemIdentity,
+                        StringComparison.Ordinal))
+                {
+                    return OutputArtifactNativeSafeDeleteResult.Replaced();
+                }
+
+                if (actualEvidence.ByteLength != expectedEvidence.ByteLength
+                    || !string.Equals(
+                        actualEvidence.Sha256,
+                        expectedEvidence.Sha256,
+                        StringComparison.Ordinal))
+                {
+                    return OutputArtifactNativeSafeDeleteResult.Modified();
+                }
+
+                return MarkOpenedFileForDeletion(handle)
+                    ? OutputArtifactNativeSafeDeleteResult.Deleted()
+                    : OutputArtifactNativeSafeDeleteResult.Failed();
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (IOException)
+            {
+                return OutputArtifactNativeSafeDeleteResult.Failed();
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return OutputArtifactNativeSafeDeleteResult.Failed();
+            }
+            catch (CryptographicException)
+            {
+                return OutputArtifactNativeSafeDeleteResult.Failed();
+            }
+            catch (NotSupportedException)
+            {
+                return OutputArtifactNativeSafeDeleteResult.Failed();
+            }
+            finally
+            {
+                ReleaseWholeFileLock(handle, ref lockState);
+            }
+        }
+        finally
+        {
+            handle?.Dispose();
+        }
+    }
+
+    public async Task<bool> VerifyIdentityAndLengthAsync(
+        string path,
+        OutputArtifactNativeEvidence expectedEvidence,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(expectedEvidence);
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        SafeFileHandle? handle = null;
+        try
+        {
+            var status = TryOpen(path, includeDeleteAccess: false, out handle);
+            if (status != OutputArtifactNativeOpenStatus.Opened || handle is null)
+            {
+                return false;
+            }
+
+            if (!TryAcquireExclusiveWholeFileLock(handle, out var lockState))
+            {
+                return false;
+            }
+
+            try
+            {
+                var filesystemIdentity = GetFileId(handle);
+                return string.Equals(
+                           filesystemIdentity,
+                           expectedEvidence.FilesystemIdentity,
+                           StringComparison.Ordinal)
+                       && GetFileLength(handle) == expectedEvidence.ByteLength;
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (IOException)
+            {
+                return false;
+            }
+            catch (UnauthorizedAccessException)
+            {
+                return false;
+            }
+            catch (NotSupportedException)
+            {
+                return false;
+            }
+            finally
+            {
+                ReleaseWholeFileLock(handle, ref lockState);
+            }
+        }
+        finally
+        {
+            handle?.Dispose();
+        }
+    }
+
+    private static async Task<OutputArtifactNativeEvidence> ReadEvidenceAsync(
+        SafeFileHandle handle,
+        CancellationToken cancellationToken)
+    {
+        var filesystemIdentity = GetFileId(handle);
+        var lengthBefore = GetFileLength(handle);
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = ArrayPool<byte>.Shared.Rent(81920);
+        try
+        {
+            long offset = 0;
+            while (true)
+            {
+                var bytesRead = await RandomAccess
+                    .ReadAsync(handle, buffer, offset, cancellationToken)
+                    .ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                hasher.AppendData(buffer, 0, bytesRead);
+                offset = checked(offset + bytesRead);
+            }
+
+            var lengthAfter = GetFileLength(handle);
+            if (lengthBefore != lengthAfter || offset != lengthAfter)
+            {
+                throw new IOException("The output changed while ownership evidence was read.");
+            }
+
+            return new OutputArtifactNativeEvidence(
+                lengthAfter,
+                Convert.ToHexStringLower(hasher.GetHashAndReset()),
+                filesystemIdentity);
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
+        }
+    }
+
+    private static OutputArtifactNativeOpenStatus TryOpen(
+        string path,
+        bool includeDeleteAccess,
+        out SafeFileHandle? handle)
+    {
+        handle = null;
+        try
+        {
+            var openedHandle = WindowsOutputArtifactNativeMethods.CreateFile(
+                path,
+                includeDeleteAccess ? GenericRead | Delete : GenericRead,
+                shareMode: 0,
+                IntPtr.Zero,
+                OpenExisting,
+                FileAttributeNormal | FileFlagOverlapped | FileFlagOpenReparsePoint,
+                IntPtr.Zero);
+            if (!openedHandle.IsInvalid)
+            {
+                handle = openedHandle;
+                return OutputArtifactNativeOpenStatus.Opened;
+            }
+
+            var error = Marshal.GetLastPInvokeError();
+            openedHandle.Dispose();
+            return error is ErrorFileNotFound or ErrorPathNotFound
+                ? OutputArtifactNativeOpenStatus.Missing
+                : OutputArtifactNativeOpenStatus.Failed;
+        }
+        catch (DllNotFoundException)
+        {
+            return OutputArtifactNativeOpenStatus.Unsupported;
+        }
+        catch (EntryPointNotFoundException)
+        {
+            return OutputArtifactNativeOpenStatus.Unsupported;
+        }
+        catch (IOException)
+        {
+            return OutputArtifactNativeOpenStatus.Failed;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return OutputArtifactNativeOpenStatus.Failed;
+        }
+        catch (ArgumentException)
+        {
+            return OutputArtifactNativeOpenStatus.Failed;
+        }
+        catch (NotSupportedException)
+        {
+            return OutputArtifactNativeOpenStatus.Failed;
+        }
+    }
+
+    private static bool MarkOpenedFileForDeletion(SafeFileHandle handle)
+    {
+        var disposition = new FileDispositionInformation
+        {
+            // FILE_DISPOSITION_INFO.DeleteFile is the one-byte Win32 BOOLEAN.
+            DeleteFile = 1
+        };
+        return WindowsOutputArtifactNativeMethods.SetFileInformationByHandle(
+            handle,
+            FileInformationByHandleClass.FileDispositionInformation,
+            in disposition,
+            (uint)Marshal.SizeOf<FileDispositionInformation>());
+    }
+
+    private static long GetFileLength(SafeFileHandle handle)
+    {
+        if (!WindowsOutputArtifactNativeMethods.GetFileSizeEx(handle, out var length))
+        {
+            throw new IOException("The output length could not be read.");
+        }
+
+        return length;
+    }
+
+    private static bool TryAcquireExclusiveWholeFileLock(
+        SafeFileHandle handle,
+        out FileLockOverlapped lockState)
+    {
+        lockState = default;
+        return WindowsOutputArtifactNativeMethods.LockFileEx(
+            handle,
+            LockFileFailImmediately | LockFileExclusiveLock,
+            reserved: 0,
+            uint.MaxValue,
+            uint.MaxValue,
+            ref lockState);
+    }
+
+    private static void ReleaseWholeFileLock(
+        SafeFileHandle handle,
+        ref FileLockOverlapped lockState)
+    {
+        _ = WindowsOutputArtifactNativeMethods.UnlockFileEx(
+            handle,
+            reserved: 0,
+            uint.MaxValue,
+            uint.MaxValue,
+            ref lockState);
+    }
+
+    private static string GetFileId(SafeFileHandle handle)
+    {
+        FileIdInformation information;
+        if (!WindowsOutputArtifactNativeMethods.GetFileInformationByHandleEx(
+                handle,
+                FileInformationByHandleClass.FileIdInformation,
+                out information,
+                (uint)Marshal.SizeOf<FileIdInformation>()))
+        {
+            throw new IOException("The output filesystem identity could not be read.");
+        }
+
+        FileBasicInformation basicInformation;
+        if (!WindowsOutputArtifactNativeMethods.GetFileInformationByHandleEx(
+                handle,
+                FileInformationByHandleClass.FileBasicInformation,
+                out basicInformation,
+                (uint)Marshal.SizeOf<FileBasicInformation>()))
+        {
+            throw new IOException("The output filesystem attributes could not be read.");
+        }
+
+        if ((basicInformation.FileAttributes & FileAttributeReparsePoint) != 0)
+        {
+            throw new IOException("Reparse points are not eligible for output ownership evidence.");
+        }
+
+        return string.Create(
+            49,
+            information,
+            static (destination, source) =>
+            {
+                source.VolumeSerialNumber.TryFormat(
+                    destination[..16],
+                    out _,
+                    "x16",
+                    CultureInfo.InvariantCulture);
+                destination[16] = ':';
+                source.FileIdHigh.TryFormat(
+                    destination.Slice(17, 16),
+                    out _,
+                    "x16",
+                    CultureInfo.InvariantCulture);
+                source.FileIdLow.TryFormat(
+                    destination.Slice(33, 16),
+                    out _,
+                    "x16",
+                    CultureInfo.InvariantCulture);
+            });
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.cs
+++ b/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactNativeFileSystem.cs
@@ -19,6 +19,9 @@ internal sealed partial class WindowsOutputArtifactNativeFileSystem
     private const uint FileAttributeReparsePoint = 0x00000400;
     private const uint FileFlagOverlapped = 0x40000000;
     private const uint FileFlagOpenReparsePoint = 0x00200000;
+    private const uint FileShareRead = 0x00000001;
+    private const uint FileShareWrite = 0x00000002;
+    private const uint FileShareDelete = 0x00000004;
     private const uint LockFileFailImmediately = 0x00000001;
     private const uint LockFileExclusiveLock = 0x00000002;
     private const int ErrorFileNotFound = 2;
@@ -153,6 +156,7 @@ internal sealed partial class WindowsOutputArtifactNativeFileSystem
                     return OutputArtifactNativeSafeDeleteResult.Modified();
                 }
 
+                _beforeDelete?.Invoke(handle);
                 return MarkOpenedFileForDeletion(handle)
                     ? OutputArtifactNativeSafeDeleteResult.Deleted()
                     : OutputArtifactNativeSafeDeleteResult.Failed();
@@ -291,7 +295,7 @@ internal sealed partial class WindowsOutputArtifactNativeFileSystem
         }
     }
 
-    private static OutputArtifactNativeOpenStatus TryOpen(
+    private OutputArtifactNativeOpenStatus TryOpen(
         string path,
         bool includeDeleteAccess,
         out SafeFileHandle? handle)
@@ -302,7 +306,7 @@ internal sealed partial class WindowsOutputArtifactNativeFileSystem
             var openedHandle = WindowsOutputArtifactNativeMethods.CreateFile(
                 path,
                 includeDeleteAccess ? GenericRead | Delete : GenericRead,
-                shareMode: 0,
+                shareMode: _shareMode,
                 IntPtr.Zero,
                 OpenExisting,
                 FileAttributeNormal | FileFlagOverlapped | FileFlagOpenReparsePoint,
@@ -422,6 +426,29 @@ internal sealed partial class WindowsOutputArtifactNativeFileSystem
             throw new IOException("Reparse points are not eligible for output ownership evidence.");
         }
 
+        return FormatFileIdForEvidence(
+            information.VolumeSerialNumber,
+            information.FileIdHigh,
+            information.FileIdLow);
+    }
+
+    internal static string FormatFileIdForEvidence(
+        ulong volumeSerialNumber,
+        ulong fileIdHigh,
+        ulong fileIdLow)
+    {
+        if ((fileIdHigh == 0 && fileIdLow == 0)
+            || (fileIdHigh == ulong.MaxValue && fileIdLow == ulong.MaxValue))
+        {
+            throw new IOException("The output filesystem returned a sentinel file identity.");
+        }
+
+        var information = new FileIdInformation
+        {
+            VolumeSerialNumber = volumeSerialNumber,
+            FileIdHigh = fileIdHigh,
+            FileIdLow = fileIdLow
+        };
         return string.Create(
             49,
             information,

--- a/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactOwnershipProvider.cs
+++ b/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactOwnershipProvider.cs
@@ -1,0 +1,301 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using DownKyi.Application.Downloads;
+
+namespace DownKyi.Services.Download;
+
+/// <summary>
+/// Windows implementation of final-output ownership validation. It opens the
+/// candidate once, reads its identity and content through that handle, and
+/// marks that same handle for deletion only after validation succeeds.
+/// </summary>
+internal sealed class WindowsOutputArtifactOwnershipProvider
+    : IOutputArtifactOwnershipProvider
+{
+    internal const string IdentityProviderName = "windows-file-id-v1";
+
+    private readonly IOutputArtifactNativeFileSystem _fileSystem;
+
+    public WindowsOutputArtifactOwnershipProvider()
+        : this(new WindowsOutputArtifactNativeFileSystem())
+    {
+    }
+
+    internal WindowsOutputArtifactOwnershipProvider(
+        IOutputArtifactNativeFileSystem fileSystem)
+    {
+        ArgumentNullException.ThrowIfNull(fileSystem);
+        _fileSystem = fileSystem;
+    }
+
+    public async Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+        string temporaryPath,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(temporaryPath);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_fileSystem.IsSupported)
+        {
+            return OutputArtifactEvidenceCaptureResult.Unsupported();
+        }
+
+        var capture = await _fileSystem
+            .CaptureEvidenceAsync(temporaryPath, cancellationToken)
+            .ConfigureAwait(false);
+        return capture.Status switch
+        {
+            OutputArtifactNativeCaptureStatus.Captured when capture.Evidence is not null =>
+                OutputArtifactEvidenceCaptureResult.Captured(
+                    new OutputArtifactPublicationEvidence(
+                        capture.Evidence.ByteLength,
+                        capture.Evidence.Sha256,
+                        IdentityProviderName,
+                        capture.Evidence.FilesystemIdentity)),
+            OutputArtifactNativeCaptureStatus.Missing =>
+                OutputArtifactEvidenceCaptureResult.Missing(),
+            OutputArtifactNativeCaptureStatus.Unsupported =>
+                OutputArtifactEvidenceCaptureResult.Unsupported(),
+            _ => OutputArtifactEvidenceCaptureResult.Failed()
+        };
+    }
+
+    public async Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+        string candidatePath,
+        DownloadOutputArtifactProvenance provenance,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(candidatePath);
+        ArgumentNullException.ThrowIfNull(provenance);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_fileSystem.IsSupported)
+        {
+            return OutputArtifactSafeDeleteResult.Unsupported();
+        }
+
+        if (!HasUsableEvidence(candidatePath, provenance))
+        {
+            return OutputArtifactSafeDeleteResult.Unproven();
+        }
+
+        var result = await _fileSystem
+            .DeleteIfEvidenceMatchesAsync(
+                candidatePath,
+                new OutputArtifactNativeEvidence(
+                    provenance.ByteLength,
+                    provenance.Sha256,
+                    provenance.FilesystemIdentity),
+                cancellationToken)
+            .ConfigureAwait(false);
+        return result.Status switch
+        {
+            OutputArtifactNativeSafeDeleteStatus.Deleted =>
+                OutputArtifactSafeDeleteResult.DeletedResult(),
+            OutputArtifactNativeSafeDeleteStatus.Missing =>
+                OutputArtifactSafeDeleteResult.Missing(),
+            OutputArtifactNativeSafeDeleteStatus.Replaced =>
+                OutputArtifactSafeDeleteResult.Replaced(),
+            OutputArtifactNativeSafeDeleteStatus.Modified =>
+                OutputArtifactSafeDeleteResult.Modified(),
+            OutputArtifactNativeSafeDeleteStatus.Unsupported =>
+                OutputArtifactSafeDeleteResult.Unsupported(),
+            _ => OutputArtifactSafeDeleteResult.Failed()
+        };
+    }
+
+    public async Task<bool> VerifyPublishedObjectIdentityAsync(
+        string destinationPath,
+        OutputArtifactPublicationEvidence evidence,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(destinationPath);
+        ArgumentNullException.ThrowIfNull(evidence);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_fileSystem.IsSupported || !HasUsableEvidence(evidence))
+        {
+            return false;
+        }
+
+        return await _fileSystem
+            .VerifyIdentityAndLengthAsync(
+                destinationPath,
+                new OutputArtifactNativeEvidence(
+                    evidence.ByteLength,
+                    evidence.Sha256,
+                    evidence.FilesystemIdentity),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static bool HasUsableEvidence(
+        string candidatePath,
+        DownloadOutputArtifactProvenance provenance)
+    {
+        if (!HasUsableEvidence(
+                new OutputArtifactPublicationEvidence(
+                    provenance.ByteLength,
+                    provenance.Sha256,
+                    provenance.IdentityProvider,
+                    provenance.FilesystemIdentity))
+            || string.IsNullOrWhiteSpace(provenance.CanonicalPath))
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!Path.IsPathFullyQualified(provenance.CanonicalPath))
+            {
+                return false;
+            }
+
+            var canonicalCandidate = Path.GetFullPath(candidatePath);
+            var canonicalProvenance = Path.GetFullPath(provenance.CanonicalPath);
+            return string.Equals(
+                canonicalCandidate,
+                canonicalProvenance,
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (IOException)
+        {
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool HasUsableEvidence(
+        OutputArtifactPublicationEvidence evidence)
+    {
+        return string.Equals(
+                   evidence.IdentityProvider,
+                   IdentityProviderName,
+                   StringComparison.Ordinal)
+               && !string.IsNullOrWhiteSpace(evidence.FilesystemIdentity)
+               && evidence.ByteLength >= 0
+               && IsCanonicalSha256(evidence.Sha256);
+    }
+
+    private static bool IsCanonicalSha256(string? value)
+    {
+        if (value is null || value.Length != 64)
+        {
+            return false;
+        }
+
+        foreach (var character in value)
+        {
+            if ((character is < '0' or > '9')
+                && (character is < 'a' or > 'f'))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}
+
+/// <summary>
+/// Internal seam between ownership policy and native handles. The Windows
+/// implementation keeps the handle entirely inside the two operations so a
+/// caller cannot validate one object and path-delete another.
+/// </summary>
+internal interface IOutputArtifactNativeFileSystem
+{
+    bool IsSupported { get; }
+
+    Task<OutputArtifactNativeCaptureResult> CaptureEvidenceAsync(
+        string path,
+        CancellationToken cancellationToken);
+
+    Task<OutputArtifactNativeSafeDeleteResult> DeleteIfEvidenceMatchesAsync(
+        string path,
+        OutputArtifactNativeEvidence expectedEvidence,
+        CancellationToken cancellationToken);
+
+    Task<bool> VerifyIdentityAndLengthAsync(
+        string path,
+        OutputArtifactNativeEvidence expectedEvidence,
+        CancellationToken cancellationToken);
+}
+
+internal enum OutputArtifactNativeCaptureStatus
+{
+    Captured,
+    Missing,
+    Unsupported,
+    Failed
+}
+
+internal sealed record OutputArtifactNativeCaptureResult(
+    OutputArtifactNativeCaptureStatus Status,
+    OutputArtifactNativeEvidence? Evidence)
+{
+    public static OutputArtifactNativeCaptureResult Captured(
+        OutputArtifactNativeEvidence evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        return new OutputArtifactNativeCaptureResult(
+            OutputArtifactNativeCaptureStatus.Captured,
+            evidence);
+    }
+
+    public static OutputArtifactNativeCaptureResult Missing() =>
+        new(OutputArtifactNativeCaptureStatus.Missing, null);
+
+    public static OutputArtifactNativeCaptureResult Unsupported() =>
+        new(OutputArtifactNativeCaptureStatus.Unsupported, null);
+
+    public static OutputArtifactNativeCaptureResult Failed() =>
+        new(OutputArtifactNativeCaptureStatus.Failed, null);
+}
+
+internal enum OutputArtifactNativeSafeDeleteStatus
+{
+    Deleted,
+    Missing,
+    Replaced,
+    Modified,
+    Unsupported,
+    Failed
+}
+
+internal sealed record OutputArtifactNativeSafeDeleteResult(
+    OutputArtifactNativeSafeDeleteStatus Status)
+{
+    public static OutputArtifactNativeSafeDeleteResult Deleted() =>
+        new(OutputArtifactNativeSafeDeleteStatus.Deleted);
+
+    public static OutputArtifactNativeSafeDeleteResult Missing() =>
+        new(OutputArtifactNativeSafeDeleteStatus.Missing);
+
+    public static OutputArtifactNativeSafeDeleteResult Replaced() =>
+        new(OutputArtifactNativeSafeDeleteStatus.Replaced);
+
+    public static OutputArtifactNativeSafeDeleteResult Modified() =>
+        new(OutputArtifactNativeSafeDeleteStatus.Modified);
+
+    public static OutputArtifactNativeSafeDeleteResult Unsupported() =>
+        new(OutputArtifactNativeSafeDeleteStatus.Unsupported);
+
+    public static OutputArtifactNativeSafeDeleteResult Failed() =>
+        new(OutputArtifactNativeSafeDeleteStatus.Failed);
+}
+
+internal sealed record OutputArtifactNativeEvidence(
+    long ByteLength,
+    string Sha256,
+    string FilesystemIdentity);
+
+

--- a/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactOwnershipProvider.cs
+++ b/src/DownKyi.Desktop/Services/Download/WindowsOutputArtifactOwnershipProvider.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Application.Downloads;
+using Microsoft.Win32.SafeHandles;
 
 namespace DownKyi.Services.Download;
 
@@ -30,11 +31,35 @@ internal sealed class WindowsOutputArtifactOwnershipProvider
         _fileSystem = fileSystem;
     }
 
+    public OutputArtifactTemporaryClaimResult ClaimTemporaryObject(
+        SafeFileHandle temporaryHandle)
+    {
+        ArgumentNullException.ThrowIfNull(temporaryHandle);
+        if (!_fileSystem.IsSupported)
+        {
+            return OutputArtifactTemporaryClaimResult.Unsupported();
+        }
+
+        var capture = _fileSystem.CaptureIdentity(temporaryHandle);
+        return capture.Status switch
+        {
+            OutputArtifactNativeIdentityCaptureStatus.Captured
+                when !string.IsNullOrWhiteSpace(capture.FilesystemIdentity) =>
+                OutputArtifactTemporaryClaimResult.Claimed(
+                    new WindowsOutputArtifactTemporaryClaim(capture.FilesystemIdentity)),
+            OutputArtifactNativeIdentityCaptureStatus.Unsupported =>
+                OutputArtifactTemporaryClaimResult.Unsupported(),
+            _ => OutputArtifactTemporaryClaimResult.Failed()
+        };
+    }
+
     public async Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
         string temporaryPath,
+        OutputArtifactTemporaryClaim temporaryClaim,
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(temporaryPath);
+        ArgumentNullException.ThrowIfNull(temporaryClaim);
         cancellationToken.ThrowIfCancellationRequested();
 
         if (!_fileSystem.IsSupported)
@@ -42,12 +67,22 @@ internal sealed class WindowsOutputArtifactOwnershipProvider
             return OutputArtifactEvidenceCaptureResult.Unsupported();
         }
 
+        if (temporaryClaim is not WindowsOutputArtifactTemporaryClaim windowsClaim)
+        {
+            return OutputArtifactEvidenceCaptureResult.Failed();
+        }
+
         var capture = await _fileSystem
             .CaptureEvidenceAsync(temporaryPath, cancellationToken)
             .ConfigureAwait(false);
         return capture.Status switch
         {
-            OutputArtifactNativeCaptureStatus.Captured when capture.Evidence is not null =>
+            OutputArtifactNativeCaptureStatus.Captured
+                when capture.Evidence is not null
+                     && string.Equals(
+                         capture.Evidence.FilesystemIdentity,
+                         windowsClaim.FilesystemIdentity,
+                         StringComparison.Ordinal) =>
                 OutputArtifactEvidenceCaptureResult.Captured(
                     new OutputArtifactPublicationEvidence(
                         capture.Evidence.ByteLength,
@@ -60,6 +95,34 @@ internal sealed class WindowsOutputArtifactOwnershipProvider
                 OutputArtifactEvidenceCaptureResult.Unsupported(),
             _ => OutputArtifactEvidenceCaptureResult.Failed()
         };
+    }
+
+    public async Task<OutputArtifactSafeDeleteResult> DeleteTemporaryIfOwnedAsync(
+        string temporaryPath,
+        OutputArtifactTemporaryClaim temporaryClaim,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(temporaryPath);
+        ArgumentNullException.ThrowIfNull(temporaryClaim);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (!_fileSystem.IsSupported)
+        {
+            return OutputArtifactSafeDeleteResult.Unsupported();
+        }
+
+        if (temporaryClaim is not WindowsOutputArtifactTemporaryClaim windowsClaim)
+        {
+            return OutputArtifactSafeDeleteResult.Unproven();
+        }
+
+        var result = await _fileSystem
+            .DeleteIfIdentityMatchesAsync(
+                temporaryPath,
+                windowsClaim.FilesystemIdentity,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return MapSafeDeleteResult(result);
     }
 
     public async Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
@@ -90,20 +153,7 @@ internal sealed class WindowsOutputArtifactOwnershipProvider
                     provenance.FilesystemIdentity),
                 cancellationToken)
             .ConfigureAwait(false);
-        return result.Status switch
-        {
-            OutputArtifactNativeSafeDeleteStatus.Deleted =>
-                OutputArtifactSafeDeleteResult.DeletedResult(),
-            OutputArtifactNativeSafeDeleteStatus.Missing =>
-                OutputArtifactSafeDeleteResult.Missing(),
-            OutputArtifactNativeSafeDeleteStatus.Replaced =>
-                OutputArtifactSafeDeleteResult.Replaced(),
-            OutputArtifactNativeSafeDeleteStatus.Modified =>
-                OutputArtifactSafeDeleteResult.Modified(),
-            OutputArtifactNativeSafeDeleteStatus.Unsupported =>
-                OutputArtifactSafeDeleteResult.Unsupported(),
-            _ => OutputArtifactSafeDeleteResult.Failed()
-        };
+        return MapSafeDeleteResult(result);
     }
 
     public async Task<bool> VerifyPublishedObjectIdentityAsync(
@@ -204,6 +254,28 @@ internal sealed class WindowsOutputArtifactOwnershipProvider
 
         return true;
     }
+
+    private static OutputArtifactSafeDeleteResult MapSafeDeleteResult(
+        OutputArtifactNativeSafeDeleteResult result)
+    {
+        return result.Status switch
+        {
+            OutputArtifactNativeSafeDeleteStatus.Deleted =>
+                OutputArtifactSafeDeleteResult.DeletedResult(),
+            OutputArtifactNativeSafeDeleteStatus.Missing =>
+                OutputArtifactSafeDeleteResult.Missing(),
+            OutputArtifactNativeSafeDeleteStatus.Replaced =>
+                OutputArtifactSafeDeleteResult.Replaced(),
+            OutputArtifactNativeSafeDeleteStatus.Modified =>
+                OutputArtifactSafeDeleteResult.Modified(),
+            OutputArtifactNativeSafeDeleteStatus.Unsupported =>
+                OutputArtifactSafeDeleteResult.Unsupported(),
+            _ => OutputArtifactSafeDeleteResult.Failed()
+        };
+    }
+
+    private sealed record WindowsOutputArtifactTemporaryClaim(
+        string FilesystemIdentity) : OutputArtifactTemporaryClaim;
 }
 
 /// <summary>
@@ -215,6 +287,9 @@ internal interface IOutputArtifactNativeFileSystem
 {
     bool IsSupported { get; }
 
+    OutputArtifactNativeIdentityCaptureResult CaptureIdentity(
+        SafeFileHandle handle);
+
     Task<OutputArtifactNativeCaptureResult> CaptureEvidenceAsync(
         string path,
         CancellationToken cancellationToken);
@@ -224,10 +299,41 @@ internal interface IOutputArtifactNativeFileSystem
         OutputArtifactNativeEvidence expectedEvidence,
         CancellationToken cancellationToken);
 
+    Task<OutputArtifactNativeSafeDeleteResult> DeleteIfIdentityMatchesAsync(
+        string path,
+        string expectedFilesystemIdentity,
+        CancellationToken cancellationToken);
+
     Task<bool> VerifyIdentityAndLengthAsync(
         string path,
         OutputArtifactNativeEvidence expectedEvidence,
         CancellationToken cancellationToken);
+}
+
+internal enum OutputArtifactNativeIdentityCaptureStatus
+{
+    Captured,
+    Unsupported,
+    Failed
+}
+
+internal sealed record OutputArtifactNativeIdentityCaptureResult(
+    OutputArtifactNativeIdentityCaptureStatus Status,
+    string? FilesystemIdentity)
+{
+    public static OutputArtifactNativeIdentityCaptureResult Captured(string filesystemIdentity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(filesystemIdentity);
+        return new OutputArtifactNativeIdentityCaptureResult(
+            OutputArtifactNativeIdentityCaptureStatus.Captured,
+            filesystemIdentity);
+    }
+
+    public static OutputArtifactNativeIdentityCaptureResult Unsupported() =>
+        new(OutputArtifactNativeIdentityCaptureStatus.Unsupported, null);
+
+    public static OutputArtifactNativeIdentityCaptureResult Failed() =>
+        new(OutputArtifactNativeIdentityCaptureStatus.Failed, null);
 }
 
 internal enum OutputArtifactNativeCaptureStatus
@@ -297,5 +403,3 @@ internal sealed record OutputArtifactNativeEvidence(
     long ByteLength,
     string Sha256,
     string FilesystemIdentity);
-
-

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.OutputArtifactProvenance.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.OutputArtifactProvenance.cs
@@ -1,0 +1,39 @@
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static partial class DownloadStoreSchema
+{
+    private static async Task ApplyVersionFiveAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        // Final-output provenance begins at version 5. Existing task rows,
+        // including their paths and transfer-file maps, are deliberately not
+        // evidence of ownership and must not be backfilled here.
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = """
+                CREATE TABLE IF NOT EXISTS download_output_artifact_provenance (
+                    task_id               TEXT NOT NULL REFERENCES download_base(id) ON DELETE CASCADE,
+                    artifact_key          TEXT NOT NULL,
+                    artifact_kind         TEXT NOT NULL,
+                    canonical_path        TEXT NOT NULL,
+                    byte_length           INTEGER NOT NULL CHECK(byte_length >= 0),
+                    sha256                TEXT NOT NULL,
+                    identity_provider     TEXT NOT NULL,
+                    filesystem_identity   TEXT NOT NULL,
+                    published_at_utc      INTEGER NOT NULL,
+                    PRIMARY KEY(task_id, artifact_key)
+                );
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await RecordMigrationAsync(connection, transaction, 5, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
@@ -8,7 +8,7 @@ namespace DownKyi.Infrastructure.Downloads;
 
 internal static partial class DownloadStoreSchema
 {
-    public const int CurrentVersion = 4;
+    public const int CurrentVersion = 5;
 
     private enum VersionTwoColumn
     {
@@ -76,6 +76,12 @@ internal static partial class DownloadStoreSchema
             if (currentVersion < 4)
             {
                 await ApplyVersionFourAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (currentVersion < 5)
+            {
+                await ApplyVersionFiveAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -371,7 +377,7 @@ internal static partial class DownloadStoreSchema
         // SQLite PRAGMA assignments do not support normal SQL parameters.
         // Keep this as a compile-time literal so CA2100 can prove that no
         // user-controlled SQL reaches CommandText.
-        command.CommandText = "PRAGMA user_version = 4";
+        command.CommandText = "PRAGMA user_version = 5";
 
         await command
             .ExecuteNonQueryAsync(cancellationToken)

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.OutputArtifactProvenance.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.OutputArtifactProvenance.cs
@@ -1,0 +1,240 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+public sealed partial class SqliteDownloadTaskStore
+{
+    public async Task<OperationResult> RecordPublishedAsync(
+        DownloadOutputArtifactProvenance provenance,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(provenance);
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+            using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            using var transaction = BeginImmediateTransaction(connection);
+            try
+            {
+                if (!await TaskExistsAsync(connection, transaction, provenance.TaskId, cancellationToken)
+                        .ConfigureAwait(false))
+                {
+                    await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                    return ProvenanceTaskNotFound(provenance.TaskId);
+                }
+
+                using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = """
+                    INSERT INTO download_output_artifact_provenance(
+                        task_id,
+                        artifact_key,
+                        artifact_kind,
+                        canonical_path,
+                        byte_length,
+                        sha256,
+                        identity_provider,
+                        filesystem_identity,
+                        published_at_utc)
+                    VALUES(
+                        @task_id,
+                        @artifact_key,
+                        @artifact_kind,
+                        @canonical_path,
+                        @byte_length,
+                        @sha256,
+                        @identity_provider,
+                        @filesystem_identity,
+                        @published_at_utc)
+                    """;
+                BindProvenance(command, provenance);
+                await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+                return OperationResult.Success();
+            }
+            catch (SqliteException exception) when (exception.SqliteErrorCode == 19)
+            {
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                return ProvenanceConflict(provenance.TaskId, provenance.ArtifactKey);
+            }
+            catch
+            {
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+                throw;
+            }
+        }
+        catch (SqliteException)
+        {
+            return ProvenanceWriteFailed(provenance.TaskId);
+        }
+        catch (IOException)
+        {
+            return ProvenanceWriteFailed(provenance.TaskId);
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return ProvenanceWriteFailed(provenance.TaskId);
+        }
+        catch (InvalidOperationException)
+        {
+            return ProvenanceWriteFailed(provenance.TaskId);
+        }
+    }
+
+    public async Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        try
+        {
+            await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+            using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                SELECT
+                    task_id,
+                    artifact_key,
+                    artifact_kind,
+                    canonical_path,
+                    byte_length,
+                    sha256,
+                    identity_provider,
+                    filesystem_identity,
+                    published_at_utc
+                FROM download_output_artifact_provenance
+                WHERE task_id = @task_id
+                ORDER BY artifact_key ASC
+                """;
+            command.Parameters.AddWithValue("@task_id", taskId.Value);
+
+            var provenance = new List<DownloadOutputArtifactProvenance>();
+            using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                provenance.Add(ReadProvenance(reader));
+            }
+
+            return OperationResult.Success<IReadOnlyList<DownloadOutputArtifactProvenance>>(provenance);
+        }
+        catch (ArgumentException)
+        {
+            return ProvenanceCorrupt(taskId);
+        }
+        catch (InvalidCastException)
+        {
+            return ProvenanceCorrupt(taskId);
+        }
+        catch (InvalidOperationException)
+        {
+            return ProvenanceCorrupt(taskId);
+        }
+        catch (IOException)
+        {
+            return ProvenanceCorrupt(taskId);
+        }
+        catch (NotSupportedException)
+        {
+            return ProvenanceCorrupt(taskId);
+        }
+        catch (SqliteException)
+        {
+            return ProvenanceReadFailed(taskId);
+        }
+    }
+
+    private static async Task<bool> TaskExistsAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            SELECT 1
+            FROM download_base
+            WHERE id = @task_id
+            LIMIT 1
+            """;
+        command.Parameters.AddWithValue("@task_id", taskId.Value);
+        return await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false) is not null;
+    }
+
+    private static void BindProvenance(
+        SqliteCommand command,
+        DownloadOutputArtifactProvenance provenance)
+    {
+        command.Parameters.AddWithValue("@task_id", provenance.TaskId.Value);
+        command.Parameters.AddWithValue("@artifact_key", provenance.ArtifactKey);
+        command.Parameters.AddWithValue("@artifact_kind", provenance.ArtifactKind);
+        command.Parameters.AddWithValue("@canonical_path", provenance.CanonicalPath);
+        command.Parameters.AddWithValue("@byte_length", provenance.ByteLength);
+        command.Parameters.AddWithValue("@sha256", provenance.Sha256);
+        command.Parameters.AddWithValue("@identity_provider", provenance.IdentityProvider);
+        command.Parameters.AddWithValue("@filesystem_identity", provenance.FilesystemIdentity);
+        command.Parameters.AddWithValue("@published_at_utc", provenance.PublishedAtUtc.ToUnixTimeMilliseconds());
+    }
+
+    private static DownloadOutputArtifactProvenance ReadProvenance(SqliteDataReader reader)
+    {
+        return new DownloadOutputArtifactProvenance(
+            new DownloadTaskId(reader.GetString(0)),
+            reader.GetString(1),
+            reader.GetString(2),
+            reader.GetString(3),
+            new OutputArtifactPublicationEvidence(
+                reader.GetInt64(4),
+                reader.GetString(5),
+                reader.GetString(6),
+                reader.GetString(7)),
+            DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(8)));
+    }
+
+    private static OperationResult ProvenanceTaskNotFound(DownloadTaskId taskId)
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.output_provenance.task_not_found",
+            $"Download task '{taskId.Value}' was not found while recording final-output provenance.",
+            OperationErrorKind.NotFound));
+    }
+
+    private static OperationResult ProvenanceConflict(DownloadTaskId taskId, string artifactKey)
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.output_provenance.conflict",
+            $"Final-output provenance already exists for artifact '{artifactKey}' on download task '{taskId.Value}'.",
+            OperationErrorKind.Conflict));
+    }
+
+    private static OperationResult ProvenanceWriteFailed(DownloadTaskId taskId)
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.output_provenance.write_failed",
+            $"Final-output provenance for download task '{taskId.Value}' could not be recorded.",
+            OperationErrorKind.Unexpected));
+    }
+
+    private static OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>> ProvenanceCorrupt(
+        DownloadTaskId taskId)
+    {
+        return OperationResult.Failure<IReadOnlyList<DownloadOutputArtifactProvenance>>(
+            new OperationError(
+                "download.output_provenance.corrupt",
+                $"Final-output provenance for download task '{taskId.Value}' is corrupt.",
+                OperationErrorKind.Validation));
+    }
+
+    private static OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>> ProvenanceReadFailed(
+        DownloadTaskId taskId)
+    {
+        return OperationResult.Failure<IReadOnlyList<DownloadOutputArtifactProvenance>>(
+            new OperationError(
+                "download.output_provenance.read_failed",
+                $"Final-output provenance for download task '{taskId.Value}' could not be read.",
+                OperationErrorKind.Unexpected));
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -8,7 +8,8 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Infrastructure.Downloads;
 
-public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDownloadTaskAtomicBatchStore, IDisposable
+public sealed partial class SqliteDownloadTaskStore
+    : IDownloadTaskStore, IDownloadTaskAtomicBatchStore, IDownloadOutputArtifactProvenanceStore, IDisposable
 {
     private const int MaximumHistoryPageSize = 500;
     private static readonly Action<ILogger, int, Exception?> LogOrphanCleanup = LoggerMessage.Define<int>(

--- a/tests/DownKyi.Application.Tests/DownloadOutputArtifactProvenanceApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadOutputArtifactProvenanceApplicationServiceTests.cs
@@ -1,0 +1,160 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Application.Time;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Tests;
+
+public sealed class DownloadOutputArtifactProvenanceApplicationServiceTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 16, 1, 2, 3, TimeSpan.Zero);
+
+    [Fact]
+    public async Task RecordPublishedBuildsDurableProvenanceWithTheApplicationClock()
+    {
+        var store = new RecordingStore();
+        var service = new DownloadOutputArtifactProvenanceApplicationService(
+            store,
+            new FixedClock(Now));
+        var taskId = new DownloadTaskId("provenance-task");
+        var path = Path.Combine(Path.GetTempPath(), "provenance-output.mp4");
+
+        var result = await service.RecordPublishedAsync(
+            taskId,
+            "media-dash",
+            "media-dash",
+            path,
+            Evidence("media-object"),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess);
+        var recorded = Assert.IsType<DownloadOutputArtifactProvenance>(store.Recorded);
+        Assert.Equal(taskId, recorded.TaskId);
+        Assert.Equal("media-dash", recorded.ArtifactKey);
+        Assert.Equal("media-dash", recorded.ArtifactKind);
+        Assert.Equal(Path.GetFullPath(path), recorded.CanonicalPath);
+        Assert.Equal(42, recorded.ByteLength);
+        Assert.Equal(new string('a', 64), recorded.Sha256);
+        Assert.Equal("windows.file-id", recorded.IdentityProvider);
+        Assert.Equal("media-object", recorded.FilesystemIdentity);
+        Assert.Equal(Now, recorded.PublishedAtUtc);
+    }
+
+    [Fact]
+    public async Task ReadFailureRemainsDistinctFromAnEmptyProvenanceSet()
+    {
+        var expectedError = new OperationError(
+            "download.output_provenance.read_failed",
+            "Read failed.");
+        var store = new RecordingStore
+        {
+            ReadResult = OperationResult.Failure<IReadOnlyList<DownloadOutputArtifactProvenance>>(expectedError)
+        };
+        var service = new DownloadOutputArtifactProvenanceApplicationService(
+            store,
+            new FixedClock(Now));
+
+        var result = await service.GetPublishedAsync(
+            new DownloadTaskId("provenance-task"),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(expectedError, result.Error);
+    }
+
+    [Fact]
+    public async Task RecordFailureIsPropagatedWithoutManufacturingProvenance()
+    {
+        var expectedError = new OperationError(
+            "download.output_provenance.write_failed",
+            "Write failed.");
+        var store = new RecordingStore
+        {
+            WriteResult = OperationResult.Failure(expectedError)
+        };
+        var service = new DownloadOutputArtifactProvenanceApplicationService(
+            store,
+            new FixedClock(Now));
+
+        var result = await service.RecordPublishedAsync(
+            new DownloadTaskId("provenance-task"),
+            "cover",
+            "cover",
+            Path.Combine(Path.GetTempPath(), "cover.jpg"),
+            Evidence("cover-object"),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Same(expectedError, result.Error);
+        Assert.Null(store.Recorded);
+    }
+
+    [Fact]
+    public void ProvenanceRejectsNonCanonicalHashesBeforeTheyReachTheDurableStore()
+    {
+        var taskId = new DownloadTaskId("provenance-task");
+
+        Assert.Throws<ArgumentException>(() => new DownloadOutputArtifactProvenance(
+            taskId,
+            "cover",
+            "cover",
+            Path.Combine(Path.GetTempPath(), "cover.jpg"),
+            new OutputArtifactPublicationEvidence(
+                42,
+                new string('A', 64),
+                "windows.file-id",
+                "cover-object"),
+            Now));
+    }
+
+    private static OutputArtifactPublicationEvidence Evidence(string filesystemIdentity)
+    {
+        return new OutputArtifactPublicationEvidence(
+            42,
+            new string('a', 64),
+            "windows.file-id",
+            filesystemIdentity);
+    }
+
+    private sealed class FixedClock(DateTimeOffset utcNow) : IClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return Task.Delay(delay, cancellationToken);
+        }
+    }
+
+    private sealed class RecordingStore : IDownloadOutputArtifactProvenanceStore
+    {
+        public DownloadOutputArtifactProvenance? Recorded { get; private set; }
+
+        public OperationResult WriteResult { get; set; } = OperationResult.Success();
+
+        public OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>> ReadResult { get; set; } =
+            OperationResult.Success<IReadOnlyList<DownloadOutputArtifactProvenance>>([]);
+
+        public Task<OperationResult> RecordPublishedAsync(
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!WriteResult.IsSuccess)
+            {
+                return Task.FromResult(WriteResult);
+            }
+
+            Recorded = provenance;
+            return Task.FromResult(OperationResult.Success());
+        }
+
+        public Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(ReadResult);
+        }
+    }
+}

--- a/tests/DownKyi.Core.Tests/FfmpegConcatRuntimeTests.cs
+++ b/tests/DownKyi.Core.Tests/FfmpegConcatRuntimeTests.cs
@@ -25,7 +25,8 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
             runner,
             validator,
             new AsyncConcurrencyGate(() => 1),
-            NullLogger<FfmpegConcatRuntime>.Instance);
+            NullLogger<FfmpegConcatRuntime>.Instance,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
         var output = Path.Combine(_testDirectory, "result.mp4");
 
         var result = await runtime.ConcatAsync(
@@ -58,7 +59,8 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
             runner,
             validator,
             new AsyncConcurrencyGate(() => 1),
-            NullLogger<FfmpegConcatRuntime>.Instance);
+            NullLogger<FfmpegConcatRuntime>.Instance,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
         var output = Path.Combine(_testDirectory, "result.mp4");
 
         var result = await runtime.ConcatAsync(
@@ -84,7 +86,8 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
             runner,
             new StubMediaValidator(isValid: true),
             new AsyncConcurrencyGate(() => 1),
-            NullLogger<FfmpegConcatRuntime>.Instance);
+            NullLogger<FfmpegConcatRuntime>.Instance,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
         var output = Path.Combine(_testDirectory, "owned-by-another-task.mp4");
         byte[] existingContent = [9, 8, 7];
         await File.WriteAllBytesAsync(output, existingContent, TestContext.Current.CancellationToken);
@@ -116,7 +119,8 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
             runner,
             new StubMediaValidator(isValid: true),
             new AsyncConcurrencyGate(() => 1),
-            NullLogger<FfmpegConcatRuntime>.Instance);
+            NullLogger<FfmpegConcatRuntime>.Instance,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await runtime.ConcatAsync(
             [new FfmpegConcatSegment(1, segment, TimeSpan.FromSeconds(5))],
@@ -141,7 +145,8 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
             runner,
             new StubMediaValidator(isValid: false),
             new AsyncConcurrencyGate(() => 1),
-            NullLogger<FfmpegConcatRuntime>.Instance);
+            NullLogger<FfmpegConcatRuntime>.Instance,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
         var output = Path.Combine(_testDirectory, "existing.mp4");
         byte[] existingContent = [6, 5, 4];
         await File.WriteAllBytesAsync(output, existingContent, TestContext.Current.CancellationToken);
@@ -170,7 +175,8 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
             runner,
             new StubMediaValidator(isValid: false),
             new AsyncConcurrencyGate(() => 1),
-            NullLogger<FfmpegConcatRuntime>.Instance);
+            NullLogger<FfmpegConcatRuntime>.Instance,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await runtime.ConcatAsync(
             [
@@ -206,7 +212,8 @@ public sealed class FfmpegConcatRuntimeTests : IDisposable
             runner,
             new StubMediaValidator(isValid: true),
             new AsyncConcurrencyGate(() => 1),
-            NullLogger<FfmpegConcatRuntime>.Instance);
+            NullLogger<FfmpegConcatRuntime>.Instance,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await runtime.ConcatAsync(
             [new FfmpegConcatSegment(1, directoryInput, TimeSpan.FromSeconds(5))],

--- a/tests/DownKyi.Core.Tests/FfmpegProcessorMergeTests.cs
+++ b/tests/DownKyi.Core.Tests/FfmpegProcessorMergeTests.cs
@@ -26,7 +26,8 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         var processor = new FfmpegProcessor(
             _settings,
             NullLoggerFactory.Instance,
-            runner);
+            runner,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await processor.MergeMediaAsync(
             _settings.Current.Video,
@@ -55,7 +56,8 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         var processor = new FfmpegProcessor(
             _settings,
             NullLoggerFactory.Instance,
-            new MergeFailureRunner(audio, DiagnosticFailure.ProcessNotStarted));
+            new MergeFailureRunner(audio, DiagnosticFailure.ProcessNotStarted),
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await processor.MergeMediaAsync(
             _settings.Current.Video,
@@ -80,7 +82,8 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         var processor = new FfmpegProcessor(
             _settings,
             NullLoggerFactory.Instance,
-            new MergeFailureRunner(audio, DiagnosticFailure.StartedInfrastructure));
+            new MergeFailureRunner(audio, DiagnosticFailure.StartedInfrastructure),
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await processor.MergeMediaAsync(
             _settings.Current.Video,
@@ -110,7 +113,8 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         var processor = new FfmpegProcessor(
             _settings,
             NullLoggerFactory.Instance,
-            runner);
+            runner,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await processor.MergeMediaAsync(
             _settings.Current.Video,
@@ -146,7 +150,8 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         var processor = new FfmpegProcessor(
             _settings,
             NullLoggerFactory.Instance,
-            runner);
+            runner,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await processor.MergeMediaAsync(
             _settings.Current.Video,
@@ -179,7 +184,8 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         var processor = new FfmpegProcessor(
             _settings,
             NullLoggerFactory.Instance,
-            new SuccessfulMergeRunner(() => File.WriteAllBytes(destination, foreignContent)));
+            new SuccessfulMergeRunner(() => File.WriteAllBytes(destination, foreignContent)),
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var result = await processor.MergeMediaAsync(
             _settings.Current.Video,
@@ -210,7 +216,8 @@ public sealed class FfmpegProcessorMergeTests : IDisposable
         var processor = new FfmpegProcessor(
             _settings,
             NullLoggerFactory.Instance,
-            runner);
+            runner,
+            FfmpegTemporaryOwnershipTestProvider.Instance);
 
         var first = processor.MergeMediaAsync(
             _settings.Current.Video,

--- a/tests/DownKyi.Core.Tests/FfmpegPublicationEvidenceTests.cs
+++ b/tests/DownKyi.Core.Tests/FfmpegPublicationEvidenceTests.cs
@@ -1,0 +1,310 @@
+using System.Security.Cryptography;
+using DownKyi.Application.Downloads;
+using DownKyi.Core.FFmpeg;
+using DownKyi.Core.Settings;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DownKyi.Core.Tests;
+
+public sealed class FfmpegPublicationEvidenceTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        $"downkyi-ffmpeg-publication-evidence-{Guid.NewGuid():N}");
+    private readonly SettingsStore _settings;
+
+    public FfmpegPublicationEvidenceTests()
+    {
+        Directory.CreateDirectory(_directory);
+        _settings = new SettingsStore(Path.Combine(_directory, "settings.json"));
+    }
+
+    [Fact]
+    public async Task DashMergeReturnsEvidenceCapturedFromTheTemporaryOutputBeforePublication()
+    {
+        var audio = CreateFile("audio.m4s", [1, 2, 3]);
+        var video = CreateFile("video.m4s", [4, 5, 6]);
+        var destination = Path.Combine(_directory, "dash.mp4");
+        byte[] media = [8, 6, 7, 5, 3, 0, 9];
+        var ownershipProvider = new RecordingOwnershipProvider(destination);
+        IFfmpegMediaMuxer processor = new FfmpegProcessor(
+            _settings,
+            NullLoggerFactory.Instance,
+            new OutputWritingRunner(media));
+
+        var result = await processor.MergeMediaWithEvidenceAsync(
+            _settings.Current.Video,
+            audio,
+            video,
+            destination,
+            overwriteDestination: false,
+            outputArtifactOwnershipProvider: ownershipProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(ownershipProvider.Evidence, result.PublicationEvidence);
+        Assert.False(ownershipProvider.DestinationExistedDuringCapture);
+        Assert.Equal(media, ownershipProvider.CapturedBytes);
+        Assert.Equal(media, await File.ReadAllBytesAsync(destination, TestContext.Current.CancellationToken));
+        Assert.NotNull(ownershipProvider.TemporaryPath);
+        Assert.False(File.Exists(ownershipProvider.TemporaryPath));
+    }
+
+    [Fact]
+    public async Task DurlConcatReturnsEvidenceCapturedFromTheTemporaryOutputBeforePublication()
+    {
+        var segment = CreateFile("segment.flv", [1, 2, 3]);
+        var destination = Path.Combine(_directory, "durl.mp4");
+        byte[] media = [1, 3, 3, 7];
+        var ownershipProvider = new RecordingOwnershipProvider(destination);
+        IFfmpegMediaMuxer processor = new FfmpegProcessor(
+            _settings,
+            NullLoggerFactory.Instance,
+            new OutputWritingRunner(media));
+
+        var result = await processor.ConcatDurlVideosWithEvidenceAsync(
+            _settings.Current.Video with
+            {
+                FfmpegHardwareAcceleration = FfmpegHardwareAcceleration.Disabled
+            },
+            [new FfmpegConcatSegment(1, segment, TimeSpan.FromSeconds(5))],
+            destination,
+            overwriteDestination: false,
+            outputArtifactOwnershipProvider: ownershipProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal(ownershipProvider.Evidence, result.PublicationEvidence);
+        Assert.False(ownershipProvider.DestinationExistedDuringCapture);
+        Assert.Equal(media, ownershipProvider.CapturedBytes);
+        Assert.Equal(media, await File.ReadAllBytesAsync(destination, TestContext.Current.CancellationToken));
+        Assert.NotNull(ownershipProvider.TemporaryPath);
+        Assert.False(File.Exists(ownershipProvider.TemporaryPath));
+    }
+
+    [Fact]
+    public async Task DestinationCollisionNeverReturnsCapturedPublicationEvidence()
+    {
+        var audio = CreateFile("collision-audio.m4s", [1, 2, 3]);
+        var video = CreateFile("collision-video.m4s", [4, 5, 6]);
+        var destination = Path.Combine(_directory, "collision.mp4");
+        byte[] foreignMedia = [9, 8, 7];
+        await File.WriteAllBytesAsync(destination, foreignMedia, TestContext.Current.CancellationToken);
+        var ownershipProvider = new RecordingOwnershipProvider(destination);
+        IFfmpegMediaMuxer processor = new FfmpegProcessor(
+            _settings,
+            NullLoggerFactory.Instance,
+            new OutputWritingRunner([1, 2, 3, 4]));
+
+        var result = await processor.MergeMediaWithEvidenceAsync(
+            _settings.Current.Video,
+            audio,
+            video,
+            destination,
+            overwriteDestination: false,
+            outputArtifactOwnershipProvider: ownershipProvider,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(FfmpegOperationFailureKind.DestinationConflict, result.FailureKind);
+        Assert.Null(result.PublicationEvidence);
+        Assert.NotNull(ownershipProvider.Evidence);
+        Assert.Equal(foreignMedia, await File.ReadAllBytesAsync(destination, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UnsupportedEvidenceCaptureDoesNotPreventMediaPublication()
+    {
+        var audio = CreateFile("unsupported-audio.m4s", [1, 2, 3]);
+        var video = CreateFile("unsupported-video.m4s", [4, 5, 6]);
+        var destination = Path.Combine(_directory, "unsupported.mp4");
+        byte[] media = [2, 4, 6, 8];
+        IFfmpegMediaMuxer processor = new FfmpegProcessor(
+            _settings,
+            NullLoggerFactory.Instance,
+            new OutputWritingRunner(media));
+
+        var result = await processor.MergeMediaWithEvidenceAsync(
+            _settings.Current.Video,
+            audio,
+            video,
+            destination,
+            overwriteDestination: false,
+            outputArtifactOwnershipProvider: new UnsupportedOwnershipProvider(),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.PublicationEvidence);
+        Assert.Equal(media, await File.ReadAllBytesAsync(destination, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task EvidenceApiDoesNotManufactureEvidenceForLegacyMuxerImplementations()
+    {
+        IFfmpegMediaMuxer muxer = new LegacyMuxer(new FfmpegOperationResult(
+            true,
+            Path.Combine(_directory, "legacy.mp4"),
+            null,
+            TimeSpan.Zero,
+            FfmpegOperationFailureKind.None,
+            []));
+
+        var result = await muxer.MergeMediaWithEvidenceAsync(
+            _settings.Current.Video,
+            "audio.m4s",
+            "video.m4s",
+            Path.Combine(_directory, "legacy.mp4"),
+            overwriteDestination: false,
+            outputArtifactOwnershipProvider: new UnsupportedOwnershipProvider(),
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.PublicationEvidence);
+    }
+
+    public void Dispose()
+    {
+        _settings.Dispose();
+        Directory.Delete(_directory, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private string CreateFile(string name, byte[] content)
+    {
+        var path = Path.Combine(_directory, name);
+        File.WriteAllBytes(path, content);
+        return path;
+    }
+
+    private sealed class OutputWritingRunner(byte[] output) : IFfmpegProcessRunner
+    {
+        public async Task<FfmpegProcessResult> RunAsync(
+            FfmpegCommand command,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (command.Operation == "merge-media" ||
+                command.Operation.StartsWith("concat-", StringComparison.Ordinal))
+            {
+                await File.WriteAllBytesAsync(command.Arguments[^1], output, cancellationToken)
+                    .ConfigureAwait(false);
+                return new FfmpegProcessResult(
+                    true,
+                    0,
+                    string.Empty,
+                    string.Empty,
+                    false);
+            }
+
+            return command.Operation switch
+            {
+                "probe-media" => new FfmpegProcessResult(
+                    true,
+                    0,
+                    "{\"streams\":[{\"codec_type\":\"video\"}],\"format\":{\"duration\":\"5\"}}",
+                    string.Empty,
+                    false),
+                "seek-decode" => new FfmpegProcessResult(
+                    true,
+                    0,
+                    "frame=1",
+                    string.Empty,
+                    false),
+                _ => throw new InvalidOperationException($"Unexpected FFmpeg operation: {command.Operation}.")
+            };
+        }
+    }
+
+    private sealed class RecordingOwnershipProvider(string destination) : IOutputArtifactOwnershipProvider
+    {
+        public byte[]? CapturedBytes { get; private set; }
+
+        public bool DestinationExistedDuringCapture { get; private set; }
+
+        public OutputArtifactPublicationEvidence? Evidence { get; private set; }
+
+        public string? TemporaryPath { get; private set; }
+
+        public async Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+            string temporaryPath,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TemporaryPath = Path.GetFullPath(temporaryPath);
+            DestinationExistedDuringCapture = File.Exists(destination);
+            var capturedBytes = await File.ReadAllBytesAsync(temporaryPath, cancellationToken)
+                .ConfigureAwait(false);
+            CapturedBytes = capturedBytes;
+            Evidence = new OutputArtifactPublicationEvidence(
+                capturedBytes.LongLength,
+                Convert.ToHexStringLower(SHA256.HashData(capturedBytes)),
+                "test",
+                "test-filesystem-identity");
+            return OutputArtifactEvidenceCaptureResult.Captured(Evidence);
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+            string candidatePath,
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(OutputArtifactSafeDeleteResult.Unsupported());
+        }
+
+        public Task<bool> VerifyPublishedObjectIdentityAsync(
+            string destinationPath,
+            OutputArtifactPublicationEvidence evidence,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(
+                string.Equals(destination, destinationPath, StringComparison.Ordinal)
+                && ReferenceEquals(Evidence, evidence));
+        }
+    }
+
+    private sealed class UnsupportedOwnershipProvider : IOutputArtifactOwnershipProvider
+    {
+        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+            string temporaryPath,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+            string candidatePath,
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(OutputArtifactSafeDeleteResult.Unsupported());
+        }
+    }
+
+    private sealed class LegacyMuxer(FfmpegOperationResult result) : IFfmpegMediaMuxer
+    {
+        public Task<FfmpegOperationResult> ConcatDurlVideosAsync(
+            VideoApplicationSettings videoSettings,
+            IReadOnlyList<FfmpegConcatSegment> segments,
+            string outputVideo,
+            bool overwriteDestination,
+            Action<string>? action = null,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(result);
+        }
+
+        public Task<FfmpegOperationResult> MergeMediaAsync(
+            VideoApplicationSettings videoSettings,
+            string? audio,
+            string? video,
+            string destination,
+            bool overwriteDestination,
+            CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/tests/DownKyi.Core.Tests/FfmpegPublicationEvidenceTests.cs
+++ b/tests/DownKyi.Core.Tests/FfmpegPublicationEvidenceTests.cs
@@ -3,6 +3,7 @@ using DownKyi.Application.Downloads;
 using DownKyi.Core.FFmpeg;
 using DownKyi.Core.Settings;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Win32.SafeHandles;
 
 namespace DownKyi.Core.Tests;
 
@@ -218,6 +219,8 @@ public sealed class FfmpegPublicationEvidenceTests : IDisposable
 
     private sealed class RecordingOwnershipProvider(string destination) : IOutputArtifactOwnershipProvider
     {
+        private sealed record TemporaryClaim : OutputArtifactTemporaryClaim;
+
         public byte[]? CapturedBytes { get; private set; }
 
         public bool DestinationExistedDuringCapture { get; private set; }
@@ -226,10 +229,20 @@ public sealed class FfmpegPublicationEvidenceTests : IDisposable
 
         public string? TemporaryPath { get; private set; }
 
+        public OutputArtifactTemporaryClaimResult ClaimTemporaryObject(
+            SafeFileHandle temporaryHandle)
+        {
+            Assert.False(temporaryHandle.IsClosed);
+            Assert.False(temporaryHandle.IsInvalid);
+            return OutputArtifactTemporaryClaimResult.Claimed(new TemporaryClaim());
+        }
+
         public async Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
             string temporaryPath,
+            OutputArtifactTemporaryClaim temporaryClaim,
             CancellationToken cancellationToken)
         {
+            Assert.IsType<TemporaryClaim>(temporaryClaim);
             cancellationToken.ThrowIfCancellationRequested();
             TemporaryPath = Path.GetFullPath(temporaryPath);
             DestinationExistedDuringCapture = File.Exists(destination);
@@ -242,6 +255,22 @@ public sealed class FfmpegPublicationEvidenceTests : IDisposable
                 "test",
                 "test-filesystem-identity");
             return OutputArtifactEvidenceCaptureResult.Captured(Evidence);
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteTemporaryIfOwnedAsync(
+            string temporaryPath,
+            OutputArtifactTemporaryClaim temporaryClaim,
+            CancellationToken cancellationToken)
+        {
+            Assert.IsType<TemporaryClaim>(temporaryClaim);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!File.Exists(temporaryPath))
+            {
+                return Task.FromResult(OutputArtifactSafeDeleteResult.Missing());
+            }
+
+            File.Delete(temporaryPath);
+            return Task.FromResult(OutputArtifactSafeDeleteResult.DeletedResult());
         }
 
         public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
@@ -266,14 +295,6 @@ public sealed class FfmpegPublicationEvidenceTests : IDisposable
 
     private sealed class UnsupportedOwnershipProvider : IOutputArtifactOwnershipProvider
     {
-        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
-            string temporaryPath,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
-        }
-
         public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
             string candidatePath,
             DownloadOutputArtifactProvenance provenance,

--- a/tests/DownKyi.Core.Tests/FfmpegTemporaryOwnershipTestProvider.cs
+++ b/tests/DownKyi.Core.Tests/FfmpegTemporaryOwnershipTestProvider.cs
@@ -1,0 +1,44 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using Microsoft.Win32.SafeHandles;
+
+namespace DownKyi.Core.Tests;
+
+internal sealed class FfmpegTemporaryOwnershipTestProvider : IOutputArtifactOwnershipProvider
+{
+    private sealed record TemporaryClaim : OutputArtifactTemporaryClaim;
+
+    public static FfmpegTemporaryOwnershipTestProvider Instance { get; } = new();
+
+    public OutputArtifactTemporaryClaimResult ClaimTemporaryObject(
+        SafeFileHandle temporaryHandle)
+    {
+        Assert.False(temporaryHandle.IsClosed);
+        Assert.False(temporaryHandle.IsInvalid);
+        return OutputArtifactTemporaryClaimResult.Claimed(new TemporaryClaim());
+    }
+
+    public Task<OutputArtifactSafeDeleteResult> DeleteTemporaryIfOwnedAsync(
+        string temporaryPath,
+        OutputArtifactTemporaryClaim temporaryClaim,
+        CancellationToken cancellationToken)
+    {
+        Assert.IsType<TemporaryClaim>(temporaryClaim);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!File.Exists(temporaryPath))
+        {
+            return Task.FromResult(OutputArtifactSafeDeleteResult.Missing());
+        }
+
+        File.Delete(temporaryPath);
+        return Task.FromResult(OutputArtifactSafeDeleteResult.DeletedResult());
+    }
+
+    public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+        string candidatePath,
+        DownloadOutputArtifactProvenance provenance,
+        CancellationToken cancellationToken)
+    {
+        return Task.FromResult(OutputArtifactSafeDeleteResult.Unsupported());
+    }
+}

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadOutputArtifactProvenanceStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadOutputArtifactProvenanceStoreTests.cs
@@ -1,0 +1,268 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Application.Time;
+using DownKyi.Domain.Downloads;
+using DownKyi.Infrastructure.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Tests;
+
+public sealed class SqliteDownloadOutputArtifactProvenanceStoreTests : IDisposable
+{
+    private static readonly DateTimeOffset Epoch = new(2026, 8, 16, 0, 0, 0, TimeSpan.Zero);
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "downkyi-output-artifact-provenance-tests",
+        Guid.NewGuid().ToString("N"));
+    private readonly TestClock _clock = new(Epoch);
+
+    [Fact]
+    public async Task PublishedProvenanceSurvivesRestart()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var task = CreateTask("restart-task");
+        var expected = CreateProvenance(task, "cover", "cover", "cover-id");
+
+        using (var store = CreateStore())
+        {
+            Assert.True((await store.AddAsync(task, cancellationToken)).IsSuccess);
+            Assert.True((await store.RecordPublishedAsync(expected, cancellationToken)).IsSuccess);
+
+            var beforeRestart = (await store.GetPublishedAsync(task.Id, cancellationToken)).RequireValue();
+            AssertProvenance(expected, Assert.Single(beforeRestart));
+        }
+
+        using var reopened = CreateStore();
+        var afterRestart = (await reopened.GetPublishedAsync(task.Id, cancellationToken)).RequireValue();
+
+        AssertProvenance(expected, Assert.Single(afterRestart));
+    }
+
+    [Fact]
+    public async Task VersionFourMigrationDoesNotBackfillFinalOutputProvenance()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var task = CreateTask("legacy-task");
+        using (var store = CreateStore())
+        {
+            Assert.True((await store.AddAsync(task, cancellationToken)).IsSuccess);
+        }
+
+        using (var connection = await OpenReadWriteConnectionAsync())
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                DROP TABLE download_output_artifact_provenance;
+                DELETE FROM download_schema_migrations WHERE version = 5;
+                PRAGMA user_version = 4;
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using var migrated = CreateStore();
+        var provenance = await migrated.GetPublishedAsync(task.Id, cancellationToken);
+        var restored = await migrated.FindAsync(task.Id, cancellationToken);
+
+        Assert.True(provenance.IsSuccess);
+        Assert.Empty(provenance.RequireValue());
+        Assert.NotNull(restored);
+        Assert.Equal("video.m4s", restored.Plan.TransferFiles["video"]);
+        Assert.Equal(5, await ReadSchemaVersionAsync());
+    }
+
+    [Fact]
+    public async Task PublishedProvenanceUsesTaskAndArtifactKeyAsUniqueIdentity()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var task = CreateTask("unique-task");
+        var original = CreateProvenance(task, "cover", "cover", "original-cover");
+        var conflict = CreateProvenance(task, "cover", "cover", "replacement-cover", hashCharacter: 'b');
+        var second = CreateProvenance(task, "danmaku", "danmaku", "danmaku-id", hashCharacter: 'c');
+        using var store = CreateStore();
+
+        Assert.True((await store.AddAsync(task, cancellationToken)).IsSuccess);
+        Assert.True((await store.RecordPublishedAsync(original, cancellationToken)).IsSuccess);
+
+        var rejected = await store.RecordPublishedAsync(conflict, cancellationToken);
+
+        Assert.False(rejected.IsSuccess);
+        Assert.Equal("download.output_provenance.conflict", rejected.Error?.Code);
+        Assert.True((await store.RecordPublishedAsync(second, cancellationToken)).IsSuccess);
+
+        var persisted = (await store.GetPublishedAsync(task.Id, cancellationToken)).RequireValue();
+        Assert.Equal(2, persisted.Count);
+        AssertProvenance(original, Assert.Single(persisted, item => item.ArtifactKey == "cover"));
+        AssertProvenance(second, Assert.Single(persisted, item => item.ArtifactKey == "danmaku"));
+    }
+
+    [Fact]
+    public async Task PublishedProvenanceRequiresAnExistingTask()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var task = CreateTask("missing-task");
+        using var store = CreateStore();
+
+        var result = await store.RecordPublishedAsync(
+            CreateProvenance(task, "cover", "cover", "cover-id"),
+            cancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.output_provenance.task_not_found", result.Error?.Code);
+    }
+
+    [Fact]
+    public async Task TaskDeletionCascadesProvenanceAfterTheTaskIsRemoved()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var task = CreateTask("cascade-task");
+        using var store = CreateStore();
+        Assert.True((await store.AddAsync(task, cancellationToken)).IsSuccess);
+        Assert.True((await store.RecordPublishedAsync(
+            CreateProvenance(task, "cover", "cover", "cover-id"),
+            cancellationToken)).IsSuccess);
+
+        var canceled = task.Cancel(Epoch.AddSeconds(1)).RequireValue();
+        Assert.True((await store.UpdateAsync(canceled, task.Version, cancellationToken)).IsSuccess);
+        var deleted = canceled.Delete(Epoch.AddSeconds(2)).RequireValue();
+        Assert.True((await store.UpdateAsync(deleted, canceled.Version, cancellationToken)).IsSuccess);
+
+        var provenance = await store.GetPublishedAsync(task.Id, cancellationToken);
+        Assert.True(provenance.IsSuccess);
+        Assert.Empty(provenance.RequireValue());
+    }
+
+    [Fact]
+    public async Task CorruptPersistedProvenanceFailsClosedInsteadOfReturningAnEmptyResult()
+    {
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var task = CreateTask("corrupt-task");
+        using (var store = CreateStore())
+        {
+            Assert.True((await store.AddAsync(task, cancellationToken)).IsSuccess);
+            Assert.True((await store.RecordPublishedAsync(
+                CreateProvenance(task, "cover", "cover", "cover-id"),
+                cancellationToken)).IsSuccess);
+        }
+
+        using (var connection = await OpenReadWriteConnectionAsync())
+        {
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE download_output_artifact_provenance
+                SET sha256 = 'not-a-digest'
+                WHERE task_id = @task_id
+                """;
+            command.Parameters.AddWithValue("@task_id", task.Id.Value);
+            await command.ExecuteNonQueryAsync(cancellationToken);
+        }
+
+        using var reopened = CreateStore();
+        var result = await reopened.GetPublishedAsync(task.Id, cancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.output_provenance.corrupt", result.Error?.Code);
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private SqliteDownloadTaskStore CreateStore()
+    {
+        Directory.CreateDirectory(_directory);
+        return new SqliteDownloadTaskStore(
+            new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
+            _clock);
+    }
+
+    private DownloadTask CreateTask(string id)
+    {
+        return DownloadTask.Create(
+            new DownloadTaskId(id),
+            new DownloadTaskMetadata(
+                new DownloadMediaIdentity("BV1TEST", 1, 2, 3, 1, 1),
+                "Collection",
+                id,
+                "00:10",
+                "AVC",
+                new DownloadQuality(80, "1080P"),
+                new DownloadQuality(30280, "192K"),
+                "cover",
+                "page-cover",
+                0),
+            new DownloadPlan(
+                new Dictionary<string, bool>(StringComparer.Ordinal) { ["video"] = true },
+                new Dictionary<string, string>(StringComparer.Ordinal) { ["video"] = "video.m4s" },
+                1),
+            new DownloadOutput(Path.Combine(_directory, id), null),
+            Epoch);
+    }
+
+    private DownloadOutputArtifactProvenance CreateProvenance(
+        DownloadTask task,
+        string artifactKey,
+        string artifactKind,
+        string identity,
+        char hashCharacter = 'a')
+    {
+        return new DownloadOutputArtifactProvenance(
+            task.Id,
+            artifactKey,
+            artifactKind,
+            Path.Combine(_directory, $"{task.Id.Value}-{artifactKey}.mp4"),
+            new OutputArtifactPublicationEvidence(
+                42,
+                new string(hashCharacter, 64),
+                "windows.file-id",
+                identity),
+            Epoch);
+    }
+
+    private static void AssertProvenance(
+        DownloadOutputArtifactProvenance expected,
+        DownloadOutputArtifactProvenance actual)
+    {
+        Assert.Equal(expected.TaskId, actual.TaskId);
+        Assert.Equal(expected.ArtifactKey, actual.ArtifactKey);
+        Assert.Equal(expected.ArtifactKind, actual.ArtifactKind);
+        Assert.Equal(expected.CanonicalPath, actual.CanonicalPath);
+        Assert.Equal(expected.ByteLength, actual.ByteLength);
+        Assert.Equal(expected.Sha256, actual.Sha256);
+        Assert.Equal(expected.IdentityProvider, actual.IdentityProvider);
+        Assert.Equal(expected.FilesystemIdentity, actual.FilesystemIdentity);
+        Assert.Equal(expected.PublishedAtUtc, actual.PublishedAtUtc);
+    }
+
+    private async Task<long> ReadSchemaVersionAsync()
+    {
+        using var connection = await OpenReadWriteConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA user_version";
+        return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken).ConfigureAwait(false))!;
+    }
+
+    private async Task<SqliteConnection> OpenReadWriteConnectionAsync()
+    {
+        var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = Path.Combine(_directory, "download.db"),
+            Mode = SqliteOpenMode.ReadWrite
+        }.ToString());
+        await connection.OpenAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+        return connection;
+    }
+
+    private sealed class TestClock(DateTimeOffset utcNow) : IClock
+    {
+        public DateTimeOffset UtcNow { get; } = utcNow;
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        {
+            return Task.Delay(delay, cancellationToken);
+        }
+    }
+}

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -24,7 +24,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(true);
         using var version = connection.CreateCommand();
         version.CommandText = "PRAGMA user_version";
-        Assert.Equal(4L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(5L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             await reopened.InitializeAsync(TestContext.Current.CancellationToken);
         }
 
-        Assert.Equal(4, await ReadSchemaVersionAsync());
+        Assert.Equal(5, await ReadSchemaVersionAsync());
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
     }
 
@@ -142,7 +142,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
 
         await store.InitializeAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(4, await ReadSchemaVersionAsync());
+        Assert.Equal(5, await ReadSchemaVersionAsync());
         Assert.Equal(1, await CountDownloadBaseRecordAsync("legacy-resume"));
         Assert.Equal(1, await CountDownloadingRecordAsync("legacy-resume"));
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
@@ -374,7 +374,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         }
 
         Assert.Equal(
-            4,
+            5,
             await ReadSchemaVersionAsync()
                 .ConfigureAwait(true));
 

--- a/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
+++ b/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
@@ -479,6 +479,305 @@ public sealed class DownloadArtifactStageTests
         Assert.Empty(context.GetTemporaryOutputFiles());
     }
 
+    [Fact]
+    public async Task AtomicPublisherReturnsEvidenceOnlyAfterTheDestinationIsPublishedAndVerified()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "downkyi-atomic-output-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var destination = Path.Combine(directory, "output.mp4");
+            var ownershipProvider = new RecordingPublicationOwnershipProvider();
+            var publisher = new AtomicOutputPublisher(ownershipProvider);
+
+            var result = await publisher.PublishAsync(
+                destination,
+                (temporaryPath, token) => File.WriteAllTextAsync(
+                    temporaryPath,
+                    "published media",
+                    token),
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+            Assert.True(result.Succeeded);
+            Assert.Same(ownershipProvider.Evidence, result.PublicationEvidence);
+            Assert.Equal("published media", await File.ReadAllTextAsync(
+                destination,
+                TestContext.Current.CancellationToken).ConfigureAwait(true));
+            var capture = Assert.Single(ownershipProvider.Captures);
+            Assert.True(capture.ExistedWhenObserved);
+            Assert.Contains(".downkyi-tmp", capture.Path, StringComparison.Ordinal);
+            var verification = Assert.Single(ownershipProvider.Verifications);
+            Assert.Equal(Path.GetFullPath(destination), verification.Path);
+            Assert.True(verification.ExistedWhenObserved);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task AtomicPublisherLeavesOutputUntrackedWhenPostMoveIdentityVerificationFails()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "downkyi-atomic-output-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
+        {
+            var destination = Path.Combine(directory, "output.mp4");
+            var ownershipProvider = new RecordingPublicationOwnershipProvider
+            {
+                VerifyPublishedIdentity = false
+            };
+            var publisher = new AtomicOutputPublisher(ownershipProvider);
+
+            var result = await publisher.PublishAsync(
+                destination,
+                (temporaryPath, token) => File.WriteAllTextAsync(
+                    temporaryPath,
+                    "published media",
+                    token),
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+            Assert.True(result.Succeeded);
+            Assert.Null(result.PublicationEvidence);
+            Assert.True(File.Exists(destination));
+            Assert.Single(ownershipProvider.Captures);
+            Assert.Single(ownershipProvider.Verifications);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData(nameof(ArtifactKind.MainCover))]
+    [InlineData(nameof(ArtifactKind.PageCover))]
+    [InlineData(nameof(ArtifactKind.Subtitle))]
+    [InlineData(nameof(ArtifactKind.Danmaku))]
+    [InlineData(nameof(ArtifactKind.Nfo))]
+    public async Task SuccessfulArtifactPublicationsPersistProvenanceAfterEachOutputIsPublished(
+        string kindName)
+    {
+        var kind = Enum.Parse<ArtifactKind>(kindName);
+        var provenance = new RecordingOutputProvenanceService();
+        var ownershipProvider = new RecordingPublicationOwnershipProvider();
+        var recorder = new DownloadOutputArtifactProvenanceRecorder(
+            provenance,
+            NullLogger<DownloadOutputArtifactProvenanceRecorder>.Instance);
+        using var context = await ArtifactTestContext.CreateAsync(
+            CreateSuccessfulArtifactClient(kind),
+            cover: kind is ArtifactKind.MainCover or ArtifactKind.PageCover,
+            subtitle: kind == ArtifactKind.Subtitle,
+            danmaku: kind == ArtifactKind.Danmaku,
+            generateMetadata: kind == ArtifactKind.Nfo,
+            outputPublisher: new AtomicOutputPublisher(ownershipProvider),
+            provenanceRecorder: recorder).ConfigureAwait(true);
+        if (kind == ArtifactKind.MainCover)
+        {
+            context.Downloading.DownloadBase.CoverUrl = "https://example.test/main.jpg";
+        }
+        else if (kind == ArtifactKind.PageCover)
+        {
+            context.Downloading.DownloadBase.PageCoverUrl = "https://example.test/page.jpg";
+        }
+
+        var result = await context.Stage.ExecuteAsync(
+            context.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        (string ArtifactKey, string ArtifactKind)[] expected = kind switch
+        {
+            ArtifactKind.MainCover =>
+            new[]
+            {
+                (DownloadArtifactWriter.MainCoverTransferKey, DownloadArtifactWriter.CoverArtifactKind)
+            },
+            ArtifactKind.PageCover =>
+            new[]
+            {
+                (DownloadArtifactWriter.PageCoverTransferKey, DownloadArtifactWriter.PageCoverArtifactKind)
+            },
+            ArtifactKind.Subtitle =>
+            new[]
+            {
+                (DownloadArtifactWriter.GetSubtitleTrackTransferKey(0), DownloadArtifactWriter.SubtitleArtifactKind),
+                (DownloadArtifactWriter.GetSubtitleTrackTransferKey(1), DownloadArtifactWriter.SubtitleArtifactKind),
+                (DownloadArtifactWriter.DefaultSubtitleTransferKey, DownloadArtifactWriter.SubtitleArtifactKind)
+            },
+            ArtifactKind.Danmaku =>
+            new[]
+            {
+                ("danmaku", DownloadArtifactWriter.DanmakuArtifactKind)
+            },
+            ArtifactKind.Nfo =>
+            new[]
+            {
+                ("nfo", DownloadArtifactWriter.NfoArtifactKind)
+            },
+            _ => throw new ArgumentOutOfRangeException(nameof(kindName), kind, null)
+        };
+
+        Assert.Equal(expected, provenance.Persisted
+            .Select(record => (record.ArtifactKey, record.ArtifactKind))
+            .ToArray());
+        Assert.Equal(expected.Length, ownershipProvider.Captures.Count);
+        Assert.Equal(expected.Length, ownershipProvider.Verifications.Count);
+        Assert.All(provenance.Persisted, record =>
+        {
+            Assert.Equal(context.Execution.TaskId, record.TaskId);
+            Assert.True(record.DestinationExistedWhenRecorded);
+            Assert.True(File.Exists(record.CanonicalPath));
+            Assert.Same(ownershipProvider.Evidence, record.PublicationEvidence);
+        });
+    }
+
+    [Fact]
+    public async Task FailedArtifactPublicationDoesNotRecordProvenance()
+    {
+        var provenance = new RecordingOutputProvenanceService();
+        var ownershipProvider = new RecordingPublicationOwnershipProvider();
+        var client = new TestBilibiliApiClient
+        {
+            DownloadFileAsyncHandler = (_, _, _) =>
+                Task.FromException(new IOException("write failed"))
+        };
+        using var context = await ArtifactTestContext.CreateAsync(
+            client,
+            cover: true,
+            outputPublisher: new AtomicOutputPublisher(ownershipProvider),
+            provenanceRecorder: new DownloadOutputArtifactProvenanceRecorder(
+                provenance,
+                NullLogger<DownloadOutputArtifactProvenanceRecorder>.Instance))
+            .ConfigureAwait(true);
+        context.Downloading.DownloadBase.CoverUrl = "https://example.test/cover.jpg";
+
+        var result = await context.Stage.ExecuteAsync(
+            context.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(result.IsSuccess);
+        Assert.Empty(provenance.Attempts);
+        Assert.Empty(provenance.Persisted);
+        Assert.Empty(ownershipProvider.Captures);
+        Assert.False(File.Exists(context.Execution.CoverFile));
+    }
+
+    [Fact]
+    public async Task DestinationCollisionDoesNotRecordProvenance()
+    {
+        string? foreignPath = null;
+        var provenance = new RecordingOutputProvenanceService();
+        var ownershipProvider = new RecordingPublicationOwnershipProvider();
+        var publisher = new AtomicOutputPublisher(
+            path =>
+            {
+                foreignPath = path;
+                File.WriteAllText(path, "foreign artifact");
+            },
+            ownershipProvider);
+        using var context = await ArtifactTestContext.CreateAsync(
+            CreateSuccessfulArtifactClient(ArtifactKind.MainCover),
+            cover: true,
+            outputPublisher: publisher,
+            provenanceRecorder: new DownloadOutputArtifactProvenanceRecorder(
+                provenance,
+                NullLogger<DownloadOutputArtifactProvenanceRecorder>.Instance))
+            .ConfigureAwait(true);
+        context.Downloading.DownloadBase.CoverUrl = "https://example.test/cover.jpg";
+
+        var result = await context.Stage.ExecuteAsync(
+            context.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.output.destination-collision", result.Error?.Code);
+        Assert.Empty(provenance.Attempts);
+        Assert.Empty(provenance.Persisted);
+        Assert.Single(ownershipProvider.Captures);
+        Assert.Empty(ownershipProvider.Verifications);
+        Assert.Equal("foreign artifact", await File.ReadAllTextAsync(
+            Assert.IsType<string>(foreignPath),
+            TestContext.Current.CancellationToken).ConfigureAwait(true));
+    }
+
+    [Fact]
+    public async Task CanceledArtifactPublicationDoesNotRecordProvenance()
+    {
+        var provenance = new RecordingOutputProvenanceService();
+        var ownershipProvider = new RecordingPublicationOwnershipProvider();
+        var client = new TestBilibiliApiClient
+        {
+            DownloadFileAsyncHandler = (_, _, token) =>
+                Task.FromException(new OperationCanceledException(token))
+        };
+        using var context = await ArtifactTestContext.CreateAsync(
+            client,
+            cover: true,
+            outputPublisher: new AtomicOutputPublisher(ownershipProvider),
+            provenanceRecorder: new DownloadOutputArtifactProvenanceRecorder(
+                provenance,
+                NullLogger<DownloadOutputArtifactProvenanceRecorder>.Instance))
+            .ConfigureAwait(true);
+        context.Downloading.DownloadBase.CoverUrl = "https://example.test/cover.jpg";
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            context.Stage.ExecuteAsync(
+                context.Execution,
+                TestContext.Current.CancellationToken)).ConfigureAwait(true);
+
+        Assert.Empty(provenance.Attempts);
+        Assert.Empty(provenance.Persisted);
+        Assert.Empty(ownershipProvider.Captures);
+        Assert.False(File.Exists(context.Execution.CoverFile));
+    }
+
+    [Fact]
+    public async Task ProvenancePersistenceFailureLeavesSuccessfulOutputUntracked()
+    {
+        var provenance = new RecordingOutputProvenanceService
+        {
+            RecordResult = OperationResult.Failure(
+                OperationError.Unexpected(
+                    "download.output_provenance.write_failed",
+                    "The durable provenance write failed."))
+        };
+        var ownershipProvider = new RecordingPublicationOwnershipProvider();
+        using var context = await ArtifactTestContext.CreateAsync(
+            CreateSuccessfulArtifactClient(ArtifactKind.MainCover),
+            cover: true,
+            outputPublisher: new AtomicOutputPublisher(ownershipProvider),
+            provenanceRecorder: new DownloadOutputArtifactProvenanceRecorder(
+                provenance,
+                NullLogger<DownloadOutputArtifactProvenanceRecorder>.Instance))
+            .ConfigureAwait(true);
+        context.Downloading.DownloadBase.CoverUrl = "https://example.test/cover.jpg";
+
+        var result = await context.Stage.ExecuteAsync(
+            context.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        Assert.Single(provenance.Attempts);
+        Assert.Empty(provenance.Persisted);
+        Assert.True(File.Exists(context.Execution.CoverFile));
+        Assert.Single(ownershipProvider.Captures);
+        Assert.Single(ownershipProvider.Verifications);
+    }
+
     private static StringComparer PathComparer =>
         OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
             ? StringComparer.OrdinalIgnoreCase
@@ -618,6 +917,107 @@ public sealed class DownloadArtifactStageTests
         };
     }
 
+    private sealed record PublicationPathObservation(
+        string Path,
+        bool ExistedWhenObserved);
+
+    private sealed record RecordedArtifactPublication(
+        DownloadTaskId TaskId,
+        string ArtifactKey,
+        string ArtifactKind,
+        string CanonicalPath,
+        OutputArtifactPublicationEvidence PublicationEvidence,
+        bool DestinationExistedWhenRecorded);
+
+    private sealed class RecordingOutputProvenanceService
+        : IDownloadOutputArtifactProvenanceApplicationService
+    {
+        public List<RecordedArtifactPublication> Attempts { get; } = [];
+
+        public List<RecordedArtifactPublication> Persisted { get; } = [];
+
+        public OperationResult RecordResult { get; init; } = OperationResult.Success();
+
+        public Task<OperationResult> RecordPublishedAsync(
+            DownloadTaskId taskId,
+            string artifactKey,
+            string artifactKind,
+            string canonicalPath,
+            OutputArtifactPublicationEvidence publicationEvidence,
+            CancellationToken cancellationToken)
+        {
+            var record = new RecordedArtifactPublication(
+                taskId,
+                artifactKey,
+                artifactKind,
+                Path.GetFullPath(canonicalPath),
+                publicationEvidence,
+                File.Exists(canonicalPath));
+            Attempts.Add(record);
+            if (RecordResult.IsSuccess)
+            {
+                Persisted.Add(record);
+            }
+
+            return Task.FromResult(RecordResult);
+        }
+
+        public Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(
+                OperationResult.Success<IReadOnlyList<DownloadOutputArtifactProvenance>>([]));
+        }
+    }
+
+    private sealed class RecordingPublicationOwnershipProvider : IOutputArtifactOwnershipProvider
+    {
+        public OutputArtifactPublicationEvidence Evidence { get; } = new(
+            ByteLength: 42,
+            Sha256: new string('a', 64),
+            IdentityProvider: "test-publication-provider",
+            FilesystemIdentity: "test-file-identity");
+
+        public List<PublicationPathObservation> Captures { get; } = [];
+
+        public List<PublicationPathObservation> Verifications { get; } = [];
+
+        public bool VerifyPublishedIdentity { get; init; } = true;
+
+        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+            string temporaryPath,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Captures.Add(new PublicationPathObservation(
+                Path.GetFullPath(temporaryPath),
+                File.Exists(temporaryPath)));
+            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Captured(Evidence));
+        }
+
+        public Task<bool> VerifyPublishedObjectIdentityAsync(
+            string destinationPath,
+            OutputArtifactPublicationEvidence evidence,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Verifications.Add(new PublicationPathObservation(
+                Path.GetFullPath(destinationPath),
+                File.Exists(destinationPath)));
+            return Task.FromResult(VerifyPublishedIdentity);
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+            string candidatePath,
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OutputArtifactSafeDeleteResult.Unsupported());
+        }
+    }
+
     private sealed class CallbackStage(Action callback) : IDownloadPipelineStage
     {
         public string Name => "finalize";
@@ -709,7 +1109,8 @@ public sealed class DownloadArtifactStageTests
             bool danmaku = false,
             bool generateMetadata = false,
             bool useMissingOutputDirectory = false,
-            IAtomicOutputPublisher? outputPublisher = null)
+            IAtomicOutputPublisher? outputPublisher = null,
+            DownloadOutputArtifactProvenanceRecorder? provenanceRecorder = null)
         {
             var directory = Path.Combine(
                 Path.GetTempPath(),
@@ -787,7 +1188,8 @@ public sealed class DownloadArtifactStageTests
                 stateWriter,
                 NullLogger<DownloadArtifactWriter>.Instance,
                 client,
-                outputPublisher);
+                outputPublisher,
+                provenanceRecorder);
             var execution = new DownloadExecutionContext(
                 taskId,
                 downloading,

--- a/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
+++ b/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
@@ -8,6 +8,7 @@ using DownKyi.Services.Download;
 using DownKyi.ViewModels.DownloadManager;
 using Google.Protobuf;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Win32.SafeHandles;
 
 namespace DownKyi.Tests;
 
@@ -973,6 +974,8 @@ public sealed class DownloadArtifactStageTests
 
     private sealed class RecordingPublicationOwnershipProvider : IOutputArtifactOwnershipProvider
     {
+        private sealed record TemporaryClaim : OutputArtifactTemporaryClaim;
+
         public OutputArtifactPublicationEvidence Evidence { get; } = new(
             ByteLength: 42,
             Sha256: new string('a', 64),
@@ -985,15 +988,41 @@ public sealed class DownloadArtifactStageTests
 
         public bool VerifyPublishedIdentity { get; init; } = true;
 
+        public OutputArtifactTemporaryClaimResult ClaimTemporaryObject(
+            SafeFileHandle temporaryHandle)
+        {
+            Assert.False(temporaryHandle.IsClosed);
+            Assert.False(temporaryHandle.IsInvalid);
+            return OutputArtifactTemporaryClaimResult.Claimed(new TemporaryClaim());
+        }
+
         public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
             string temporaryPath,
+            OutputArtifactTemporaryClaim temporaryClaim,
             CancellationToken cancellationToken)
         {
+            Assert.IsType<TemporaryClaim>(temporaryClaim);
             cancellationToken.ThrowIfCancellationRequested();
             Captures.Add(new PublicationPathObservation(
                 Path.GetFullPath(temporaryPath),
                 File.Exists(temporaryPath)));
             return Task.FromResult(OutputArtifactEvidenceCaptureResult.Captured(Evidence));
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteTemporaryIfOwnedAsync(
+            string temporaryPath,
+            OutputArtifactTemporaryClaim temporaryClaim,
+            CancellationToken cancellationToken)
+        {
+            Assert.IsType<TemporaryClaim>(temporaryClaim);
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!File.Exists(temporaryPath))
+            {
+                return Task.FromResult(OutputArtifactSafeDeleteResult.Missing());
+            }
+
+            File.Delete(temporaryPath);
+            return Task.FromResult(OutputArtifactSafeDeleteResult.DeletedResult());
         }
 
         public Task<bool> VerifyPublishedObjectIdentityAsync(

--- a/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
@@ -50,7 +50,7 @@ public sealed class DownloadManagerCoordinatorTests
     }
 
     [Fact]
-    public async Task DeleteCanBeRetriedAfterAFormerFileCleanupLeftTaskCanceled()
+    public async Task DeleteOfCanceledTaskPreservesUnprovenTransferFileAndRemovesTask()
     {
         using var context = new CoordinatorContext();
         var item = context.CreateDownloadingItem("delete-retry", DownloadStatus.WaitForDownload);
@@ -64,7 +64,7 @@ public sealed class DownloadManagerCoordinatorTests
 
         await context.Coordinator.DeleteAsync(item, TestContext.Current.CancellationToken);
 
-        Assert.False(File.Exists(media));
+        Assert.True(File.Exists(media));
         Assert.DoesNotContain(item, context.State.Downloading);
         Assert.Equal(
             item.DownloadBase.Id,
@@ -75,7 +75,7 @@ public sealed class DownloadManagerCoordinatorTests
     }
 
     [Fact]
-    public async Task DeleteRemovesGeneratedFilesResumeSidecarsStoreRowAndProjection()
+    public async Task DeletePreservesFilenameDiscoveredTransferFilesAndResumeSidecars()
     {
         using var context = new CoordinatorContext();
         var item = context.CreateDownloadingItem("delete-complete", DownloadStatus.WaitForDownload);
@@ -87,12 +87,51 @@ public sealed class DownloadManagerCoordinatorTests
 
         await context.Coordinator.DeleteAsync(item, TestContext.Current.CancellationToken);
 
-        Assert.False(File.Exists(media));
-        Assert.False(File.Exists(sidecar));
+        Assert.True(File.Exists(media));
+        Assert.True(File.Exists(sidecar));
         Assert.DoesNotContain(item, context.State.Downloading);
         Assert.Null(await context.Store.FindAsync(
             new DownloadTaskId(item.DownloadBase.Id),
             TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteRemovesProvenOutputAndPreservesFilenameDiscoveredTransferArtifacts()
+    {
+        using var context = new CoordinatorContext(enableOutputProvenance: true);
+        var item = context.CreateDownloadingItem("delete-proven", DownloadStatus.WaitForDownload);
+        item.Downloading.DownloadFiles["video"] = "delete-proven.mp4";
+        context.State.AddDownloading(item);
+        await context.Storage.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+        var provenOutput = context.CreateFile("renamed-output.mp4", "owned final output");
+        var transfer = context.CreateFile("delete-proven.mp4", "transfer artifact");
+        var sidecar = context.CreateFile("delete-proven.mp4.aria2", "resume state");
+        var taskId = new DownloadTaskId(item.DownloadBase.Id);
+        var recorded = await context.OutputProvenance!.RecordPublishedAsync(
+            taskId,
+            "media",
+            "media",
+            provenOutput,
+            new OutputArtifactPublicationEvidence(
+                new FileInfo(provenOutput).Length,
+                new string('a', 64),
+                "test-ownership-provider",
+                "owned-final-output"),
+            TestContext.Current.CancellationToken);
+        Assert.True(recorded.IsSuccess);
+
+        await context.Coordinator.DeleteAsync(item, TestContext.Current.CancellationToken);
+
+        Assert.False(File.Exists(provenOutput));
+        Assert.True(File.Exists(transfer));
+        Assert.True(File.Exists(sidecar));
+        Assert.DoesNotContain(item, context.State.Downloading);
+        Assert.Null(await context.Store.FindAsync(taskId, TestContext.Current.CancellationToken));
+        var remainingProvenance = await context.Store.GetPublishedAsync(
+            taskId,
+            TestContext.Current.CancellationToken);
+        Assert.True(remainingProvenance.IsSuccess);
+        Assert.Empty(remainingProvenance.RequireValue());
     }
 
     [Fact]
@@ -139,7 +178,7 @@ public sealed class DownloadManagerCoordinatorTests
             "downkyi-download-manager-tests",
             Guid.NewGuid().ToString("N"));
 
-        public CoordinatorContext()
+        public CoordinatorContext(bool enableOutputProvenance = false)
         {
             Directory.CreateDirectory(_directory);
             Store = new SqliteDownloadTaskStore(
@@ -152,9 +191,14 @@ public sealed class DownloadManagerCoordinatorTests
             Queue = new RecordingDownloadTaskQueue();
             State = new DownloadListState();
             Launcher = new RecordingPlatformLauncher();
+            OutputProvenance = enableOutputProvenance
+                ? new DownloadOutputArtifactProvenanceApplicationService(Store, clock)
+                : null;
             var fileService = new DownloadTaskFileService(
                 new AriaRuntimeClientRegistry(),
-                NullLogger<DownloadTaskFileService>.Instance);
+                NullLogger<DownloadTaskFileService>.Instance,
+                OutputProvenance,
+                enableOutputProvenance ? new DeletingOwnershipProvider() : null);
             Coordinator = new DownloadManagerCoordinator(
                 Storage,
                 StateWriter,
@@ -177,6 +221,8 @@ public sealed class DownloadManagerCoordinatorTests
         public DownloadListState State { get; }
 
         public RecordingPlatformLauncher Launcher { get; }
+
+        public DownloadOutputArtifactProvenanceApplicationService? OutputProvenance { get; }
 
         public DownloadManagerCoordinator Coordinator { get; }
 
@@ -254,6 +300,27 @@ public sealed class DownloadManagerCoordinatorTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(true);
+        }
+    }
+
+    private sealed class DeletingOwnershipProvider : IOutputArtifactOwnershipProvider
+    {
+        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+            string temporaryPath,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+            string candidatePath,
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Delete(candidatePath);
+            return Task.FromResult(OutputArtifactSafeDeleteResult.DeletedResult());
         }
     }
 }

--- a/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
@@ -305,14 +305,6 @@ public sealed class DownloadManagerCoordinatorTests
 
     private sealed class DeletingOwnershipProvider : IOutputArtifactOwnershipProvider
     {
-        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
-            string temporaryPath,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
-        }
-
         public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
             string candidatePath,
             DownloadOutputArtifactProvenance provenance,

--- a/tests/DownKyi.Tests/DownloadTaskFileServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskFileServiceTests.cs
@@ -1,4 +1,9 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+using DownKyi.Models;
 using DownKyi.Services.Download;
+using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Tests;
@@ -72,6 +77,180 @@ public sealed class DownloadTaskFileServiceTests : IDisposable
         Assert.Throws<ArgumentNullException>(() => _service.GetGeneratedFiles(null!));
     }
 
+    [Fact]
+    public async Task DeleteGeneratedFilesAsyncDeletesOnlyDurablyProvenArtifacts()
+    {
+        Directory.CreateDirectory(_directory);
+        var durableOutput = CreateFile("renamed-output.mp4", "durably published output");
+        var filenameMatchedOutput = CreateFile("episode-01.mp4", "legacy-looking output");
+        var transfer = CreateFile("video-stream.mp4", "transfer artifact");
+        var sidecar = CreateFile("video-stream.mp4.aria2", "transfer sidecar");
+        var taskId = "durable-cleanup";
+        var provenance = CreateProvenance(taskId, "media", durableOutput);
+        var provenanceService = new FakeOutputProvenanceService([provenance]);
+        var ownershipProvider = new RecordingOwnershipProvider((candidate, _) =>
+        {
+            File.Delete(candidate);
+            return OutputArtifactSafeDeleteResult.DeletedResult();
+        });
+        var service = CreateProvenanceAwareService(provenanceService, ownershipProvider);
+        var item = CreateDownloadingItem(taskId, "episode-01");
+        item.Downloading.DownloadFiles["video"] = Path.GetFileName(transfer);
+
+        var result = await service.DeleteGeneratedFilesAsync(
+            item,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.False(File.Exists(durableOutput));
+        Assert.True(File.Exists(filenameMatchedOutput));
+        Assert.True(File.Exists(transfer));
+        Assert.True(File.Exists(sidecar));
+        Assert.Equal([Path.GetFullPath(durableOutput)], ownershipProvider.DeleteCandidates);
+        Assert.Equal(
+            DownloadOutputArtifactCleanupStatus.Deleted,
+            Assert.Single(result.Entries, entry => entry.ArtifactKey == "media").Status);
+        Assert.Equal(
+            DownloadOutputArtifactCleanupStatus.PreservedUnproven,
+            Assert.Single(result.Entries, entry => entry.Path == Path.GetFullPath(filenameMatchedOutput)).Status);
+    }
+
+    [Fact]
+    public async Task DeleteGeneratedFilesAsyncPreservesLegacyFilenameMatchedOutputWithoutProvenance()
+    {
+        Directory.CreateDirectory(_directory);
+        var output = CreateFile("legacy-task.mp4", "legacy output");
+        var taskId = "legacy-task";
+        var provenanceService = new FakeOutputProvenanceService([]);
+        var ownershipProvider = new RecordingOwnershipProvider((_, _) =>
+            throw new InvalidOperationException("Untracked outputs must not reach the ownership provider."));
+        var service = CreateProvenanceAwareService(provenanceService, ownershipProvider);
+
+        var result = await service.DeleteGeneratedFilesAsync(
+            CreateDownloadingItem(taskId, taskId),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.True(File.Exists(output));
+        Assert.Empty(ownershipProvider.DeleteCandidates);
+        Assert.Equal(
+            DownloadOutputArtifactCleanupStatus.PreservedUnproven,
+            Assert.Single(result.Entries).Status);
+    }
+
+    [Fact]
+    public async Task DeleteGeneratedFilesAsyncDeletesOnlyIndividuallyProvenSubtitleTracks()
+    {
+        Directory.CreateDirectory(_directory);
+        var englishSubtitle = CreateFile("episode-02_en.srt", "English subtitle");
+        var japaneseSubtitle = CreateFile("episode-02_ja.srt", "Japanese subtitle");
+        var taskId = "subtitle-provenance";
+        var provenance = CreateProvenance(taskId, "subtitle:en", englishSubtitle);
+        var provenanceService = new FakeOutputProvenanceService([provenance]);
+        var ownershipProvider = new RecordingOwnershipProvider((candidate, _) =>
+        {
+            File.Delete(candidate);
+            return OutputArtifactSafeDeleteResult.DeletedResult();
+        });
+        var service = CreateProvenanceAwareService(provenanceService, ownershipProvider);
+
+        var result = await service.DeleteGeneratedFilesAsync(
+            CreateDownloadingItem(taskId, "episode-02"),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.False(File.Exists(englishSubtitle));
+        Assert.True(File.Exists(japaneseSubtitle));
+        Assert.Equal([Path.GetFullPath(englishSubtitle)], ownershipProvider.DeleteCandidates);
+        Assert.Equal(
+            DownloadOutputArtifactCleanupStatus.Deleted,
+            Assert.Single(result.Entries, entry => entry.ArtifactKey == "subtitle:en").Status);
+        Assert.Equal(
+            DownloadOutputArtifactCleanupStatus.PreservedUnproven,
+            Assert.Single(result.Entries, entry => entry.Path == Path.GetFullPath(japaneseSubtitle)).Status);
+    }
+
+    [Theory]
+    [InlineData(OutputArtifactSafeDeleteStatus.Replaced, (int)DownloadOutputArtifactCleanupStatus.PreservedReplaced)]
+    [InlineData(OutputArtifactSafeDeleteStatus.Modified, (int)DownloadOutputArtifactCleanupStatus.PreservedModified)]
+    [InlineData(OutputArtifactSafeDeleteStatus.Unsupported, (int)DownloadOutputArtifactCleanupStatus.PreservedUnsupported)]
+    public async Task DeleteGeneratedFilesAsyncReportsNonDestructiveOwnershipOutcomes(
+        OutputArtifactSafeDeleteStatus safeDeleteStatus,
+        int expectedCleanupStatus)
+    {
+        Directory.CreateDirectory(_directory);
+        var output = CreateFile("episode-03.mp4", "published output");
+        var taskId = "ownership-outcome";
+        var provenance = CreateProvenance(taskId, "media", output);
+        var provenanceService = new FakeOutputProvenanceService([provenance]);
+        var ownershipProvider = new RecordingOwnershipProvider((_, _) => new(safeDeleteStatus));
+        var service = CreateProvenanceAwareService(provenanceService, ownershipProvider);
+
+        var result = await service.DeleteGeneratedFilesAsync(
+            CreateDownloadingItem(taskId, "episode-03"),
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.Succeeded);
+        Assert.True(File.Exists(output));
+        Assert.Equal(
+            (DownloadOutputArtifactCleanupStatus)expectedCleanupStatus,
+            Assert.Single(result.Entries, entry => entry.ArtifactKey == "media").Status);
+    }
+
+    [Fact]
+    public async Task DeleteGeneratedFilesAsyncReportsFailedAndPreservesFilesWhenProvenanceCannotBeLoaded()
+    {
+        Directory.CreateDirectory(_directory);
+        var output = CreateFile("failed-read.mp4", "published output");
+        var taskId = "failed-read";
+        var provenanceService = new FakeOutputProvenanceService([])
+        {
+            PublishedResult = OperationResult.Failure<IReadOnlyList<DownloadOutputArtifactProvenance>>(
+                new OperationError(
+                    "download.output_provenance.read_failed",
+                    "Provenance read failed."))
+        };
+        var ownershipProvider = new RecordingOwnershipProvider((_, _) =>
+            throw new InvalidOperationException("Failed provenance reads must not reach the ownership provider."));
+        var service = CreateProvenanceAwareService(provenanceService, ownershipProvider);
+
+        var result = await service.DeleteGeneratedFilesAsync(
+            CreateDownloadingItem(taskId, taskId),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.Equal(1, result.FailedCount);
+        Assert.True(File.Exists(output));
+        Assert.Empty(ownershipProvider.DeleteCandidates);
+        Assert.Contains(
+            result.Entries,
+            entry => entry.Status == DownloadOutputArtifactCleanupStatus.PreservedUnproven
+                && entry.Path == Path.GetFullPath(output));
+    }
+
+    [Fact]
+    public async Task DeleteGeneratedFilesAsyncFailsClosedWhenOwnershipDeletionHasIoUncertainty()
+    {
+        Directory.CreateDirectory(_directory);
+        var output = CreateFile("io-uncertain.mp4", "published output");
+        var taskId = "io-uncertain";
+        var provenance = CreateProvenance(taskId, "media", output);
+        var provenanceService = new FakeOutputProvenanceService([provenance]);
+        var ownershipProvider = new RecordingOwnershipProvider((_, _) =>
+            throw new IOException("The output could not be opened safely."));
+        var service = CreateProvenanceAwareService(provenanceService, ownershipProvider);
+
+        var result = await service.DeleteGeneratedFilesAsync(
+            CreateDownloadingItem(taskId, taskId),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.Succeeded);
+        Assert.True(File.Exists(output));
+        Assert.Equal(
+            DownloadOutputArtifactCleanupStatus.Failed,
+            Assert.Single(result.Entries, entry => entry.ArtifactKey == "media").Status);
+    }
+
     private string CreateFile(string name, string contents)
     {
         var file = Path.Combine(_directory, name);
@@ -79,11 +258,108 @@ public sealed class DownloadTaskFileServiceTests : IDisposable
         return file;
     }
 
+    private static DownloadTaskFileService CreateProvenanceAwareService(
+        IDownloadOutputArtifactProvenanceApplicationService provenanceService,
+        IOutputArtifactOwnershipProvider ownershipProvider)
+    {
+        return new DownloadTaskFileService(
+            new AriaRuntimeClientRegistry(),
+            NullLogger<DownloadTaskFileService>.Instance,
+            provenanceService,
+            ownershipProvider);
+    }
+
+    private DownloadingItem CreateDownloadingItem(string id, string baseFileName)
+    {
+        return new DownloadingItem
+        {
+            DownloadBase = new DownloadBase
+            {
+                Id = id,
+                FilePath = Path.Combine(_directory, baseFileName)
+            },
+            Downloading = new Downloading
+            {
+                Id = id
+            }
+        };
+    }
+
+    private static DownloadOutputArtifactProvenance CreateProvenance(
+        string taskId,
+        string artifactKey,
+        string path)
+    {
+        return new DownloadOutputArtifactProvenance(
+            new DownloadTaskId(taskId),
+            artifactKey,
+            "test-output",
+            Path.GetFullPath(path),
+            new OutputArtifactPublicationEvidence(
+                new FileInfo(path).Length,
+                new string('a', 64),
+                "test-ownership-provider",
+                $"identity:{artifactKey}"),
+            DateTimeOffset.UtcNow);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_directory))
         {
             Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private sealed class FakeOutputProvenanceService(
+        IReadOnlyList<DownloadOutputArtifactProvenance> published)
+        : IDownloadOutputArtifactProvenanceApplicationService
+    {
+        public OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>> PublishedResult { get; set; } =
+            OperationResult.Success(published);
+
+        public Task<OperationResult> RecordPublishedAsync(
+            DownloadTaskId taskId,
+            string artifactKey,
+            string artifactKind,
+            string canonicalPath,
+            OutputArtifactPublicationEvidence publicationEvidence,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(OperationResult.Success());
+        }
+
+        public Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(PublishedResult);
+        }
+    }
+
+    private sealed class RecordingOwnershipProvider(
+        Func<string, DownloadOutputArtifactProvenance, OutputArtifactSafeDeleteResult> delete)
+        : IOutputArtifactOwnershipProvider
+    {
+        public List<string> DeleteCandidates { get; } = [];
+
+        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+            string temporaryPath,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+            string candidatePath,
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DeleteCandidates.Add(candidatePath);
+            return Task.FromResult(delete(candidatePath, provenance));
         }
     }
 }

--- a/tests/DownKyi.Tests/DownloadTaskFileServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskFileServiceTests.cs
@@ -344,14 +344,6 @@ public sealed class DownloadTaskFileServiceTests : IDisposable
     {
         public List<string> DeleteCandidates { get; } = [];
 
-        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
-            string temporaryPath,
-            CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
-        }
-
         public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
             string candidatePath,
             DownloadOutputArtifactProvenance provenance,

--- a/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
+++ b/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
@@ -180,6 +180,77 @@ public sealed class MuxFailureRecoveryTests
         Assert.Contains(sources[2].TransferKey, task.Transfer.CompletedFileKeys);
     }
 
+    [Fact]
+    public async Task DashMuxRecordsTheEvidenceReturnedByTheFfmpegPublicationBoundary()
+    {
+        var test = await MuxTestContext.CreateAsync().ConfigureAwait(true);
+        await using var testLifetime = test.ConfigureAwait(true);
+        var finalPath = MuxStage.GetDashOutputPath(test.Execution);
+        await File.WriteAllTextAsync(
+            finalPath,
+            "published dash media",
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+        var evidence = CreatePublicationEvidence("dash-object");
+        var muxer = new StubMuxer(Success(finalPath, evidence));
+        var provenance = new RecordingOutputProvenanceService();
+        var ownershipProvider = new TestOwnershipProvider();
+        var stage = test.CreateStage(
+            muxer,
+            ownershipProvider,
+            new DownloadOutputArtifactProvenanceRecorder(
+                provenance,
+                NullLogger<DownloadOutputArtifactProvenanceRecorder>.Instance));
+
+        var result = await stage.ExecuteAsync(
+            test.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        Assert.Same(ownershipProvider, muxer.MergeEvidenceProvider);
+        var record = Assert.Single(provenance.Records);
+        Assert.Equal(test.Execution.TaskId, record.TaskId);
+        Assert.Equal("media", record.ArtifactKey);
+        Assert.Equal("dash-media", record.ArtifactKind);
+        Assert.Equal(Path.GetFullPath(finalPath), record.CanonicalPath);
+        Assert.Same(evidence, record.Evidence);
+    }
+
+    [Fact]
+    public async Task DurlMuxRecordsTheEvidenceReturnedByTheFfmpegPublicationBoundary()
+    {
+        var test = await MuxTestContext.CreateAsync().ConfigureAwait(true);
+        await using var testLifetime = test.ConfigureAwait(true);
+        await test.AddDurlSourcesAsync().ConfigureAwait(true);
+        var finalPath = $"{test.Execution.Downloading.DownloadBase.FilePath}.mp4";
+        await File.WriteAllTextAsync(
+            finalPath,
+            "published durl media",
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+        var evidence = CreatePublicationEvidence("durl-object");
+        var muxer = new StubMuxer(Success(finalPath, evidence));
+        var provenance = new RecordingOutputProvenanceService();
+        var ownershipProvider = new TestOwnershipProvider();
+        var stage = test.CreateStage(
+            muxer,
+            ownershipProvider,
+            new DownloadOutputArtifactProvenanceRecorder(
+                provenance,
+                NullLogger<DownloadOutputArtifactProvenanceRecorder>.Instance));
+
+        var result = await stage.ExecuteAsync(
+            test.Execution,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.IsSuccess, result.Error?.Message);
+        Assert.Same(ownershipProvider, muxer.ConcatEvidenceProvider);
+        var record = Assert.Single(provenance.Records);
+        Assert.Equal(test.Execution.TaskId, record.TaskId);
+        Assert.Equal("media", record.ArtifactKey);
+        Assert.Equal("durl-media", record.ArtifactKind);
+        Assert.Equal(Path.GetFullPath(finalPath), record.CanonicalPath);
+        Assert.Same(evidence, record.Evidence);
+    }
+
     private static FfmpegOperationResult ConfirmedInvalidInputs(
         string reason,
         params string[] paths)
@@ -190,6 +261,29 @@ public sealed class MuxFailureRecoveryTests
             paths.Select(path => new FfmpegInputFailure(
                 path,
                 FfmpegInputFailureKind.DecodeCorruption)).ToArray());
+    }
+
+    private static FfmpegOperationResult Success(
+        string outputPath,
+        OutputArtifactPublicationEvidence evidence)
+    {
+        return new FfmpegOperationResult(
+            true,
+            outputPath,
+            null,
+            TimeSpan.Zero,
+            FfmpegOperationFailureKind.None,
+            [],
+            evidence);
+    }
+
+    private static OutputArtifactPublicationEvidence CreatePublicationEvidence(string identity)
+    {
+        return new OutputArtifactPublicationEvidence(
+            ByteLength: 20,
+            Sha256: new string('a', 64),
+            IdentityProvider: "test-provider",
+            FilesystemIdentity: identity);
     }
 
     private sealed class MuxTestContext : IAsyncDisposable
@@ -334,11 +428,21 @@ public sealed class MuxFailureRecoveryTests
 
         public MuxStage CreateStage(FfmpegOperationResult result)
         {
+            return CreateStage(new StubMuxer(result));
+        }
+
+        public MuxStage CreateStage(
+            IFfmpegMediaMuxer muxer,
+            IOutputArtifactOwnershipProvider? ownershipProvider = null,
+            DownloadOutputArtifactProvenanceRecorder? provenanceRecorder = null)
+        {
             return new MuxStage(
                 new DownloadActivityPresenter(_stateWriter),
-                new StubMuxer(result),
+                muxer,
                 _stateWriter,
-                NullLogger<MuxStage>.Instance);
+                NullLogger<MuxStage>.Instance,
+                ownershipProvider,
+                provenanceRecorder);
         }
 
         public async Task<DurlTestSource[]> AddDurlSourcesAsync()
@@ -399,6 +503,10 @@ public sealed class MuxFailureRecoveryTests
 
     private sealed class StubMuxer(FfmpegOperationResult result) : IFfmpegMediaMuxer
     {
+        public IOutputArtifactOwnershipProvider? ConcatEvidenceProvider { get; private set; }
+
+        public IOutputArtifactOwnershipProvider? MergeEvidenceProvider { get; private set; }
+
         public Task<FfmpegOperationResult> ConcatDurlVideosAsync(
             VideoApplicationSettings videoSettings,
             IReadOnlyList<FfmpegConcatSegment> segments,
@@ -408,6 +516,19 @@ public sealed class MuxFailureRecoveryTests
             CancellationToken cancellationToken = default) =>
             Task.FromResult(result);
 
+        public Task<FfmpegOperationResult> ConcatDurlVideosWithEvidenceAsync(
+            VideoApplicationSettings videoSettings,
+            IReadOnlyList<FfmpegConcatSegment> segments,
+            string outputVideo,
+            bool overwriteDestination,
+            IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null,
+            Action<string>? action = null,
+            CancellationToken cancellationToken = default)
+        {
+            ConcatEvidenceProvider = outputArtifactOwnershipProvider;
+            return Task.FromResult(result);
+        }
+
         public Task<FfmpegOperationResult> MergeMediaAsync(
             VideoApplicationSettings videoSettings,
             string? audio,
@@ -416,6 +537,76 @@ public sealed class MuxFailureRecoveryTests
             bool overwriteDestination,
             CancellationToken cancellationToken = default) =>
             Task.FromResult(result);
+
+        public Task<FfmpegOperationResult> MergeMediaWithEvidenceAsync(
+            VideoApplicationSettings videoSettings,
+            string? audio,
+            string? video,
+            string destination,
+            bool overwriteDestination,
+            IOutputArtifactOwnershipProvider? outputArtifactOwnershipProvider = null,
+            CancellationToken cancellationToken = default)
+        {
+            MergeEvidenceProvider = outputArtifactOwnershipProvider;
+            return Task.FromResult(result);
+        }
+    }
+
+    private sealed class RecordingOutputProvenanceService
+        : IDownloadOutputArtifactProvenanceApplicationService
+    {
+        public List<RecordedProvenance> Records { get; } = [];
+
+        public Task<OperationResult> RecordPublishedAsync(
+            DownloadTaskId taskId,
+            string artifactKey,
+            string artifactKind,
+            string canonicalPath,
+            OutputArtifactPublicationEvidence publicationEvidence,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Records.Add(new RecordedProvenance(
+                taskId,
+                artifactKey,
+                artifactKind,
+                Path.GetFullPath(canonicalPath),
+                publicationEvidence));
+            return Task.FromResult(OperationResult.Success());
+        }
+
+        public Task<OperationResult<IReadOnlyList<DownloadOutputArtifactProvenance>>> GetPublishedAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(
+                OperationResult.Success<IReadOnlyList<DownloadOutputArtifactProvenance>>([]));
+        }
+    }
+
+    private sealed record RecordedProvenance(
+        DownloadTaskId TaskId,
+        string ArtifactKey,
+        string ArtifactKind,
+        string CanonicalPath,
+        OutputArtifactPublicationEvidence Evidence);
+
+    private sealed class TestOwnershipProvider : IOutputArtifactOwnershipProvider
+    {
+        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+            string temporaryPath,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+            string candidatePath,
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(OutputArtifactSafeDeleteResult.Unsupported());
+        }
     }
 
     private sealed record DurlTestSource(int Order, string TransferKey, string FilePath);

--- a/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
+++ b/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
@@ -593,13 +593,6 @@ public sealed class MuxFailureRecoveryTests
 
     private sealed class TestOwnershipProvider : IOutputArtifactOwnershipProvider
     {
-        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
-            string temporaryPath,
-            CancellationToken cancellationToken)
-        {
-            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Unsupported());
-        }
-
         public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
             string candidatePath,
             DownloadOutputArtifactProvenance provenance,

--- a/tests/DownKyi.Tests/OutputArtifactOwnershipAdversarialTests.cs
+++ b/tests/DownKyi.Tests/OutputArtifactOwnershipAdversarialTests.cs
@@ -1,0 +1,435 @@
+using System.Reflection;
+using System.Security.Cryptography;
+using DownKyi.Application.Downloads;
+using DownKyi.Core.FFmpeg;
+using DownKyi.Core.Settings;
+using DownKyi.Domain.Downloads;
+using DownKyi.Services.Download;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Win32.SafeHandles;
+
+namespace DownKyi.Tests;
+
+public sealed class OutputArtifactOwnershipAdversarialTests : IDisposable
+{
+    private const string MergePath = "merge";
+    private const string ConcatPath = "concat";
+
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "downkyi-output-ownership-adversarial",
+        Guid.NewGuid().ToString("N"));
+    private readonly SettingsStore _settings;
+
+    public OutputArtifactOwnershipAdversarialTests()
+    {
+        Directory.CreateDirectory(_directory);
+        _settings = new SettingsStore(Path.Combine(_directory, "settings.json"));
+    }
+
+    [Fact]
+    public async Task AtomicPublisherDoesNotGrantProvenanceToSubstitutedProducerObject()
+    {
+        RequireWindows();
+        var destination = Path.Combine(_directory, "atomic-substitution.mp4");
+        var publisher = new AtomicOutputPublisher(new WindowsOutputArtifactOwnershipProvider());
+
+        var result = await publisher.PublishAsync(
+            destination,
+            async (temporaryPath, cancellationToken) =>
+            {
+                await File.WriteAllTextAsync(
+                    temporaryPath,
+                    "producer object",
+                    cancellationToken).ConfigureAwait(true);
+                File.Move(temporaryPath, $"{temporaryPath}.producer");
+                await File.WriteAllTextAsync(
+                    $"{temporaryPath}.foreign",
+                    "foreign substitution",
+                    cancellationToken).ConfigureAwait(true);
+                File.Move($"{temporaryPath}.foreign", temporaryPath);
+            },
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.PublicationEvidence);
+        Assert.Equal(
+            "foreign substitution",
+            await File.ReadAllTextAsync(destination, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true));
+    }
+
+    [Theory]
+    [InlineData(MergePath)]
+    [InlineData(ConcatPath)]
+    public async Task FfmpegDoesNotGrantProvenanceToSubstitutedProducerObject(string publicationPath)
+    {
+        RequireWindows();
+        var destination = Path.Combine(_directory, $"ffmpeg-{publicationPath}-substitution.mp4");
+        byte[] foreignOutput = [9, 8, 7, 6];
+        var runner = new AdversarialFfmpegRunner(async (temporaryPath, cancellationToken) =>
+        {
+            await File.WriteAllBytesAsync(temporaryPath, [1, 2, 3, 4], cancellationToken)
+                .ConfigureAwait(true);
+            File.Move(temporaryPath, $"{temporaryPath}.producer");
+            await File.WriteAllBytesAsync(
+                $"{temporaryPath}.foreign",
+                foreignOutput,
+                cancellationToken).ConfigureAwait(true);
+            File.Move($"{temporaryPath}.foreign", temporaryPath);
+        });
+
+        var result = await RunFfmpegPublicationAsync(
+            publicationPath,
+            destination,
+            runner,
+            new WindowsOutputArtifactOwnershipProvider(),
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.Succeeded);
+        Assert.Null(result.PublicationEvidence);
+        Assert.Equal(
+            foreignOutput,
+            await File.ReadAllBytesAsync(destination, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true));
+    }
+
+    [Fact]
+    public async Task AtomicPublisherCancellationAfterCapturePreventsPublicationMove()
+    {
+        var destination = Path.Combine(_directory, "atomic-canceled.mp4");
+        using var cancellation = new CancellationTokenSource();
+        var publisher = new AtomicOutputPublisher(
+            new AdversarialOwnershipProvider(onCapture: _ => cancellation.Cancel()));
+
+        var exception = await Record.ExceptionAsync(() => publisher.PublishAsync(
+            destination,
+            (temporaryPath, cancellationToken) => File.WriteAllTextAsync(
+                temporaryPath,
+                "completed producer output",
+                cancellationToken),
+            cancellation.Token)).ConfigureAwait(true);
+
+        Assert.IsAssignableFrom<OperationCanceledException>(exception);
+        Assert.False(File.Exists(destination));
+    }
+
+    [Theory]
+    [InlineData(MergePath)]
+    [InlineData(ConcatPath)]
+    public async Task FfmpegCancellationAfterCapturePreventsPublicationMove(string publicationPath)
+    {
+        var destination = Path.Combine(_directory, $"ffmpeg-{publicationPath}-canceled.mp4");
+        using var cancellation = new CancellationTokenSource();
+        var provider = new AdversarialOwnershipProvider(onCapture: _ => cancellation.Cancel());
+        var runner = new AdversarialFfmpegRunner((temporaryPath, cancellationToken) =>
+            File.WriteAllBytesAsync(temporaryPath, [1, 2, 3, 4], cancellationToken));
+
+        var exception = await Record.ExceptionAsync(() => RunFfmpegPublicationAsync(
+            publicationPath,
+            destination,
+            runner,
+            provider,
+            cancellation.Token)).ConfigureAwait(true);
+
+        Assert.IsAssignableFrom<OperationCanceledException>(exception);
+        Assert.False(File.Exists(destination));
+    }
+
+    [Fact]
+    public async Task AtomicPublisherTempCleanupPreservesReplacementObject()
+    {
+        var destination = Path.Combine(_directory, "atomic-cleanup.mp4");
+        var provider = new AdversarialOwnershipProvider(onVerify: temporaryPath =>
+            File.WriteAllText(temporaryPath, "foreign temp replacement"));
+        var publisher = new AtomicOutputPublisher(provider);
+
+        var result = await publisher.PublishAsync(
+            destination,
+            (temporaryPath, cancellationToken) => File.WriteAllTextAsync(
+                temporaryPath,
+                "producer output",
+                cancellationToken),
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.Succeeded);
+        var temporaryPath = Assert.IsType<string>(provider.TemporaryPath);
+        Assert.Equal(
+            "foreign temp replacement",
+            await File.ReadAllTextAsync(temporaryPath, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true));
+    }
+
+    [Theory]
+    [InlineData(MergePath)]
+    [InlineData(ConcatPath)]
+    public async Task FfmpegTempCleanupPreservesReplacementObject(string publicationPath)
+    {
+        var destination = Path.Combine(_directory, $"ffmpeg-{publicationPath}-cleanup.mp4");
+        var provider = new AdversarialOwnershipProvider(onVerify: temporaryPath =>
+            File.WriteAllText(temporaryPath, "foreign temp replacement"));
+        var runner = new AdversarialFfmpegRunner((temporaryPath, cancellationToken) =>
+            File.WriteAllBytesAsync(temporaryPath, [1, 2, 3, 4], cancellationToken));
+
+        var result = await RunFfmpegPublicationAsync(
+            publicationPath,
+            destination,
+            runner,
+            provider,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(result.Succeeded);
+        var temporaryPath = Assert.IsType<string>(provider.TemporaryPath);
+        Assert.Equal(
+            "foreign temp replacement",
+            await File.ReadAllTextAsync(temporaryPath, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true));
+    }
+
+    [Theory]
+    [InlineData(0UL, 0UL)]
+    [InlineData(ulong.MaxValue, ulong.MaxValue)]
+    public void FileId128SentinelsFailAtAuthoritativeConversionBoundary(
+        ulong fileIdHigh,
+        ulong fileIdLow)
+    {
+        var conversion = typeof(WindowsOutputArtifactNativeFileSystem).GetMethod(
+            "FormatFileIdForEvidence",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(conversion);
+
+        var exception = Assert.Throws<TargetInvocationException>(() => conversion.Invoke(
+            null,
+            [0x123456789abcdef0UL, fileIdHigh, fileIdLow]));
+        Assert.IsType<IOException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task NativeDeleteKeepsValidatedHandleAcrossDestructiveBoundary()
+    {
+        RequireWindows();
+        var candidate = CreateFile("native-delete.mp4", "validated object");
+        var replacement = CreateFile("native-replacement.mp4", "foreign replacement");
+        var displaced = Path.Combine(_directory, "native-displaced.mp4");
+        var constructor = typeof(WindowsOutputArtifactNativeFileSystem).GetConstructor(
+            BindingFlags.Instance | BindingFlags.NonPublic,
+            binder: null,
+            types: [typeof(Action<SafeFileHandle>)],
+            modifiers: null);
+        Assert.NotNull(constructor);
+
+        var replacementWasPerformed = false;
+        Action<SafeFileHandle> beforeDelete = handle =>
+        {
+            Assert.False(handle.IsClosed);
+            Assert.False(handle.IsInvalid);
+            File.Move(candidate, displaced);
+            File.Move(replacement, candidate);
+            replacementWasPerformed = true;
+        };
+        var fileSystem = Assert.IsAssignableFrom<IOutputArtifactNativeFileSystem>(
+            constructor.Invoke([beforeDelete]));
+        var capture = await fileSystem.CaptureEvidenceAsync(
+            candidate,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+        var evidence = Assert.IsType<OutputArtifactNativeEvidence>(capture.Evidence);
+
+        var result = await fileSystem.DeleteIfEvidenceMatchesAsync(
+            candidate,
+            evidence,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(replacementWasPerformed, $"Native delete returned {result.Status} before the boundary callback.");
+        Assert.True(result.Status is OutputArtifactNativeSafeDeleteStatus.Deleted
+            or OutputArtifactNativeSafeDeleteStatus.Failed);
+        Assert.Equal(
+            "foreign replacement",
+            await File.ReadAllTextAsync(candidate, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true));
+        Assert.False(File.Exists(replacement));
+    }
+
+    private async Task<FfmpegOperationResult> RunFfmpegPublicationAsync(
+        string publicationPath,
+        string destination,
+        IFfmpegProcessRunner runner,
+        IOutputArtifactOwnershipProvider provider,
+        CancellationToken cancellationToken)
+    {
+        var processor = new FfmpegProcessor(
+            _settings,
+            NullLoggerFactory.Instance,
+            runner);
+        if (publicationPath == MergePath)
+        {
+            var audio = CreateFile($"{Path.GetFileNameWithoutExtension(destination)}-audio.m4s", "audio");
+            var video = CreateFile($"{Path.GetFileNameWithoutExtension(destination)}-video.m4s", "video");
+            return await processor.MergeMediaWithEvidenceAsync(
+                _settings.Current.Video,
+                audio,
+                video,
+                destination,
+                overwriteDestination: false,
+                outputArtifactOwnershipProvider: provider,
+                cancellationToken: cancellationToken).ConfigureAwait(true);
+        }
+
+        var segment = CreateFile(
+            $"{Path.GetFileNameWithoutExtension(destination)}-segment.flv",
+            "segment");
+        return await processor.ConcatDurlVideosWithEvidenceAsync(
+            _settings.Current.Video with
+            {
+                FfmpegHardwareAcceleration = FfmpegHardwareAcceleration.Disabled
+            },
+            [new FfmpegConcatSegment(1, segment, TimeSpan.FromSeconds(5))],
+            destination,
+            overwriteDestination: false,
+            outputArtifactOwnershipProvider: provider,
+            cancellationToken: cancellationToken).ConfigureAwait(true);
+    }
+
+    private string CreateFile(string name, string content)
+    {
+        var path = Path.Combine(_directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static void RequireWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Windows object identity is required for this regression.");
+        }
+    }
+
+    public void Dispose()
+    {
+        _settings.Dispose();
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private sealed class AdversarialOwnershipProvider(
+        Action<string>? onCapture = null,
+        Action<string>? onVerify = null) : IOutputArtifactOwnershipProvider
+    {
+        private static readonly OutputArtifactPublicationEvidence Evidence = new(
+            ByteLength: 4,
+            Sha256: Convert.ToHexStringLower(SHA256.HashData([1, 2, 3, 4])),
+            IdentityProvider: "adversarial-test",
+            FilesystemIdentity: "adversarial-object");
+
+        private bool _temporaryWasReplaced;
+
+        public string? TemporaryPath { get; private set; }
+
+        public OutputArtifactTemporaryClaimResult ClaimTemporaryObject(
+            SafeFileHandle temporaryHandle)
+        {
+            return OutputArtifactTemporaryClaimResult.Claimed(new TemporaryClaim());
+        }
+
+        public Task<OutputArtifactEvidenceCaptureResult> CapturePublicationEvidenceAsync(
+            string temporaryPath,
+            OutputArtifactTemporaryClaim temporaryClaim,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TemporaryPath = Path.GetFullPath(temporaryPath);
+            onCapture?.Invoke(TemporaryPath);
+            return Task.FromResult(OutputArtifactEvidenceCaptureResult.Captured(Evidence));
+        }
+
+        public Task<bool> VerifyPublishedObjectIdentityAsync(
+            string destinationPath,
+            OutputArtifactPublicationEvidence evidence,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (onVerify is not null)
+            {
+                onVerify(Assert.IsType<string>(TemporaryPath));
+                _temporaryWasReplaced = true;
+            }
+
+            return Task.FromResult(true);
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteTemporaryIfOwnedAsync(
+            string temporaryPath,
+            OutputArtifactTemporaryClaim temporaryClaim,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!File.Exists(temporaryPath))
+            {
+                return Task.FromResult(OutputArtifactSafeDeleteResult.Missing());
+            }
+
+            if (_temporaryWasReplaced)
+            {
+                return Task.FromResult(OutputArtifactSafeDeleteResult.Replaced());
+            }
+
+            File.Delete(temporaryPath);
+            return Task.FromResult(OutputArtifactSafeDeleteResult.DeletedResult());
+        }
+
+        public Task<OutputArtifactSafeDeleteResult> DeleteIfOwnedAsync(
+            string candidatePath,
+            DownloadOutputArtifactProvenance provenance,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(OutputArtifactSafeDeleteResult.Unsupported());
+        }
+
+        private sealed record TemporaryClaim : OutputArtifactTemporaryClaim;
+    }
+
+    private sealed class AdversarialFfmpegRunner(
+        Func<string, CancellationToken, Task> writeOutput) : IFfmpegProcessRunner
+    {
+        public async Task<FfmpegProcessResult> RunAsync(
+            FfmpegCommand command,
+            TimeSpan timeout,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (command.Operation == "merge-media"
+                || command.Operation.StartsWith("concat-", StringComparison.Ordinal))
+            {
+                await writeOutput(command.Arguments[^1], cancellationToken).ConfigureAwait(true);
+                return Success();
+            }
+
+            return command.Operation switch
+            {
+                "probe-media" => new FfmpegProcessResult(
+                    true,
+                    0,
+                    "{\"streams\":[{\"codec_type\":\"video\"}],\"format\":{\"duration\":\"5\"}}",
+                    string.Empty,
+                    false),
+                "seek-decode" => new FfmpegProcessResult(
+                    true,
+                    0,
+                    "frame=1",
+                    string.Empty,
+                    false),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected FFmpeg operation: {command.Operation}.")
+            };
+        }
+
+        private static FfmpegProcessResult Success() => new(
+            true,
+            0,
+            string.Empty,
+            string.Empty,
+            false);
+    }
+}

--- a/tests/DownKyi.Tests/WindowsOutputArtifactOwnershipProviderTests.cs
+++ b/tests/DownKyi.Tests/WindowsOutputArtifactOwnershipProviderTests.cs
@@ -1,0 +1,419 @@
+using System.Security.Cryptography;
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Services.Download;
+
+namespace DownKyi.Tests;
+
+public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
+{
+    private readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        "downkyi-output-ownership-tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Fact]
+    public async Task CaptureBeforeRenameAndDeleteAfterRenameUsesWindowsFileIdentity()
+    {
+        RequireWindows();
+        Directory.CreateDirectory(_directory);
+        var temporaryPath = CreateFile(".episode.downkyi-tmp.mp4", "owned output");
+        var destinationPath = Path.Combine(_directory, "episode.mp4");
+        var provider = new WindowsOutputArtifactOwnershipProvider();
+
+        var capture = await provider.CapturePublicationEvidenceAsync(
+            temporaryPath,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(capture.Succeeded);
+        var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
+        Assert.Equal("windows-file-id-v1", evidence.IdentityProvider);
+        Assert.Equal(new FileInfo(temporaryPath).Length, evidence.ByteLength);
+        Assert.Equal(Sha256File(temporaryPath), evidence.Sha256);
+        Assert.False(string.IsNullOrWhiteSpace(evidence.FilesystemIdentity));
+
+        File.Move(temporaryPath, destinationPath);
+        Assert.True(await provider.VerifyPublishedObjectIdentityAsync(
+            destinationPath,
+            evidence,
+            TestContext.Current.CancellationToken));
+
+        var result = await provider.DeleteIfOwnedAsync(
+            destinationPath,
+            CreateProvenance(destinationPath, evidence),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Deleted, result.Status);
+        Assert.False(File.Exists(destinationPath));
+    }
+
+    [Fact]
+    public async Task PostPublishIdentityVerificationRejectsAReplacementWithoutRehashing()
+    {
+        RequireWindows();
+        Directory.CreateDirectory(_directory);
+        var temporaryPath = CreateFile(".episode.downkyi-tmp.mp4", "owned output");
+        var destinationPath = Path.Combine(_directory, "episode.mp4");
+        var replacementPath = CreateFile(".foreign.downkyi-tmp.mp4", "foreign output");
+        var provider = new WindowsOutputArtifactOwnershipProvider();
+        var capture = await provider.CapturePublicationEvidenceAsync(
+            temporaryPath,
+            TestContext.Current.CancellationToken);
+        var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
+
+        File.Move(temporaryPath, destinationPath);
+        Assert.True(await provider.VerifyPublishedObjectIdentityAsync(
+            destinationPath,
+            evidence,
+            TestContext.Current.CancellationToken));
+
+        File.Move(replacementPath, destinationPath, overwrite: true);
+
+        Assert.False(await provider.VerifyPublishedObjectIdentityAsync(
+            destinationPath,
+            evidence,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(
+            "foreign output",
+            await File.ReadAllTextAsync(
+                destinationPath,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteIfOwnedPreservesReplacedOutput()
+    {
+        RequireWindows();
+        Directory.CreateDirectory(_directory);
+        var temporaryPath = CreateFile(".episode.downkyi-tmp.mp4", "owned output");
+        var destinationPath = Path.Combine(_directory, "episode.mp4");
+        var replacementPath = CreateFile(".foreign.downkyi-tmp.mp4", "foreign output");
+        var provider = new WindowsOutputArtifactOwnershipProvider();
+        var capture = await provider.CapturePublicationEvidenceAsync(
+            temporaryPath,
+            TestContext.Current.CancellationToken);
+        var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
+
+        File.Move(temporaryPath, destinationPath);
+        File.Move(replacementPath, destinationPath, overwrite: true);
+
+        var result = await provider.DeleteIfOwnedAsync(
+            destinationPath,
+            CreateProvenance(destinationPath, evidence),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Replaced, result.Status);
+        Assert.Equal(
+            "foreign output",
+            await File.ReadAllTextAsync(
+                destinationPath,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteIfOwnedPreservesInPlaceModifiedOutput()
+    {
+        RequireWindows();
+        Directory.CreateDirectory(_directory);
+        var temporaryPath = CreateFile(".episode.downkyi-tmp.mp4", "owned output");
+        var destinationPath = Path.Combine(_directory, "episode.mp4");
+        var provider = new WindowsOutputArtifactOwnershipProvider();
+        var capture = await provider.CapturePublicationEvidenceAsync(
+            temporaryPath,
+            TestContext.Current.CancellationToken);
+        var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
+
+        File.Move(temporaryPath, destinationPath);
+        await File.WriteAllTextAsync(
+            destinationPath,
+            "other output",
+            TestContext.Current.CancellationToken);
+
+        var result = await provider.DeleteIfOwnedAsync(
+            destinationPath,
+            CreateProvenance(destinationPath, evidence),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Modified, result.Status);
+        Assert.Equal(
+            "other output",
+            await File.ReadAllTextAsync(
+                destinationPath,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task DeleteIfOwnedReportsMissingProvenOutputAsNoOp()
+    {
+        RequireWindows();
+        Directory.CreateDirectory(_directory);
+        var temporaryPath = CreateFile(".episode.downkyi-tmp.mp4", "owned output");
+        var destinationPath = Path.Combine(_directory, "episode.mp4");
+        var provider = new WindowsOutputArtifactOwnershipProvider();
+        var capture = await provider.CapturePublicationEvidenceAsync(
+            temporaryPath,
+            TestContext.Current.CancellationToken);
+        var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
+
+        File.Move(temporaryPath, destinationPath);
+        File.Delete(destinationPath);
+
+        var result = await provider.DeleteIfOwnedAsync(
+            destinationPath,
+            CreateProvenance(destinationPath, evidence),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Missing, result.Status);
+    }
+
+    [Fact]
+    public async Task UnsupportedProviderFailsClosedWithoutOpeningOrDeleting()
+    {
+        Directory.CreateDirectory(_directory);
+        var path = CreateFile("foreign.mp4", "foreign output");
+        var fileSystem = new FakeFileSystem
+        {
+            IsSupported = false
+        };
+        var provider = new WindowsOutputArtifactOwnershipProvider(fileSystem);
+        var evidence = CreateEvidence();
+
+        var capture = await provider.CapturePublicationEvidenceAsync(
+            path,
+            TestContext.Current.CancellationToken);
+        var deletion = await provider.DeleteIfOwnedAsync(
+            path,
+            CreateProvenance(path, evidence),
+            TestContext.Current.CancellationToken);
+        var verified = await provider.VerifyPublishedObjectIdentityAsync(
+            path,
+            evidence,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactEvidenceCaptureStatus.Unsupported, capture.Status);
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Unsupported, deletion.Status);
+        Assert.False(verified);
+        Assert.Equal(0, fileSystem.CaptureCalls);
+        Assert.Equal(0, fileSystem.DeleteCalls);
+        Assert.Equal(0, fileSystem.VerifyCalls);
+        Assert.True(File.Exists(path));
+    }
+
+    [Fact]
+    public async Task CanceledDeletionDoesNotOpenTheCandidate()
+    {
+        var path = Path.Combine(_directory, "episode.mp4");
+        var fileSystem = new FakeFileSystem();
+        var provider = new WindowsOutputArtifactOwnershipProvider(fileSystem);
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            provider.DeleteIfOwnedAsync(
+                path,
+                CreateProvenance(path, CreateEvidence()),
+                cancellation.Token));
+
+        Assert.Equal(0, fileSystem.DeleteCalls);
+    }
+
+    [Fact]
+    public async Task InvalidOrForeignProviderEvidenceIsUnprovenAndNeverOpened()
+    {
+        var path = Path.Combine(_directory, "episode.mp4");
+        var fileSystem = new FakeFileSystem();
+        var provider = new WindowsOutputArtifactOwnershipProvider(fileSystem);
+        var evidence = CreateEvidence() with
+        {
+            IdentityProvider = "foreign-provider"
+        };
+
+        var result = await provider.DeleteIfOwnedAsync(
+            path,
+            CreateProvenance(path, evidence),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Unproven, result.Status);
+        Assert.Equal(0, fileSystem.DeleteCalls);
+    }
+
+    [Fact]
+    public async Task NativeReplacementResultPreservesCandidate()
+    {
+        var path = Path.Combine(_directory, "episode.mp4");
+        var fileSystem = new FakeFileSystem
+        {
+            DeleteResult = OutputArtifactNativeSafeDeleteResult.Replaced()
+        };
+        var provider = new WindowsOutputArtifactOwnershipProvider(fileSystem);
+
+        var result = await provider.DeleteIfOwnedAsync(
+            path,
+            CreateProvenance(path, CreateEvidence()),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Replaced, result.Status);
+        Assert.Equal(1, fileSystem.DeleteCalls);
+    }
+
+    [Fact]
+    public async Task NativeModifiedResultPreservesCandidate()
+    {
+        var path = Path.Combine(_directory, "episode.mp4");
+        var fileSystem = new FakeFileSystem
+        {
+            DeleteResult = OutputArtifactNativeSafeDeleteResult.Modified()
+        };
+        var provider = new WindowsOutputArtifactOwnershipProvider(fileSystem);
+
+        var result = await provider.DeleteIfOwnedAsync(
+            path,
+            CreateProvenance(path, CreateEvidence()),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Modified, result.Status);
+        Assert.Equal(1, fileSystem.DeleteCalls);
+    }
+
+    [Fact]
+    public async Task ValidatedDeletionDelegatesToTheHandleBoundOperationWhenThePathIsSwapped()
+    {
+        Directory.CreateDirectory(_directory);
+        var path = Path.Combine(_directory, "episode.mp4");
+        await File.WriteAllTextAsync(
+            path,
+            "validated object",
+            TestContext.Current.CancellationToken);
+        var foreignPath = CreateFile("foreign.mp4", "foreign replacement");
+        var replacementStillExists = false;
+        var originalDeleted = false;
+        var fileSystem = new FakeFileSystem
+        {
+            DeleteResult = OutputArtifactNativeSafeDeleteResult.Deleted(),
+            OnDeleteIfEvidenceMatches = () =>
+            {
+                File.Move(foreignPath, path, overwrite: true);
+                replacementStillExists = true;
+                originalDeleted = true;
+            }
+        };
+        var provider = new WindowsOutputArtifactOwnershipProvider(fileSystem);
+
+        var result = await provider.DeleteIfOwnedAsync(
+            path,
+            CreateProvenance(path, CreateEvidence()),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(OutputArtifactSafeDeleteStatus.Deleted, result.Status);
+        Assert.True(originalDeleted);
+        Assert.True(replacementStillExists);
+        Assert.Equal(
+            "foreign replacement",
+            await File.ReadAllTextAsync(
+                path,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(1, fileSystem.DeleteCalls);
+    }
+
+    private static DownloadOutputArtifactProvenance CreateProvenance(
+        string path,
+        OutputArtifactPublicationEvidence evidence)
+    {
+        return new DownloadOutputArtifactProvenance(
+            new DownloadTaskId("safe-delete-test"),
+            "media",
+            "media",
+            path,
+            evidence,
+            DateTimeOffset.UtcNow);
+    }
+
+    private static OutputArtifactPublicationEvidence CreateEvidence()
+    {
+        return new OutputArtifactPublicationEvidence(
+            ByteLength: 12,
+            Sha256: new string('a', 64),
+            IdentityProvider: WindowsOutputArtifactOwnershipProvider.IdentityProviderName,
+            FilesystemIdentity: "owned");
+    }
+
+    private string CreateFile(string name, string content)
+    {
+        var path = Path.Combine(_directory, name);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    private static string Sha256File(string path)
+    {
+        return Convert.ToHexStringLower(
+            SHA256.HashData(File.ReadAllBytes(path)));
+    }
+
+    private static void RequireWindows()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("The Windows handle-bound provider is only available on Windows.");
+        }
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+        {
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private sealed class FakeFileSystem : IOutputArtifactNativeFileSystem
+    {
+        public bool IsSupported { get; init; } = true;
+
+        public OutputArtifactNativeCaptureResult CaptureResult { get; init; } =
+            OutputArtifactNativeCaptureResult.Failed();
+
+        public OutputArtifactNativeSafeDeleteResult DeleteResult { get; init; } =
+            OutputArtifactNativeSafeDeleteResult.Failed();
+
+        public bool VerifyResult { get; init; }
+
+        public Action? OnDeleteIfEvidenceMatches { get; init; }
+
+        public int CaptureCalls { get; private set; }
+
+        public int DeleteCalls { get; private set; }
+
+        public int VerifyCalls { get; private set; }
+
+        public Task<OutputArtifactNativeCaptureResult> CaptureEvidenceAsync(
+            string path,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            CaptureCalls++;
+            return Task.FromResult(CaptureResult);
+        }
+
+        public Task<OutputArtifactNativeSafeDeleteResult> DeleteIfEvidenceMatchesAsync(
+            string path,
+            OutputArtifactNativeEvidence expectedEvidence,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DeleteCalls++;
+            OnDeleteIfEvidenceMatches?.Invoke();
+            return Task.FromResult(DeleteResult);
+        }
+
+        public Task<bool> VerifyIdentityAndLengthAsync(
+            string path,
+            OutputArtifactNativeEvidence expectedEvidence,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            VerifyCalls++;
+            return Task.FromResult(VerifyResult);
+        }
+    }
+}

--- a/tests/DownKyi.Tests/WindowsOutputArtifactOwnershipProviderTests.cs
+++ b/tests/DownKyi.Tests/WindowsOutputArtifactOwnershipProviderTests.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using DownKyi.Application.Downloads;
 using DownKyi.Domain.Downloads;
 using DownKyi.Services.Download;
+using Microsoft.Win32.SafeHandles;
 
 namespace DownKyi.Tests;
 
@@ -21,7 +22,8 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         var destinationPath = Path.Combine(_directory, "episode.mp4");
         var provider = new WindowsOutputArtifactOwnershipProvider();
 
-        var capture = await provider.CapturePublicationEvidenceAsync(
+        var capture = await CaptureClaimedEvidenceAsync(
+            provider,
             temporaryPath,
             TestContext.Current.CancellationToken);
 
@@ -56,7 +58,8 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         var destinationPath = Path.Combine(_directory, "episode.mp4");
         var replacementPath = CreateFile(".foreign.downkyi-tmp.mp4", "foreign output");
         var provider = new WindowsOutputArtifactOwnershipProvider();
-        var capture = await provider.CapturePublicationEvidenceAsync(
+        var capture = await CaptureClaimedEvidenceAsync(
+            provider,
             temporaryPath,
             TestContext.Current.CancellationToken);
         var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
@@ -89,7 +92,8 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         var destinationPath = Path.Combine(_directory, "episode.mp4");
         var replacementPath = CreateFile(".foreign.downkyi-tmp.mp4", "foreign output");
         var provider = new WindowsOutputArtifactOwnershipProvider();
-        var capture = await provider.CapturePublicationEvidenceAsync(
+        var capture = await CaptureClaimedEvidenceAsync(
+            provider,
             temporaryPath,
             TestContext.Current.CancellationToken);
         var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
@@ -118,7 +122,8 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         var temporaryPath = CreateFile(".episode.downkyi-tmp.mp4", "owned output");
         var destinationPath = Path.Combine(_directory, "episode.mp4");
         var provider = new WindowsOutputArtifactOwnershipProvider();
-        var capture = await provider.CapturePublicationEvidenceAsync(
+        var capture = await CaptureClaimedEvidenceAsync(
+            provider,
             temporaryPath,
             TestContext.Current.CancellationToken);
         var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
@@ -150,7 +155,8 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         var temporaryPath = CreateFile(".episode.downkyi-tmp.mp4", "owned output");
         var destinationPath = Path.Combine(_directory, "episode.mp4");
         var provider = new WindowsOutputArtifactOwnershipProvider();
-        var capture = await provider.CapturePublicationEvidenceAsync(
+        var capture = await CaptureClaimedEvidenceAsync(
+            provider,
             temporaryPath,
             TestContext.Current.CancellationToken);
         var evidence = Assert.IsType<OutputArtifactPublicationEvidence>(capture.Evidence);
@@ -178,9 +184,16 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         var provider = new WindowsOutputArtifactOwnershipProvider(fileSystem);
         var evidence = CreateEvidence();
 
-        var capture = await provider.CapturePublicationEvidenceAsync(
-            path,
-            TestContext.Current.CancellationToken);
+        OutputArtifactTemporaryClaimResult claim;
+        using (var stream = new FileStream(
+                   path,
+                   FileMode.Open,
+                   FileAccess.ReadWrite,
+                   FileShare.None))
+        {
+            claim = provider.ClaimTemporaryObject(stream.SafeFileHandle);
+        }
+
         var deletion = await provider.DeleteIfOwnedAsync(
             path,
             CreateProvenance(path, evidence),
@@ -190,7 +203,7 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
             evidence,
             TestContext.Current.CancellationToken);
 
-        Assert.Equal(OutputArtifactEvidenceCaptureStatus.Unsupported, capture.Status);
+        Assert.Equal(OutputArtifactTemporaryClaimStatus.Unsupported, claim.Status);
         Assert.Equal(OutputArtifactSafeDeleteStatus.Unsupported, deletion.Status);
         Assert.False(verified);
         Assert.Equal(0, fileSystem.CaptureCalls);
@@ -315,6 +328,28 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         Assert.Equal(1, fileSystem.DeleteCalls);
     }
 
+    private static async Task<OutputArtifactEvidenceCaptureResult> CaptureClaimedEvidenceAsync(
+        WindowsOutputArtifactOwnershipProvider provider,
+        string path,
+        CancellationToken cancellationToken)
+    {
+        OutputArtifactTemporaryClaim claim;
+        using (var stream = new FileStream(
+                   path,
+                   FileMode.Open,
+                   FileAccess.ReadWrite,
+                   FileShare.None))
+        {
+            var claimed = provider.ClaimTemporaryObject(stream.SafeFileHandle);
+            Assert.True(claimed.Succeeded);
+            claim = Assert.IsAssignableFrom<OutputArtifactTemporaryClaim>(claimed.Claim);
+        }
+
+        return await provider
+            .CapturePublicationEvidenceAsync(path, claim, cancellationToken)
+            .ConfigureAwait(true);
+    }
+
     private static DownloadOutputArtifactProvenance CreateProvenance(
         string path,
         OutputArtifactPublicationEvidence evidence)
@@ -373,6 +408,9 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         public OutputArtifactNativeCaptureResult CaptureResult { get; init; } =
             OutputArtifactNativeCaptureResult.Failed();
 
+        public OutputArtifactNativeIdentityCaptureResult IdentityCaptureResult { get; init; } =
+            OutputArtifactNativeIdentityCaptureResult.Failed();
+
         public OutputArtifactNativeSafeDeleteResult DeleteResult { get; init; } =
             OutputArtifactNativeSafeDeleteResult.Failed();
 
@@ -382,9 +420,18 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
 
         public int CaptureCalls { get; private set; }
 
+        public int IdentityCaptureCalls { get; private set; }
+
         public int DeleteCalls { get; private set; }
 
         public int VerifyCalls { get; private set; }
+
+        public OutputArtifactNativeIdentityCaptureResult CaptureIdentity(
+            SafeFileHandle handle)
+        {
+            IdentityCaptureCalls++;
+            return IdentityCaptureResult;
+        }
 
         public Task<OutputArtifactNativeCaptureResult> CaptureEvidenceAsync(
             string path,
@@ -398,6 +445,17 @@ public sealed class WindowsOutputArtifactOwnershipProviderTests : IDisposable
         public Task<OutputArtifactNativeSafeDeleteResult> DeleteIfEvidenceMatchesAsync(
             string path,
             OutputArtifactNativeEvidence expectedEvidence,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            DeleteCalls++;
+            OnDeleteIfEvidenceMatches?.Invoke();
+            return Task.FromResult(DeleteResult);
+        }
+
+        public Task<OutputArtifactNativeSafeDeleteResult> DeleteIfIdentityMatchesAsync(
+            string path,
+            string expectedFilesystemIdentity,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
## Summary

Hardens Issue #177 output ownership so DownKyi cannot grant provenance or deletion authority to a foreign filesystem object that merely occupies a known pathname.

- Claim temporary object identity from the live creation handle before producer execution.
- Use the same ownership provider for identity-bound temporary deletion.
- Keep temporary cleanup authority separate from final provenance (identity + length + SHA-256).
- Recheck cancellation immediately before each publication move.
- Validate and delete Windows final outputs through the same live native handle.

## Adversarial regression gate

- **12/12 adversarial regressions pass on this PR head.**
- **The old 1f68e5c implementation fails 12/12 adversarial regressions.**
- Producer temp substitution cannot acquire provenance.
- All-zero and all-FF FILE_ID_128 values fail closed at the authoritative conversion boundary.
- Cancellation injected after evidence capture prevents the Atomic, FFmpeg merge, and FFmpeg concat publication moves.
- A foreign object swapped into a temp pathname survives finally cleanup.
- The native replacement regression enters the real Windows validate-to-delete boundary inside WindowsOutputArtifactNativeFileSystem.DeleteIfEvidenceMatchesAsync, between live-handle evidence validation and SetFileInformationByHandle.

## Scope boundary

- No pathname-normalization fix was added.
- Issue #176 junction/physical-path identity is not included in this PR.
- No parallel ownership service was introduced.

## Validation

- Focused adversarial regressions: 12/12 passed
- Existing output-provenance semantic slice: 91/91 passed
- Architecture tests: 236/236 passed
- Full Release solution: all 7 test projects passed
- Strict Release build: 0 warnings, 0 errors
- Review invariant gate: 11 invariants, 7 projects, 356 tests, 1 accepted adversarial mutation proof
- dotnet format --verify-no-changes: passed
- Exact working-tree git diff --check against output-ownership-integration: passed
- Lifecycle gate intentionally not run for this stage

Refs #177