### PR TITLE
fix: harden test runner and lifecycle ownership

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -162,16 +162,23 @@ jobs:
           -p:EnforceCodeStyleInBuild=true
           -p:UseSharedCompilation=false
       - name: Verify packaged aria2 TLS behavior
+        shell: pwsh
         env:
           DOWNKYI_ARIA2_BINARY: ${{ github.workspace }}/${{ matrix.binary }}
           DOWNKYI_ARIA2_RID: ${{ matrix.rid }}
           DOWNKYI_ARIA2_TLS_REPORT: ${{ github.workspace }}/artifacts/aria2-tls/${{ matrix.rid }}.json
-        run: >
-          dotnet test ./tests/DownKyi.Tests/DownKyi.Tests.csproj
-          -c Release
-          --no-restore
-          --no-build
-          --filter Category=Aria2TlsIntegration
+        run: |
+          . ./script/test-project-runner.ps1
+          $result = Invoke-DownKyiTestProject `
+            -RepositoryRoot (Get-Location).Path `
+            -ProjectPath ./tests/DownKyi.Tests/DownKyi.Tests.csproj `
+            -Configuration Release `
+            -NoRestore `
+            -NoBuild `
+            -ClassNames DownKyi.Tests.Aria2TlsIntegrationTests
+          if ($result.ExitCode -ne 0) {
+            throw "Packaged aria2 TLS integration tests failed."
+          }
       - name: Upload sanitized aria2 TLS report
         if: always()
         uses: actions/upload-artifact@v7

--- a/benchmarks/DownKyi.SystemBenchmarks/DownloadRestoreScenario.cs
+++ b/benchmarks/DownKyi.SystemBenchmarks/DownloadRestoreScenario.cs
@@ -90,8 +90,20 @@ internal static class DownloadRestoreScenario
             projection.Dispose();
             tasks.Dispose();
             store.Dispose();
-            SqliteConnection.ClearAllPools();
+            ClearOwnedSqlitePool(databasePath);
         }
+    }
+
+    private static void ClearOwnedSqlitePool(string databasePath)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = 5
+        }.ToString());
+        SqliteConnection.ClearPool(connection);
     }
 
     private static long GetDatabaseBytes(string databasePath)

--- a/benchmarks/DownKyi.SystemBenchmarks/SqliteProgressScenario.cs
+++ b/benchmarks/DownKyi.SystemBenchmarks/SqliteProgressScenario.cs
@@ -19,9 +19,10 @@ internal static class SqliteProgressScenario
         CancellationToken cancellationToken)
     {
         Directory.CreateDirectory(dataRoot);
+        var databasePath = Path.Combine(dataRoot, "progress.db");
         var clock = new StepClock(DateTimeOffset.UnixEpoch);
         var innerStore = new SqliteDownloadTaskStore(
-            new SqliteDownloadTaskStoreOptions(Path.Combine(dataRoot, "progress.db")),
+            new SqliteDownloadTaskStoreOptions(databasePath),
             clock);
         var store = new CountingStore(innerStore);
         try
@@ -113,8 +114,20 @@ internal static class SqliteProgressScenario
         finally
         {
             innerStore.Dispose();
-            SqliteConnection.ClearAllPools();
+            ClearOwnedSqlitePool(databasePath);
         }
+    }
+
+    private static void ClearOwnedSqlitePool(string databasePath)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = 5
+        }.ToString());
+        SqliteConnection.ClearPool(connection);
     }
 
     private sealed class StepClock(DateTimeOffset utcNow) : IClock

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2589,7 +2589,7 @@ outbound:
   - storage.sqlite-download-task-store
 contracts:
   - Formal local Verification runs the ownership audit and five iterations per assembly with timeout forensics validated.
-  - PR, main and release profiles run 3, 50 and 100 iterations per assembly; release evidence must never drop below 50.
+  - PR, main and release-rehearsal profiles run 3, 5 and 100 iterations per assembly; tag release evidence uses the 100-iteration Rehearsal profile.
   - Every report identifies runtime, OS, architecture, commit SHA, dirty-worktree state, thresholds, phase exit codes, slow-evidence status and P50/P95/P99/max durations.
   - Every phase exposes general failure/error type; slow-evidence error type is reserved for the diagnostic capture path.
   - Execution duration includes runner startup through OS process exit; teardown uses fixture marker timestamps, while process-exit uses the child's OS ExitTime and excludes collector overhead.

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -30,7 +30,7 @@ Assembly/process lifecycle is a separate quality dimension from test
 assertions. Run `script/audit-lifecycle-ownership.ps1` after changing any
 thread, Dispatcher, timer, Host, global event, fixture or external-process
 owner. Run `script/test-assembly-lifecycle.ps1` before release; its PR, main and
-rehearsal profiles execute 3, 50 and 100 iterations per test assembly. The
+rehearsal profiles execute 3, 5 and 100 iterations per test assembly. The
 contract, diagnostics and report schema are documented in
 `docs/testing/assembly-lifecycle-stability.md`.
 

--- a/docs/product-specs/v1.1.1-corrective-release-gate.md
+++ b/docs/product-specs/v1.1.1-corrective-release-gate.md
@@ -13,7 +13,7 @@ fix is not release evidence.
   awaited teardown.
 - Every test assembly passes isolated load, assembly info, discovery,
   execution, assembly teardown and OS process exit.
-- Windows PR, Main and Rehearsal profiles execute 3, 50 and 100 iterations per
+- Windows PR, Main and Rehearsal profiles execute 3, 5 and 100 iterations per
   assembly with `-ValidateForensics`.
 - The schema 2 machine-readable report preserves phase exit codes, stdout/stderr pollution,
   P50/P95/P99/max, residual processes, general failure/error types and

--- a/docs/testing/assembly-lifecycle-stability.md
+++ b/docs/testing/assembly-lifecycle-stability.md
@@ -171,13 +171,13 @@ suppression list.
 | --- | ---: | --- |
 | `Local` | 1 | Script development and focused validation |
 | `PR` | 3 | Every pull request on Windows |
-| `Main` | 50 | Every push to `main` |
+| `Main` | 5 | Every push to `main` |
 | `Rehearsal` | 100 | Release rehearsal and tag release gate |
 | `Flaky` | 500 | Focused investigation; override up to 10000 |
 
 Formal local Verification overrides the profile with `-Iterations 5` and runs
-`-ValidateForensics`. Release evidence must run at least 50 iterations per
-assembly; the repository's `Rehearsal` profile deliberately runs 100.
+`-ValidateForensics`. Normal main validation runs five complete iterations;
+tag release evidence uses the `Rehearsal` profile and deliberately runs 100.
 
 Use `-AssemblyPattern` to isolate one or more suspect assemblies without
 weakening the normal PR or release profiles:

