### PR TITLE
fix(release): support explicit macOS recovery trust modes

### DIFF
--- a/.github/workflows/release-v112-recovery.yml
+++ b/.github/workflows/release-v112-recovery.yml
@@ -566,10 +566,10 @@ jobs:
             echo "::error::Published release has $asset_count assets; expected 27."
             exit 1
           fi
-          jq -e '.assets[] | select((.browser_download_url | length) == 0)' <<<"$release_json" >/dev/null && {
+          if jq -e '.assets[] | select((.browser_download_url | length) == 0)' <<<"$release_json" >/dev/null; then
             echo "::error::A published asset has no download URL."
             exit 1
-          } || true
+          fi
           pwsh ./tooling/script/validate-v112-recovery-subject.ps1 \
             -SubjectDirectory ./subject \
             -ReleaseVersion v1.1.2 \

--- a/.github/workflows/release-v112-recovery.yml
+++ b/.github/workflows/release-v112-recovery.yml
@@ -38,8 +38,10 @@ jobs:
   authority:
     name: Validate recovery authority
     runs-on: ubuntu-latest
+    outputs:
+      macos_trust_mode: ${{ steps.macos_trust.outputs.macos_trust_mode }}
+      has_macos_signing: ${{ steps.macos_trust.outputs.has_macos_signing }}
     env:
