### PR TITLE
fix(release): fail closed macOS signing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,6 +372,7 @@ jobs:
     needs: changelog
     env:
       HAS_MACOS_SIGNING: ${{ secrets.MACOS_CERTIFICATE != '' && secrets.MACOS_CERTIFICATE_PWD != '' && secrets.APPLE_ID != '' && secrets.TEAM_ID != '' && secrets.APP_SPECIFIC_PASSWORD != '' }}
+      MACOS_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -379,12 +380,26 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Require macOS signing credentials for release
+        if: ${{ env.MACOS_SIGNING_REQUIRED == 'true' && env.HAS_MACOS_SIGNING != 'true' }}
+        run: |
+          echo "::error::Formal macOS releases require MACOS_CERTIFICATE, MACOS_CERTIFICATE_PWD, APPLE_ID, TEAM_ID, and APP_SPECIFIC_PASSWORD."
+          exit 1
       - name: Import certificate
         if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
         uses: apple-actions/import-codesign-certs@v7
         with:
           p12-file-base64: ${{ secrets.MACOS_CERTIFICATE }}
           p12-password: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+      - name: Resolve signing identity
+        if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
+        run: |
+          identity="$(security find-identity -v -p codesigning | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
+          if [ -z "$identity" ]; then
+            echo "::error::No Developer ID Application signing identity was imported."
+            exit 1
+          fi
+          echo "MACOS_SIGNING_IDENTITY=$identity" >> "$GITHUB_ENV"
       - name: Install Tool Via HomeBrew
         run: |
           export HOMEBREW_NO_AUTO_UPDATE=true
