### PR TITLE
fix(release): allow verified ad-hoc macOS tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -372,7 +372,6 @@ jobs:
     needs: changelog
     env:
       HAS_MACOS_SIGNING: ${{ secrets.MACOS_CERTIFICATE != '' && secrets.MACOS_CERTIFICATE_PWD != '' && secrets.APPLE_ID != '' && secrets.TEAM_ID != '' && secrets.APP_SPECIFIC_PASSWORD != '' }}
-      MACOS_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/') }}
     strategy:
       fail-fast: false
       matrix:
@@ -380,11 +379,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
-      - name: Require macOS signing credentials for release
-        if: ${{ env.MACOS_SIGNING_REQUIRED == 'true' && env.HAS_MACOS_SIGNING != 'true' }}
-        run: |
-          echo "::error::Formal macOS releases require MACOS_CERTIFICATE, MACOS_CERTIFICATE_PWD, APPLE_ID, TEAM_ID, and APP_SPECIFIC_PASSWORD."
-          exit 1
       - name: Import certificate
         if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
         uses: apple-actions/import-codesign-certs@v7

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2722,9 +2722,9 @@ contracts:
   - `script/validate-release-version.ps1` requires stable `major.minor.patch` text and blocks a tag whose `refs/tags/v<version>` value differs from `version.txt`.
   - Each RID validates a fixed publish directory containing non-empty DownKyi, aria2, FFmpeg, ffprobe, and dependency-manifest files.
   - Publish validation checks the expected assembly version, requires Fluent, rejects Simple, and emits per-file SHA-256 values.
-  - Formal macOS tag releases require imported Developer ID signing and Apple notarization credentials; missing credentials fail the macOS package job before any release artifact can be uploaded.
-  - macOS package scripts copy app contents and apply executable permissions before signing. The final app bundle is then signed, verified with `codesign --verify --deep --strict`, notarized, stapled, and Gatekeeper-assessed before DMG creation.
-  - macOS release DMGs are signed, verified, notarized, stapled, and assessed before hashing or upload. Non-tag CI may ad-hoc sign the app to test bundle integrity, but it is not formal release evidence.
+  - macOS tag releases without Apple credentials ad-hoc sign the final app and must pass `codesign --verify --deep --strict` before DMG creation. This proves bundle integrity but is not Developer ID signing, notarization, stapling, or Gatekeeper trust.
+  - macOS package scripts copy app contents and apply executable permissions before signing. The final app bundle is then signed and strictly verified; when Developer ID and notarization credentials are available, it is additionally notarized, stapled, and Gatekeeper-assessed before DMG creation.
+  - With Apple credentials, macOS release DMGs are signed, verified, notarized, stapled, and assessed before hashing or upload. Without them, the DMG remains unnotarized and is hashed or uploaded only after the ad-hoc signed app passes strict bundle verification.
   - Every package uploads its own `.sha256` sidecar and publish manifest with the artifact.
   - External archive URLs and SHA-256 values have one owner in `script/assets/external-assets.json`; every PowerShell and Bash downloader resolves that manifest relative to its own file.
   - External archives use immutable release tags and are accepted only after TLS validation, a successful HTTP status and their manifest SHA-256 match.
@@ -2736,7 +2736,7 @@ hazards:
   - Inferring the SDK `RuntimeIdentifier` from the runner host corrupts cross-target restore graphs, such as osx-x64 publication on an arm64 runner.
   - Inspecting PupNet's temporary publish path is not stable; validation publish directories must be explicit.
   - Cross-compiling proves package shape, not native execution. Native Host/XAML tests remain owned by each matrix runner.
-  - A green GitHub Actions release run is not sufficient macOS evidence if signing, notarization, final app verification, or final DMG verification were skipped.
+  - A green GitHub Actions release run is not sufficient macOS evidence if final app signing or strict verification was skipped. Developer ID, notarization, stapling, Gatekeeper, and signed-DMG verification are additional evidence only when Apple credentials are available.
 tests:
   - test.release-packaging
   - github.actions
@@ -3167,8 +3167,8 @@ test.release-packaging:
     - release workflow remains manually dispatchable and gates packages on strict Windows/Linux/macOS build and tests
     - all three platform package jobs run the shared publish validator and emit SHA-256 sidecars
     - publish output requires DownKyi, aria2, FFmpeg, ffprobe, expected version, and Fluent without Simple
-    - formal macOS tag releases fail closed when Developer ID signing or notarization credentials are absent
-    - final macOS app and DMG verification steps run after signing/notarization and before hash/upload
+    - macOS tag releases without Apple credentials use ad-hoc signing and still fail closed when final app strict verification fails
+    - final macOS app verification runs after signing and before DMG creation; credentialed DMG verification runs after signing/notarization and before hash/upload
 
 test.null-contracts:
   paths:

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -407,8 +407,8 @@ Before pushing a release tag:
 
 1. Confirm `version.txt` matches the planned tag.
 2. Manually dispatch `.github/workflows/build.yml` on the release commit and require all Windows, Linux, and macOS release-gate/package jobs to pass.