-      HAS_MACOS_SIGNING: ${{ secrets.MACOS_CERTIFICATE != '' && secrets.MACOS_CERTIFICATE_PWD != '' && secrets.APPLE_ID != '' && secrets.TEAM_ID != '' && secrets.APP_SPECIFIC_PASSWORD != '' }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout recovery tooling
@@ -61,6 +63,18 @@ jobs:
           -SubjectDirectory ./subject
           -ReleaseVersion '${{ inputs.release_version }}'
           -SubjectSha '${{ inputs.subject_sha }}'
+      - name: Resolve macOS release trust mode
+        id: macos_trust
+        shell: pwsh
+        env:
+          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          TEAM_ID: ${{ secrets.TEAM_ID }}
+          APP_SPECIFIC_PASSWORD: ${{ secrets.APP_SPECIFIC_PASSWORD }}
+        run: >
+          ./tooling/script/resolve-v112-macos-trust.ps1
+          -GitHubOutputPath $env:GITHUB_OUTPUT
       - name: Validate prior Build gate
         shell: bash
         run: |
@@ -82,6 +96,10 @@ jobs:
           fi
           critical_paths=(
             .github/workflows/build.yml
+            .github/workflows/release-v112-recovery.yml
+            docs/operations/v1.1.2-release-notes.md
+            script/resolve-v112-macos-trust.ps1
+            script/render-v112-recovery-release-notes.ps1
             script/macos/codesign-common.sh
             script/macos/prepare-app-layout.sh
             script/macos/sign.sh
@@ -100,14 +118,6 @@ jobs:
               exit 1
             fi
           done
-      - name: Require Apple credentials for formal publish
-        if: ${{ inputs.publish_release }}
-        shell: bash
-        run: |
-          if [ "$HAS_MACOS_SIGNING" != "true" ]; then
-            echo "::error::Formal v1.1.2 recovery requires all Apple signing and notarization credentials."
-            exit 1
-          fi
       - name: Validate recovery workflow syntax
         uses: raven-actions/actionlint@v2
         with:
@@ -323,7 +333,7 @@ jobs:
     needs: authority
     runs-on: ${{ matrix.os }}
     env:
-      HAS_MACOS_SIGNING: ${{ secrets.MACOS_CERTIFICATE != '' && secrets.MACOS_CERTIFICATE_PWD != '' && secrets.APPLE_ID != '' && secrets.TEAM_ID != '' && secrets.APP_SPECIFIC_PASSWORD != '' }}
+      HAS_MACOS_SIGNING: ${{ needs.authority.outputs.has_macos_signing }}
     strategy:
       fail-fast: false
       matrix:
@@ -531,13 +541,19 @@ jobs:
       - name: Revalidate release assets
         shell: pwsh
         run: ./tooling/script/validate-v112-release-artifacts.ps1 -ArtifactsDirectory ./artifacts
+      - name: Render release notes for selected trust mode
+        shell: pwsh
+        run: >
+          ./tooling/script/render-v112-recovery-release-notes.ps1
+          -TrustMode '${{ needs.authority.outputs.macos_trust_mode }}'
+          -OutputPath ./tooling/artifacts/v1.1.2-release-notes.md
       - name: Publish to existing v1.1.2 tag
         uses: ncipollo/release-action@v1
         with:
           tag: v1.1.2
           commit: 16c690d8719f86eb6eecb56c24efabc1afc41d55
           name: v1.1.2
-          body: 'Recovered v1.1.2 release. Product source: 16c690d8719f86eb6eecb56c24efabc1afc41d55.'
+          bodyFile: tooling/artifacts/v1.1.2-release-notes.md
           artifacts: artifacts/*
           artifactErrorsFailBuild: true
           allowUpdates: true

--- a/.github/workflows/release-v112-recovery.yml
+++ b/.github/workflows/release-v112-recovery.yml
@@ -263,9 +263,8 @@ jobs:
       - name: Get exact-subject dependencies
         working-directory: subject/script
         run: |
-          chmod +x ffmpeg.sh aria2.sh
-          ./ffmpeg.sh linux ${{ matrix.cpu }}
-          ./aria2.sh linux-${{ matrix.cpu }}
+          /bin/bash ./ffmpeg.sh linux ${{ matrix.cpu }}
+          /bin/bash ./aria2.sh linux-${{ matrix.cpu }}
       - name: Build validation publish from exact subject
         run: >
           dotnet publish ./subject/DownKyi/DownKyi.csproj
@@ -385,9 +384,8 @@ jobs:
       - name: Get exact-subject dependencies
         working-directory: subject/script
         run: |
-          chmod +x aria2.sh ffmpeg.sh
-          ./aria2.sh osx-${{ matrix.cpu }}
-          ./ffmpeg.sh mac ${{ matrix.cpu }}
+          /bin/bash ./aria2.sh osx-${{ matrix.cpu }}
+          /bin/bash ./ffmpeg.sh mac ${{ matrix.cpu }}
       - name: Build exact release subject
         working-directory: subject
         run: |

--- a/docs/operations/v1.1.2-release-notes.md
+++ b/docs/operations/v1.1.2-release-notes.md
@@ -17,20 +17,18 @@ bundle 的簽章完整性發布邊界。
 
 ## macOS 發布信任邊界
 
-本版本沒有使用付費 Apple Developer Program 憑證。macOS x64 與 arm64
-App 使用 ad-hoc identity `-` 簽章並接受嚴格 bundle 完整性驗證，但不是
-Developer ID 簽章，也沒有 Apple notarization、stapling 或 Gatekeeper
-信任。workflow 保留完整 Apple credentials 可用時的 Developer ID、App/DMG
-notarization、stapling、Gatekeeper 與 signed-DMG 驗證路徑。
+Recovery workflow 只允許兩種明確模式：完整 Apple credentials 使用
+Developer ID、notarization、stapling 與 Gatekeeper 驗證；完全沒有 credentials
+則使用 ad-hoc identity `-`，但仍強制執行 strict codesign、DMG remount 與
+實際啟動驗證。正式 Release notes 會附加本次實際採用的模式。
 
 ## 驗證範圍
 
-本版本沒有修改 lifecycle、thread 或 process ownership。依 repository
-owner 明確的 test-scope exception，`v1.1.2` 接受 #171/#188 路徑既有的
-Assembly Lifecycle Stability 成功證據，正式 tag workflow 不重跑該長測試；
-其餘三平台 Release build/test、package validation、macOS final-app strict
-codesign verification、SHA-256 sidecar、manifest 與 release asset gate 仍須
-全部通過。
+本版本沒有修改 lifecycle、thread 或 process ownership。Recovery publish
+必須引用同一 control-plane head 上成功的手動 Build run；該 run 仍執行正常
+Assembly Lifecycle release gate。Recovery workflow 不重複該長測試，但會重新
+執行三平台 package validation、macOS final-app strict codesign、SHA-256
+sidecar、manifest 與 release asset gate。
 
 ## 相容性
 

--- a/script/render-v112-recovery-release-notes.ps1
+++ b/script/render-v112-recovery-release-notes.ps1
@@ -1,0 +1,41 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [ValidateSet('ad-hoc', 'developer-id')]
+    [string]$TrustMode,
+
+    [Parameter(Mandatory = $true)]
+    [string]$OutputPath,
+
+    [string]$BaseNotesPath = (Join-Path $PSScriptRoot '..\docs\operations\v1.1.2-release-notes.md')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$baseNotes = Get-Content -LiteralPath $BaseNotesPath -Raw
+$trustDisclosure = if ($TrustMode -eq 'developer-id') {
+    @'
+## Published macOS trust mode
+
+The macOS artifacts use Developer ID signing. Apple notarization, stapling,
+strict codesign verification, Gatekeeper assessment, DMG remount verification,
+and packaged-app launch validation completed before publication.
+'@
+}
+else {
+    @'
+## Published macOS trust mode
+
+The macOS artifacts use ad-hoc identity `-` and passed strict
+`codesign --verify --deep --strict`, DMG remount verification, and packaged-app
+launch validation. They are not notarized. This macOS release does not have Gatekeeper distribution trust.
+'@
+}
+
+$parent = Split-Path -Parent $OutputPath
+if (-not [string]::IsNullOrWhiteSpace($parent)) {
+    [void](New-Item -ItemType Directory -Path $parent -Force)
+}
+
+"$($baseNotes.TrimEnd())`n`n$($trustDisclosure.Trim())`n" |
+    Set-Content -LiteralPath $OutputPath -Encoding utf8

--- a/script/resolve-v112-macos-trust.ps1
+++ b/script/resolve-v112-macos-trust.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+param(
+    [string]$OutputPath,
+    [string]$GitHubOutputPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+if ([string]::IsNullOrWhiteSpace($OutputPath) -and
+    [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    throw 'OutputPath or GitHubOutputPath is required.'
+}
+
+$credentialNames = @(
+    'MACOS_CERTIFICATE',
+    'MACOS_CERTIFICATE_PWD',
+    'APPLE_ID',
+    'TEAM_ID',
+    'APP_SPECIFIC_PASSWORD'
+)
+$presentNames = @(
+    $credentialNames | Where-Object {
+        -not [string]::IsNullOrWhiteSpace([Environment]::GetEnvironmentVariable($_))
+    }
+)
+
+if ($presentNames.Count -eq 0) {
+    $trustMode = 'ad-hoc'
+    $hasMacOsSigning = 'false'
+}
+elseif ($presentNames.Count -eq $credentialNames.Count) {
+    $trustMode = 'developer-id'
+    $hasMacOsSigning = 'true'
+}
+else {
+    $missingNames = @($credentialNames | Where-Object { $_ -notin $presentNames })
+    throw "Partial Apple credentials are not a valid release trust mode. Missing: $($missingNames -join ', ')."
+}
+
+if (-not [string]::IsNullOrWhiteSpace($OutputPath)) {
+    [ordered]@{
+        macosTrustMode = $trustMode
+        hasMacosSigning = $hasMacOsSigning -eq 'true'
+    } | ConvertTo-Json | Set-Content -LiteralPath $OutputPath -Encoding utf8
+}
+
+if (-not [string]::IsNullOrWhiteSpace($GitHubOutputPath)) {
+    @(
+        "macos_trust_mode=$trustMode"
+        "has_macos_signing=$hasMacOsSigning"
+    ) | Add-Content -LiteralPath $GitHubOutputPath -Encoding utf8
+}
+
+Write-Output "Resolved macOS release trust mode: $trustMode"

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -469,8 +469,24 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("ref: ${{ inputs.subject_sha }}", workflow, StringComparison.Ordinal);
         Assert.Contains("dotnet publish ./subject/DownKyi/DownKyi.csproj", workflow, StringComparison.Ordinal);
         Assert.Contains("working-directory: subject", workflow, StringComparison.Ordinal);
-        Assert.Contains("Formal v1.1.2 recovery requires all Apple signing and notarization credentials.", workflow, StringComparison.Ordinal);
+        Assert.Contains("Resolve macOS release trust mode", workflow, StringComparison.Ordinal);
+        Assert.Contains("macos_trust_mode: ${{ steps.macos_trust.outputs.macos_trust_mode }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("HAS_MACOS_SIGNING: ${{ needs.authority.outputs.has_macos_signing }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("MACOS_ADHOC_SIGNING: ${{ env.HAS_MACOS_SIGNING != 'true' }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("if: ${{ env.HAS_MACOS_SIGNING == 'true' }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("Strictly verify final app", workflow, StringComparison.Ordinal);
         Assert.Contains("./verify-dmg-contents.sh", workflow, StringComparison.Ordinal);
+        Assert.Contains("Render release notes for selected trust mode", workflow, StringComparison.Ordinal);
+        Assert.Contains("bodyFile: tooling/artifacts/v1.1.2-release-notes.md", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("Require Apple credentials for formal publish", workflow, StringComparison.Ordinal);
+
+        var macSteps = GetWorkflowSteps(workflow, "  build-macos:");
+        AssertStepCondition(macSteps, "Import Apple certificate", "${{ env.HAS_MACOS_SIGNING == 'true' }}");
+        AssertStepCondition(macSteps, "Resolve Developer ID identity", "${{ env.HAS_MACOS_SIGNING == 'true' }}");
+        AssertStepCondition(macSteps, "Notarize and verify app", "${{ env.HAS_MACOS_SIGNING == 'true' }}");
+        AssertStepCondition(macSteps, "Sign, notarize, and verify DMG", "${{ env.HAS_MACOS_SIGNING == 'true' }}");
+        AssertStepHasNoCondition(macSteps, "Strictly verify final app");
+        AssertStepHasNoCondition(macSteps, "Remount DMG, strictly verify, and launch app");
         Assert.Contains("tag: v1.1.2", workflow, StringComparison.Ordinal);
         Assert.Contains("commit: 16c690d8719f86eb6eecb56c24efabc1afc41d55", workflow, StringComparison.Ordinal);
         Assert.Contains("prerelease: false", workflow, StringComparison.Ordinal);
@@ -485,6 +501,85 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("Validated $($expected.Count) v1.1.2 packages", artifactValidator, StringComparison.Ordinal);
         Assert.Contains("Get-FileHash", artifactValidator, StringComparison.Ordinal);
         Assert.Contains("Publish manifest contract failed", artifactValidator, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void V112MacosTrustResolverRequiresZeroOrAllCredentials()
+    {
+        var script = Path.Combine(RepositoryRoot, "script", "resolve-v112-macos-trust.ps1");
+        var outputPath = Path.GetTempFileName();
+
+        try
+        {
+            var adHoc = RunPowerShellScript(
+                script,
+                ["-OutputPath", outputPath],
+                new Dictionary<string, string>());
+            Assert.Equal(0, adHoc.ExitCode);
+            Assert.Contains("ad-hoc", File.ReadAllText(outputPath), StringComparison.Ordinal);
+            Assert.DoesNotContain("developer-id", File.ReadAllText(outputPath), StringComparison.Ordinal);
+
+            IReadOnlyDictionary<string, string> developerIdEnvironment = new Dictionary<string, string>
+            {
+                ["MACOS_CERTIFICATE"] = "fixture-certificate",
+                ["MACOS_CERTIFICATE_PWD"] = "fixture-password",
+                ["APPLE_ID"] = "fixture@example.invalid",
+                ["TEAM_ID"] = "FIXTURETEAM",
+                ["APP_SPECIFIC_PASSWORD"] = "fixture-app-password"
+            };
+            var developerId = RunPowerShellScript(
+                script,
+                ["-OutputPath", outputPath],
+                developerIdEnvironment);
+            Assert.Equal(0, developerId.ExitCode);
+            Assert.Contains("developer-id", File.ReadAllText(outputPath), StringComparison.Ordinal);
+
+            var partial = RunPowerShellScript(
+                script,
+                ["-OutputPath", outputPath],
+                new Dictionary<string, string> { ["APPLE_ID"] = "fixture@example.invalid" });
+            Assert.NotEqual(0, partial.ExitCode);
+            Assert.Contains("Partial Apple credentials", partial.StandardError, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public void V112RecoveryReleaseNotesDiscloseSelectedTrustMode()
+    {
+        var script = Path.Combine(RepositoryRoot, "script", "render-v112-recovery-release-notes.ps1");
+        var outputPath = Path.GetTempFileName();
+
+        try
+        {
+            var adHoc = RunPowerShellScript(
+                script,
+                ["-TrustMode", "ad-hoc", "-OutputPath", outputPath],
+                new Dictionary<string, string>());
+            Assert.Equal(0, adHoc.ExitCode);
+            var adHocNotes = File.ReadAllText(outputPath);
+            Assert.Contains("ad-hoc identity", adHocNotes, StringComparison.Ordinal);
+            Assert.Contains("not notarized", adHocNotes, StringComparison.Ordinal);
+            Assert.Contains("does not have Gatekeeper distribution trust", adHocNotes, StringComparison.Ordinal);
+
+            var developerId = RunPowerShellScript(
+                script,
+                ["-TrustMode", "developer-id", "-OutputPath", outputPath],
+                new Dictionary<string, string>());
+            Assert.Equal(0, developerId.ExitCode);
+            var developerIdNotes = File.ReadAllText(outputPath);
+            Assert.Contains("Developer ID", developerIdNotes, StringComparison.Ordinal);
+            Assert.Contains("notarization", developerIdNotes, StringComparison.Ordinal);
+            Assert.Contains("stapling", developerIdNotes, StringComparison.Ordinal);
+            Assert.DoesNotContain("not notarized", developerIdNotes, StringComparison.Ordinal);
+        }
+        finally
+        {
+            File.Delete(outputPath);
+        }
     }
 
     [Fact]
@@ -537,6 +632,56 @@ public sealed class ReleaseWorkflowArchitectureTests
         return source.Split(value, StringSplitOptions.None).Length - 1;
     }
 
+    private static PowerShellResult RunPowerShellScript(
+        string script,
+        IReadOnlyList<string> arguments,
+        IReadOnlyDictionary<string, string> environment)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "pwsh",
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-NoLogo");
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-File");
+        startInfo.ArgumentList.Add(script);
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        string[] credentialNames =
+        [
+            "MACOS_CERTIFICATE",
+            "MACOS_CERTIFICATE_PWD",
+            "APPLE_ID",
+            "TEAM_ID",
+            "APP_SPECIFIC_PASSWORD"
+        ];
+        foreach (var name in credentialNames)
+        {
+            startInfo.Environment.Remove(name);
+        }
+
+        foreach (var pair in environment)
+        {
+            startInfo.Environment[pair.Key] = pair.Value;
+        }
+
+        using var process = Process.Start(startInfo);
+        Assert.NotNull(process);
+        var standardOutput = process.StandardOutput.ReadToEnd();
+        var standardError = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(30_000), $"Release trust regression timed out: {script}");
+        return new PowerShellResult(process.ExitCode, standardOutput, standardError);
+    }
+
+    private sealed record PowerShellResult(int ExitCode, string StandardOutput, string StandardError);
+
     private static void AssertInOrder(string source, params string[] fragments)
     {
         var previousIndex = -1;
@@ -572,6 +717,49 @@ public sealed class ReleaseWorkflowArchitectureTests
             !HasYamlKey(step, 8, "continue-on-error: true"));
 
         return pullRequestDetector && steps.Count == 1;
+    }
+
+    private static List<List<string>> GetWorkflowSteps(string workflow, string jobHeader)
+    {
+        var lines = workflow.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var job = GetYamlBlock(lines, jobHeader, 2);
+        var stepsStart = job.FindIndex(line =>
+            GetIndent(line) == 4 && string.Equals(line.Trim(), "steps:", StringComparison.Ordinal));
+        Assert.True(stepsStart >= 0, $"Workflow job {jobHeader.Trim()} has no steps.");
+        return GetYamlSequenceBlocks(job[(stepsStart + 1)..], 6);
+    }
+
+    private static void AssertStepCondition(
+        IReadOnlyList<List<string>> steps,
+        string stepName,
+        string expectedCondition)
+    {
+        var step = FindWorkflowStep(steps, stepName);
+        Assert.Contains(
+            step,
+            line => GetIndent(line) == 8 &&
+                    string.Equals(line.Trim(), $"if: {expectedCondition}", StringComparison.Ordinal));
+    }
+
+    private static void AssertStepHasNoCondition(
+        IReadOnlyList<List<string>> steps,
+        string stepName)
+    {
+        var step = FindWorkflowStep(steps, stepName);
+        Assert.DoesNotContain(
+            step,
+            line => GetIndent(line) == 8 && line.Trim().StartsWith("if:", StringComparison.Ordinal));
+    }
+
+    private static List<string> FindWorkflowStep(
+        IReadOnlyList<List<string>> steps,
+        string stepName)
+    {
+        var step = steps.SingleOrDefault(candidate => candidate.Any(line =>
+            GetIndent(line) == 6 &&
+            string.Equals(line.Trim(), $"- name: {stepName}", StringComparison.Ordinal)));
+        Assert.NotNull(step);
+        return step;
     }
 
     private static List<string> GetYamlBlock(


### PR DESCRIPTION
## Summary\n\n- retain the exact-subject and immutable-tag recovery controls\n- select one fail-closed macOS trust mode: all Apple credentials use Developer ID notarization, no credentials use ad-hoc signing with strict verification\n- render formal release notes that disclose the selected trust mode\n- include the two post-merge workflow corrections already proven by recovery rehearsal\n\n## Scope\n\nRelease/build/package tooling only. No product source changes and no PR #191 instrumentation.\n\n## Verification\n\n- strict Architecture test project build: 0 warnings/errors\n- Architecture tests: 244 passed\n- dual trust resolver/release-note regressions: 3 passed\n- actionlint v1.7.12: passed\n- dotnet format: passed\n- git diff --check: passed\n- v1.1.2 tag still dereferences to 16c690d8719f86eb6eecb56c24efabc1afc41d55\n\nFormal recovery publish remains blocked until this PR is reviewed and a fresh rehearsal succeeds.