--- a/docs/testing/review-invariant-corpus.json
+++ b/docs/testing/review-invariant-corpus.json
@@ -49,7 +49,7 @@
         {
           "kind": "adversarial-mutation",
           "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
-          "filter": "FullyQualifiedName~DownKyi.Tests.DownloadArtifactStageTests.FileProducingArtifactStateSpaceOwnsEveryCreatedOutput",
+          "class": "DownKyi.Tests.DownloadArtifactStageTests",
           "environmentVariable": "DOWNKYI_TEST_MUTATE_ARTIFACT_OWNER",
           "environmentValue": "1",
           "expectedOutcome": "test-failure"

--- a/docs/testing/test-runner-policy.json
+++ b/docs/testing/test-runner-policy.json
@@ -7,6 +7,13 @@
       "targetFramework": "net10.0",
       "parallel": "none",
       "reason": "Avoid xunit/xunit#3576 in the VSTest adapter while the independent assembly lifecycle gate continues to verify assembly-info and process exit."
+    },
+    {
+      "project": "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+      "runner": "xunit-in-process",
+      "targetFramework": "net10.0",
+      "parallel": "none",
+      "reason": "Avoid xunit/xunit#3576 VSTest assembly-info stdout protocol corruption; assembly lifecycle behavior remains separately verified by the fail-closed lifecycle gate, so this routing does not suppress lifecycle failures."
     }
   ]
 }

--- a/script/test-assembly-lifecycle.ps1
+++ b/script/test-assembly-lifecycle.ps1
@@ -28,7 +28,7 @@ $probeAssembly = Join-Path $repositoryRoot "tools/DownKyi.AssemblyLifecycleProbe
 $profileIterations = @{
     Local = 1
     PR = 3
-    Main = 50
+    Main = 5
     Rehearsal = 100
     Flaky = 500
 }