@@ -427,10 +442,15 @@ jobs:
             -ExpectedVersion "${{ steps.version.outputs.content }}" `
             -OutputPath "script/macos/publish-manifest-osx-${{ matrix.cpu }}.json"
       - name: Sign app
-        if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
         run: |
-          chmod +x sign.sh
+          chmod +x codesign-common.sh sign.sh verify-app.sh sign-dmg.sh verify-dmg.sh
           ./sign.sh
+        working-directory: ./script/macos
+        env:
+          MACOS_ADHOC_SIGNING: ${{ env.HAS_MACOS_SIGNING != 'true' }}
+      - name: Verify app signature
+        run: |
+          ./verify-app.sh
         working-directory: ./script/macos
       - name: Notarize app
         if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
@@ -440,6 +460,13 @@ jobs:
           xcrun stapler staple 哔哩下载姬.app
           rm -rf ./哔哩下载姬.zip
         working-directory: ./script/macos
+      - name: Verify notarized app
+        if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
+        run: |
+          ./verify-app.sh
+        working-directory: ./script/macos
+        env:
+          MACOS_VERIFY_GATEKEEPER: true
       - name: Create DMG
         run: |
           create-dmg \
@@ -450,12 +477,29 @@ jobs:
           --window-size 660 400 \
           DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg 哔哩下载姬.app
         working-directory: ./script/macos
+      - name: Sign DMG
+        if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
+        run: |
+          ./sign-dmg.sh DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg
+        working-directory: ./script/macos
+      - name: Verify signed DMG
+        if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
+        run: |
+          ./verify-dmg.sh DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg
+        working-directory: ./script/macos
       - name: Notarize DMG
         if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
         run: |
           xcrun notarytool submit DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg --apple-id "${{ secrets.APPLE_ID }}" --team-id "${{ secrets.TEAM_ID }}" --password "${{ secrets.APP_SPECIFIC_PASSWORD }}" --wait
           xcrun stapler staple DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg
         working-directory: ./script/macos
+      - name: Verify notarized DMG
+        if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
+        run: |
+          ./verify-dmg.sh DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg
+        working-directory: ./script/macos
+        env:
+          MACOS_VERIFY_NOTARIZATION: true
       - name: Hash DMG
         shell: pwsh
         run: |

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2701,6 +2701,11 @@ paths:
   - script/aria2.sh
   - script/ffmpeg.ps1
   - script/ffmpeg.sh
+  - script/macos/package.sh
+  - script/macos/sign.sh
+  - script/macos/sign-dmg.sh
+  - script/macos/verify-app.sh
+  - script/macos/verify-dmg.sh
 responsibility: Gates tags and manual release rehearsals on strict cross-platform tests, builds every supported package, verifies required runtime contents, and publishes SHA-256 evidence.
 inbound:
   - github.tag
@@ -2717,6 +2722,9 @@ contracts:
   - `script/validate-release-version.ps1` requires stable `major.minor.patch` text and blocks a tag whose `refs/tags/v<version>` value differs from `version.txt`.
   - Each RID validates a fixed publish directory containing non-empty DownKyi, aria2, FFmpeg, ffprobe, and dependency-manifest files.
   - Publish validation checks the expected assembly version, requires Fluent, rejects Simple, and emits per-file SHA-256 values.
+  - Formal macOS tag releases require imported Developer ID signing and Apple notarization credentials; missing credentials fail the macOS package job before any release artifact can be uploaded.
+  - macOS package scripts copy app contents and apply executable permissions before signing. The final app bundle is then signed, verified with `codesign --verify --deep --strict`, notarized, stapled, and Gatekeeper-assessed before DMG creation.
+  - macOS release DMGs are signed, verified, notarized, stapled, and assessed before hashing or upload. Non-tag CI may ad-hoc sign the app to test bundle integrity, but it is not formal release evidence.
   - Every package uploads its own `.sha256` sidecar and publish manifest with the artifact.
   - External archive URLs and SHA-256 values have one owner in `script/assets/external-assets.json`; every PowerShell and Bash downloader resolves that manifest relative to its own file.
   - External archives use immutable release tags and are accepted only after TLS validation, a successful HTTP status and their manifest SHA-256 match.
@@ -2728,6 +2736,7 @@ hazards:
   - Inferring the SDK `RuntimeIdentifier` from the runner host corrupts cross-target restore graphs, such as osx-x64 publication on an arm64 runner.
   - Inspecting PupNet's temporary publish path is not stable; validation publish directories must be explicit.
   - Cross-compiling proves package shape, not native execution. Native Host/XAML tests remain owned by each matrix runner.
+  - A green GitHub Actions release run is not sufficient macOS evidence if signing, notarization, final app verification, or final DMG verification were skipped.
 tests:
   - test.release-packaging
   - github.actions
@@ -3158,6 +3167,8 @@ test.release-packaging:
     - release workflow remains manually dispatchable and gates packages on strict Windows/Linux/macOS build and tests
     - all three platform package jobs run the shared publish validator and emit SHA-256 sidecars
     - publish output requires DownKyi, aria2, FFmpeg, ffprobe, expected version, and Fluent without Simple
+    - formal macOS tag releases fail closed when Developer ID signing or notarization credentials are absent
+    - final macOS app and DMG verification steps run after signing/notarization and before hash/upload
 
 test.null-contracts:
   paths:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -407,13 +407,17 @@ Before pushing a release tag:
 
 1. Confirm `version.txt` matches the planned tag.
 2. Manually dispatch `.github/workflows/build.yml` on the release commit and require all Windows, Linux, and macOS release-gate/package jobs to pass.
-3. Confirm each uploaded publish manifest contains non-empty DownKyi, aria2, FFmpeg, and ffprobe binaries with SHA-256 values and the expected application version.
-4. Run the quality commands from the dependency section and `git diff --check`.
-5. Review `README.md` and `CHANGELOG.md` for user-visible changes.
-6. Push `main`, then push the `v*` tag so the same workflow recreates the validated packages.
-7. Verify generated packages, per-package `.sha256` files, and publish manifests are attached to the release.
+3. For macOS, treat unsigned or unnotarized DMGs as rehearsal-only artifacts. A formal tag release requires `MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PWD`, `APPLE_ID`, `TEAM_ID`, and `APP_SPECIFIC_PASSWORD`; missing credentials must fail the macOS package job.
+4. Confirm macOS x64 and arm64 final app bundles passed `codesign --verify --deep --strict`, notarization, stapling, Gatekeeper assessment, DMG signing, DMG verification, DMG notarization, and final DMG assessment before upload.
+5. Confirm each uploaded publish manifest contains non-empty DownKyi, aria2, FFmpeg, and ffprobe binaries with SHA-256 values and the expected application version.
+6. Run the quality commands from the dependency section and `git diff --check`.
+7. Review `README.md` and `CHANGELOG.md` for user-visible changes.
+8. Push `main`, then push the `v*` tag so the same workflow recreates the validated packages.
+9. Verify generated packages, per-package `.sha256` files, and publish manifests are attached to the release.
 
 `script/validate-publish-output.ps1` is the common package-content gate. It also rejects a runtime that drops the Fluent theme, restores the Simple theme, omits ffprobe, or publishes a mismatched assembly version. Do not replace it with a file-exists check in only one platform job.
+
+macOS signing is deliberately last-mile. `script/macos/package.sh` may create the app bundle, copy `Info.plist`, icon and publish output, and apply executable bits to aria2/FFmpeg. No content or permission step may run after `script/macos/sign.sh`; a later mutation invalidates the resource seal. The release workflow verifies the exact app bundle that will enter the DMG, not just an earlier signing command.
 
 ## Regression Checklist
 

--- a/docs/operations/verification-and-rollback.md
+++ b/docs/operations/verification-and-rollback.md
@@ -109,7 +109,10 @@ Core 只保存外部 binary catalog，不得選擇平台內容或設定 SDK
 catalog 檔案加入 output/publish；自訂 RID 不得跨 ProjectReference。
 推 tag 前手動執行 `build.yml`，下載每個 artifact，重算 package
 sidecar，並檢查 manifest、版本、必要 binary、Fluent theme 與使用者
-資料排除。
+資料排除。macOS artifact 另需確認 x64 與 arm64 package job 沒有跳過
+Developer ID signing、app notarization、DMG signing、DMG notarization 或最終
+verification steps；正式 release 若缺任一 Apple signing/notary credential
+必須 fail closed，不得產生可發布 DMG。
 
 歷史 rehearsal `30431043860` 證明 v1.1.0 candidate 的三個 release
 gate、九個 package job、sidecar、manifest 與實際套件內容正確；它不是

--- a/script/macos/codesign-common.sh
+++ b/script/macos/codesign-common.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+resolve_signing_identity() {
+  if [ "${MACOS_ADHOC_SIGNING:-false}" = "true" ]; then
+    printf '%s\n' "-"
+    return 0
+  fi
+
+  if [ -n "${MACOS_SIGNING_IDENTITY:-}" ]; then
+    printf '%s\n' "$MACOS_SIGNING_IDENTITY"
+    return 0
+  fi
+
+  if ! command -v security >/dev/null 2>&1; then
+    echo "::error::security is required to resolve a Developer ID signing identity." >&2
+    return 1
+  fi
+
+  local identity
+  identity="$(security find-identity -v -p codesigning | awk -F '"' '/Developer ID Application/ { print $2; exit }')"
+  if [ -z "$identity" ]; then
+    echo "::error::No Developer ID Application signing identity is available." >&2
+    return 1
+  fi
+
+  printf '%s\n' "$identity"
+}
+
+set_codesign_timestamp_args() {
+  CODESIGN_TIMESTAMP_ARGS=()
+  if [ "$1" != "-" ]; then
+    CODESIGN_TIMESTAMP_ARGS=(--timestamp)
+  fi
+}

--- a/script/macos/package.sh
+++ b/script/macos/package.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -euo pipefail
+
 arch=$1
 APP_NAME="./哔哩下载姬.app"
 PUBLISH_OUTPUT_DIRECTORY="../../DownKyi/bin/Release/net10.0/osx-$arch/publish/."
@@ -19,9 +21,9 @@ mkdir "$APP_NAME/Contents/Resources"
 cp "$INFO_PLIST" "$APP_NAME/Contents/Info.plist"
 cp "$ICON_FILE" "$APP_NAME/Contents/Resources/$ICON_FILE"
 cp -a "$PUBLISH_OUTPUT_DIRECTORY" "$APP_NAME/Contents/MacOS"
-if [ ! -x $APP_NAME/Contents/MacOS/aria2/aria2c ]; then
-  chmod +x $APP_NAME/Contents/MacOS/aria2/aria2c
+if [ ! -x "$APP_NAME/Contents/MacOS/aria2/aria2c" ]; then
+  chmod +x "$APP_NAME/Contents/MacOS/aria2/aria2c"
 fi
-if [ ! -x $APP_NAME/Contents/MacOS/ffmpeg/ffmpeg ]; then
-  chmod +x $APP_NAME/Contents/MacOS/ffmpeg/ffmpeg
+if [ ! -x "$APP_NAME/Contents/MacOS/ffmpeg/ffmpeg" ]; then
+  chmod +x "$APP_NAME/Contents/MacOS/ffmpeg/ffmpeg"
 fi

--- a/script/macos/sign-dmg.sh
+++ b/script/macos/sign-dmg.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/codesign-common.sh"
+
+DMG_PATH="${1:?DMG path is required.}"
+SIGNING_IDENTITY="$(resolve_signing_identity)"
+
+if [ "$SIGNING_IDENTITY" = "-" ]; then
+  echo "::error::DMG signing requires a Developer ID identity." >&2
+  exit 1
+fi
+
+codesign --force --timestamp --sign "$SIGNING_IDENTITY" "$DMG_PATH"

--- a/script/macos/sign.sh
+++ b/script/macos/sign.sh
@@ -1,15 +1,21 @@
 #!/bin/bash
-APP_NAME="哔哩下载姬.app"
-ENTITLEMENTS="DownKyi.entitlements"
-SIGNING_IDENTITY="biao yao" # matches Keychain Access certificate name
+set -euo pipefail
 
-find "$APP_NAME/Contents/MacOS/" -type f | while read -r file; do
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/codesign-common.sh"
+
+APP_NAME="${1:-哔哩下载姬.app}"
+ENTITLEMENTS="${MACOS_ENTITLEMENTS:-$SCRIPT_DIR/DownKyi.entitlements}"
+SIGNING_IDENTITY="$(resolve_signing_identity)"
+set_codesign_timestamp_args "$SIGNING_IDENTITY"
+
+find "$APP_NAME/Contents" -type f -print0 | while IFS= read -r -d '' file; do
   if file "$file" | grep -q "Mach-O"; then
     echo "[INFO] Signing $file"
-    codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$file"
+    codesign --force "${CODESIGN_TIMESTAMP_ARGS[@]}" --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$file"
   fi
 done
 
-echo "[INFO] Signing app file"
+echo "[INFO] Signing app bundle"
 
-codesign --deep --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$APP_NAME"
+codesign --force "${CODESIGN_TIMESTAMP_ARGS[@]}" --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$APP_NAME"

--- a/script/macos/verify-app.sh
+++ b/script/macos/verify-app.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_NAME="${1:-哔哩下载姬.app}"
+
+codesign --verify --deep --strict --verbose=2 "$APP_NAME"
+codesign -dv --verbose=4 "$APP_NAME"
+
+if [ "${MACOS_VERIFY_GATEKEEPER:-false}" = "true" ]; then
+  spctl --assess --type execute --verbose=4 "$APP_NAME"
+fi

--- a/script/macos/verify-dmg.sh
+++ b/script/macos/verify-dmg.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+DMG_PATH="${1:?DMG path is required.}"
+
+codesign --verify --verbose=2 "$DMG_PATH"
+
+if [ "${MACOS_VERIFY_NOTARIZATION:-false}" = "true" ]; then
+  xcrun stapler validate "$DMG_PATH"
+  spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG_PATH"
+fi

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -371,6 +371,59 @@ public sealed class ReleaseWorkflowArchitectureTests
     }
 
     [Fact]
+    public void MacReleaseFailsClosedAndVerifiesFinalSignedArtifacts()
+    {
+        var workflow = File.ReadAllText(
+            Path.Combine(RepositoryRoot, ".github", "workflows", "build.yml"));
+        var signScript = File.ReadAllText(
+            Path.Combine(RepositoryRoot, "script", "macos", "sign.sh"));
+        var verifyAppScript = File.ReadAllText(
+            Path.Combine(RepositoryRoot, "script", "macos", "verify-app.sh"));
+        var verifyDmgScript = File.ReadAllText(
+            Path.Combine(RepositoryRoot, "script", "macos", "verify-dmg.sh"));
+
+        Assert.Contains(
+            "MACOS_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/') }}",
+            workflow,
+            StringComparison.Ordinal);
+        Assert.Contains("Require macOS signing credentials for release", workflow, StringComparison.Ordinal);
+        Assert.Contains(
+            "Formal macOS releases require MACOS_CERTIFICATE, MACOS_CERTIFICATE_PWD, APPLE_ID, TEAM_ID, and APP_SPECIFIC_PASSWORD.",
+            workflow,
+            StringComparison.Ordinal);
+        Assert.Contains("Resolve signing identity", workflow, StringComparison.Ordinal);
+        Assert.Contains("MACOS_ADHOC_SIGNING: ${{ env.HAS_MACOS_SIGNING != 'true' }}", workflow, StringComparison.Ordinal);
+
+        AssertInOrder(
+            workflow,
+            "Package app",
+            "Validate packaged runtime",
+            "Sign app",
+            "Verify app signature",
+            "Notarize app",
+            "Verify notarized app",
+            "Create DMG",
+            "Sign DMG",
+            "Verify signed DMG",
+            "Notarize DMG",
+            "Verify notarized DMG",
+            "Hash DMG",
+            "Upload build artifacts");
+
+        Assert.DoesNotContain("biao yao", signScript, StringComparison.Ordinal);
+        Assert.DoesNotContain("codesign --deep --force", signScript, StringComparison.Ordinal);
+        Assert.Contains("resolve_signing_identity", signScript, StringComparison.Ordinal);
+        Assert.Contains("find \"$APP_NAME/Contents\" -type f", signScript, StringComparison.Ordinal);
+        Assert.Contains("codesign --force \"${CODESIGN_TIMESTAMP_ARGS[@]}\" --options=runtime", signScript, StringComparison.Ordinal);
+
+        Assert.Contains("codesign --verify --deep --strict --verbose=2", verifyAppScript, StringComparison.Ordinal);
+        Assert.Contains("spctl --assess --type execute", verifyAppScript, StringComparison.Ordinal);
+        Assert.Contains("codesign --verify --verbose=2", verifyDmgScript, StringComparison.Ordinal);
+        Assert.Contains("xcrun stapler validate", verifyDmgScript, StringComparison.Ordinal);
+        Assert.Contains("spctl --assess --type open --context context:primary-signature", verifyDmgScript, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void VersionFileIsTheOnlyProjectVersionSourceAndControlsAssemblyMetadata()
     {
         var versionText = File.ReadAllText(Path.Combine(RepositoryRoot, "version.txt")).Trim();
@@ -418,6 +471,17 @@ public sealed class ReleaseWorkflowArchitectureTests
     private static int CountOccurrences(string source, string value)
     {
         return source.Split(value, StringSplitOptions.None).Length - 1;
+    }
+
+    private static void AssertInOrder(string source, params string[] fragments)
+    {
+        var previousIndex = -1;
+        foreach (var fragment in fragments)
+        {
+            var index = source.IndexOf(fragment, previousIndex + 1, StringComparison.Ordinal);
+            Assert.True(index > previousIndex, $"Expected '{fragment}' after index {previousIndex}.");
+            previousIndex = index;
+        }
     }
 
     private static bool HasRunnableManifestDetectionDependency(string workflow)


### PR DESCRIPTION
## Summary

- fail formal tag macOS package jobs when required Apple signing/notarization credentials are absent
- sign and verify the final `.app` bundle after all package content and executable-bit changes
- sign, verify, notarize, staple, and assess the DMG before hash/upload when Developer ID credentials are present
- add release workflow architecture coverage and update the existing release documentation

## Normalized base

PR #171 is now merged into `main`, so this PR has been rebased onto current `origin/main` and contains only the Issue #172 release-signing fix commit.

## Issue #172 evidence

- v1.0.32 tag workflow run `29068029945` skipped Import certificate, Sign app, Notarize app, and Notarize DMG for both macOS jobs while still succeeding and uploading DMGs.
- v1.1.1 tag workflow run `31680175619` repeated the same skipped-signing/notarization path and still reached Publish release.
- The downloaded official v1.0.32 arm64 DMG SHA-256 matches the Issue report: `4cd28b7f9d4beca5a7e5744f6ff68edb723bbb8321b6daf61a925c89d9310cb0`.

## Verification

Local Windows verification:

- `bash -n script/macos/package.sh script/macos/sign.sh script/macos/codesign-common.sh script/macos/sign-dmg.sh script/macos/verify-app.sh script/macos/verify-dmg.sh`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -- .github/workflows/build.yml`
- `dotnet test .\tests\DownKyi.Architecture.Tests\DownKyi.Architecture.Tests.csproj -c Release --filter "FullyQualifiedName~ReleaseWorkflowArchitectureTests"` -> 14 passed
- `git diff --check`

## Remaining release blocker

Do not replace v1.1.1 macOS assets from this PR alone. A controlled v1.1.2 macOS release still needs the corrected workflow to run on GitHub macOS runners with real Apple Developer ID and notarization credentials, then verify x64 and arm64 final App/DMG signing, notarization, stapling, `codesign`, and `spctl` evidence from the actually published release artifacts.

Refs #172