### PR TITLE
build(deps): update mirrored FFmpeg to ffmpeg-btbn-autobuild-2026-08-16-13-00

### DIFF
--- a/script/assets/external-assets.json
+++ b/script/assets/external-assets.json
@@ -38,7 +38,7 @@
     }
   },
   "ffmpeg": {
-    "version": "btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned",
+    "version": "btbn-autobuild-2026-08-16-13-00",
     "repository": "Windows x64/Linux: https://github.com/BtbN/FFmpeg-Builds; Windows x86: https://github.com/yt-dlp/FFmpeg-Builds; macOS: https://ffmpeg.martin-riedl.de",
     "assets": {
       "win-x86": {
@@ -55,42 +55,42 @@
         }
       },
       "win-x64": {
-        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned/ffmpeg-win-x64-autobuild-2026-08-12-13-15-40b7fd8eebbc5ec7.zip",
-        "sha256": "40b7fd8eebbc5ec79b7f39e647654927165ab85621ff637e8de8f6985f851f23",
-        "fileName": "ffmpeg-win-x64-autobuild-2026-08-12-13-15-40b7fd8eebbc5ec7.zip",
+        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-16-13-00/ffmpeg-win-x64-autobuild-2026-08-16-13-00-bfe8c6a9c9894ed4.zip",
+        "sha256": "bfe8c6a9c9894ed46ad28ebe835d2695e4948dd426c6c43a5a543a50586c4c9d",
+        "fileName": "ffmpeg-win-x64-autobuild-2026-08-16-13-00-bfe8c6a9c9894ed4.zip",
         "provenance": {
           "upstreamRepository": "https://github.com/BtbN/FFmpeg-Builds",
-          "upstreamRelease": "autobuild-2026-08-12-13-15",
-          "originalAssetName": "ffmpeg-N-126086-ge5ecfe8970-win64-gpl.zip",
-          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-12-13-15/ffmpeg-N-126086-ge5ecfe8970-win64-gpl.zip",
-          "mirroredAt": "2026-08-13T05:32:08Z",
-          "ffmpegVersion": "ffmpeg-N-126086-ge5ecfe8970-win64-gpl.zip"
+          "upstreamRelease": "autobuild-2026-08-16-13-00",
+          "originalAssetName": "ffmpeg-N-126175-g0056dd32fd-win64-gpl.zip",
+          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-16-13-00/ffmpeg-N-126175-g0056dd32fd-win64-gpl.zip",
+          "mirroredAt": "2026-08-17T04:01:19Z",
+          "ffmpegVersion": "ffmpeg-N-126175-g0056dd32fd-win64-gpl.zip"
         }
       },
       "linux-x64": {
-        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned/ffmpeg-linux-x64-autobuild-2026-08-12-13-15-cf55934e9faa1969.tar.xz",
-        "sha256": "cf55934e9faa1969bff4c3fc1e1352707c9c9384e4d7986388830a8c8a726913",
-        "fileName": "ffmpeg-linux-x64-autobuild-2026-08-12-13-15-cf55934e9faa1969.tar.xz",
+        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-16-13-00/ffmpeg-linux-x64-autobuild-2026-08-16-13-00-d6c3aeff33a32365.tar.xz",
+        "sha256": "d6c3aeff33a323659ddc8c185fb8c5fc2f7fe7386053a40af5e326cae95cd0d4",
+        "fileName": "ffmpeg-linux-x64-autobuild-2026-08-16-13-00-d6c3aeff33a32365.tar.xz",
         "provenance": {
           "upstreamRepository": "https://github.com/BtbN/FFmpeg-Builds",
-          "upstreamRelease": "autobuild-2026-08-12-13-15",
-          "originalAssetName": "ffmpeg-N-126086-ge5ecfe8970-linux64-gpl.tar.xz",
-          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-12-13-15/ffmpeg-N-126086-ge5ecfe8970-linux64-gpl.tar.xz",
-          "mirroredAt": "2026-08-13T05:32:08Z",
-          "ffmpegVersion": "ffmpeg-N-126086-ge5ecfe8970-linux64-gpl.tar.xz"
+          "upstreamRelease": "autobuild-2026-08-16-13-00",
+          "originalAssetName": "ffmpeg-N-126175-g0056dd32fd-linux64-gpl.tar.xz",
+          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-16-13-00/ffmpeg-N-126175-g0056dd32fd-linux64-gpl.tar.xz",
+          "mirroredAt": "2026-08-17T04:01:19Z",
+          "ffmpegVersion": "ffmpeg-N-126175-g0056dd32fd-linux64-gpl.tar.xz"
         }
       },
       "linux-arm64": {
-        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned/ffmpeg-linux-arm64-autobuild-2026-08-12-13-15-6fb99e871709d0c7.tar.xz",
-        "sha256": "6fb99e871709d0c77256d5737d67f440c8cb03a02d71c37a7632f9b66dc55e2d",
-        "fileName": "ffmpeg-linux-arm64-autobuild-2026-08-12-13-15-6fb99e871709d0c7.tar.xz",
+        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-16-13-00/ffmpeg-linux-arm64-autobuild-2026-08-16-13-00-f275964503c6ca56.tar.xz",
+        "sha256": "f275964503c6ca5672d66879e4b8ddee74a182d77ad51106931206dfea796b7b",
+        "fileName": "ffmpeg-linux-arm64-autobuild-2026-08-16-13-00-f275964503c6ca56.tar.xz",
         "provenance": {
           "upstreamRepository": "https://github.com/BtbN/FFmpeg-Builds",
-          "upstreamRelease": "autobuild-2026-08-12-13-15",
-          "originalAssetName": "ffmpeg-N-126086-ge5ecfe8970-linuxarm64-gpl.tar.xz",
-          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-12-13-15/ffmpeg-N-126086-ge5ecfe8970-linuxarm64-gpl.tar.xz",
-          "mirroredAt": "2026-08-13T05:32:08Z",
-          "ffmpegVersion": "ffmpeg-N-126086-ge5ecfe8970-linuxarm64-gpl.tar.xz"
+          "upstreamRelease": "autobuild-2026-08-16-13-00",
+          "originalAssetName": "ffmpeg-N-126175-g0056dd32fd-linuxarm64-gpl.tar.xz",
+          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-16-13-00/ffmpeg-N-126175-g0056dd32fd-linuxarm64-gpl.tar.xz",
+          "mirroredAt": "2026-08-17T04:01:19Z",
+          "ffmpegVersion": "ffmpeg-N-126175-g0056dd32fd-linuxarm64-gpl.tar.xz"
         }
       },
       "osx-x64": {


### PR DESCRIPTION
Updates mirrored FFmpeg to `btbn-autobuild-2026-08-16-13-00`.

- Previous version: `btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned`
- New version: `btbn-autobuild-2026-08-16-13-00`
- Mirror release: `crazysmile-PhD/downkyi-runtime-assets@ffmpeg-btbn-autobuild-2026-08-16-13-00`
- Validation: archive layout, ffmpeg/ffprobe execution, SHA-256, and required encoder checks on native runners.
- Historical mirror releases are retained; this PR only points the manifest at a new fixed tag.

| RID | Upstream release | SHA-256 |
| --- | --- | --- |
| win-x64 | autobuild-2026-08-16-13-00 | `bfe8c6a9c9894ed46ad28ebe835d2695e4948dd426c6c43a5a543a50586c4c9d` |
| linux-x64 | autobuild-2026-08-16-13-00 | `d6c3aeff33a323659ddc8c185fb8c5fc2f7fe7386053a40af5e326cae95cd0d4` |
| linux-arm64 | autobuild-2026-08-16-13-00 | `f275964503c6ca5672d66879e4b8ddee74a182d77ad51106931206dfea796b7b` |