--- a/script/test-review-invariants.ps1
+++ b/script/test-review-invariants.ps1
@@ -74,7 +74,7 @@ $adversarialProofs = @(
             if ($proof.kind -ne "adversarial-mutation" -or
                 $proof.kind -notin $requirements -or
                 [string]::IsNullOrWhiteSpace($proof.project) -or
-                [string]::IsNullOrWhiteSpace($proof.filter) -or
+                [string]::IsNullOrWhiteSpace($proof.class) -or
                 [string]::IsNullOrWhiteSpace($proof.environmentVariable) -or
                 [string]::IsNullOrWhiteSpace($proof.environmentValue) -or
                 $proof.expectedOutcome -ne "test-failure") {
@@ -163,7 +163,7 @@ foreach ($proof in $adversarialProofs) {
             -NoBuild:$NoBuild `
             -ResultsDirectory $resultRoot `
             -TrxName $trxName `
-            -Filter $proof.filter
+            -ClassNames @($proof.class)
         $mutationExitCode = $result.ExitCode
     }
     finally {
@@ -183,7 +183,7 @@ foreach ($proof in $adversarialProofs) {
     $failed = [int]$counters.failed
     $executed = [int]$counters.executed
     if ($mutationExitCode -eq 0 -or $failed -eq 0 -or $executed -eq 0) {
-        throw "Adversarial proof did not make the invariant test fail closed: project=$($proof.project) filter=$($proof.filter) exitCode=$mutationExitCode executed=$executed failed=$failed."
+        throw "Adversarial proof did not make the invariant test fail closed: project=$($proof.project) class=$($proof.class) exitCode=$mutationExitCode executed=$executed failed=$failed."
     }
 
     Write-Host "Adversarial proof rejected the injected mutation: executed=$executed failed=$failed."

--- a/src/DownKyi.Desktop/Platform/AvaloniaApplicationLifecycle.cs
+++ b/src/DownKyi.Desktop/Platform/AvaloniaApplicationLifecycle.cs
@@ -14,7 +14,7 @@ namespace DownKyi.Platform;
 
 internal sealed class AvaloniaApplicationLifecycle : IApplicationLifecycle
 {
-    private static readonly TimeSpan CleanupTimeout = TimeSpan.FromSeconds(5);
+    internal static readonly TimeSpan DefaultCleanupTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan LogFlushTimeout = TimeSpan.FromSeconds(2);
     private readonly object _sync = new();
     private readonly AvaloniaDesktopContext _desktopContext;
@@ -22,6 +22,7 @@ internal sealed class AvaloniaApplicationLifecycle : IApplicationLifecycle
     private readonly ISettingsStore _settingsStore;
     private readonly IApplicationLogService _logService;
     private readonly ILogger<AvaloniaApplicationLifecycle> _logger;
+    private readonly TimeSpan _cleanupTimeout;
     private IHost? _host;
     private Task? _hostStartupTask;
     private Task? _shutdownTask;
@@ -32,12 +33,31 @@ internal sealed class AvaloniaApplicationLifecycle : IApplicationLifecycle
         ISettingsStore settingsStore,
         IApplicationLogService logService,
         ILogger<AvaloniaApplicationLifecycle> logger)
+        : this(
+            desktopContext,
+            restartLauncher,
+            settingsStore,
+            logService,
+            logger,
+            DefaultCleanupTimeout)
+    {
+    }
+
+    internal AvaloniaApplicationLifecycle(
+        AvaloniaDesktopContext desktopContext,
+        IProcessRestartLauncher restartLauncher,
+        ISettingsStore settingsStore,
+        IApplicationLogService logService,
+        ILogger<AvaloniaApplicationLifecycle> logger,
+        TimeSpan cleanupTimeout)
     {
         _desktopContext = desktopContext ?? throw new ArgumentNullException(nameof(desktopContext));
         _restartLauncher = restartLauncher ?? throw new ArgumentNullException(nameof(restartLauncher));
         _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
         _logService = logService ?? throw new ArgumentNullException(nameof(logService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        ArgumentOutOfRangeException.ThrowIfLessThan(cleanupTimeout, TimeSpan.Zero);
+        _cleanupTimeout = cleanupTimeout;
     }
 
     public CancellationToken ShutdownToken => GetHost()
@@ -135,7 +155,8 @@ internal sealed class AvaloniaApplicationLifecycle : IApplicationLifecycle
         }
 
         var cleanup = Task.WhenAll(cleanupTasks);
-        if (await Task.WhenAny(cleanup, Task.Delay(CleanupTimeout)).ConfigureAwait(false) == cleanup)
+        TimeoutException? cleanupTimeoutException = null;
+        if (await Task.WhenAny(cleanup, Task.Delay(_cleanupTimeout)).ConfigureAwait(false) == cleanup)
         {
             try
             {
@@ -165,6 +186,8 @@ internal sealed class AvaloniaApplicationLifecycle : IApplicationLifecycle
                 CancellationToken.None,
                 TaskContinuationOptions.OnlyOnFaulted,
                 TaskScheduler.Default);
+            cleanupTimeoutException = new TimeoutException(
+                $"Application cleanup did not complete within {_cleanupTimeout}.");
         }
 
         using var flushCancellation = new CancellationTokenSource(LogFlushTimeout);
@@ -180,6 +203,11 @@ internal sealed class AvaloniaApplicationLifecycle : IApplicationLifecycle
             or InvalidOperationException)
         {
             _logger.LogErrorMessage("Application log flush failed during shutdown.", e);
+        }
+
+        if (cleanupTimeoutException != null)
+        {
+            throw cleanupTimeoutException;
         }
     }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadOrchestrator.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOrchestrator.cs
@@ -16,6 +16,7 @@ namespace DownKyi.Services.Download;
 
 internal sealed class DownloadOrchestrator : IDownloadRuntime
 {
+    internal static readonly TimeSpan WorkerShutdownTimeout = TimeSpan.FromSeconds(4);
     private readonly IDownloadTaskExecutor _executor;
     private readonly DownloadTaskStateWriter _stateWriter;
     private readonly IDownloadTaskApplicationService _tasks;
@@ -134,7 +135,7 @@ internal sealed class DownloadOrchestrator : IDownloadRuntime
             await DownloadShutdownCoordinator.StopAsync(
                 _tokenSource,
                 [.. _downloadWorkers, _admissionWorker],
-                TimeSpan.FromSeconds(30),
+                WorkerShutdownTimeout,
                 exception => _logger.LogErrorMessage(
                     "Download workers failed during shutdown.",
                     exception),

--- a/src/DownKyi.Desktop/Services/Download/DownloadShutdownCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadShutdownCoordinator.cs
@@ -61,6 +61,7 @@ internal static class DownloadShutdownCoordinator
         catch (TimeoutException e)
         {
             timeoutObserver(e);
+            throw;
         }
         catch (OperationCanceledException) when (shutdownToken.IsCancellationRequested)
         {

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace DownKyi.Architecture.Tests;
 
@@ -25,6 +26,60 @@ public sealed class AssemblyLifecycleArchitectureTests
             string.Concat("Process", "Exit"),
             fixture,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DesktopSmokeTestsClearOnlyTheirOwnedSqlitePools()
+    {
+        var source = Read("tests/DownKyi.Desktop.Tests/UiSmokeTests.cs");
+        var globalCleanupCall = string.Concat("SqliteConnection.", "ClearAllPools()");
+
+        Assert.DoesNotContain(
+            globalCleanupCall,
+            source,
+            StringComparison.Ordinal);
+        Assert.Equal(
+            3,
+            Regex.Count(
+                source,
+                @"(?m)^\s+ClearOwnedSqlitePool\(databasePath\);$",
+                RegexOptions.CultureInvariant));
+        Assert.Contains(
+            "DataSource = databasePath",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Mode = SqliteOpenMode.ReadWriteCreate",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains("Pooling = true", source, StringComparison.Ordinal);
+        Assert.Contains("DefaultTimeout = 5", source, StringComparison.Ordinal);
+        Assert.Contains(
+            "SqliteConnection.ClearPool(connection)",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GlobalSqlitePoolCleanupRequiresExplicitProcessOwnership()
+    {
+        var globalCleanupCall = string.Concat("SqliteConnection.", "ClearAllPools()");
+        string[] allowedProcessOwners =
+        [
+            "benchmarks/DownKyi.SystemBenchmarks/Program.cs"
+        ];
+        var actualOwners = Directory
+            .EnumerateFiles(RepositoryRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !IsGeneratedPath(path))
+            .Where(path => File.ReadAllText(path).Contains(
+                globalCleanupCall,
+                StringComparison.Ordinal))
+            .Select(path => Path.GetRelativePath(RepositoryRoot, path)
+                .Replace('\\', '/'))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Equal(allowedProcessOwners, actualOwners);
     }
 
     [Fact]
@@ -223,14 +278,42 @@ public sealed class AssemblyLifecycleArchitectureTests
     [Fact]
     public void LifecycleProfilesRemainConfiguredForNormalRelease()
     {
+        var lifecycle = Read("script/test-assembly-lifecycle.ps1");
         var quality = Read(".github/workflows/quality.yml");
         var release = Read(".github/workflows/build.yml");
+        var expectedProfiles = new Dictionary<string, int>(StringComparer.Ordinal)
+        {
+            ["Local"] = 1,
+            ["PR"] = 3,
+            ["Main"] = 5,
+            ["Rehearsal"] = 100,
+            ["Flaky"] = 500
+        };
+        var actualProfiles = Regex.Matches(
+                lifecycle,
+                @"(?m)^\s+(Local|PR|Main|Rehearsal|Flaky) = ([0-9]+)\s*$",
+                RegexOptions.CultureInvariant)
+            .ToDictionary(
+                match => match.Groups[1].Value,
+                match => int.Parse(match.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture),
+                StringComparer.Ordinal);
+
+        Assert.Equal(expectedProfiles, actualProfiles);
 
         Assert.Contains("assembly-lifecycle:", quality, StringComparison.Ordinal);
-        Assert.Contains("\"PR\"", quality, StringComparison.Ordinal);
-        Assert.Contains("\"Main\"", quality, StringComparison.Ordinal);
+        Assert.Contains("pull_request:", quality, StringComparison.Ordinal);
+        Assert.Contains(
+            "branches:\n      - main",
+            quality.Replace("\r\n", "\n", StringComparison.Ordinal),
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "$profile = if (\"${{ github.event_name }}\" -eq \"pull_request\") { \"PR\" } else { \"Main\" }",
+            quality,
+            StringComparison.Ordinal);
         Assert.Contains("-ValidateForensics", quality, StringComparison.Ordinal);
         Assert.Contains("dotnet-stack", quality, StringComparison.Ordinal);
+        Assert.DoesNotContain("-Profile Rehearsal", quality, StringComparison.Ordinal);
+        Assert.DoesNotContain("-Profile Flaky", quality, StringComparison.Ordinal);
 
         Assert.Contains("assembly-lifecycle-release:", release, StringComparison.Ordinal);
         Assert.Contains("-Profile Rehearsal", release, StringComparison.Ordinal);
@@ -349,6 +432,14 @@ public sealed class AssemblyLifecycleArchitectureTests
         return File.ReadAllText(Path.Combine(
             RepositoryRoot,
             relativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static bool IsGeneratedPath(string path)
+    {
+        var relativePath = Path.GetRelativePath(RepositoryRoot, path);
+        return relativePath
+            .Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(segment => segment is "bin" or "obj" or ".git");
     }
 
     private static string FindRepositoryRoot()

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -282,6 +282,8 @@ public sealed class AssemblyLifecycleArchitectureTests
         var lifecycle = Read("script/test-assembly-lifecycle.ps1");
         var quality = Read(".github/workflows/quality.yml");
         var release = Read(".github/workflows/build.yml");
+        var activeReleaseContract = Read(
+            "docs/product-specs/v1.1.1-corrective-release-gate.md");
         var expectedProfiles = new Dictionary<string, int>(StringComparer.Ordinal)
         {
             ["Local"] = 1,
@@ -300,6 +302,16 @@ public sealed class AssemblyLifecycleArchitectureTests
                 StringComparer.Ordinal);
 
         Assert.Equal(expectedProfiles, actualProfiles);
+        Assert.Contains(
+            "profiles execute 3, 5 and 100 iterations",
+            activeReleaseContract.Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace("\n  ", " ", StringComparison.Ordinal),
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "profiles execute 3, 50 and 100 iterations",
+            activeReleaseContract.Replace("\r\n", "\n", StringComparison.Ordinal)
+                .Replace("\n  ", " ", StringComparison.Ordinal),
+            StringComparison.Ordinal);
 
         Assert.Contains("assembly-lifecycle:", quality, StringComparison.Ordinal);
         Assert.Contains("pull_request:", quality, StringComparison.Ordinal);

--- a/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AssemblyLifecycleArchitectureTests.cs
@@ -32,6 +32,7 @@ public sealed class AssemblyLifecycleArchitectureTests
     public void DesktopSmokeTestsClearOnlyTheirOwnedSqlitePools()
     {
         var source = Read("tests/DownKyi.Desktop.Tests/UiSmokeTests.cs");
+        var normalizedSource = source.Replace("\r\n", "\n", StringComparison.Ordinal);
         var globalCleanupCall = string.Concat("SqliteConnection.", "ClearAllPools()");
 
         Assert.DoesNotContain(
@@ -41,7 +42,7 @@ public sealed class AssemblyLifecycleArchitectureTests
         Assert.Equal(
             3,
             Regex.Count(
-                source,
+                normalizedSource,
                 @"(?m)^\s+ClearOwnedSqlitePool\(databasePath\);$",
                 RegexOptions.CultureInvariant));
         Assert.Contains(

--- a/tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReviewInvariantCorpusTests.cs
@@ -48,7 +48,7 @@ public sealed class ReviewInvariantCorpusTests
             {
                 var project = adversarialProof.GetProperty("project").GetString();
                 Assert.Equal("adversarial-mutation", adversarialProof.GetProperty("kind").GetString());
-                Assert.False(string.IsNullOrWhiteSpace(adversarialProof.GetProperty("filter").GetString()));
+                Assert.False(string.IsNullOrWhiteSpace(adversarialProof.GetProperty("class").GetString()));
                 Assert.False(string.IsNullOrWhiteSpace(
                     adversarialProof.GetProperty("environmentVariable").GetString()));
                 Assert.False(string.IsNullOrWhiteSpace(

--- a/tests/DownKyi.Architecture.Tests/TestRunnerPolicyArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/TestRunnerPolicyArchitectureTests.cs
@@ -73,16 +73,49 @@ public sealed class TestRunnerPolicyArchitectureTests
         {
             var projectPath = project.GetProperty("project").GetString()
                 ?? throw new InvalidDataException("Runner policy project path cannot be null.");
-            var directInvocation = new Regex(
-                $"dotnet[ \\t]+test(?:[ \\t]+|\\r?\\n[ \\t]+)[\"']?(?:\\./)?{Regex.Escape(projectPath)}[\"']?",
-                RegexOptions.CultureInvariant);
 
             foreach (var workflowPath in workflowPaths)
             {
-                var workflow = File.ReadAllText(workflowPath).Replace('\\', '/');
-                Assert.DoesNotMatch(directInvocation, workflow);
+                var workflow = File.ReadAllText(workflowPath);
+                Assert.DoesNotContain(
+                    ExtractWorkflowRunScripts(workflow),
+                    runScript => ContainsDirectDotnetTestInvocation(runScript, projectPath));
             }
         }
+    }
+
+    [Theory]
+    [InlineData("steps:\n  - run: dotnet test ./tests/DownKyi.Tests/DownKyi.Tests.csproj --no-build")]
+    [InlineData("steps:\n  - run: dotnet test --no-build ./tests/DownKyi.Tests/DownKyi.Tests.csproj")]
+    [InlineData("steps:\n  - run: >\n      dotnet test\n      --no-build\n      ./tests/DownKyi.Tests/DownKyi.Tests.csproj")]
+    [InlineData("steps:\n  - run: |\n      dotnet test `\n        --no-build `\n        ./tests/DownKyi.Tests/DownKyi.Tests.csproj")]
+    [InlineData("steps:\n  - run: |\n      dotnet test \\\n        --no-build \\\n        ./tests/DownKyi.Tests/DownKyi.Tests.csproj")]
+    public void DirectTestInvocationDetectorRejectsRepresentativeOptionOrderings(string workflow)
+    {
+        ArgumentNullException.ThrowIfNull(workflow);
+        var runScript = Assert.Single(ExtractWorkflowRunScripts(workflow));
+
+        Assert.True(ContainsDirectDotnetTestInvocation(
+            runScript,
+            "tests/DownKyi.Tests/DownKyi.Tests.csproj"));
+    }
+
+    [Fact]
+    public void DirectTestInvocationDetectorAllowsTheSharedRunner()
+    {
+        const string workflow = """
+            steps:
+              - run: |
+                  . ./script/test-project-runner.ps1
+                  Invoke-DownKyiTestProject `
+                    -ProjectPath ./tests/DownKyi.Tests/DownKyi.Tests.csproj `
+                    -ClassNames DownKyi.Tests.Aria2TlsIntegrationTests
+            """;
+        var runScript = Assert.Single(ExtractWorkflowRunScripts(workflow));
+
+        Assert.False(ContainsDirectDotnetTestInvocation(
+            runScript,
+            "tests/DownKyi.Tests/DownKyi.Tests.csproj"));
     }
 
     [Fact]
@@ -105,6 +138,73 @@ public sealed class TestRunnerPolicyArchitectureTests
         return File.ReadAllText(Path.Combine(
             RepositoryRoot,
             relativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static List<string> ExtractWorkflowRunScripts(string workflow)
+    {
+        var lines = workflow.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var scripts = new List<string>();
+        for (var index = 0; index < lines.Length; index++)
+        {
+            var match = Regex.Match(
+                lines[index],
+                @"^(?<indent>\s*)(?:-\s+)?run:\s*(?<value>.*)$",
+                RegexOptions.CultureInvariant);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            var indentation = match.Groups["indent"].Value.Length;
+            var value = match.Groups["value"].Value.Trim();
+            if (!value.StartsWith('|') && !value.StartsWith('>'))
+            {
+                scripts.Add(value);
+                continue;
+            }
+
+            var blockLines = new List<string>();
+            while (++index < lines.Length)
+            {
+                var line = lines[index];
+                if (line.Length == 0)
+                {
+                    blockLines.Add(string.Empty);
+                    continue;
+                }
+
+                var contentIndentation = line.Length - line.TrimStart().Length;
+                if (contentIndentation <= indentation)
+                {
+                    index--;
+                    break;
+                }
+
+                blockLines.Add(line.TrimStart());
+            }
+
+            scripts.Add(value.StartsWith('>')
+                ? string.Join(' ', blockLines)
+                : string.Join('\n', blockLines));
+        }
+
+        return scripts;
+    }
+
+    private static bool ContainsDirectDotnetTestInvocation(string runScript, string projectPath)
+    {
+        var normalized = runScript
+            .Replace("\\\n", " ", StringComparison.Ordinal)
+            .Replace("`\n", " ", StringComparison.Ordinal)
+            .Replace('\\', '/');
+        var commands = Regex.Matches(
+            normalized,
+            @"(?im)(?:^|[;&|]\s*)dotnet\s+test\b(?<arguments>[^\r\n;&|]*)",
+            RegexOptions.CultureInvariant);
+
+        return commands.Any(command => command.Groups["arguments"].Value.Contains(
+            projectPath,
+            StringComparison.OrdinalIgnoreCase));
     }
 
     private static string FindRepositoryRoot()

--- a/tests/DownKyi.Architecture.Tests/TestRunnerPolicyArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/TestRunnerPolicyArchitectureTests.cs
@@ -85,6 +85,21 @@ public sealed class TestRunnerPolicyArchitectureTests
         }
     }
 