-3. For macOS, treat unsigned or unnotarized DMGs as rehearsal-only artifacts. A formal tag release requires `MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PWD`, `APPLE_ID`, `TEAM_ID`, and `APP_SPECIFIC_PASSWORD`; missing credentials must fail the macOS package job.
-4. Confirm macOS x64 and arm64 final app bundles passed `codesign --verify --deep --strict`, notarization, stapling, Gatekeeper assessment, DMG signing, DMG verification, DMG notarization, and final DMG assessment before upload.
+3. For macOS without Apple credentials, require the final app bundle to use ad-hoc signing and pass `codesign --verify --deep --strict` before DMG creation. Record that the resulting DMG is not Developer ID signed, notarized, stapled, or Gatekeeper-trusted.
+4. When `MACOS_CERTIFICATE`, `MACOS_CERTIFICATE_PWD`, `APPLE_ID`, `TEAM_ID`, and `APP_SPECIFIC_PASSWORD` are available, additionally confirm macOS x64 and arm64 app notarization, stapling, Gatekeeper assessment, DMG signing, DMG verification, DMG notarization, and final DMG assessment before upload.
 5. Confirm each uploaded publish manifest contains non-empty DownKyi, aria2, FFmpeg, and ffprobe binaries with SHA-256 values and the expected application version.
 6. Run the quality commands from the dependency section and `git diff --check`.
 7. Review `README.md` and `CHANGELOG.md` for user-visible changes.

--- a/docs/operations/verification-and-rollback.md
+++ b/docs/operations/verification-and-rollback.md
@@ -109,10 +109,11 @@ Core 只保存外部 binary catalog，不得選擇平台內容或設定 SDK
 catalog 檔案加入 output/publish；自訂 RID 不得跨 ProjectReference。
 推 tag 前手動執行 `build.yml`，下載每個 artifact，重算 package
 sidecar，並檢查 manifest、版本、必要 binary、Fluent theme 與使用者
-資料排除。macOS artifact 另需確認 x64 與 arm64 package job 沒有跳過
-Developer ID signing、app notarization、DMG signing、DMG notarization 或最終
-verification steps；正式 release 若缺任一 Apple signing/notary credential
-必須 fail closed，不得產生可發布 DMG。
+資料排除。macOS artifact 另需確認 x64 與 arm64 final app 均已完成簽章並
+通過 `codesign --verify --deep --strict`；缺少 Apple credentials 時使用 ad-hoc
+簽章，Developer ID、notarization、stapling、Gatekeeper 與 signed-DMG 驗證會
+跳過，產物不得宣稱具備這些信任屬性。具備完整 Apple credentials 時才要求
+上述額外步驟全部通過。任何 final app bundle 完整性失敗仍必須 fail closed。
 
 歷史 rehearsal `30431043860` 證明 v1.1.0 candidate 的三個 release
 gate、九個 package job、sidecar、manifest 與實際套件內容正確；它不是

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -371,7 +371,7 @@ public sealed class ReleaseWorkflowArchitectureTests
     }
 
     [Fact]
-    public void MacReleaseFailsClosedAndVerifiesFinalSignedArtifacts()
+    public void MacReleaseAdHocSignsAndVerifiesFinalArtifacts()
     {
         var workflow = File.ReadAllText(
             Path.Combine(RepositoryRoot, ".github", "workflows", "build.yml"));
@@ -382,12 +382,15 @@ public sealed class ReleaseWorkflowArchitectureTests
         var verifyDmgScript = File.ReadAllText(
             Path.Combine(RepositoryRoot, "script", "macos", "verify-dmg.sh"));
 
-        Assert.Contains(
-            "MACOS_SIGNING_REQUIRED: ${{ startsWith(github.ref, 'refs/tags/') }}",
+        Assert.DoesNotContain(
+            "MACOS_SIGNING_REQUIRED",
             workflow,
             StringComparison.Ordinal);
-        Assert.Contains("Require macOS signing credentials for release", workflow, StringComparison.Ordinal);
-        Assert.Contains(
+        Assert.DoesNotContain(
+            "Require macOS signing credentials for release",
+            workflow,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
             "Formal macOS releases require MACOS_CERTIFICATE, MACOS_CERTIFICATE_PWD, APPLE_ID, TEAM_ID, and APP_SPECIFIC_PASSWORD.",
             workflow,
             StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- remove only the formal-tag failure caused by missing Apple credentials
- preserve ad-hoc final-app signing and mandatory strict codesign verification
- preserve optional Developer ID, notarization, stapling, Gatekeeper, and signed-DMG paths
- correct existing release documentation to distinguish bundle integrity from Apple distribution trust

## Verification

- macOS script syntax passed against the repository LF blobs
- actionlint passed for .github/workflows/build.yml
- ReleaseWorkflowArchitectureTests passed: 14/14
- git diff --check passed
- PR CI passed for Windows/Linux/macOS build and tests, format, six aria2 TLS matrices, package audit, CodeQL, and workflow lint
- Assembly Lifecycle Stability was intentionally not run per owner test-scope exception; the automatic Quality run was cancelled before the gate step, then every non-lifecycle job was rerun individually to success

Refs #172