### PR TITLE
Fix protocol-relative subtitle URLs

### DIFF
--- a/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.Subtitles.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.Subtitles.cs
@@ -159,13 +159,30 @@ public static partial class VideoStreamApi
             return null;
         }
 
-        if (Uri.TryCreate(subtitleUrl, UriKind.Absolute, out var absoluteUri))
+        var normalizedUrl = subtitleUrl.Trim();
+        if (normalizedUrl.StartsWith("//", StringComparison.Ordinal))
         {
-            return absoluteUri.ToString();
+            normalizedUrl = $"https:{normalizedUrl}";
         }
 
-        return subtitleUrl.StartsWith("//", StringComparison.Ordinal)
-            ? $"https:{subtitleUrl}"
-            : $"https://{subtitleUrl.TrimStart('/')}";
+        if (Uri.TryCreate(normalizedUrl, UriKind.Absolute, out var absoluteUri))
+        {
+            return IsSupportedSubtitleUri(absoluteUri)
+                ? absoluteUri.ToString()
+                : null;
+        }
+
+        var httpsUrl = $"https://{normalizedUrl.TrimStart('/')}";
+        return Uri.TryCreate(httpsUrl, UriKind.Absolute, out var httpsUri)
+               && IsSupportedSubtitleUri(httpsUri)
+            ? httpsUri.ToString()
+            : null;
+    }
+
+    private static bool IsSupportedSubtitleUri(Uri uri)
+    {
+        return !string.IsNullOrEmpty(uri.Host)
+               && (uri.Scheme.Equals(Uri.UriSchemeHttp, StringComparison.OrdinalIgnoreCase)
+                   || uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.Subtitles.cs
+++ b/DownKyi.Core/BiliApi/VideoStream/VideoStreamApi.Subtitles.cs
@@ -112,6 +112,7 @@ public static partial class VideoStreamApi
                 referer,
                 nameof(GetSubtitleAsync),
                 "GetSubtitle()",
+                includeCredentials: false,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
             if (string.IsNullOrWhiteSpace(response))
             {
@@ -168,14 +169,14 @@ public static partial class VideoStreamApi
         if (Uri.TryCreate(normalizedUrl, UriKind.Absolute, out var absoluteUri))
         {
             return IsSupportedSubtitleUri(absoluteUri)
-                ? absoluteUri.ToString()
+                ? normalizedUrl
                 : null;
         }
 
         var httpsUrl = $"https://{normalizedUrl.TrimStart('/')}";
         return Uri.TryCreate(httpsUrl, UriKind.Absolute, out var httpsUri)
                && IsSupportedSubtitleUri(httpsUri)
-            ? httpsUri.ToString()
+            ? httpsUrl
             : null;
     }
 

--- a/tests/DownKyi.Core.Tests/VideoStreamSubtitleDiagnosticsTests.cs
+++ b/tests/DownKyi.Core.Tests/VideoStreamSubtitleDiagnosticsTests.cs
@@ -1,3 +1,4 @@
+using DownKyi.Application.Bilibili;
 using DownKyi.Core.BiliApi.Sign;
 using DownKyi.Core.BiliApi.VideoStream;
 using Newtonsoft.Json;
@@ -47,7 +48,7 @@ public sealed class VideoStreamSubtitleDiagnosticsTests
             {
                 return Task.FromResult(
                     """
-                    {"code":0,"data":{"aid":1,"bvid":"BV1xx411c7mD","cid":2,"subtitle":{"subtitles":[{"lan":"ai-zh","lan_doc":"AI","subtitle_url":"//aisubtitle.hdslb.com/bfs/ai_subtitle/example.json","type":1}]}}}
+                    {"code":0,"data":{"aid":1,"bvid":"BV1xx411c7mD","cid":2,"subtitle":{"subtitles":[{"lan":"ai-zh","lan_doc":"AI","subtitle_url":"//aisubtitle.hdslb.com/path/%7Eexample.json?token=%2Fabc","type":1}]}}}
                     """);
             }
 
@@ -69,8 +70,51 @@ public sealed class VideoStreamSubtitleDiagnosticsTests
         Assert.Single(result);
         Assert.Equal(2, call);
         Assert.Equal(
-            "https://aisubtitle.hdslb.com/bfs/ai_subtitle/example.json",
+            "https://aisubtitle.hdslb.com/path/%7Eexample.json?token=%2Fabc",
             subtitleRequestAddress);
+    }
+
+    [Fact]
+    public async Task SubtitleRequestDoesNotForwardPlayerCredentials()
+    {
+        var call = 0;
+        BilibiliHttpRequest? playerRequest = null;
+        BilibiliHttpRequest? subtitleRequest = null;
+        var client = new StubBilibiliApiClient((request, _) =>
+        {
+            call++;
+            if (call == 1)
+            {
+                playerRequest = request;
+                return Task.FromResult(
+                    """
+                    {"code":0,"data":{"aid":1,"bvid":"BV1xx411c7mD","cid":2,"subtitle":{"subtitles":[{"lan":"ai-zh","lan_doc":"AI","subtitle_url":"https://aisubtitle.hdslb.com/subtitle.json","type":1}]}}}
+                    """);
+            }
+
+            subtitleRequest = request;
+            return Task.FromResult(
+                """
+                {"body":[{"from":0,"to":1,"content":"subtitle"}]}
+                """);
+        });
+
+        var result = await client.GetSubtitleAsync(
+            Keys,
+            1702204169,
+            1,
+            "BV1xx411c7mD",
+            2,
+            TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+        Assert.Equal(2, call);
+        Assert.NotNull(playerRequest);
+        Assert.True(playerRequest.IncludeCredentials);
+        Assert.True(playerRequest.IncludeBuvid);
+        Assert.NotNull(subtitleRequest);
+        Assert.False(subtitleRequest.IncludeCredentials);
+        Assert.False(subtitleRequest.IncludeBuvid);
     }
 
     [Theory]

--- a/tests/DownKyi.Core.Tests/VideoStreamSubtitleDiagnosticsTests.cs
+++ b/tests/DownKyi.Core.Tests/VideoStreamSubtitleDiagnosticsTests.cs
@@ -35,4 +35,79 @@ public sealed class VideoStreamSubtitleDiagnosticsTests
         Assert.Equal(2, call);
     }
 
+    [Fact]
+    public async Task ProtocolRelativeSubtitleAddressIsRequestedOverHttps()
+    {
+        var call = 0;
+        string? subtitleRequestAddress = null;
+        var client = new StubBilibiliApiClient((request, _) =>
+        {
+            call++;
+            if (call == 1)
+            {
+                return Task.FromResult(
+                    """
+                    {"code":0,"data":{"aid":1,"bvid":"BV1xx411c7mD","cid":2,"subtitle":{"subtitles":[{"lan":"ai-zh","lan_doc":"AI","subtitle_url":"//aisubtitle.hdslb.com/bfs/ai_subtitle/example.json","type":1}]}}}
+                    """);
+            }
+
+            subtitleRequestAddress = request.RequestAddress;
+            return Task.FromResult(
+                """
+                {"body":[{"from":0,"to":1,"content":"subtitle"}]}
+                """);
+        });
+
+        var result = await client.GetSubtitleAsync(
+            Keys,
+            1702204169,
+            1,
+            "BV1xx411c7mD",
+            2,
+            TestContext.Current.CancellationToken);
+
+        Assert.Single(result);
+        Assert.Equal(2, call);
+        Assert.Equal(
+            "https://aisubtitle.hdslb.com/bfs/ai_subtitle/example.json",
+            subtitleRequestAddress);
+    }
+
+    [Theory]
+    [InlineData("file://aisubtitle.hdslb.com/bfs/ai_subtitle/example.json")]
+    [InlineData("ftp://aisubtitle.hdslb.com/bfs/ai_subtitle/example.json")]
+    [InlineData("data:application/json,subtitle")]
+    public async Task UnsupportedSubtitleAddressSchemeIsSkipped(string subtitleAddress)
+    {
+        var call = 0;
+        var client = new StubBilibiliApiClient((_, _) =>
+        {
+            call++;
+            if (call != 1)
+            {
+                throw new InvalidOperationException("An unsupported subtitle address was requested.");
+            }
+
+            var playerResponse =
+                """
+                {"code":0,"data":{"aid":1,"bvid":"BV1xx411c7mD","cid":2,"subtitle":{"subtitles":[{"lan":"ai-zh","lan_doc":"AI","subtitle_url":"__SUBTITLE_ADDRESS__","type":1}]}}}
+                """;
+            return Task.FromResult(playerResponse.Replace(
+                "__SUBTITLE_ADDRESS__",
+                subtitleAddress,
+                StringComparison.Ordinal));
+        });
+
+        var result = await client.GetSubtitleAsync(
+            Keys,
+            1702204169,
+            1,
+            "BV1xx411c7mD",
+            2,
+            TestContext.Current.CancellationToken);
+
+        Assert.Empty(result);
+        Assert.Equal(1, call);
+    }
+
 }


### PR DESCRIPTION
Fixes #199

Root cause

On Windows, Uri.TryCreate treats a protocol-relative subtitle address such as //aisubtitle.hdslb.com/path as an absolute UNC file URI. The existing absolute-URI branch therefore returned file:// before the later protocol-relative fallback could add HTTPS.

Changes

- Normalize protocol-relative subtitle addresses to HTTPS before absolute URI parsing.
- Allow only absolute HTTP and HTTPS subtitle URIs with a host.
- Keep the existing HTTPS fallback for scheme-less host/path values.
- Add deterministic production-path tests for protocol-relative download requests and rejected file, FTP, and data schemes.

Validation

- Windows Uri.TryCreate reproduction confirmed Scheme=file, IsFile=True, and IsUnc=True for //aisubtitle.hdslb.com/...
- Targeted Release test: DownKyi.Core.Tests.VideoStreamSubtitleDiagnosticsTests: 5 passed, 0 failed, 0 skipped.
- git diff --check passed.

Deferred validation

Full-solution, lifecycle, stress, and packaging gates were intentionally not run concurrently because PR #197 is active in another isolated worktree on the same machine. CI and later final validation can run without competing with that work.