+    [Fact]
+    public void ReviewInvariantMutationsUseRunnerNeutralClassLocators()
+    {
+        var runner = Read("script/test-review-invariants.ps1");
+        var corpus = Read("docs/testing/review-invariant-corpus.json");
+
+        Assert.Contains("-ClassNames @($proof.class)", runner, StringComparison.Ordinal);
+        Assert.DoesNotContain("-Filter $proof.filter", runner, StringComparison.Ordinal);
+        Assert.Contains(
+            "\"class\": \"DownKyi.Tests.DownloadArtifactStageTests\"",
+            corpus,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("FullyQualifiedName~", corpus, StringComparison.Ordinal);
+    }
+
     private static string Read(string relativePath)
     {
         return File.ReadAllText(Path.Combine(

--- a/tests/DownKyi.Architecture.Tests/TestRunnerPolicyArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/TestRunnerPolicyArchitectureTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class TestRunnerPolicyArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    public void DownKyiTestsUsesTheInProcessRunnerForVstestProtocolSafety()
+    {
+        using var policy = JsonDocument.Parse(Read("docs/testing/test-runner-policy.json"));
+        var project = policy.RootElement
+            .GetProperty("projects")
+            .EnumerateArray()
+            .Single(entry => string.Equals(
+                entry.GetProperty("project").GetString(),
+                "tests/DownKyi.Tests/DownKyi.Tests.csproj",
+                StringComparison.Ordinal));
+
+        Assert.Equal("xunit-in-process", project.GetProperty("runner").GetString());
+        Assert.Equal("net10.0", project.GetProperty("targetFramework").GetString());
+        Assert.Equal("none", project.GetProperty("parallel").GetString());
+
+        var reason = project.GetProperty("reason").GetString();
+        Assert.Contains("xunit/xunit#3576", reason, StringComparison.Ordinal);
+        Assert.Contains("assembly-info stdout protocol corruption", reason, StringComparison.Ordinal);
+        Assert.Contains("lifecycle", reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("separately verified", reason, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Aria2TlsWorkflowUsesTheSharedRunnerAndExactTestClass()
+    {
+        var workflow = Read(".github/workflows/quality.yml");
+        var stepStart = workflow.IndexOf(
+            "      - name: Verify packaged aria2 TLS behavior",
+            StringComparison.Ordinal);
+        var stepEnd = workflow.IndexOf(
+            "      - name: Upload sanitized aria2 TLS report",
+            stepStart,
+            StringComparison.Ordinal);
+        Assert.True(stepStart >= 0 && stepEnd > stepStart, "The aria2 TLS workflow step is missing.");
+        var step = workflow[stepStart..stepEnd];
+
+        Assert.Contains("shell: pwsh", step, StringComparison.Ordinal);
+        Assert.Contains(". ./script/test-project-runner.ps1", step, StringComparison.Ordinal);
+        Assert.Contains("Invoke-DownKyiTestProject", step, StringComparison.Ordinal);
+        Assert.Contains(
+            "-ProjectPath ./tests/DownKyi.Tests/DownKyi.Tests.csproj",
+            step,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "-ClassNames DownKyi.Tests.Aria2TlsIntegrationTests",
+            step,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("--filter Category=Aria2TlsIntegration", step, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PolicyOwnedProjectsCannotBypassTheSharedRunnerInCiWorkflows()
+    {
+        using var policy = JsonDocument.Parse(Read("docs/testing/test-runner-policy.json"));
+        var workflowPaths = Directory.EnumerateFiles(
+                Path.Combine(RepositoryRoot, ".github", "workflows"),
+                "*.y*ml",
+                SearchOption.TopDirectoryOnly)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        foreach (var project in policy.RootElement.GetProperty("projects").EnumerateArray())
+        {
+            var projectPath = project.GetProperty("project").GetString()
+                ?? throw new InvalidDataException("Runner policy project path cannot be null.");
+            var directInvocation = new Regex(
+                $"dotnet[ \\t]+test(?:[ \\t]+|\\r?\\n[ \\t]+)[\"']?(?:\\./)?{Regex.Escape(projectPath)}[\"']?",
+                RegexOptions.CultureInvariant);
+
+            foreach (var workflowPath in workflowPaths)
+            {
+                var workflow = File.ReadAllText(workflowPath).Replace('\\', '/');
+                Assert.DoesNotMatch(directInvocation, workflow);
+            }
+        }
+    }
+
+    private static string Read(string relativePath)
+    {
+        return File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            relativePath.Replace('/', Path.DirectorySeparatorChar)));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+               ?? throw new DirectoryNotFoundException("Could not locate the DownKyi repository root.");
+    }
+}

--- a/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
+++ b/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
@@ -296,6 +296,7 @@ public sealed class UiSmokeTests
             AssertVideoPageSelectionBehavior();
 
             var testDirectory = Path.Combine(Path.GetTempPath(), $"downkyi-host-smoke-{Guid.NewGuid():N}");
+            var databasePath = Path.Combine(testDirectory, "downkyi.db");
             var settingsStore = new SettingsStore(Path.Combine(testDirectory, "settings.json"));
             var logProvider = new ApplicationLogProvider(
                 new ApplicationLogOptions(Path.Combine(testDirectory, "logs")));
@@ -308,7 +309,7 @@ public sealed class UiSmokeTests
                     services.AddDownKyiDesktop(loggerFactory, logProvider);
                     services.Replace(ServiceDescriptor.Singleton<ISettingsStore>(settingsStore));
                     services.Replace(ServiceDescriptor.Singleton(
-                        new SqliteDownloadTaskStoreOptions(Path.Combine(testDirectory, "downkyi.db"))));
+                        new SqliteDownloadTaskStoreOptions(databasePath)));
                 });
 
                 var window = host.Services.GetRequiredService<MainWindow>();
@@ -375,7 +376,7 @@ public sealed class UiSmokeTests
                 loggerFactory.Dispose();
                 await logProvider.DisposeAsync().ConfigureAwait(true);
                 await settingsStore.DisposeAsync().ConfigureAwait(true);
-                SqliteConnection.ClearAllPools();
+                ClearOwnedSqlitePool(databasePath);
                 if (Directory.Exists(testDirectory))
                 {
                     Directory.Delete(testDirectory, recursive: true);
@@ -390,6 +391,7 @@ public sealed class UiSmokeTests
         await AvaloniaTestDispatcher.RunAsync(async () =>
         {
             var testDirectory = Path.Combine(Path.GetTempPath(), $"downkyi-close-smoke-{Guid.NewGuid():N}");
+            var databasePath = Path.Combine(testDirectory, "downkyi.db");
             var settingsStore = new SettingsStore(Path.Combine(testDirectory, "settings.json"));
             var logProvider = new ApplicationLogProvider(
                 new ApplicationLogOptions(Path.Combine(testDirectory, "logs")));
@@ -405,7 +407,7 @@ public sealed class UiSmokeTests
                     services.Replace(ServiceDescriptor.Singleton<ISettingsStore>(settingsStore));
                     services.Replace(ServiceDescriptor.Singleton<IApplicationLifecycle>(lifecycle));
                     services.Replace(ServiceDescriptor.Singleton(
-                        new SqliteDownloadTaskStoreOptions(Path.Combine(testDirectory, "downkyi.db"))));
+                        new SqliteDownloadTaskStoreOptions(databasePath)));
                 });
                 var window = host.Services.GetRequiredService<MainWindow>();
                 var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -430,7 +432,7 @@ public sealed class UiSmokeTests
                 loggerFactory.Dispose();
                 await logProvider.DisposeAsync().ConfigureAwait(true);
                 await settingsStore.DisposeAsync().ConfigureAwait(true);
-                SqliteConnection.ClearAllPools();
+                ClearOwnedSqlitePool(databasePath);
                 if (Directory.Exists(testDirectory))
                 {
                     Directory.Delete(testDirectory, recursive: true);
@@ -469,6 +471,7 @@ public sealed class UiSmokeTests
             var testDirectory = Path.Combine(
                 Path.GetTempPath(),
                 $"downkyi-host-lifecycle-{Guid.NewGuid():N}");
+            var databasePath = Path.Combine(testDirectory, "downkyi.db");
             var settingsStore = new SettingsStore(Path.Combine(testDirectory, "settings.json"));
             var logProvider = new ApplicationLogProvider(
                 new ApplicationLogOptions(Path.Combine(testDirectory, "logs")));
@@ -483,7 +486,7 @@ public sealed class UiSmokeTests
                     services.AddDownKyiDesktop(loggerFactory, logProvider);
                     services.Replace(ServiceDescriptor.Singleton<ISettingsStore>(settingsStore));
                     services.Replace(ServiceDescriptor.Singleton(
-                        new SqliteDownloadTaskStoreOptions(Path.Combine(testDirectory, "downkyi.db"))));
+                        new SqliteDownloadTaskStoreOptions(databasePath)));
                     services.Replace(ServiceDescriptor.Singleton<IDownloadRuntimeFactory>(
                         new LifecycleProbeDownloadRuntimeFactory(runtime)));
                 });
