### PR TITLE
build(deps): update mirrored FFmpeg to ffmpeg-btbn-autobuild-2026-08-23-13-03

### DIFF
--- a/script/assets/external-assets.json
+++ b/script/assets/external-assets.json
@@ -38,7 +38,7 @@
     }
   },
   "ffmpeg": {
-    "version": "btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned",
+    "version": "btbn-autobuild-2026-08-23-13-03",
     "repository": "Windows x64/Linux: https://github.com/BtbN/FFmpeg-Builds; Windows x86: https://github.com/yt-dlp/FFmpeg-Builds; macOS: https://ffmpeg.martin-riedl.de",
     "assets": {
       "win-x86": {
@@ -55,42 +55,42 @@
         }
       },
       "win-x64": {
-        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned/ffmpeg-win-x64-autobuild-2026-08-12-13-15-40b7fd8eebbc5ec7.zip",
-        "sha256": "40b7fd8eebbc5ec79b7f39e647654927165ab85621ff637e8de8f6985f851f23",
-        "fileName": "ffmpeg-win-x64-autobuild-2026-08-12-13-15-40b7fd8eebbc5ec7.zip",
+        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-23-13-03/ffmpeg-win-x64-autobuild-2026-08-23-13-03-89f459586270a5ad.zip",
+        "sha256": "89f459586270a5ad84a79c9c921a385d6a14450398e072e1cf32c62277a6a410",
+        "fileName": "ffmpeg-win-x64-autobuild-2026-08-23-13-03-89f459586270a5ad.zip",
         "provenance": {
           "upstreamRepository": "https://github.com/BtbN/FFmpeg-Builds",
-          "upstreamRelease": "autobuild-2026-08-12-13-15",
-          "originalAssetName": "ffmpeg-N-126086-ge5ecfe8970-win64-gpl.zip",
-          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-12-13-15/ffmpeg-N-126086-ge5ecfe8970-win64-gpl.zip",
-          "mirroredAt": "2026-08-13T05:32:08Z",
-          "ffmpegVersion": "ffmpeg-N-126086-ge5ecfe8970-win64-gpl.zip"
+          "upstreamRelease": "autobuild-2026-08-23-13-03",
+          "originalAssetName": "ffmpeg-N-126247-gb79d4c4c0a-win64-gpl.zip",
+          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-23-13-03/ffmpeg-N-126247-gb79d4c4c0a-win64-gpl.zip",
+          "mirroredAt": "2026-08-24T04:03:49Z",
+          "ffmpegVersion": "ffmpeg-N-126247-gb79d4c4c0a-win64-gpl.zip"
         }
       },
       "linux-x64": {
-        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned/ffmpeg-linux-x64-autobuild-2026-08-12-13-15-cf55934e9faa1969.tar.xz",
-        "sha256": "cf55934e9faa1969bff4c3fc1e1352707c9c9384e4d7986388830a8c8a726913",
-        "fileName": "ffmpeg-linux-x64-autobuild-2026-08-12-13-15-cf55934e9faa1969.tar.xz",
+        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-23-13-03/ffmpeg-linux-x64-autobuild-2026-08-23-13-03-d2228832ee667078.tar.xz",
+        "sha256": "d2228832ee66707848a6f6742d7f6bccfff893c2c6d7f974436ffa0507def80a",
+        "fileName": "ffmpeg-linux-x64-autobuild-2026-08-23-13-03-d2228832ee667078.tar.xz",
         "provenance": {
           "upstreamRepository": "https://github.com/BtbN/FFmpeg-Builds",
-          "upstreamRelease": "autobuild-2026-08-12-13-15",
-          "originalAssetName": "ffmpeg-N-126086-ge5ecfe8970-linux64-gpl.tar.xz",
-          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-12-13-15/ffmpeg-N-126086-ge5ecfe8970-linux64-gpl.tar.xz",
-          "mirroredAt": "2026-08-13T05:32:08Z",
-          "ffmpegVersion": "ffmpeg-N-126086-ge5ecfe8970-linux64-gpl.tar.xz"
+          "upstreamRelease": "autobuild-2026-08-23-13-03",
+          "originalAssetName": "ffmpeg-N-126247-gb79d4c4c0a-linux64-gpl.tar.xz",
+          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-23-13-03/ffmpeg-N-126247-gb79d4c4c0a-linux64-gpl.tar.xz",
+          "mirroredAt": "2026-08-24T04:03:49Z",
+          "ffmpegVersion": "ffmpeg-N-126247-gb79d4c4c0a-linux64-gpl.tar.xz"
         }
       },
       "linux-arm64": {
-        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned/ffmpeg-linux-arm64-autobuild-2026-08-12-13-15-6fb99e871709d0c7.tar.xz",
-        "sha256": "6fb99e871709d0c77256d5737d67f440c8cb03a02d71c37a7632f9b66dc55e2d",
-        "fileName": "ffmpeg-linux-arm64-autobuild-2026-08-12-13-15-6fb99e871709d0c7.tar.xz",
+        "url": "https://github.com/crazysmile-PhD/downkyi-runtime-assets/releases/download/ffmpeg-btbn-autobuild-2026-08-23-13-03/ffmpeg-linux-arm64-autobuild-2026-08-23-13-03-343babe6f9039142.tar.xz",
+        "sha256": "343babe6f90391427c80e6e94799028d7efdd728ff676ded5155b8c4aa05aad6",
+        "fileName": "ffmpeg-linux-arm64-autobuild-2026-08-23-13-03-343babe6f9039142.tar.xz",
         "provenance": {
           "upstreamRepository": "https://github.com/BtbN/FFmpeg-Builds",
-          "upstreamRelease": "autobuild-2026-08-12-13-15",
-          "originalAssetName": "ffmpeg-N-126086-ge5ecfe8970-linuxarm64-gpl.tar.xz",
-          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-12-13-15/ffmpeg-N-126086-ge5ecfe8970-linuxarm64-gpl.tar.xz",
-          "mirroredAt": "2026-08-13T05:32:08Z",
-          "ffmpegVersion": "ffmpeg-N-126086-ge5ecfe8970-linuxarm64-gpl.tar.xz"
+          "upstreamRelease": "autobuild-2026-08-23-13-03",
+          "originalAssetName": "ffmpeg-N-126247-gb79d4c4c0a-linuxarm64-gpl.tar.xz",
+          "upstreamUrl": "https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-08-23-13-03/ffmpeg-N-126247-gb79d4c4c0a-linuxarm64-gpl.tar.xz",
+          "mirroredAt": "2026-08-24T04:03:49Z",
+          "ffmpegVersion": "ffmpeg-N-126247-gb79d4c4c0a-linuxarm64-gpl.tar.xz"
         }
       },
       "osx-x64": {


### PR DESCRIPTION
Updates mirrored FFmpeg to `btbn-autobuild-2026-08-23-13-03`.

- Previous version: `btbn-autobuild-2026-08-12-13-15_ytdlp-autobuild-2026-08-11-18-08_martin-riedl-pinned`
- New version: `btbn-autobuild-2026-08-23-13-03`
- Mirror release: `crazysmile-PhD/downkyi-runtime-assets@ffmpeg-btbn-autobuild-2026-08-23-13-03`
- Validation: archive layout, ffmpeg/ffprobe execution, SHA-256, and required encoder checks on native runners.
- Historical mirror releases are retained; this PR only points the manifest at a new fixed tag.

| RID | Upstream release | SHA-256 |
| --- | --- | --- |
| win-x64 | autobuild-2026-08-23-13-03 | `89f459586270a5ad84a79c9c921a385d6a14450398e072e1cf32c62277a6a410` |
| linux-x64 | autobuild-2026-08-23-13-03 | `d2228832ee66707848a6f6742d7f6bccfff893c2c6d7f974436ffa0507def80a` |
| linux-arm64 | autobuild-2026-08-23-13-03 | `343babe6f90391427c80e6e94799028d7efdd728ff676ded5155b8c4aa05aad6` |