@@ -525,7 +528,7 @@ public sealed class UiSmokeTests
                 loggerFactory.Dispose();
                 await logProvider.DisposeAsync().ConfigureAwait(true);
                 await settingsStore.DisposeAsync().ConfigureAwait(true);
-                SqliteConnection.ClearAllPools();
+                ClearOwnedSqlitePool(databasePath);
                 if (Directory.Exists(testDirectory))
                 {
                     Directory.Delete(testDirectory, recursive: true);
@@ -593,6 +596,18 @@ public sealed class UiSmokeTests
         }
 
         host.Dispose();
+    }
+
+    private static void ClearOwnedSqlitePool(string databasePath)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = 5
+        }.ToString());
+        SqliteConnection.ClearPool(connection);
     }
 
     private static string[] GetUserDataPaths()

--- a/tests/DownKyi.Infrastructure.Tests/LegacySqlCipherCompatibilityTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/LegacySqlCipherCompatibilityTests.cs
@@ -64,7 +64,6 @@ public sealed class LegacySqlCipherCompatibilityTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
         if (Directory.Exists(_directory))
         {
             Directory.Delete(_directory, recursive: true);

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -401,7 +401,14 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = Path.Combine(_directory, "download.db"),
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = 5
+        }.ToString());
+        SqliteConnection.ClearPool(connection);
         if (Directory.Exists(_directory))
         {
             Directory.Delete(_directory, recursive: true);
@@ -487,7 +494,8 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         var connection = new SqliteConnection(new SqliteConnectionStringBuilder
         {
             DataSource = Path.Combine(_directory, "download.db"),
-            Mode = SqliteOpenMode.ReadOnly
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false
         }.ToString());
         await connection.OpenAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
         return connection;
@@ -567,7 +575,8 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         var connection = new SqliteConnection(new SqliteConnectionStringBuilder
         {
             DataSource = Path.Combine(_directory, "download.db"),
-            Mode = readOnly ? SqliteOpenMode.ReadOnly : SqliteOpenMode.ReadWrite
+            Mode = readOnly ? SqliteOpenMode.ReadOnly : SqliteOpenMode.ReadWrite,
+            Pooling = false
         }.ToString());
         await connection.OpenAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
         return connection;
@@ -579,7 +588,8 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
         {
             DataSource = Path.Combine(_directory, "download.db"),
-            Mode = SqliteOpenMode.ReadWriteCreate
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = false
         }.ToString());
         await connection.OpenAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
         using var schema = connection.CreateCommand();
@@ -628,7 +638,8 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
         {
             DataSource = Path.Combine(_directory, "download.db"),
-            Mode = SqliteOpenMode.ReadWriteCreate
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = false
         }.ToString());
         await connection.OpenAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
         using var schema = connection.CreateCommand();

--- a/tests/DownKyi.Tests/AvaloniaApplicationLifecycleTests.cs
+++ b/tests/DownKyi.Tests/AvaloniaApplicationLifecycleTests.cs
@@ -3,6 +3,7 @@ using DownKyi.Application.Lifetime;
 using DownKyi.Core.Settings;
 using DownKyi.Desktop.Composition;
 using DownKyi.Platform;
+using DownKyi.Services.Download;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,6 +12,14 @@ namespace DownKyi.Tests;
 
 public sealed class AvaloniaApplicationLifecycleTests
 {
+    [Fact]
+    public void DownloadWorkerDeadlinePrecedesApplicationCleanupDeadline()
+    {
+        Assert.True(
+            DownloadOrchestrator.WorkerShutdownTimeout <
+            AvaloniaApplicationLifecycle.DefaultCleanupTimeout);
+    }
+
     [Fact]
     public async Task RequestShutdownIsIdempotentAndFlushesOwnedState()
     {
@@ -78,6 +87,41 @@ public sealed class AvaloniaApplicationLifecycleTests
         finally
         {
             hostedService.AllowStop.TrySetResult();
+            await settingsStore.DisposeAsync().ConfigureAwait(true);
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task RequestShutdownFailsClosedWhenHostedServiceDoesNotBecomeQuiescent()
+    {
+        var directory = CreateTemporaryDirectory();
+        var settingsStore = new SettingsStore(Path.Combine(directory, "settings.json"));
+        var hostedService = new BlockingStopHostedService();
+        using var host = DownKyiHost.Create(services =>
+            services.AddSingleton<IHostedService>(hostedService));
+        var logService = new RecordingLogService();
+        var lifecycle = CreateLifecycle(
+            settingsStore,
+            logService,
+            new StubRestartLauncher(false),
+            TimeSpan.Zero);
+        lifecycle.AttachHost(host);
+
+        try
+        {
+            await lifecycle.StartHostAsync().ConfigureAwait(true);
+
+            await Assert.ThrowsAsync<TimeoutException>(() =>
+                lifecycle.RequestShutdownAsync(TestContext.Current.CancellationToken));
+
+            Assert.False(hostedService.IsQuiescent);
+            Assert.Equal(1, logService.FlushCount);
+        }
+        finally
+        {
+            hostedService.AllowStop.TrySetResult();
+            await host.StopAsync(CancellationToken.None).ConfigureAwait(true);
             await settingsStore.DisposeAsync().ConfigureAwait(true);
             Directory.Delete(directory, recursive: true);
         }
@@ -153,14 +197,23 @@ public sealed class AvaloniaApplicationLifecycleTests
     private static AvaloniaApplicationLifecycle CreateLifecycle(
         ISettingsStore settingsStore,
         IApplicationLogService logService,
-        IProcessRestartLauncher restartLauncher)
+        IProcessRestartLauncher restartLauncher,
+        TimeSpan? cleanupTimeout = null)
     {
-        return new AvaloniaApplicationLifecycle(
-            new AvaloniaDesktopContext(),
-            restartLauncher,
-            settingsStore,
-            logService,
-            NullLogger<AvaloniaApplicationLifecycle>.Instance);
+        return cleanupTimeout is { } timeout
+            ? new AvaloniaApplicationLifecycle(
+                new AvaloniaDesktopContext(),
+                restartLauncher,
+                settingsStore,
+                logService,
+                NullLogger<AvaloniaApplicationLifecycle>.Instance,
+                timeout)
+            : new AvaloniaApplicationLifecycle(
+                new AvaloniaDesktopContext(),
+                restartLauncher,
+                settingsStore,
+                logService,
+                NullLogger<AvaloniaApplicationLifecycle>.Instance);
     }
 
     private static string CreateTemporaryDirectory()

--- a/tests/DownKyi.Tests/AvaloniaApplicationLifecycleTests.cs
+++ b/tests/DownKyi.Tests/AvaloniaApplicationLifecycleTests.cs
@@ -44,6 +44,46 @@ public sealed class AvaloniaApplicationLifecycleTests
     }
 
     [Fact]
+    public async Task RequestShutdownWaitsForHostedServiceQuiescence()
+    {
+        var directory = CreateTemporaryDirectory();
+        var settingsStore = new SettingsStore(Path.Combine(directory, "settings.json"));
+        var hostedService = new BlockingStopHostedService();
+        using var host = DownKyiHost.Create(services =>
+            services.AddSingleton<IHostedService>(hostedService));
+        var lifecycle = CreateLifecycle(
+            settingsStore,
+            new RecordingLogService(),
+            new StubRestartLauncher(false));
+        lifecycle.AttachHost(host);
+
+        try
+        {
+            await lifecycle.StartHostAsync().ConfigureAwait(true);
+            var shutdownTask = lifecycle.RequestShutdownAsync(TestContext.Current.CancellationToken);
+            await hostedService.StopEntered.Task.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+
+            Assert.False(shutdownTask.IsCompleted);
+            Assert.False(hostedService.IsQuiescent);
+
+            hostedService.AllowStop.TrySetResult();
+            await shutdownTask.WaitAsync(
+                TimeSpan.FromSeconds(5),
+                TestContext.Current.CancellationToken);
+
+            Assert.True(hostedService.IsQuiescent);
+        }
+        finally
+        {
+            hostedService.AllowStop.TrySetResult();
+            await settingsStore.DisposeAsync().ConfigureAwait(true);
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
     public async Task RestartHelperFailureKeepsRunningApplicationAlive()
     {
         var directory = CreateTemporaryDirectory();
@@ -181,6 +221,29 @@ public sealed class AvaloniaApplicationLifecycleTests
         public Task StopAsync(CancellationToken cancellationToken)
         {
             return Task.FromException(new InvalidOperationException("stop failed"));
+        }
+    }
+
+    private sealed class BlockingStopHostedService : IHostedService
+    {
+        public TaskCompletionSource StopEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowStop { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool IsQuiescent { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken)
+        {
+            StopEntered.TrySetResult();
+            await AllowStop.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            IsQuiescent = true;
         }
     }
 }

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -44,17 +44,49 @@ public sealed class DownloadBootstrapHostedServiceTests
     }
 
     [Fact]
+    public async Task StopAsyncWaitsForOwnedRuntimeToBecomeQuiescent()
+    {
+        using var runtime = new BlockingDownloadRuntime();
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(new EmptyDownloadTaskStore(), clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        using var service = new DownloadBootstrapHostedService(
+            new DownloadListState(),
+            storage,
+            new DownloadTaskStateWriter(tasks),
+            new RecordingRuntimeFactory(runtime),
+            new DownloadTaskQueueGateway(),
+            new ImmediateUiDispatcher(),
+            NullLogger<DownloadBootstrapHostedService>.Instance);
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+        var stopTask = service.StopAsync(TestContext.Current.CancellationToken);
+        await runtime.StopEntered.Task.WaitAsync(
+            TimeSpan.FromSeconds(5),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(stopTask.IsCompleted);
+        Assert.False(runtime.IsQuiescent);
+
+        runtime.AllowStop.TrySetResult();
+        await stopTask.WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        Assert.True(runtime.IsQuiescent);
+    }
+
+    [Fact]
     public async Task StartupQueuesPersistedAndInterruptedTasksWithoutUiPolling()
     {
         var directory = Path.Combine(
             Path.GetTempPath(),
             "downkyi-bootstrap-queue-tests",
             Guid.NewGuid().ToString("N"));
+        var databasePath = Path.Combine(directory, "download.db");
         Directory.CreateDirectory(directory);
         try
         {
             using var store = new SqliteDownloadTaskStore(
-                new SqliteDownloadTaskStoreOptions(Path.Combine(directory, "download.db")),
+                new SqliteDownloadTaskStoreOptions(databasePath),
                 new SystemClock());
             var clock = new SystemClock();
             using var tasks = new DownloadTaskApplicationService(store, clock);
@@ -94,7 +126,7 @@ public sealed class DownloadBootstrapHostedServiceTests
         }
         finally
         {
-            SqliteConnection.ClearAllPools();
+            ClearOwnedSqlitePool(databasePath);
             Directory.Delete(directory, recursive: true);
         }
     }
@@ -142,6 +174,18 @@ public sealed class DownloadBootstrapHostedServiceTests
             new DownloadPlan([], [], 0),
             new DownloadOutput(id, null),
             DateTimeOffset.UnixEpoch);
+    }
+
+    private static void ClearOwnedSqlitePool(string databasePath)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = 5
+        }.ToString());
+        SqliteConnection.ClearPool(connection);
     }
 
     private sealed class RecordingRuntimeFactory(IDownloadRuntime runtime) : IDownloadRuntimeFactory
@@ -198,6 +242,47 @@ public sealed class DownloadBootstrapHostedServiceTests
         public void Dispose()
         {
             Disposed = true;
+        }
+    }
+
+    private sealed class BlockingDownloadRuntime : IDownloadRuntime
+    {
+        public TaskCompletionSource StopEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowStop { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool IsQuiescent { get; private set; }
+
+        public Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public async Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            StopEntered.TrySetResult();
+            await AllowStop.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            IsQuiescent = true;
+        }
+
+        public Task EnqueueAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> CancelAsync(DownloadTaskId taskId)
+        {
+            return Task.FromResult(false);
+        }
+
+        public void Dispose()
+        {
         }
     }
 

--- a/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
@@ -138,12 +138,14 @@ public sealed class DownloadManagerCoordinatorTests
             Path.GetTempPath(),
             "downkyi-download-manager-tests",
             Guid.NewGuid().ToString("N"));
+        private readonly string _databasePath;
 
         public CoordinatorContext()
         {
             Directory.CreateDirectory(_directory);
+            _databasePath = Path.Combine(_directory, "download.db");
             Store = new SqliteDownloadTaskStore(
-                new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
+                new SqliteDownloadTaskStoreOptions(_databasePath),
                 new SystemClock());
             var clock = new SystemClock();
             TaskService = new DownloadTaskApplicationService(Store, clock);
@@ -225,7 +227,14 @@ public sealed class DownloadManagerCoordinatorTests
             Storage.Dispose();
             TaskService.Dispose();
             Store.Dispose();
-            SqliteConnection.ClearAllPools();
+            using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+            {
+                DataSource = _databasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = true,
+                DefaultTimeout = 5
+            }.ToString());
+            SqliteConnection.ClearPool(connection);
             if (Directory.Exists(_directory))
             {
                 Directory.Delete(_directory, recursive: true);

--- a/tests/DownKyi.Tests/DownloadShutdownCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadShutdownCoordinatorTests.cs
@@ -72,17 +72,51 @@ public sealed class DownloadShutdownCoordinatorTests
     }
 
     [Fact]
+    public async Task StopAsyncFailsClosedWhenOwnedWorkerMissesTimeout()
+    {
+        var workerCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var timeoutObserved = false;
+        var recoveryCount = 0;
+
+        try
+        {
+            await Assert.ThrowsAsync<TimeoutException>(() =>
+                DownloadShutdownCoordinator.StopAsync(
+                    null,
+                    [workerCompletion.Task],
+                    TimeSpan.Zero,
+                    _ => timeoutObserved = true,
+                    () =>
+                    {
+                        recoveryCount++;
+                        return Task.CompletedTask;
+                    }));
+
+            Assert.True(timeoutObserved);
+            Assert.Equal(1, recoveryCount);
+            Assert.False(workerCompletion.Task.IsCompleted);
+        }
+        finally
+        {
+            workerCompletion.TrySetResult();
+            await workerCompletion.Task.ConfigureAwait(true);
+        }
+    }
+
+    [Fact]
     public async Task ShutdownRecoveryQueuesActiveDomainTaskAndPreservesResumeData()
     {
         var directory = Path.Combine(
             Path.GetTempPath(),
             "downkyi-shutdown-recovery-tests",
             Guid.NewGuid().ToString("N"));
+        var databasePath = Path.Combine(directory, "download.db");
         Directory.CreateDirectory(directory);
         try
         {
             using var store = new SqliteDownloadTaskStore(
-                new SqliteDownloadTaskStoreOptions(Path.Combine(directory, "download.db")),
+                new SqliteDownloadTaskStoreOptions(databasePath),
                 new SystemClock());
             var clock = new SystemClock();
             using var tasks = new DownloadTaskApplicationService(store, clock);
@@ -131,8 +165,20 @@ public sealed class DownloadShutdownCoordinatorTests
         }
         finally
         {
-            SqliteConnection.ClearAllPools();
+            ClearOwnedSqlitePool(databasePath);
             Directory.Delete(directory, recursive: true);
         }
+    }
+
+    private static void ClearOwnedSqlitePool(string databasePath)
+    {
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = databasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = 5
+        }.ToString());
+        SqliteConnection.ClearPool(connection);
     }
 }

--- a/tests/DownKyi.Tests/DownloadTaskProjectionStoreResumeTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskProjectionStoreResumeTests.cs
@@ -94,7 +94,12 @@ public sealed class DownloadTaskProjectionStoreResumeTests : IDisposable
             Assert.Equal("6 GB", restored.DownloadBase.FileSize);
         }
 
-        using var connection = new SqliteConnection($"Data Source={database};Mode=ReadOnly");
+        using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = database,
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false
+        }.ToString());
         await connection.OpenAsync(TestContext.Current.CancellationToken);
         using var command = connection.CreateCommand();
         command.CommandText = "SELECT gid, download_files, downloaded_files, download_status, progress FROM downloading WHERE id = @id";
@@ -226,9 +231,23 @@ public sealed class DownloadTaskProjectionStoreResumeTests : IDisposable
 
     public void Dispose()
     {
-        SqliteConnection.ClearAllPools();
         if (Directory.Exists(_directory))
         {
+            foreach (var databasePath in Directory.EnumerateFiles(
+                         _directory,
+                         "*.db",
+                         SearchOption.TopDirectoryOnly))
+            {
+                using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+                {
+                    DataSource = databasePath,
+                    Mode = SqliteOpenMode.ReadWriteCreate,
+                    Pooling = true,
+                    DefaultTimeout = 5
+                }.ToString());
+                SqliteConnection.ClearPool(connection);
+            }
+
             Directory.Delete(_directory, recursive: true);
         }
     }


### PR DESCRIPTION
## Summary

### A. xUnit runner policy
- routes policy-owned `DownKyi.Tests` through `Invoke-DownKyiTestProject` and the central `xunit-in-process` policy instead of direct VSTest execution
- fixes the xunit/xunit#3576 routing bypass in the packaged aria2 TLS workflow
- adds Architecture regression coverage that rejects direct `dotnet test` bypasses for policy-owned projects

### B. Lifecycle profile policy
- changes the central `Main` profile from 50 to 5 complete lifecycle iterations
- preserves `Local = 1`, `PR = 3`, `Rehearsal = 100`, and `Flaky = 500`
- keeps release Rehearsal, forensics, process-exit, teardown, residual-child, stdout-contract, and fail-closed checks unchanged

### C. SQLite ownership
- removes process-global `ClearAllPools()` from per-test and local owners
- uses exact connection-string `ClearPool()` or non-pooled helper connections for local resources
- adds a repository-wide Architecture gate that rejects new global pool cleanup by default
- explicitly allows only the system benchmark process entry point, which owns the complete benchmark process data root

### D. Shutdown fail-closed
- propagates owned-worker timeout from `DownloadShutdownCoordinator` instead of reporting it and returning success
- preserves recovery in the existing `finally`
- adds a deterministic red-to-green timeout regression
- adds blocking-runtime tests proving hosted-service and application lifecycle shutdown wait for owned work to become quiescent

## Verification
- strict Release builds: affected production, benchmark, and test projects passed with 0 warnings / 0 errors
- Architecture tests: 249 passed
- Desktop tests: passed through the shared in-process runner
- Windows `test-solution.ps1`: 8 applicable projects passed; packaged aria2 integration remained conditionally skipped without its external binary
- `git diff --check`: passed
- long lifecycle stress was intentionally not rerun; release Rehearsal remains unchanged at 100