### PR TITLE
fix(downloads): improve startup, TLS recovery, and batch actions

### DIFF
--- a/src/DownKyi.Desktop/App.axaml
+++ b/src/DownKyi.Desktop/App.axaml
@@ -66,6 +66,7 @@
         <FluentTheme />
         <StyleInclude Source="avares://Avalonia.Controls.DataGrid/Themes/Fluent.xaml" />
         <StyleInclude Source="/Themes/Styles/loading.axaml" />
+        <StyleInclude Source="/Themes/Styles/download-preparation-status.axaml" />
         <Style Selector="Window">
             <Setter Property="FontFamily" Value="{DynamicResource ProgramFont}" />
         </Style>

--- a/src/DownKyi.Desktop/Commands/DownKyiAsyncCommandGate.cs
+++ b/src/DownKyi.Desktop/Commands/DownKyiAsyncCommandGate.cs
@@ -1,0 +1,39 @@
+using System;
+using System.ComponentModel;
+using System.Threading;
+
+namespace DownKyi.Commands;
+
+internal sealed class DownKyiAsyncCommandGate : INotifyPropertyChanged
+{
+    private int _isExecuting;
+
+    public event EventHandler? IsExecutingChanged;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool IsExecuting => Volatile.Read(ref _isExecuting) != 0;
+
+    internal bool TryEnter()
+    {
+        if (Interlocked.CompareExchange(ref _isExecuting, 1, 0) != 0)
+        {
+            return false;
+        }
+
+        IsExecutingChanged?.Invoke(this, EventArgs.Empty);
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExecuting)));
+        return true;
+    }
+
+    internal void Exit()
+    {
+        if (Interlocked.Exchange(ref _isExecuting, 0) == 0)
+        {
+            return;
+        }
+
+        IsExecutingChanged?.Invoke(this, EventArgs.Empty);
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExecuting)));
+    }
+}

--- a/src/DownKyi.Desktop/Commands/DownKyiAsyncDelegateCommand.cs
+++ b/src/DownKyi.Desktop/Commands/DownKyiAsyncDelegateCommand.cs
@@ -15,7 +15,7 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
     private readonly Func<T, bool>? _canExecute;
     private readonly ILogger _logger;
     private readonly Func<bool>? _isCancellationExpected;
-    private int _isExecuting;
+    private readonly DownKyiAsyncCommandGate _executionGate;
 
     public event EventHandler? CanExecuteChanged;
 
@@ -23,32 +23,34 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
         Func<T?, Task> execute,
         ILogger logger,
         Func<T, bool>? canExecute = null,
-        Func<bool>? isCancellationExpected = null)
+        Func<bool>? isCancellationExpected = null,
+        DownKyiAsyncCommandGate? executionGate = null)
     {
         _execute = execute ?? throw new ArgumentNullException(nameof(execute));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _canExecute = canExecute;
         _isCancellationExpected = isCancellationExpected;
+        _executionGate = executionGate ?? new DownKyiAsyncCommandGate();
+        _executionGate.IsExecutingChanged += OnExecutionGateChanged;
     }
 
     public bool CanExecute(object? parameter)
     {
         if (parameter is null && typeof(T) == typeof(object))
         {
-            return Volatile.Read(ref _isExecuting) == 0 && (_canExecute?.Invoke(default!) ?? true);
+            return !_executionGate.IsExecuting && (_canExecute?.Invoke(default!) ?? true);
         }
 
         if (parameter is not T typedParameter)
         {
             return false;
         }
-        return Volatile.Read(ref _isExecuting) == 0 && (_canExecute?.Invoke(typedParameter) ?? true);
+        return !_executionGate.IsExecuting && (_canExecute?.Invoke(typedParameter) ?? true);
     }
 
     public void Execute(object? parameter)
     {
-        if (!CanExecute(parameter)
-            || Interlocked.CompareExchange(ref _isExecuting, 1, 0) != 0)
+        if (!CanExecute(parameter) || !_executionGate.TryEnter())
         {
             return;
         }
@@ -63,24 +65,22 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
 
     private async Task ExecuteAsync(object? parameter)
     {
-        T? executionParameter;
-        if (parameter is null && typeof(T) == typeof(object))
-        {
-            executionParameter = default;
-        }
-        else if (parameter is T typedParameter)
-        {
-            executionParameter = typedParameter;
-        }
-        else
-        {
-            return;
-        }
-
-        OnCanExecuteChanged();
-
         try
         {
+            T? executionParameter;
+            if (parameter is null && typeof(T) == typeof(object))
+            {
+                executionParameter = default;
+            }
+            else if (parameter is T typedParameter)
+            {
+                executionParameter = typedParameter;
+            }
+            else
+            {
+                return;
+            }
+
             await _execute(executionParameter).ConfigureAwait(true);
         }
         catch (OperationCanceledException e) when (IsExpectedCancellation(e))
@@ -97,8 +97,7 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
         }
         finally
         {
-            Volatile.Write(ref _isExecuting, 0);
-            OnCanExecuteChanged();
+            _executionGate.Exit();
         }
     }
 
@@ -112,6 +111,11 @@ internal class DownKyiAsyncDelegateCommand<T> : ICommand
     {
         CanExecuteChanged?.Invoke(this, EventArgs.Empty);
     }
+
+    private void OnExecutionGateChanged(object? sender, EventArgs e)
+    {
+        OnCanExecuteChanged();
+    }
 }
 
 internal class DownKyiAsyncDelegateCommand : DownKyiAsyncDelegateCommand<object>
@@ -120,8 +124,9 @@ internal class DownKyiAsyncDelegateCommand : DownKyiAsyncDelegateCommand<object>
         Func<object?, Task> execute,
         ILogger logger,
         Func<object, bool>? canExecute = null,
-        Func<bool>? isCancellationExpected = null)
-        : base(execute, logger, canExecute, isCancellationExpected)
+        Func<bool>? isCancellationExpected = null,
+        DownKyiAsyncCommandGate? executionGate = null)
+        : base(execute, logger, canExecute, isCancellationExpected, executionGate)
     {
     }
 
@@ -129,10 +134,12 @@ internal class DownKyiAsyncDelegateCommand : DownKyiAsyncDelegateCommand<object>
         Func<Task> execute,
         ILogger logger,
         Func<bool>? canExecute = null,
-        Func<bool>? isCancellationExpected = null)
+        Func<bool>? isCancellationExpected = null,
+        DownKyiAsyncCommandGate? executionGate = null)
         : this(_ => execute(), logger,
             canExecute != null ? _ => canExecute() : null,
-            isCancellationExpected)
+            isCancellationExpected,
+            executionGate)
     {
     }
 }

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/IAsyncImageLoader.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/IAsyncImageLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
 
@@ -11,5 +12,7 @@ internal interface IAsyncImageLoader : IDisposable
     /// </summary>
     /// <param name="url">Target url</param>
     /// <returns>Bitmap</returns>
-    public Task<Bitmap?> ProvideImageAsync(string url);
+    public Task<Bitmap?> ProvideImageAsync(
+        string url,
+        CancellationToken cancellationToken = default);
 }

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/ImageBrushLoader.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/ImageBrushLoader.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -18,6 +19,10 @@ internal static class ImageBrushLoader
         Avalonia.Logging.Logger.TryGet(LogEventLevel.Error, ImageLoader.AsyncImageLoaderLogArea);
     public static readonly AttachedProperty<string?> SourceProperty =
         AvaloniaProperty.RegisterAttached<ImageBrush, string?>("Source", typeof(ImageLoader));
+    private static readonly AttachedProperty<CancellationTokenSource?> PendingOperationProperty =
+        AvaloniaProperty.RegisterAttached<ImageBrush, CancellationTokenSource?>(
+            "PendingOperation",
+            typeof(ImageBrushLoader));
     public static IAsyncImageLoader AsyncImageLoader { get; set; } = NullAsyncImageLoader.Instance;
 
     static ImageBrushLoader()
@@ -36,6 +41,7 @@ internal static class ImageBrushLoader
         if (oldValue == newValue)
             return;
 
+        var cancellation = ReplacePendingOperation(imageBrush);
         SetIsLoading(imageBrush, true);
 
         Bitmap? bitmap = null;
@@ -46,18 +52,35 @@ internal static class ImageBrushLoader
                 // 注意缩放比例
                 var width = GetWidth(imageBrush);
                 var height = GetHeight(imageBrush);
+                PixelSize? targetSize = null;
                 if (width > 0 && height > 0)
                 {
                     var scale = await Dispatcher.UIThread.InvokeAsync(GetDesktopScaling);
-                    var actualWidth = Convert.ToInt32(width * scale);
-                    var actualHeight = Convert.ToInt32(height * scale);
-                    bitmap = (await AsyncImageLoader.ProvideImageAsync(newValue).ConfigureAwait(true))?.CreateScaledBitmap(new PixelSize(actualWidth, actualHeight));
+                    targetSize = new PixelSize(
+                        Convert.ToInt32(width * scale),
+                        Convert.ToInt32(height * scale));
                 }
-                else
+
+                bitmap = await Task.Run(async () =>
                 {
-                    bitmap = await AsyncImageLoader.ProvideImageAsync(newValue).ConfigureAwait(true);
-                }
+                    var sourceBitmap = await AsyncImageLoader
+                        .ProvideImageAsync(newValue, cancellation.Token)
+                        .ConfigureAwait(false);
+                    if (sourceBitmap == null || !targetSize.HasValue)
+                    {
+                        return sourceBitmap;
+                    }
+
+                    using (sourceBitmap)
+                    {
+                        return sourceBitmap.CreateScaledBitmap(targetSize.Value);
+                    }
+                }, CancellationToken.None).ConfigureAwait(true);
             }
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+            return;
         }
         catch (HttpRequestException e)
         {
@@ -72,10 +95,63 @@ internal static class ImageBrushLoader
             Logger?.Log("ImageBrushLoader", "ImageBrushLoader image resolution failed: {0}", e);
         }
 
-        if (GetSource(imageBrush) != newValue) return;
-        imageBrush.Source = bitmap;
+        finally
+        {
+            if (GetSource(imageBrush) != newValue)
+            {
+                bitmap?.Dispose();
+            }
+            else
+            {
+                imageBrush.Source = bitmap;
+            }
 
-        SetIsLoading(imageBrush, false);
+            if (CompletePendingOperation(imageBrush, cancellation))
+            {
+                SetIsLoading(imageBrush, false);
+            }
+        }
+    }
+
+    private static CancellationTokenSource ReplacePendingOperation(ImageBrush imageBrush)
+    {
+        var previous = imageBrush.GetValue(PendingOperationProperty);
+        var current = new CancellationTokenSource();
+        imageBrush.SetValue(PendingOperationProperty, current);
+        if (previous != null)
+        {
+            CancelBestEffort(previous);
+        }
+
+        return current;
+    }
+
+    private static void CancelBestEffort(CancellationTokenSource cancellationTokenSource)
+    {
+        try
+        {
+            cancellationTokenSource.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            return;
+        }
+    }
+
+    private static bool CompletePendingOperation(
+        ImageBrush imageBrush,
+        CancellationTokenSource operation)
+    {
+        var ownsPendingOperation = ReferenceEquals(
+            imageBrush.GetValue(PendingOperationProperty),
+            operation);
+        if (ownsPendingOperation)
+        {
+            imageBrush.SetValue(PendingOperationProperty, null);
+        }
+
+        operation.Dispose();
+        return ownsPendingOperation;
     }
 
     public static string? GetSource(ImageBrush element)

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/ImageLoader.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/ImageLoader.cs
@@ -73,7 +73,9 @@ internal static class ImageLoader
                 try
                 {
                     await Task.Delay(10, cts.Token).ConfigureAwait(false);
-                    var loaded = await AsyncImageLoader.ProvideImageAsync(url).ConfigureAwait(false);
+                    var loaded = await AsyncImageLoader
+                        .ProvideImageAsync(url, cts.Token)
+                        .ConfigureAwait(false);
                     if (loaded == null || !targetSize.HasValue)
                     {
                         return loaded;

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/AdvancedImage.axaml.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/AdvancedImage.axaml.cs
@@ -226,6 +226,7 @@ internal class AdvancedImage : ContentControl
 
         Bitmap? bitmap;
         var wasCancelled = false;
+        var ownsUpdate = false;
         try
         {
             bitmap = await Task.Run(async () =>
@@ -246,7 +247,9 @@ internal class AdvancedImage : ContentControl
                     }
 
                     loader ??= ImageLoader.AsyncImageLoader;
-                    return await loader.ProvideImageAsync(source).ConfigureAwait(true);
+                    return await loader
+                        .ProvideImageAsync(source, cancellationTokenSource.Token)
+                        .ConfigureAwait(true);
                 }
                 catch (TaskCanceledException)
                 {
@@ -278,17 +281,35 @@ internal class AdvancedImage : ContentControl
         }
         finally
         {
-            Interlocked.CompareExchange(ref _updateCancellationToken, null, cancellationTokenSource);
+            ownsUpdate = ReferenceEquals(
+                Interlocked.CompareExchange(
+                    ref _updateCancellationToken,
+                    null,
+                    cancellationTokenSource),
+                cancellationTokenSource);
             cancellationTokenSource.Dispose();
         }
 
         if (wasCancelled)
         {
             bitmap?.Dispose();
+            if (ownsUpdate)
+            {
+                IsLoading = false;
+            }
+
             return;
         }
-        CurrentImage = bitmap is null ? null : new ImageWrapper(bitmap);
-        IsLoading = false;
+
+        if (ownsUpdate)
+        {
+            CurrentImage = bitmap is null ? null : new ImageWrapper(bitmap);
+            IsLoading = false;
+        }
+        else
+        {
+            bitmap?.Dispose();
+        }
     }
 
     private static async Task CancelPreviousAsync(CancellationTokenSource cancellationTokenSource)

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/BaseWebImageLoader.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/BaseWebImageLoader.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Logging;
 using Avalonia.Media.Imaging;
@@ -12,6 +15,8 @@ internal class BaseWebImageLoader : IAsyncImageLoader
 {
     private readonly ParametrizedLogger? _logger;
     private readonly bool _shouldDisposeHttpClient;
+    private readonly ConcurrentDictionary<string, SharedDownload> _downloads = new(StringComparer.Ordinal);
+    private static readonly SemaphoreSlim NetworkGate = new(8, 8);
 
     /// <summary>
     ///     Initializes a new instance with the provided <see cref="HttpClient" />, and specifies whether that
@@ -32,9 +37,11 @@ internal class BaseWebImageLoader : IAsyncImageLoader
     protected HttpClient HttpClient { get; }
 
     /// <inheritdoc />
-    public virtual async Task<Bitmap?> ProvideImageAsync(string url)
+    public virtual async Task<Bitmap?> ProvideImageAsync(
+        string url,
+        CancellationToken cancellationToken = default)
     {
-        return await LoadAsync(url).ConfigureAwait(false);
+        return await LoadAsync(url, cancellationToken).ConfigureAwait(false);
     }
 
     public void Dispose()
@@ -48,22 +55,39 @@ internal class BaseWebImageLoader : IAsyncImageLoader
     /// </summary>
     /// <param name="url">Target url</param>
     /// <returns>Bitmap</returns>
-    protected virtual async Task<Bitmap?> LoadAsync(string url)
+    protected virtual async Task<Bitmap?> LoadAsync(
+        string url,
+        CancellationToken cancellationToken = default)
     {
-        var internalOrCachedBitmap = ImageSourceUriResolver.ResolveExternal(url) == null
-            ? LoadFromLocal(url) ?? LoadFromInternal(url) ?? LoadFromGlobalCache(url)
-            : LoadFromGlobalCache(url);
-        if (internalOrCachedBitmap != null) return internalOrCachedBitmap;
-
+        cancellationToken.ThrowIfCancellationRequested();
         try
         {
-            var externalBytes = await LoadDataFromExternalAsync(url).ConfigureAwait(false);
+            var internalOrCachedBitmap = ImageSourceUriResolver.ResolveExternal(url) == null
+                ? LoadFromLocal(url) ?? LoadFromInternal(url) ?? LoadFromGlobalCache(url)
+                : LoadFromGlobalCache(url);
+            if (internalOrCachedBitmap != null) return internalOrCachedBitmap;
+
+            var externalBytes = await LoadSharedDataFromExternalAsync(url, cancellationToken)
+                .ConfigureAwait(false);
             if (externalBytes == null) return null;
 
+            cancellationToken.ThrowIfCancellationRequested();
             using var memoryStream = new MemoryStream(externalBytes);
             var bitmap = new Bitmap(memoryStream);
-            await SaveToGlobalCache(url, externalBytes).ConfigureAwait(false);
-            return bitmap;
+            try
+            {
+                await SaveToGlobalCache(url, externalBytes, cancellationToken).ConfigureAwait(false);
+                return bitmap;
+            }
+            catch
+            {
+                bitmap.Dispose();
+                throw;
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (HttpRequestException e)
         {
@@ -155,7 +179,9 @@ internal class BaseWebImageLoader : IAsyncImageLoader
     /// </summary>
     /// <param name="url">Target url</param>
     /// <returns>Image bytes</returns>
-    protected virtual async Task<byte[]?> LoadDataFromExternalAsync(string url)
+    protected virtual async Task<byte[]?> LoadDataFromExternalAsync(
+        string url,
+        CancellationToken cancellationToken)
     {
         var uri = ImageSourceUriResolver.ResolveExternal(url);
         if (uri == null)
@@ -163,7 +189,15 @@ internal class BaseWebImageLoader : IAsyncImageLoader
 
         try
         {
-            return await HttpClient.GetByteArrayAsync(uri).ConfigureAwait(false);
+            await NetworkGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                return await HttpClient.GetByteArrayAsync(uri, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                NetworkGate.Release();
+            }
         }
         catch (HttpRequestException e)
         {
@@ -176,6 +210,38 @@ internal class BaseWebImageLoader : IAsyncImageLoader
             _logger?.Log(this,
                 "Failed to resolve image from request with uri: {RequestUri}\nException: {Exception}", url, e);
             return null;
+        }
+    }
+
+    private async Task<byte[]?> LoadSharedDataFromExternalAsync(
+        string url,
+        CancellationToken cancellationToken)
+    {
+        SharedDownload download;
+        Task<byte[]?> task;
+        while (true)
+        {
+            download = _downloads.GetOrAdd(url, static _ => new SharedDownload());
+            if (download.TryAcquire(
+                    token => LoadDataFromExternalAsync(url, token),
+                    out task))
+            {
+                break;
+            }
+
+            _downloads.TryRemove(new KeyValuePair<string, SharedDownload>(url, download));
+        }
+
+        try
+        {
+            return await task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (download.Release())
+            {
+                _downloads.TryRemove(new KeyValuePair<string, SharedDownload>(url, download));
+            }
         }
     }
 
@@ -196,7 +262,10 @@ internal class BaseWebImageLoader : IAsyncImageLoader
     /// <param name="url">Target url</param>
     /// <param name="imageBytes">Bytes to save</param>
     /// <returns>Bitmap</returns>
-    protected virtual Task SaveToGlobalCache(string url, byte[] imageBytes)
+    protected virtual Task SaveToGlobalCache(
+        string url,
+        byte[] imageBytes,
+        CancellationToken cancellationToken)
     {
         // Current implementation does not provide global caching
         return Task.CompletedTask;
@@ -209,7 +278,108 @@ internal class BaseWebImageLoader : IAsyncImageLoader
 
     protected virtual void Dispose(bool disposing)
     {
-        if (disposing && _shouldDisposeHttpClient) HttpClient.Dispose();
+        if (!disposing)
+        {
+            return;
+        }
+
+        foreach (var download in _downloads.Values)
+        {
+            download.Dispose();
+        }
+
+        _downloads.Clear();
+        if (_shouldDisposeHttpClient) HttpClient.Dispose();
+    }
+
+    private sealed class SharedDownload : IDisposable
+    {
+        private readonly object _sync = new();
+        private readonly CancellationTokenSource _cancellation = new();
+        private Task<byte[]?>? _task;
+        private int _waiters;
+        private bool _closed;
+
+        public bool TryAcquire(
+            Func<CancellationToken, Task<byte[]?>> factory,
+            out Task<byte[]?> task)
+        {
+            lock (_sync)
+            {
+                if (_closed)
+                {
+                    task = Task.FromCanceled<byte[]?>(new CancellationToken(canceled: true));
+                    return false;
+                }
+
+                _waiters++;
+                _task ??= factory(_cancellation.Token);
+                task = _task;
+                return true;
+            }
+        }
+
+        public bool Release()
+        {
+            lock (_sync)
+            {
+                _waiters--;
+                if (_waiters > 0)
+                {
+                    return false;
+                }
+
+                _closed = true;
+                if (_task is { IsCompleted: false })
+                {
+                    _cancellation.Cancel();
+                }
+
+                DisposeCancellationWhenComplete();
+                return true;
+            }
+        }
+
+        public void Dispose()
+        {
+            lock (_sync)
+            {
+                if (!_cancellation.IsCancellationRequested)
+                {
+                    _cancellation.Cancel();
+                }
+
+                if (_task == null || _task.IsCompleted)
+                {
+                    _cancellation.Dispose();
+                }
+                else
+                {
+                    DisposeCancellationWhenComplete();
+                }
+            }
+        }
+
+        private void DisposeCancellationWhenComplete()
+        {
+            var task = _task;
+            if (task == null || task.IsCompleted)
+            {
+                _cancellation.Dispose();
+                return;
+            }
+
+            _ = task.ContinueWith(
+                static (completed, state) =>
+                {
+                    _ = completed.Exception;
+                    ((CancellationTokenSource)state!).Dispose();
+                },
+                _cancellation,
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
     }
 
 }

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/DiskCachedWebImageLoader.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/DiskCachedWebImageLoader.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
 
@@ -25,11 +26,14 @@ internal class DiskCachedWebImageLoader : BaseWebImageLoader
         return File.Exists(path) ? new Bitmap(path) : null;
     }
 
-    protected override async Task SaveToGlobalCache(string url, byte[] imageBytes)
+    protected override async Task SaveToGlobalCache(
+        string url,
+        byte[] imageBytes,
+        CancellationToken cancellationToken)
     {
         var path = Path.Combine(_cacheFolder, CreateCacheKey(url));
         Directory.CreateDirectory(_cacheFolder);
-        await File.WriteAllBytesAsync(path, imageBytes).ConfigureAwait(false);
+        await File.WriteAllBytesAsync(path, imageBytes, cancellationToken).ConfigureAwait(false);
     }
 
     protected static string CreateCacheKey(string input)

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/RamCachedWebImageLoader.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/Loaders/RamCachedWebImageLoader.cs
@@ -1,5 +1,7 @@
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
 
@@ -15,9 +17,29 @@ internal class RamCachedWebImageLoader : BaseWebImageLoader
     }
 
     /// <inheritdoc />
-    public override async Task<Bitmap?> ProvideImageAsync(string url)
+    public override async Task<Bitmap?> ProvideImageAsync(
+        string url,
+        CancellationToken cancellationToken = default)
     {
-        var bitmap = await _memoryCache.GetOrAdd(url, LoadAsync).ConfigureAwait(false);
+        var loadTask = _memoryCache.GetOrAdd(
+            url,
+            key => LoadAsync(key, CancellationToken.None));
+        Bitmap? bitmap;
+        try
+        {
+            bitmap = await loadTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            if (loadTask.IsCompleted && !loadTask.IsCompletedSuccessfully)
+            {
+                _memoryCache.TryRemove(
+                    new KeyValuePair<string, Task<Bitmap?>>(url, loadTask));
+            }
+
+            throw;
+        }
+
         // If load failed - remove from cache and return
         // Next load attempt will try to load image again
         if (bitmap == null) _memoryCache.TryRemove(url, out _);

--- a/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/NullAsyncImageLoader.cs
+++ b/src/DownKyi.Desktop/CustomControl/AsyncImageLoader/NullAsyncImageLoader.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia.Media.Imaging;
 
@@ -11,8 +12,11 @@ internal sealed class NullAsyncImageLoader : IAsyncImageLoader
     {
     }
 
-    public Task<Bitmap?> ProvideImageAsync(string url)
+    public Task<Bitmap?> ProvideImageAsync(
+        string url,
+        CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         return Task.FromResult<Bitmap?>(null);
     }
 

--- a/src/DownKyi.Desktop/CustomControl/DownloadPreparationStatus.cs
+++ b/src/DownKyi.Desktop/CustomControl/DownloadPreparationStatus.cs
@@ -1,0 +1,37 @@
+using System.Windows.Input;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Layout;
+
+namespace DownKyi.CustomControl;
+
+internal sealed class DownloadPreparationStatus : TemplatedControl
+{
+    public static readonly StyledProperty<bool> IsActiveProperty =
+        AvaloniaProperty.Register<DownloadPreparationStatus, bool>(nameof(IsActive));
+
+    public static readonly StyledProperty<ICommand?> CancelCommandProperty =
+        AvaloniaProperty.Register<DownloadPreparationStatus, ICommand?>(nameof(CancelCommand));
+
+    public static readonly StyledProperty<Orientation> OrientationProperty =
+        AvaloniaProperty.Register<DownloadPreparationStatus, Orientation>(nameof(Orientation));
+
+    public bool IsActive
+    {
+        get => GetValue(IsActiveProperty);
+        set => SetValue(IsActiveProperty, value);
+    }
+
+    public ICommand? CancelCommand
+    {
+        get => GetValue(CancelCommandProperty);
+        set => SetValue(CancelCommandProperty, value);
+    }
+
+    public Orientation Orientation
+    {
+        get => GetValue(OrientationProperty);
+        set => SetValue(OrientationProperty, value);
+    }
+}

--- a/src/DownKyi.Desktop/Languages/Default.axaml
+++ b/src/DownKyi.Desktop/Languages/Default.axaml
@@ -91,6 +91,7 @@
     <!--  Publication  -->
     <system:String x:Key="DownloadSelectedPublication">下载选中项</system:String>
     <system:String x:Key="DownloadAllPublication">下载全部</system:String>
+    <system:String x:Key="PreparingDownloads">正在添加到下载列表…</system:String>
     <system:String x:Key="PublicationWait">请稍等，马上就好~</system:String>
     
     <!--  Friend  -->

--- a/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.Failures.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.Failures.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Net.Http;
+
+namespace DownKyi.Services.Download;
+
+internal sealed partial class Aria2TransferBackend
+{
+    internal static DownloadTransferResult ClassifyHttpTransportFailure(
+        HttpRequestException exception,
+        string transientErrorCode)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        ArgumentException.ThrowIfNullOrWhiteSpace(transientErrorCode);
+        if (!TlsFailureClassifier.TryClassify(exception, out var tlsErrorCode))
+        {
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.TransientNetwork,
+                transientErrorCode);
+        }
+
+        return TlsFailureClassifier.CreateTransferFailure(
+            tlsErrorCode,
+            transientErrorCode);
+    }
+
+    internal static string GetSafeHost(string address)
+    {
+        return Uri.TryCreate(address, UriKind.Absolute, out var uri)
+            ? uri.IdnHost
+            : "invalid";
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2TransferBackend.cs
@@ -103,11 +103,47 @@ internal sealed partial class Aria2TransferBackend : ITransferBackend
                 "download.transfer.single-address-required");
         }
 
+        AriaDownloadAddressResolution resolution;
+        try
+        {
+            resolution = await _addressResolver.ResolveAsync(
+                request.Urls[0],
+                _networkSettings.UserAgent,
+                LoginHelper.GetLoginInfoCookiesString(),
+                request.CancellationToken).ConfigureAwait(true);
+        }
+        catch (HttpRequestException exception)
+        {
+            var result = ClassifyHttpTransportFailure(
+                exception,
+                "download.transfer.network");
+            _logger.LogWarningMessage(
+                $"aria2 address validation transport failed; " +
+                $"host={GetSafeHost(request.Urls[0])}; " +
+                $"httpError={exception.HttpRequestError}; " +
+                $"innerType={exception.InnerException?.GetType().Name ?? "none"}; " +
+                $"failure={result.FailureKind}; code={result.ErrorCode}");
+            return result;
+        }
+        catch (Exception exception) when (exception is IOException or TimeoutException)
+        {
+            _logger.LogWarningMessage(
+                $"aria2 address validation transport failed; " +
+                $"host={GetSafeHost(request.Urls[0])}; " +
+                $"type={exception.GetType().Name}; " +
+                $"failure={DownloadTransferFailureKind.TransientNetwork}; " +
+                $"code=download.transfer.network");
+            return DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.TransientNetwork,
+                "download.transfer.network");
+        }
+
         string? activeGid;
         try
         {
             var preparation = await EnsureAriaTaskAsync(
-                request).ConfigureAwait(true);
+                request,
+                resolution).ConfigureAwait(true);
             if (preparation.ErrorCode != null)
             {
                 _logger.LogWarningMessage(
@@ -123,11 +159,15 @@ internal sealed partial class Aria2TransferBackend : ITransferBackend
         catch (HttpRequestException exception) when (
             TlsFailureClassifier.TryClassify(exception, out var tlsErrorCode))
         {
+            var result = TlsFailureClassifier.CreateTransferFailure(
+                tlsErrorCode,
+                "download.transfer.aria2-rpc");
             _logger.LogWarningMessage(
-                $"aria2 address validation failed TLS policy; code={tlsErrorCode}");
-            return DownloadTransferResult.Failed(
-                DownloadTransferFailureKind.Tls,
-                tlsErrorCode);
+                $"aria2 RPC secure transport failed; " +
+                $"httpError={exception.HttpRequestError}; " +
+                $"innerType={exception.InnerException?.GetType().Name ?? "none"}; " +
+                $"failure={result.FailureKind}; code={result.ErrorCode}");
+            return result;
         }
         catch (Exception exception) when (exception is HttpRequestException
             or IOException
@@ -240,13 +280,9 @@ internal sealed partial class Aria2TransferBackend : ITransferBackend
     }
 
     private async Task<AriaTaskPreparation> EnsureAriaTaskAsync(
-        DownloadTransferRequest request)
+        DownloadTransferRequest request,
+        AriaDownloadAddressResolution resolution)
     {
-        var resolution = await _addressResolver.ResolveAsync(
-            request.Urls[0],
-            _networkSettings.UserAgent,
-            LoginHelper.GetLoginInfoCookiesString(),
-            request.CancellationToken).ConfigureAwait(true);
         if (resolution.ErrorCode != null)
         {
             return AriaTaskPreparation.Rejected(resolution.ErrorCode);

--- a/src/DownKyi.Desktop/Services/Download/Aria2TransferFailureClassifier.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2TransferFailureClassifier.cs
@@ -24,9 +24,9 @@ internal static class Aria2TransferFailureClassifier
 
         if (TlsFailureClassifier.TryClassify(errorMessage, out var tlsErrorCode))
         {
-            return DownloadTransferResult.Failed(
-                DownloadTransferFailureKind.Tls,
-                tlsErrorCode);
+            return TlsFailureClassifier.CreateTransferFailure(
+                tlsErrorCode,
+                SanitizeErrorCode(errorCode));
         }
 
         if (errorMessage?.Contains(
@@ -94,10 +94,16 @@ internal static class Aria2TransferFailureClassifier
         DownloadTransferFailureKind kind,
         string? ariaErrorCode)
     {
-        var sanitizedCode = string.IsNullOrWhiteSpace(ariaErrorCode)
+        return DownloadTransferResult.Failed(
+            kind,
+            SanitizeErrorCode(ariaErrorCode));
+    }
+
+    private static string SanitizeErrorCode(string? ariaErrorCode)
+    {
+        return string.IsNullOrWhiteSpace(ariaErrorCode)
             ? "download.transfer.aria2"
             : $"download.transfer.aria2-{ariaErrorCode}";
-        return DownloadTransferResult.Failed(kind, sanitizedCode);
     }
 
     private static bool ContainsHttpStatus(string? message, string statusCode)

--- a/src/DownKyi.Desktop/Services/Download/BuiltinTransferBackend.cs
+++ b/src/DownKyi.Desktop/Services/Download/BuiltinTransferBackend.cs
@@ -289,9 +289,9 @@ internal sealed class BuiltinTransferBackend : ITransferBackend
     {
         if (TlsFailureClassifier.TryClassify(exception, out var tlsErrorCode))
         {
-            return DownloadTransferResult.Failed(
-                DownloadTransferFailureKind.Tls,
-                tlsErrorCode);
+            return TlsFailureClassifier.CreateTransferFailure(
+                tlsErrorCode,
+                "download.transfer.network");
         }
 
         if (FindException<HttpRequestException>(exception) is { } httpException)

--- a/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
@@ -24,7 +24,6 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
     private readonly IUiDispatcher _uiDispatcher;
     private readonly ILogger<DownloadBootstrapHostedService> _logger;
     private IDownloadRuntime? _downloadRuntime;
-    private Task? _historyLoadTask;
     private bool _disposed;
 
     public DownloadBootstrapHostedService(
@@ -55,10 +54,8 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             await _uiDispatcher.InvokeAsync(() =>
             {
                 _downloadLists.AddDownloadingRange(state.DownloadingItems);
-                _downloadLists.AddDownloadedRange(state.DownloadedItems);
             }).ConfigureAwait(false);
 
-            _historyLoadTask = LoadRemainingHistoryAsync(cancellationToken);
             _downloadRuntime = _downloadRuntimeFactory.Create();
             if (_downloadRuntime != null)
             {
@@ -87,16 +84,11 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
-        var stopTasks = new List<Task>(2);
+        var stopTasks = new List<Task>(1);
         if (_downloadRuntime != null)
         {
             _queueGateway.Detach(_downloadRuntime);
             stopTasks.Add(_downloadRuntime.StopAsync(cancellationToken));
-        }
-
-        if (_historyLoadTask != null)
-        {
-            stopTasks.Add(_historyLoadTask);
         }
 
         if (stopTasks.Count > 0)
@@ -132,43 +124,12 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
 
     private async Task<DownloadStartupState> LoadStartupStateAsync(CancellationToken cancellationToken)
     {
-        var downloadingStateTask = _projectionStore.GetDownloadingStateAsync(cancellationToken);
-        var downloadedItemsTask = _projectionStore.GetRecentDownloadedAsync(100, cancellationToken);
-
-        await Task.WhenAll(downloadingStateTask, downloadedItemsTask).ConfigureAwait(false);
-        var downloadingState = await downloadingStateTask.ConfigureAwait(false);
+        var downloadingState = await _projectionStore
+            .GetDownloadingStateAsync(cancellationToken)
+            .ConfigureAwait(false);
         return new DownloadStartupState(
             downloadingState.Tasks,
-            downloadingState.Projections,
-            await downloadedItemsTask.ConfigureAwait(false));
-    }
-
-    private async Task LoadRemainingHistoryAsync(CancellationToken cancellationToken)
-    {
-        try
-        {
-            var allItems = await _projectionStore
-                .GetDownloadedAsync(cancellationToken)
-                .ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
-            await _uiDispatcher.InvokeAsync(() =>
-            {
-                var loadedIds = _downloadLists.Downloaded
-                    .Select(item => item.DownloadBase.Id)
-                    .ToHashSet(StringComparer.Ordinal);
-                _downloadLists.AddDownloadedRange(
-                    allItems.Where(item => loadedIds.Add(item.DownloadBase.Id)));
-            }).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
-            or InvalidOperationException or SqliteException)
-        {
-            _logger.LogErrorMessage("Remaining download history load failed.", exception);
-        }
+            downloadingState.Projections);
     }
 
     private async Task QueueStartupTasksAsync(
@@ -214,6 +175,5 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
 
     private sealed record DownloadStartupState(
         IReadOnlyList<DownloadTask> UnfinishedTasks,
-        IReadOnlyList<DownloadingItem> DownloadingItems,
-        IReadOnlyList<DownloadedItem> DownloadedItems);
+        IReadOnlyList<DownloadingItem> DownloadingItems);
 }

--- a/src/DownKyi.Desktop/Services/Download/DownloadListState.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadListState.cs
@@ -44,13 +44,24 @@ internal sealed class DownloadListState
     public void AddDownloaded(DownloadedItem item)
     {
         ArgumentNullException.ThrowIfNull(item);
+        if (_downloaded.Any(existing => string.Equals(
+                existing.DownloadBase.Id,
+                item.DownloadBase.Id,
+                StringComparison.Ordinal)))
+        {
+            return;
+        }
+
         _downloaded.Add(item);
     }
 
     public void AddDownloadedRange(IEnumerable<DownloadedItem> items)
     {
         ArgumentNullException.ThrowIfNull(items);
-        _downloaded.AddRange(items);
+        var loadedIds = _downloaded
+            .Select(item => item.DownloadBase.Id)
+            .ToHashSet(StringComparer.Ordinal);
+        _downloaded.AddRange(items.Where(item => loadedIds.Add(item.DownloadBase.Id)));
     }
 
     public bool RemoveDownloaded(DownloadedItem item)

--- a/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
@@ -413,7 +413,7 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
         return durl == null ? null : CreateDurlDownloadDescriptor([durl]);
     }
 
-    private static List<string> CreateAddresses(PlayUrlDashVideo media)
+    internal static List<string> CreateAddresses(PlayUrlDashVideo media)
     {
         var addresses = new List<string>();
         if (!string.IsNullOrWhiteSpace(media.BaseAddress))
@@ -421,7 +421,8 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
             addresses.Add(media.BaseAddress);
         }
 
-        addresses.AddRange(media.BackupUrl.Where(url => !string.IsNullOrWhiteSpace(url)));
+        addresses.AddRange((media.BackupUrl ?? Array.Empty<string>())
+            .Where(url => !string.IsNullOrWhiteSpace(url)));
         return addresses;
     }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskProjectionStore.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskProjectionStore.cs
@@ -132,6 +132,18 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
         return page;
     }
 
+    public async Task<DownloadedProjectionPage> GetDownloadedProjectionPageAsync(
+        DownloadHistoryCursor? cursor,
+        int pageSize,
+        CancellationToken cancellationToken = default)
+    {
+        var page = await GetDownloadedPageAsync(cursor, pageSize, cancellationToken)
+            .ConfigureAwait(true);
+        return new DownloadedProjectionPage(
+            page.Items.Select(DownloadTaskProjectionMapper.ToDownloadedItem).ToArray(),
+            page.NextCursor);
+    }
+
     public async Task<IReadOnlyList<DownloadedItem>> GetDownloadedAsync(
         CancellationToken cancellationToken = default)
     {
@@ -139,8 +151,9 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
         DownloadHistoryCursor? cursor = null;
         do
         {
-            var page = await GetDownloadedPageAsync(cursor, 500, cancellationToken).ConfigureAwait(true);
-            items.AddRange(page.Items.Select(DownloadTaskProjectionMapper.ToDownloadedItem));
+            var page = await GetDownloadedProjectionPageAsync(cursor, 500, cancellationToken)
+                .ConfigureAwait(true);
+            items.AddRange(page.Items);
             cursor = page.NextCursor;
         }
         while (cursor != null);
@@ -270,3 +283,7 @@ internal sealed class DownloadTaskProjectionStore : IDisposable
 internal sealed record DownloadTaskProjectionStartupState(
     IReadOnlyList<DownloadTask> Tasks,
     IReadOnlyList<DownloadingItem> Projections);
+
+internal sealed record DownloadedProjectionPage(
+    IReadOnlyList<DownloadedItem> Items,
+    DownloadHistoryCursor? NextCursor);

--- a/src/DownKyi.Desktop/Services/Download/TlsFailureClassifier.cs
+++ b/src/DownKyi.Desktop/Services/Download/TlsFailureClassifier.cs
@@ -105,13 +105,18 @@ internal static class TlsFailureClassifier
             return true;
         }
 
+        if (ContainsAny(message, "certificate"))
+        {
+            errorCode = Prefix + "validation";
+            return true;
+        }
+
         if (ContainsAny(message,
                 "ssl/tls handshake",
                 "tls handshake",
                 "ssl handshake",
                 "secure connection",
-                "authentication failed",
-                "certificate"))
+                "authentication failed"))
         {
             errorCode = Prefix + "handshake";
             return true;
@@ -124,6 +129,30 @@ internal static class TlsFailureClassifier
     public static bool IsTlsErrorCode(string? errorCode)
     {
         return errorCode?.StartsWith(Prefix, StringComparison.Ordinal) == true;
+    }
+
+    public static bool IsCertificateValidationErrorCode(string? errorCode)
+    {
+        return IsTlsErrorCode(errorCode) &&
+               !string.Equals(
+                   errorCode,
+                   Prefix + "handshake",
+                   StringComparison.Ordinal);
+    }
+
+    public static DownloadTransferResult CreateTransferFailure(
+        string tlsErrorCode,
+        string transientErrorCode)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(tlsErrorCode);
+        ArgumentException.ThrowIfNullOrWhiteSpace(transientErrorCode);
+        return IsCertificateValidationErrorCode(tlsErrorCode)
+            ? DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.Tls,
+                tlsErrorCode)
+            : DownloadTransferResult.Failed(
+                DownloadTransferFailureKind.TransientNetwork,
+                transientErrorCode);
     }
 
     public static string GetResourceKey(string errorCode)

--- a/src/DownKyi.Desktop/Services/Media/ContentDownloadCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Media/ContentDownloadCoordinator.cs
@@ -4,12 +4,15 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using DownKyi.Application.Bilibili;
+using DownKyi.Application.Diagnostics;
 using DownKyi.Application.Downloads;
 using DownKyi.Core.BiliApi.Sign;
 using DownKyi.Core.BiliApi.VideoStream;
 using DownKyi.Core.Settings;
 using DownKyi.Services.Download;
 using DownKyi.Services.Video;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Services.Media;
 
@@ -86,13 +89,23 @@ internal sealed class ContentDownloadCoordinator : IContentDownloadCoordinator
 {
     private readonly IAddToDownloadServiceFactory _serviceFactory;
     private readonly IContentInfoServiceFactory _infoServiceFactory;
+    private readonly ILogger<ContentDownloadCoordinator> _logger;
 
     public ContentDownloadCoordinator(
         IAddToDownloadServiceFactory serviceFactory,
         IContentInfoServiceFactory infoServiceFactory)
+        : this(serviceFactory, infoServiceFactory, NullLogger<ContentDownloadCoordinator>.Instance)
+    {
+    }
+
+    public ContentDownloadCoordinator(
+        IAddToDownloadServiceFactory serviceFactory,
+        IContentInfoServiceFactory infoServiceFactory,
+        ILogger<ContentDownloadCoordinator> logger)
     {
         _serviceFactory = serviceFactory ?? throw new ArgumentNullException(nameof(serviceFactory));
         _infoServiceFactory = infoServiceFactory ?? throw new ArgumentNullException(nameof(infoServiceFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<int?> AddAsync(
@@ -111,26 +124,40 @@ internal sealed class ContentDownloadCoordinator : IContentDownloadCoordinator
             return 0;
         }
 
-        var addToDownloadSession = _serviceFactory.Create(ToPlayStreamType(selectedItems[0].Kind));
-        return await DownloadAddCoordinator.AddToDownloadIfDirectorySelectedAsync(
-            () => addToDownloadSession.SetDirectory(cancellationToken),
-            directory => AddItemsAsync(
-                addToDownloadSession,
-                selectedItems,
-                directory,
-                cancellationToken),
-            cancellationToken).ConfigureAwait(true);
+        _logger.LogInformationMessage($"Preparing {selectedItems.Length} item(s) for the download queue.");
+        try
+        {
+            var addToDownloadSession = _serviceFactory.Create(ToPlayStreamType(selectedItems[0].Kind));
+            var addedCount = await DownloadAddCoordinator.AddToDownloadIfDirectorySelectedAsync(
+                () => addToDownloadSession.SetDirectory(cancellationToken),
+                directory => AddItemsAsync(
+                    addToDownloadSession,
+                    selectedItems,
+                    directory,
+                    cancellationToken),
+                cancellationToken).ConfigureAwait(true);
+            _logger.LogInformationMessage(addedCount == null
+                ? "Download preparation stopped because no directory was selected."
+                : $"Download preparation completed with {addedCount.Value} queued item(s).");
+            return addedCount;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogInformationMessage("Download preparation was canceled.");
+            throw;
+        }
     }
 
     private Task<int> AddItemsAsync(
         IAddToDownloadSession addToDownloadSession,
-        IReadOnlyList<ContentDownloadItem> items,
+        ContentDownloadItem[] items,
         string directory,
         CancellationToken cancellationToken)
     {
         return Task.Run(async () =>
         {
             var addedCount = 0;
+            var processedCount = 0;
             foreach (var item in items)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -146,6 +173,8 @@ internal sealed class ContentDownloadCoordinator : IContentDownloadCoordinator
                 addedCount += await addToDownloadSession
                     .AddToDownload(directory, cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
+                processedCount++;
+                _logger.LogDebugMessage($"Prepared download item {processedCount} of {items.Length}.");
             }
 
             return addedCount;

--- a/src/DownKyi.Desktop/Themes/Styles/download-preparation-status.axaml
+++ b/src/DownKyi.Desktop/Themes/Styles/download-preparation-status.axaml
@@ -1,0 +1,28 @@
+<Styles xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:DownKyi.CustomControl">
+    <Style Selector="local|DownloadPreparationStatus">
+        <Setter Property="HorizontalAlignment" Value="Center" />
+        <Setter Property="VerticalAlignment" Value="Center" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <StackPanel
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    IsVisible="{TemplateBinding IsActive}"
+                    Orientation="{TemplateBinding Orientation}"
+                    Spacing="8">
+                    <ProgressBar Width="60" IsIndeterminate="True" />
+                    <TextBlock
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Text="{DynamicResource PreparingDownloads}" />
+                    <Button
+                        HorizontalAlignment="Center"
+                        Command="{TemplateBinding CancelCommand}"
+                        Content="{DynamicResource Cancel}" />
+                </StackPanel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+</Styles>

--- a/src/DownKyi.Desktop/ViewModels/DownloadManager/ViewDownloadFinishedViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/DownloadManager/ViewDownloadFinishedViewModel.cs
@@ -16,6 +16,7 @@ namespace DownKyi.ViewModels.DownloadManager;
 
 internal class ViewDownloadFinishedViewModel : ViewModelBase
 {
+    private readonly DownKyiAsyncCommandGate _listMutationCommandGate = new();
     public const string Tag = "PageDownloadManagerDownloadFinished";
 
     private readonly IDownloadManagerCoordinator _downloadManagerCoordinator;
@@ -126,7 +127,10 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
     private DownKyiAsyncDelegateCommand? _loadMoreCommand;
 
     public DownKyiAsyncDelegateCommand LoadMoreCommand =>
-        _loadMoreCommand ??= new DownKyiAsyncDelegateCommand(LoadNextPageAsync, _logger);
+        _loadMoreCommand ??= new DownKyiAsyncDelegateCommand(
+            LoadNextPageAsync,
+            _logger,
+            executionGate: _listMutationCommandGate);
 
     private Task LoadNextPageAsync() => LoadNextPageAsync(retryIfBusy: false);
 
@@ -176,7 +180,11 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
 
     // 清空下载完成列表事件
     private DownKyiAsyncDelegateCommand? _clearAllDownloadedCommand;
-    public DownKyiAsyncDelegateCommand ClearAllDownloadedCommand => _clearAllDownloadedCommand ??= new DownKyiAsyncDelegateCommand(ExecuteClearAllDownloadedCommand, _logger);
+    public DownKyiAsyncDelegateCommand ClearAllDownloadedCommand =>
+        _clearAllDownloadedCommand ??= new DownKyiAsyncDelegateCommand(
+            ExecuteClearAllDownloadedCommand,
+            _logger,
+            executionGate: _listMutationCommandGate);
 
     /// <summary>
     /// 清空下载完成列表事件
@@ -247,7 +255,11 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
     // 删除事件
     private DownKyiAsyncDelegateCommand<DownloadedItem>? _removeVideoCommand;
 
-    public DownKyiAsyncDelegateCommand<DownloadedItem> RemoveVideoCommand => _removeVideoCommand ??= new DownKyiAsyncDelegateCommand<DownloadedItem>(ExecuteRemoveVideoCommand, _logger);
+    public DownKyiAsyncDelegateCommand<DownloadedItem> RemoveVideoCommand =>
+        _removeVideoCommand ??= new DownKyiAsyncDelegateCommand<DownloadedItem>(
+            ExecuteRemoveVideoCommand,
+            _logger,
+            executionGate: _listMutationCommandGate);
 
     /// <summary>
     /// 删除事件

--- a/src/DownKyi.Desktop/ViewModels/DownloadManager/ViewDownloadFinishedViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/DownloadManager/ViewDownloadFinishedViewModel.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
 using DownKyi.Application.Desktop;
+using DownKyi.Application.Downloads;
 using DownKyi.Commands;
 using DownKyi.Core.Settings;
 using DownKyi.Services;
@@ -18,8 +20,15 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
 
     private readonly IDownloadManagerCoordinator _downloadManagerCoordinator;
     private readonly DownloadListState _downloadLists;
+    private readonly DownloadTaskProjectionStore _projectionStore;
     private readonly ILogger<ViewDownloadFinishedViewModel> _logger;
     private readonly ISettingsStore _settingsStore;
+    private CancellationTokenSource? _loadCancellation;
+    private DownloadHistoryCursor? _nextCursor;
+    private bool _hasMoreHistory = true;
+    private bool _isLoadingPage;
+    private bool _retryPageLoad;
+    private const int HistoryPageSize = 250;
 
     #region 页面属性申明
 
@@ -38,6 +47,7 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
     public ViewDownloadFinishedViewModel(
         IDesktopInteractionContext desktopInteractions,
         DownloadListState downloadLists,
+        DownloadTaskProjectionStore projectionStore,
         ISettingsStore settingsStore,
         IDownloadManagerCoordinator downloadManagerCoordinator,
         ILogger<ViewDownloadFinishedViewModel> logger
@@ -45,6 +55,7 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
     {
         // 初始化DownloadedList
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
+        _projectionStore = projectionStore ?? throw new ArgumentNullException(nameof(projectionStore));
         _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
         _downloadManagerCoordinator = downloadManagerCoordinator
             ?? throw new ArgumentNullException(nameof(downloadManagerCoordinator));
@@ -110,6 +121,57 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
         {
             Basic = settings.Basic with { DownloadFinishedSort = sort }
         });
+    }
+
+    private DownKyiAsyncDelegateCommand? _loadMoreCommand;
+
+    public DownKyiAsyncDelegateCommand LoadMoreCommand =>
+        _loadMoreCommand ??= new DownKyiAsyncDelegateCommand(LoadNextPageAsync, _logger);
+
+    private Task LoadNextPageAsync() => LoadNextPageAsync(retryIfBusy: false);
+
+    private Task LoadInitialPageAsync() => LoadNextPageAsync(retryIfBusy: true);
+
+    private async Task LoadNextPageAsync(bool retryIfBusy)
+    {
+        if (_isLoadingPage)
+        {
+            _retryPageLoad |= retryIfBusy;
+            return;
+        }
+
+        if (!_hasMoreHistory)
+        {
+            return;
+        }
+
+        _loadCancellation ??= new CancellationTokenSource();
+        var cancellationToken = _loadCancellation.Token;
+        _isLoadingPage = true;
+        try
+        {
+            var page = await _projectionStore
+                .GetDownloadedProjectionPageAsync(_nextCursor, HistoryPageSize, cancellationToken)
+                .ConfigureAwait(true);
+            cancellationToken.ThrowIfCancellationRequested();
+            _downloadLists.AddDownloadedRange(page.Items);
+            _nextCursor = page.NextCursor;
+            _hasMoreHistory = page.NextCursor != null;
+            _downloadLists.SortDownloaded(_settingsStore.Current.Basic.DownloadFinishedSort);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        finally
+        {
+            _isLoadingPage = false;
+            if (_retryPageLoad && _loadCancellation is { IsCancellationRequested: false })
+            {
+                _retryPageLoad = false;
+                RunFireAndForget(LoadNextPageAsync(), nameof(LoadNextPageAsync), _logger);
+            }
+        }
     }
 
     // 清空下载完成列表事件
@@ -220,6 +282,37 @@ internal class ViewDownloadFinishedViewModel : ViewModelBase
         {
             Notifications.Show(message);
         }
+    }
+
+    public override void OnNavigatedTo(AppNavigationContext navigationContext)
+    {
+        ArgumentNullException.ThrowIfNull(navigationContext);
+        base.OnNavigatedTo(navigationContext);
+        CancelAndDispose(ref _loadCancellation);
+        _loadCancellation = new CancellationTokenSource();
+        _nextCursor = null;
+        _hasMoreHistory = true;
+        _retryPageLoad = false;
+        RunFireAndForget(LoadInitialPageAsync(), nameof(LoadInitialPageAsync), _logger);
+    }
+
+    public override void OnNavigatedFrom(AppNavigationContext navigationContext)
+    {
+        CancelAndDispose(ref _loadCancellation);
+        base.OnNavigatedFrom(navigationContext);
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing && !IsDisposed)
+        {
+            _retryPageLoad = false;
+            _loadCancellation?.Cancel();
+            _loadCancellation?.Dispose();
+            _loadCancellation = null;
+        }
+
+        base.Dispose(disposing);
     }
 
     #endregion

--- a/src/DownKyi.Desktop/ViewModels/DownloadManager/ViewDownloadingViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/DownloadManager/ViewDownloadingViewModel.cs
@@ -16,6 +16,7 @@ namespace DownKyi.ViewModels.DownloadManager
 
         private readonly IDownloadManagerCoordinator _downloadManagerCoordinator;
         private readonly ILogger<ViewDownloadingViewModel> _logger;
+        private readonly DownKyiAsyncCommandGate _listMutationCommandGate = new();
 
         #region 页面属性申明
 
@@ -44,7 +45,8 @@ namespace DownKyi.ViewModels.DownloadManager
         public DownKyiAsyncDelegateCommand PauseAllDownloadingCommand =>
             _pauseAllDownloadingCommand ??= new DownKyiAsyncDelegateCommand(
                 ExecutePauseAllDownloadingCommand,
-                _logger);
+                _logger,
+                executionGate: _listMutationCommandGate);
 
         /// <summary>
         /// 暂停所有下载事件
@@ -60,7 +62,8 @@ namespace DownKyi.ViewModels.DownloadManager
         public DownKyiAsyncDelegateCommand ContinueAllDownloadingCommand =>
             _continueAllDownloadingCommand ??= new DownKyiAsyncDelegateCommand(
                 ExecuteContinueAllDownloadingCommand,
-                _logger);
+                _logger,
+                executionGate: _listMutationCommandGate);
 
         /// <summary>
         /// 继续所有下载事件
@@ -75,7 +78,8 @@ namespace DownKyi.ViewModels.DownloadManager
         public DownKyiAsyncDelegateCommand<DownloadingItem> ToggleDownloadingCommand =>
             _toggleDownloadingCommand ??= new DownKyiAsyncDelegateCommand<DownloadingItem>(
                 ExecuteToggleDownloadingCommand,
-                _logger);
+                _logger,
+                executionGate: _listMutationCommandGate);
 
         private Task ExecuteToggleDownloadingCommand(DownloadingItem? downloadingItem)
         {
@@ -87,7 +91,11 @@ namespace DownKyi.ViewModels.DownloadManager
         // 删除所有下载事件
         private DownKyiAsyncDelegateCommand? _deleteAllDownloadingCommand;
 
-        public DownKyiAsyncDelegateCommand DeleteAllDownloadingCommand => _deleteAllDownloadingCommand ??= new DownKyiAsyncDelegateCommand(ExecuteDeleteAllDownloadingCommand, _logger);
+        public DownKyiAsyncDelegateCommand DeleteAllDownloadingCommand =>
+            _deleteAllDownloadingCommand ??= new DownKyiAsyncDelegateCommand(
+                ExecuteDeleteAllDownloadingCommand,
+                _logger,
+                executionGate: _listMutationCommandGate);
 
         /// <summary>
         /// 删除所有下载事件
@@ -107,7 +115,11 @@ namespace DownKyi.ViewModels.DownloadManager
 
         // 下载列表删除事件
         private DownKyiAsyncDelegateCommand<DownloadingItem>? _deleteCommand;
-        public DownKyiAsyncDelegateCommand<DownloadingItem> DeleteCommand => _deleteCommand ??= new DownKyiAsyncDelegateCommand<DownloadingItem>(ExecuteDeleteCommand, _logger);
+        public DownKyiAsyncDelegateCommand<DownloadingItem> DeleteCommand =>
+            _deleteCommand ??= new DownKyiAsyncDelegateCommand<DownloadingItem>(
+                ExecuteDeleteCommand,
+                _logger,
+                executionGate: _listMutationCommandGate);
 
         /// <summary>
         /// 下载列表删除事件

--- a/src/DownKyi.Desktop/ViewModels/ViewMyBangumiFollowViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyBangumiFollowViewModel.cs
@@ -33,6 +33,8 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
     private CancellationTokenSource? _loadCancellation;
     private CancellationTokenSource? _downloadCancellation;
 
+    public DownKyiAsyncCommandGate DownloadCommandGate { get; } = new();
+
     private long _mid = -1;
 
     // 每页视频数量，暂时在此写死，以后在设置中增加选项
@@ -230,7 +232,10 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
     // 添加选中项到下载列表事件
     private DownKyiAsyncDelegateCommand? _addToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(true), _logger);
+    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(true),
+        _logger,
+        executionGate: DownloadCommandGate);
 
     /// <summary>
     /// 添加选中项到下载列表事件
@@ -238,7 +243,15 @@ internal partial class ViewMyBangumiFollowViewModel : ViewModelBase
     // 添加所有视频到下载列表事件
     private DownKyiAsyncDelegateCommand? _addAllToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger);
+    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(false),
+        _logger,
+        executionGate: DownloadCommandGate);
+
+    private RelayCommand? _cancelDownloadPreparationCommand;
+
+    public RelayCommand CancelDownloadPreparationCommand =>
+        _cancelDownloadPreparationCommand ??= new RelayCommand(() => _downloadCancellation?.Cancel());
 
     /// <summary>
     /// 添加所有视频到下载列表事件

--- a/src/DownKyi.Desktop/ViewModels/ViewMyFavoritesViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyFavoritesViewModel.cs
@@ -31,6 +31,8 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
     private CancellationTokenSource? _mediaLoadCancellation;
     private CancellationTokenSource? _downloadCancellation;
 
+    public DownKyiAsyncCommandGate DownloadCommandGate { get; } = new();
+
     private long _mid = -1;
 
     // 每页视频数量，暂时在此写死，以后在设置中增加选项
@@ -334,7 +336,10 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
     // 添加选中项到下载列表事件
     private DownKyiAsyncDelegateCommand? _addToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(true), _logger);
+    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(true),
+        _logger,
+        executionGate: DownloadCommandGate);
 
     /// <summary>
     /// 添加选中项到下载列表事件
@@ -342,7 +347,15 @@ internal partial class ViewMyFavoritesViewModel : ViewModelBase
     // 添加所有视频到下载列表事件
     private DownKyiAsyncDelegateCommand? _addAllToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger);
+    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(false),
+        _logger,
+        executionGate: DownloadCommandGate);
+
+    private RelayCommand? _cancelDownloadPreparationCommand;
+
+    public RelayCommand CancelDownloadPreparationCommand =>
+        _cancelDownloadPreparationCommand ??= new RelayCommand(() => _downloadCancellation?.Cancel());
 
     /// <summary>
     /// 添加所有视频到下载列表事件

--- a/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyHistoryViewModel.cs
@@ -30,6 +30,8 @@ internal class ViewMyHistoryViewModel : ViewModelBase
     private const int VideoNumberInPage = 30;
     private CancellationTokenSource? _loadCancellation;
     private CancellationTokenSource? _downloadCancellation;
+
+    public DownKyiAsyncCommandGate DownloadCommandGate { get; } = new();
     private bool _isLoadingPage;
     private bool _hasMoreHistory = true;
     private int _loadVersion;
@@ -237,7 +239,10 @@ internal class ViewMyHistoryViewModel : ViewModelBase
     private DownKyiAsyncDelegateCommand? _addToDownloadCommand;
 
     public DownKyiAsyncDelegateCommand AddToDownloadCommand =>
-        _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(true), _logger);
+        _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+            () => AddToDownloadAsync(true),
+            _logger,
+            executionGate: DownloadCommandGate);
 
     /// <summary>
     /// 添加选中项到下载列表事件
@@ -246,7 +251,15 @@ internal class ViewMyHistoryViewModel : ViewModelBase
     private DownKyiAsyncDelegateCommand? _addAllToDownloadCommand;
 
     public DownKyiAsyncDelegateCommand AddAllToDownloadCommand =>
-        _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger);
+        _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+            () => AddToDownloadAsync(false),
+            _logger,
+            executionGate: DownloadCommandGate);
+
+    private RelayCommand? _cancelDownloadPreparationCommand;
+
+    public RelayCommand CancelDownloadPreparationCommand =>
+        _cancelDownloadPreparationCommand ??= new RelayCommand(() => _downloadCancellation?.Cancel());
 
     private DownKyiAsyncDelegateCommand? _loadMoreCommand;
 

--- a/src/DownKyi.Desktop/ViewModels/ViewMyToViewVideoViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewMyToViewVideoViewModel.cs
@@ -28,6 +28,8 @@ internal class ViewMyToViewVideoViewModel : ViewModelBase
     private CancellationTokenSource? _loadCancellation;
     private CancellationTokenSource? _downloadCancellation;
 
+    public DownKyiAsyncCommandGate DownloadCommandGate { get; } = new();
+
     #region 页面属性申明
 
     private string _pageName = Tag;
@@ -227,7 +229,10 @@ internal class ViewMyToViewVideoViewModel : ViewModelBase
     // 添加选中项到下载列表事件
     private DownKyiAsyncDelegateCommand? _addToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(true), _logger);
+    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(true),
+        _logger,
+        executionGate: DownloadCommandGate);
 
     /// <summary>
     /// 添加选中项到下载列表事件
@@ -235,7 +240,15 @@ internal class ViewMyToViewVideoViewModel : ViewModelBase
     // 添加所有视频到下载列表事件
     private DownKyiAsyncDelegateCommand? _addAllToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger);
+    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(false),
+        _logger,
+        executionGate: DownloadCommandGate);
+
+    private RelayCommand? _cancelDownloadPreparationCommand;
+
+    public RelayCommand CancelDownloadPreparationCommand =>
+        _cancelDownloadPreparationCommand ??= new RelayCommand(() => _downloadCancellation?.Cancel());
 
     /// <summary>
     /// 添加所有视频到下载列表事件

--- a/src/DownKyi.Desktop/ViewModels/ViewPublicFavoritesViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewPublicFavoritesViewModel.cs
@@ -32,6 +32,8 @@ internal class ViewPublicFavoritesViewModel : ViewModelBase
     private CancellationTokenSource? _loadCancellation;
     private CancellationTokenSource? _downloadCancellation;
 
+    public DownKyiAsyncCommandGate DownloadCommandGate { get; } = new();
+
     #region 页面属性申明
 
     private string _pageName = Tag;
@@ -246,7 +248,10 @@ internal class ViewPublicFavoritesViewModel : ViewModelBase
     // 添加选中项到下载列表事件
     private DownKyiAsyncDelegateCommand? _addToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(true), _logger);
+    public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(true),
+        _logger,
+        executionGate: DownloadCommandGate);
 
     /// <summary>
     /// 添加选中项到下载列表事件
@@ -254,7 +259,15 @@ internal class ViewPublicFavoritesViewModel : ViewModelBase
     // 添加所有视频到下载列表事件
     private DownKyiAsyncDelegateCommand? _addAllToDownloadCommand;
 
-    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger);
+    public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+        () => AddToDownloadAsync(false),
+        _logger,
+        executionGate: DownloadCommandGate);
+
+    private RelayCommand? _cancelDownloadPreparationCommand;
+
+    public RelayCommand CancelDownloadPreparationCommand =>
+        _cancelDownloadPreparationCommand ??= new RelayCommand(() => _downloadCancellation?.Cancel());
 
     /// <summary>
     /// 添加所有视频到下载列表事件

--- a/src/DownKyi.Desktop/ViewModels/ViewPublicationViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewPublicationViewModel.cs
@@ -31,6 +31,8 @@ namespace DownKyi.ViewModels
         private CancellationTokenSource? _loadCancellation;
         private CancellationTokenSource? _downloadCancellation;
 
+        public DownKyiAsyncCommandGate DownloadCommandGate { get; } = new();
+
         private long _mid = -1;
 
         // 每页视频数量，暂时在此写死，以后在设置中增加选项
@@ -295,7 +297,10 @@ namespace DownKyi.ViewModels
         // 添加选中项到下载列表事件
         private DownKyiAsyncDelegateCommand? _addToDownloadCommand;
 
-        public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(true), _logger);
+        public DownKyiAsyncDelegateCommand AddToDownloadCommand => _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+            () => AddToDownloadAsync(true),
+            _logger,
+            executionGate: DownloadCommandGate);
 
         /// <summary>
         /// 添加选中项到下载列表事件
@@ -303,7 +308,15 @@ namespace DownKyi.ViewModels
         // 添加所有视频到下载列表事件
         private DownKyiAsyncDelegateCommand? _addAllToDownloadCommand;
 
-        public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger);
+        public DownKyiAsyncDelegateCommand AddAllToDownloadCommand => _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+            () => AddToDownloadAsync(false),
+            _logger,
+            executionGate: DownloadCommandGate);
+
+        private RelayCommand? _cancelDownloadPreparationCommand;
+
+        public RelayCommand CancelDownloadPreparationCommand =>
+            _cancelDownloadPreparationCommand ??= new RelayCommand(() => _downloadCancellation?.Cancel());
 
         /// <summary>
         /// 添加所有视频到下载列表事件

--- a/src/DownKyi.Desktop/ViewModels/ViewSeasonsSeriesDetailViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewSeasonsSeriesDetailViewModel.cs
@@ -35,6 +35,8 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
     private readonly ILogger<ViewSeasonsSeriesDetailViewModel> _logger;
     private CancellationTokenSource? _loadCancellation;
     private CancellationTokenSource? _downloadCancellation;
+
+    public DownKyiAsyncCommandGate DownloadCommandGate { get; } = new();
     private long _mid = -1;
     private long _id = -1;
     private SeasonsSeriesKind _kind;
@@ -201,12 +203,23 @@ internal class ViewSeasonsSeriesDetailViewModel : ViewModelBase
     private DownKyiAsyncDelegateCommand? _addToDownloadCommand;
 
     public DownKyiAsyncDelegateCommand AddToDownloadCommand =>
-        _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(true), _logger);
+        _addToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+            () => AddToDownloadAsync(true),
+            _logger,
+            executionGate: DownloadCommandGate);
 
     private DownKyiAsyncDelegateCommand? _addAllToDownloadCommand;
 
     public DownKyiAsyncDelegateCommand AddAllToDownloadCommand =>
-        _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger);
+        _addAllToDownloadCommand ??= new DownKyiAsyncDelegateCommand(
+            () => AddToDownloadAsync(false),
+            _logger,
+            executionGate: DownloadCommandGate);
+
+    private RelayCommand? _cancelDownloadPreparationCommand;
+
+    public RelayCommand CancelDownloadPreparationCommand =>
+        _cancelDownloadPreparationCommand ??= new RelayCommand(() => _downloadCancellation?.Cancel());
 
     private async Task AddToDownloadAsync(bool onlySelected)
     {

--- a/src/DownKyi.Desktop/ViewModels/ViewVideoDetailViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/ViewVideoDetailViewModel.cs
@@ -45,23 +45,23 @@ internal sealed class ViewVideoDetailViewModel : ViewModelBase
         _workflow = workflow ?? throw new ArgumentNullException(nameof(workflow));
         _downloadCoordinator = downloadCoordinator ?? throw new ArgumentNullException(nameof(downloadCoordinator));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        var operationCommandGate = new DownKyiAsyncCommandGate();
         UiState.DownloadManage = CreateDownloadManageIcon();
         BackSpaceCommand = new RelayCommand(ExecuteBackSpace);
         DownloadManagerCommand = new RelayCommand(ExecuteDownloadManagerCommand);
-        InputCommand = new DownKyiAsyncDelegateCommand(ExecuteInputCommandAsync, _logger, () => !UiState.IsBusy);
+        InputCommand = new DownKyiAsyncDelegateCommand(ExecuteInputCommandAsync, _logger, () => !UiState.IsBusy, executionGate: operationCommandGate);
         InputSearchCommand = new RelayCommand(() => _workflow.ApplySearch(UiState.InputSearchText));
         CopyCoverUrlCommand = new DownKyiAsyncDelegateCommand(ExecuteCopyCoverUrlCommandAsync, _logger);
         UpperCommand = new RelayCommand(ExecuteUpperCommand);
         SelectAllCommand = new RelayCommand(() => SetAllSelected(UiState.IsSelectAll));
         ClearSelectionCommand = new RelayCommand(() => SetAllSelected(isSelected: false));
-        ParseCommand = new DownKyiAsyncDelegateCommand<object>(ExecuteParseCommandAsync, _logger, _ => !UiState.IsBusy);
-        ParseAllVideoCommand = new DownKyiAsyncDelegateCommand(ExecuteParseAllVideoCommandAsync, _logger, () => !UiState.IsBusy);
-        AddToDownloadCommand = new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger, () => !UiState.IsBusy);
+        ParseCommand = new DownKyiAsyncDelegateCommand<object>(ExecuteParseCommandAsync, _logger, _ => !UiState.IsBusy, executionGate: operationCommandGate);
+        ParseAllVideoCommand = new DownKyiAsyncDelegateCommand(ExecuteParseAllVideoCommandAsync, _logger, () => !UiState.IsBusy, executionGate: operationCommandGate);
+        AddToDownloadCommand = new DownKyiAsyncDelegateCommand(() => AddToDownloadAsync(false), _logger, () => !UiState.IsBusy, executionGate: operationCommandGate);
         UiState.IsBusyChanged += OnIsBusyChanged;
     }
 
     public VideoDetailUiState UiState { get; } = new();
-
     public RangeObservableCollection<VideoSection> VideoSections { get; } = new();
 
     public RelayCommand BackSpaceCommand { get; }

--- a/src/DownKyi.Desktop/Views/DownloadManager/ViewDownloadFinished.axaml
+++ b/src/DownKyi.Desktop/Views/DownloadManager/ViewDownloadFinished.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="DownKyi.Views.DownloadManager.ViewDownloadFinished"
              xmlns:vmdm="clr-namespace:DownKyi.ViewModels.DownloadManager"
+             xmlns:customAction="clr-namespace:DownKyi.CustomAction"
              x:DataType="vmdm:ViewDownloadFinishedViewModel">
     <UserControl.Resources>
         <ControlTheme x:Key="DownloadedStyle" TargetType="{x:Type ListBoxItem}" x:DataType="vmdm:DownloadedItem">
@@ -152,6 +153,9 @@
                 BorderThickness="0"
                 ItemContainerTheme="{StaticResource DownloadedStyle}"
                 ItemsSource="{Binding DownloadedList}">
+                <Interaction.Behaviors>
+                    <customAction:InfiniteScrollBehavior LoadMoreCommand="{Binding LoadMoreCommand}" />
+                </Interaction.Behaviors>
                 <ListBox.ItemsPanel>
                     <ItemsPanelTemplate>
                         <VirtualizingStackPanel />

--- a/src/DownKyi.Desktop/Views/ViewMyBangumiFollow.axaml
+++ b/src/DownKyi.Desktop/Views/ViewMyBangumiFollow.axaml
@@ -292,11 +292,18 @@
                     Foreground="{DynamicResource BrushTextDark}"
                     IsChecked="{Binding IsSelectAll, Mode=TwoWay}" />
 
-                <custom:CustomPager
+                <Grid
                     Grid.Column="1"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
-                    DataContext="{Binding Pager}" />
+                    IsVisible="{Binding !DownloadCommandGate.IsExecuting}">
+                    <custom:CustomPager DataContext="{Binding Pager}" />
+                </Grid>
+
+                <custom:DownloadPreparationStatus
+                    Grid.Column="1"
+                    CancelCommand="{Binding CancelDownloadPreparationCommand}"
+                    IsActive="{Binding DownloadCommandGate.IsExecuting}" />
 
                 <Button
                     Grid.Column="2"

--- a/src/DownKyi.Desktop/Views/ViewMyFavorites.axaml
+++ b/src/DownKyi.Desktop/Views/ViewMyFavorites.axaml
@@ -311,11 +311,19 @@
                         Foreground="{DynamicResource BrushTextDark}"
                         IsChecked="{Binding IsSelectAll, Mode=TwoWay}" />
 
-                    <custom:CustomPager
+                    <Grid
                         Grid.Column="1"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        DataContext="{Binding Pager}" />
+                        IsVisible="{Binding !DownloadCommandGate.IsExecuting}">
+                        <custom:CustomPager DataContext="{Binding Pager}" />
+                    </Grid>
+
+                    <custom:DownloadPreparationStatus
+                        x:Name="DownloadPreparationStatus"
+                        Grid.Column="1"
+                        CancelCommand="{Binding CancelDownloadPreparationCommand}"
+                        IsActive="{Binding DownloadCommandGate.IsExecuting}" />
 
                     <Button
                         Grid.Column="2"

--- a/src/DownKyi.Desktop/Views/ViewMyHistory.axaml
+++ b/src/DownKyi.Desktop/Views/ViewMyHistory.axaml
@@ -311,6 +311,11 @@
                     Foreground="{DynamicResource BrushTextDark}"
                     IsChecked="{Binding IsSelectAll, Mode=TwoWay}" />
 
+                <custom:DownloadPreparationStatus
+                    Grid.Column="1"
+                    CancelCommand="{Binding CancelDownloadPreparationCommand}"
+                    IsActive="{Binding DownloadCommandGate.IsExecuting}" />
+
                 <Button
                     Grid.Column="2"
                     Margin="0,0,10,0"

--- a/src/DownKyi.Desktop/Views/ViewMyToViewVideo.axaml
+++ b/src/DownKyi.Desktop/Views/ViewMyToViewVideo.axaml
@@ -228,6 +228,11 @@
                     Foreground="{DynamicResource BrushTextDark}"
                     IsChecked="{Binding IsSelectAll, Mode=TwoWay}" />
 
+                <custom:DownloadPreparationStatus
+                    Grid.Column="1"
+                    CancelCommand="{Binding CancelDownloadPreparationCommand}"
+                    IsActive="{Binding DownloadCommandGate.IsExecuting}" />
+
                 <Button
                     Grid.Column="2"
                     Margin="0,0,10,0"

--- a/src/DownKyi.Desktop/Views/ViewPublicFavorites.axaml
+++ b/src/DownKyi.Desktop/Views/ViewPublicFavorites.axaml
@@ -263,8 +263,13 @@
                     Content="{DynamicResource AddAllToDownload}"
                     FontSize="12"
                     Foreground="{DynamicResource BrushText}" />
-            </StackPanel>
 
+                <custom:DownloadPreparationStatus
+                    Margin="0,12,0,0"
+                    CancelCommand="{Binding CancelDownloadPreparationCommand}"
+                    IsActive="{Binding DownloadCommandGate.IsExecuting}"
+                    Orientation="Vertical" />
+            </StackPanel>
 
             <!--  右侧内容区  -->
             <ListBox

--- a/src/DownKyi.Desktop/Views/ViewPublication.axaml
+++ b/src/DownKyi.Desktop/Views/ViewPublication.axaml
@@ -288,11 +288,18 @@
                         Foreground="{DynamicResource BrushTextDark}"
                         IsChecked="{Binding IsSelectAll, Mode=TwoWay}" />
 
-                    <custom:CustomPager
+                    <Grid
                         Grid.Column="1"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
-                        DataContext="{Binding Pager}" />
+                        IsVisible="{Binding !DownloadCommandGate.IsExecuting}">
+                        <custom:CustomPager DataContext="{Binding Pager}" />
+                    </Grid>
+
+                    <custom:DownloadPreparationStatus
+                        Grid.Column="1"
+                        CancelCommand="{Binding CancelDownloadPreparationCommand}"
+                        IsActive="{Binding DownloadCommandGate.IsExecuting}" />
 
                     <Button
                         Grid.Column="2"

--- a/src/DownKyi.Desktop/Views/ViewSeasonsSeriesDetail.axaml
+++ b/src/DownKyi.Desktop/Views/ViewSeasonsSeriesDetail.axaml
@@ -262,11 +262,17 @@
                     Content="{DynamicResource SelectAll}"
                     Foreground="{DynamicResource BrushTextDark}"
                     IsChecked="{Binding IsSelectAll, Mode=TwoWay}" />
-                <custom:CustomPager
+                <Grid
                     Grid.Column="1"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
-                    DataContext="{Binding Pager}" />
+                    IsVisible="{Binding !DownloadCommandGate.IsExecuting}">
+                    <custom:CustomPager DataContext="{Binding Pager}" />
+                </Grid>
+                <custom:DownloadPreparationStatus
+                    Grid.Column="1"
+                    CancelCommand="{Binding CancelDownloadPreparationCommand}"
+                    IsActive="{Binding DownloadCommandGate.IsExecuting}" />
                 <Button
                     Grid.Column="2"
                     Margin="0,0,10,0"

--- a/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
@@ -22,6 +22,23 @@ internal static class DownloadTaskSqlReader
         LEFT JOIN downloaded d ON d.id = db.id
         """;
 
+    public const string SelectUnfinishedColumns = """
+        SELECT
+            db.id, db.need_download_content, db.bvid, db.avid, db.cid, db.episode_id,
+            db.cover_url, db.page_cover_url, db.zone_id, db.[order], db.main_title,
+            db.name, db.duration, db.video_codec_name, db.resolution, db.audio_codec,
+            db.file_path, db.file_size, db.page, db.version, db.created_at_utc, db.updated_at_utc,
+            dl.gid, dl.download_files, dl.downloaded_files, dl.play_stream_type,
+            dl.download_status, dl.download_content, dl.download_status_title, dl.progress,
+            dl.downloading_file_size, dl.max_speed, dl.speed_display, dl.phase,
+            dl.failure_code, dl.failure_message, dl.failure_transient,
+            dl.downloaded_bytes, dl.total_bytes, dl.bytes_per_second,
+            d.max_speed_display, d.finished_timestamp, d.finished_time
+        FROM downloading dl
+        CROSS JOIN download_base db ON db.id = dl.id
+        LEFT JOIN downloaded d ON d.id = db.id
+        """;
+
     public static async Task<IReadOnlyList<DownloadTask>> ReadManyAsync(
         SqliteConnection connection,
         SqliteCommand command,

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -214,9 +214,8 @@ public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDispo
         await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
         using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         using var command = connection.CreateCommand();
-        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
-            WHERE dl.id IS NOT NULL
-              AND NOT EXISTS (
+        command.CommandText = DownloadTaskSqlReader.SelectUnfinishedColumns + "\n" + """
+            WHERE NOT EXISTS (
                   SELECT 1 FROM download_quarantine q
                   WHERE q.source_table = 'downloading' AND q.record_id = db.id)
             ORDER BY db.main_title COLLATE NOCASE, db.[order] ASC, db.id ASC

--- a/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
+++ b/tests/DownKyi.Desktop.Tests/UiSmokeTests.cs
@@ -139,6 +139,86 @@ public sealed class UiSmokeTests
     }
 
     [AvaloniaFact]
+    public async Task FavoritesDownloadCommandsAreMutuallyExclusiveAndCancelable()
+    {
+        await AvaloniaTestDispatcher.RunAsync(async () =>
+        {
+            DesktopTestResources.EnsureProductThemeResources();
+            var directory = Path.Combine(Path.GetTempPath(), $"downkyi-favorites-download-gate-{Guid.NewGuid():N}");
+            var settings = new SettingsStore(Path.Combine(directory, "settings.json"));
+            try
+            {
+                using var navigation = new AvaloniaNavigationService(
+                    _ => new NavigationProbe(AppRoute.MyFavorites),
+                    static action => action());
+                var downloadCoordinator = new ContentDownloadCoordinatorStub
+                {
+                    WaitForCancellation = true
+                };
+                using var favorites = new ViewMyFavoritesViewModel(
+                    new DesktopInteractionContextStub(navigation),
+                    downloadCoordinator,
+                    new FavoritesCoordinatorStub(navigation, settings),
+                    NullLogger<ViewMyFavoritesViewModel>.Instance);
+                var view = new ViewMyFavorites { DataContext = favorites };
+                var window = new Window { Content = view };
+                var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+                favorites.AddAllToDownloadCommand.CanExecuteChanged += (_, _) =>
+                {
+                    if (favorites.AddAllToDownloadCommand.CanExecute(null))
+                    {
+                        completion.TrySetResult();
+                    }
+                };
+
+                try
+                {
+                    window.Show();
+                    var status = Assert.IsType<DownKyi.CustomControl.DownloadPreparationStatus>(
+                        view.FindControl<DownKyi.CustomControl.DownloadPreparationStatus>("DownloadPreparationStatus"));
+                    Assert.False(status.IsActive);
+
+                    favorites.AddAllToDownloadCommand.Execute(null);
+                    await downloadCoordinator.Requested.Task
+                        .WaitAsync(TestContext.Current.CancellationToken)
+                        .ConfigureAwait(true);
+
+                    Assert.True(favorites.DownloadCommandGate.IsExecuting);
+                    Assert.True(status.IsActive);
+                    Assert.False(favorites.AddAllToDownloadCommand.CanExecute(null));
+                    Assert.False(favorites.AddToDownloadCommand.CanExecute(null));
+
+                    favorites.AddToDownloadCommand.Execute(null);
+                    Assert.Equal(1, downloadCoordinator.RequestCount);
+
+                    favorites.CancelDownloadPreparationCommand.Execute(null);
+                    await completion.Task
+                        .WaitAsync(TestContext.Current.CancellationToken)
+                        .ConfigureAwait(true);
+
+                    Assert.False(favorites.DownloadCommandGate.IsExecuting);
+                    Assert.False(status.IsActive);
+                    Assert.True(favorites.AddAllToDownloadCommand.CanExecute(null));
+                    Assert.True(favorites.AddToDownloadCommand.CanExecute(null));
+                }
+                finally
+                {
+                    window.Close();
+                }
+            }
+            finally
+            {
+                await settings.DisposeAsync().ConfigureAwait(true);
+            }
+
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }).ConfigureAwait(true);
+    }
+
+    [AvaloniaFact]
     public Task PublicFavoritesBackArrowRemainsVisibleInLightAndDarkThemes()
     {
         return AvaloniaTestDispatcher.RunAsync(() =>
@@ -827,13 +907,27 @@ public sealed class UiSmokeTests
 
     private sealed class ContentDownloadCoordinatorStub : IContentDownloadCoordinator
     {
-        public Task<int?> AddAsync(
+        public bool WaitForCancellation { get; init; }
+
+        public int RequestCount { get; private set; }
+
+        public TaskCompletionSource Requested { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<int?> AddAsync(
             IReadOnlyList<ContentDownloadItem> items,
             bool onlySelected,
             CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            return Task.FromResult<int?>(0);
+            RequestCount++;
+            Requested.TrySetResult();
+            if (WaitForCancellation)
+            {
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(true);
+            }
+
+            return 0;
         }
     }
 

--- a/tests/DownKyi.Desktop.Tests/VideoDetailCommandStateTests.cs
+++ b/tests/DownKyi.Desktop.Tests/VideoDetailCommandStateTests.cs
@@ -169,6 +169,53 @@ public sealed class VideoDetailCommandStateTests
     }
 
     [Avalonia.Headless.XUnit.AvaloniaFact]
+    public async Task DownloadPreparationDisablesEveryCompetingWorkflowCommand()
+    {
+        DesktopTestResources.EnsureProductThemeResources();
+        var settingsPath = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-video-detail-download-gate-{Guid.NewGuid():N}.json");
+        using var settings = new SettingsStore(settingsPath);
+        using var workflow = new VideoDetailWorkflowCoordinatorStub();
+        var downloadCoordinator = new VideoDetailDownloadCoordinatorStub
+        {
+            WaitForRelease = true
+        };
+        using var viewModel = new ViewVideoDetailViewModel(
+            new DesktopInteractionContextStub(),
+            new ClipboardServiceStub(),
+            settings,
+            workflow,
+            downloadCoordinator,
+            NullLogger<ViewVideoDetailViewModel>.Instance);
+        viewModel.UiState.VideoInfoView = new DownKyi.Presentation.VideoInfoView();
+        viewModel.UiState.DisplayState = VideoDetailDisplayState.Content;
+        var completion = WaitUntilExecutableAfterDisabled(viewModel.AddToDownloadCommand);
+
+        viewModel.AddToDownloadCommand.Execute(null);
+        await downloadCoordinator.AddRequested.Task
+            .WaitAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.False(viewModel.InputCommand.CanExecute(null));
+        Assert.False(viewModel.ParseCommand.CanExecute(null));
+        Assert.False(viewModel.ParseAllVideoCommand.CanExecute(null));
+        Assert.False(viewModel.AddToDownloadCommand.CanExecute(null));
+        Assert.Equal(1, workflow.OperationStartCount);
+
+        viewModel.ParseAllVideoCommand.Execute(null);
+        Assert.Equal(1, workflow.OperationStartCount);
+
+        downloadCoordinator.ReleaseAdd();
+        await completion.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(viewModel.InputCommand.CanExecute(null));
+        Assert.True(viewModel.ParseCommand.CanExecute(null));
+        Assert.True(viewModel.ParseAllVideoCommand.CanExecute(null));
+        Assert.True(viewModel.AddToDownloadCommand.CanExecute(null));
+    }
+
+    [Avalonia.Headless.XUnit.AvaloniaFact]
     public async Task AutoParseCompletionReEnablesSelectedDownload()
     {
         DesktopTestResources.EnsureProductThemeResources();
@@ -352,6 +399,8 @@ public sealed class VideoDetailCommandStateTests
         public TaskCompletionSource PageStreamsStarted { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
+        public int OperationStartCount => Volatile.Read(ref _version);
+
         public VideoDetailOperation StartOperation()
         {
             return new VideoDetailOperation(Interlocked.Increment(ref _version), CancellationToken.None);
@@ -420,14 +469,19 @@ public sealed class VideoDetailCommandStateTests
 
     private sealed class VideoDetailDownloadCoordinatorStub : IVideoDetailDownloadCoordinator
     {
+        private readonly TaskCompletionSource _releaseAdd =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
         public TaskCompletionSource AddRequested { get; } =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public bool WaitForRelease { get; init; }
 
         public bool LastIsAll { get; private set; }
 
         public DownKyi.Presentation.VideoInfoView? LastVideoInfo { get; private set; }
 
-        public Task<int?> AddAsync(
+        public async Task<int?> AddAsync(
             string input,
             DownKyi.Presentation.VideoInfoView videoInfoView,
             IList<DownKyi.Presentation.VideoSection> videoSections,
@@ -438,7 +492,17 @@ public sealed class VideoDetailCommandStateTests
             LastIsAll = isAll;
             LastVideoInfo = videoInfoView;
             AddRequested.TrySetResult();
-            return Task.FromResult<int?>(1);
+            if (WaitForRelease)
+            {
+                await _releaseAdd.Task.WaitAsync(cancellationToken).ConfigureAwait(true);
+            }
+
+            return 1;
+        }
+
+        public void ReleaseAdd()
+        {
+            _releaseAdd.TrySetResult();
         }
     }
 

--- a/tests/DownKyi.Tests/AsyncDelegateCommandTests.cs
+++ b/tests/DownKyi.Tests/AsyncDelegateCommandTests.cs
@@ -112,6 +112,51 @@ public sealed class AsyncDelegateCommandTests
         Assert.Equal(1, Volatile.Read(ref executionCount));
     }
 
+    [Fact]
+    public async Task SharedGateDisablesSiblingCommandAndRejectsOverlappingExecution()
+    {
+        var gate = new DownKyiAsyncCommandGate();
+        var firstStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseFirst = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var firstExecutionCount = 0;
+        var secondExecutionCount = 0;
+        var first = new DownKyiAsyncDelegateCommand(
+            async () =>
+            {
+                Interlocked.Increment(ref firstExecutionCount);
+                firstStarted.TrySetResult();
+                await releaseFirst.Task.ConfigureAwait(true);
+            },
+            new RecordingLogger(),
+            executionGate: gate);
+        var second = new DownKyiAsyncDelegateCommand(
+            () =>
+            {
+                Interlocked.Increment(ref secondExecutionCount);
+                return Task.CompletedTask;
+            },
+            new RecordingLogger(),
+            executionGate: gate);
+        var firstCompletion = ObserveCompletion(first);
+
+        first.Execute(null);
+        await firstStarted.Task.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.True(gate.IsExecuting);
+        Assert.False(first.CanExecute(null));
+        Assert.False(second.CanExecute(null));
+        second.Execute(null);
+        Assert.Equal(0, Volatile.Read(ref secondExecutionCount));
+
+        releaseFirst.TrySetResult();
+        await firstCompletion.WaitAsync(TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.False(gate.IsExecuting);
+        Assert.True(first.CanExecute(null));
+        Assert.True(second.CanExecute(null));
+        Assert.Equal(1, Volatile.Read(ref firstExecutionCount));
+    }
+
     private static Task ObserveCompletion(DownKyiAsyncDelegateCommand command)
     {
         var completion = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -20,7 +20,8 @@ public sealed class DownloadBootstrapHostedServiceTests
         var dispatcher = new ImmediateUiDispatcher();
         var listState = new DownloadListState();
         var clock = new FixedClock();
-        using var tasks = new DownloadTaskApplicationService(new EmptyDownloadTaskStore(), clock);
+        var taskStore = new EmptyDownloadTaskStore();
+        using var tasks = new DownloadTaskApplicationService(taskStore, clock);
         using var storage = new DownloadTaskProjectionStore(tasks, clock);
         var stateWriter = new DownloadTaskStateWriter(tasks);
         var queueGateway = new DownloadTaskQueueGateway();
@@ -38,7 +39,8 @@ public sealed class DownloadBootstrapHostedServiceTests
 
         Assert.True(runtime.Started);
         Assert.True(runtime.Ended);
-        Assert.True(dispatcher.InvocationCount >= 2);
+        Assert.Equal(1, dispatcher.InvocationCount);
+        Assert.Equal(0, taskStore.HistoryPageCallCount);
         Assert.Empty(listState.Downloading);
         Assert.Empty(listState.Downloaded);
     }
@@ -312,6 +314,8 @@ public sealed class DownloadBootstrapHostedServiceTests
     private sealed class EmptyDownloadTaskStore(
         IReadOnlyList<DownloadTask>? unfinished = null) : IDownloadTaskStore
     {
+        public int HistoryPageCallCount { get; private set; }
+
         public Task InitializeAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
@@ -357,6 +361,7 @@ public sealed class DownloadBootstrapHostedServiceTests
             int pageSize,
             CancellationToken cancellationToken)
         {
+            HistoryPageCallCount++;
             return Task.FromResult(new DownloadHistoryPage(Array.Empty<DownloadTask>(), null));
         }
 

--- a/tests/DownKyi.Tests/DownloadListStateTests.cs
+++ b/tests/DownKyi.Tests/DownloadListStateTests.cs
@@ -50,6 +50,20 @@ public sealed class DownloadListStateTests
     }
 
     [Fact]
+    public void AddDownloadedRangeDoesNotDuplicateItemsAcrossPages()
+    {
+        var state = new DownloadListState();
+        var first = CreateDownloadedItem("A", order: 1, finishedTimestamp: 10);
+        var duplicate = CreateDownloadedItem("A", order: 1, finishedTimestamp: 10);
+        var second = CreateDownloadedItem("B", order: 2, finishedTimestamp: 20);
+
+        state.AddDownloadedRange([first]);
+        state.AddDownloadedRange([duplicate, second]);
+
+        Assert.Equal([first, second], state.Downloaded);
+    }
+
+    [Fact]
     public void ExposedCollectionsRejectExternalMutation()
     {
         var state = new DownloadListState();

--- a/tests/DownKyi.Tests/DownloadPipelineStageTests.cs
+++ b/tests/DownKyi.Tests/DownloadPipelineStageTests.cs
@@ -11,6 +11,20 @@ namespace DownKyi.Tests;
 public sealed class DownloadPipelineStageTests
 {
     [Fact]
+    public void CreateAddressesTreatsExplicitNullBackupUrlsAsEmpty()
+    {
+        var media = new PlayUrlDashVideo
+        {
+            BaseAddress = "https://example.test/media.m4s",
+            BackupUrl = null!
+        };
+
+        var addresses = DownloadMediaStage.CreateAddresses(media);
+
+        Assert.Equal(["https://example.test/media.m4s"], addresses);
+    }
+
+    [Fact]
     public async Task StageSequenceStopsAtFirstFailureAndPreservesOrder()
     {
         using var settings = new TestSettingsStore();

--- a/tests/DownKyi.Tests/DownloadRetryPolicyTests.cs
+++ b/tests/DownKyi.Tests/DownloadRetryPolicyTests.cs
@@ -538,6 +538,22 @@ public sealed class DownloadRetryPolicyTests
         Assert.Equal(DownloadTransferFailureKind.TransientNetwork, result.FailureKind);
     }
 
+    [Fact]
+    public void BuiltinBackendClassifiesCertificateFreeSecureConnectionFailureAsTransient()
+    {
+        var exception = new HttpRequestException(
+            HttpRequestError.SecureConnectionError,
+            "The SSL connection could not be established.",
+            new IOException("The remote endpoint closed the transport stream."));
+
+        var result = BuiltinTransferBackend.ClassifyFailure(
+            exception,
+            reportedCanceled: false);
+
+        Assert.Equal(DownloadTransferFailureKind.TransientNetwork, result.FailureKind);
+        Assert.Equal("download.transfer.network", result.ErrorCode);
+    }
+
     [Theory]
     [MemberData(nameof(TransientDownloaderFailures))]
     public void BuiltinBackendClassifiesDownloaderTransportFailuresAsTransient(
@@ -586,13 +602,56 @@ public sealed class DownloadRetryPolicyTests
         Assert.Equal("download.transfer.tls.untrusted", result.ErrorCode);
     }
 
+    [Fact]
+    public void AriaAddressProbeClassifiesCertificateFreeHandshakeFailureAsTransient()
+    {
+        var exception = new HttpRequestException(
+            HttpRequestError.SecureConnectionError,
+            "The SSL connection could not be established.",
+            new IOException("The remote endpoint closed the transport stream."));
+
+        var result = Aria2TransferBackend.ClassifyHttpTransportFailure(
+            exception,
+            "download.transfer.network");
+
+        Assert.Equal(DownloadTransferFailureKind.TransientNetwork, result.FailureKind);
+        Assert.Equal("download.transfer.network", result.ErrorCode);
+    }
+
+    [Fact]
+    public void AriaAddressProbeKeepsExplicitCertificateFailureFailClosed()
+    {
+        var exception = new HttpRequestException(
+            HttpRequestError.SecureConnectionError,
+            "The SSL connection could not be established.",
+            new AuthenticationException(
+                "The remote certificate is invalid because the certificate chain is untrusted."));
+
+        var result = Aria2TransferBackend.ClassifyHttpTransportFailure(
+            exception,
+            "download.transfer.network");
+
+        Assert.Equal(DownloadTransferFailureKind.Tls, result.FailureKind);
+        Assert.Equal("download.transfer.tls.untrusted", result.ErrorCode);
+    }
+
+    [Fact]
+    public void AriaAddressProbeDiagnosticHostExcludesSensitiveUrlComponents()
+    {
+        var host = Aria2TransferBackend.GetSafeHost(
+            "https://cdn.example/media?token=private#fragment");
+
+        Assert.Equal("cdn.example", host);
+        Assert.DoesNotContain("private", host, StringComparison.Ordinal);
+    }
+
     [Theory]
     [InlineData("SSL/TLS handshake failure: unknown CA", "download.transfer.tls.untrusted")]
     [InlineData("certificate has expired", "download.transfer.tls.expired")]
     [InlineData("certificate is not yet valid", "download.transfer.tls.not-yet-valid")]
     [InlineData("certificate hostname does not match", "download.transfer.tls.hostname")]
     [InlineData("certificate chain building failed", "download.transfer.tls.chain")]
-    [InlineData("SSL/TLS handshake failure", "download.transfer.tls.handshake")]
+    [InlineData("remote certificate is invalid", "download.transfer.tls.validation")]
     [InlineData("SSL/TLS handshake failure (80090325)", "download.transfer.tls.untrusted")]
     [InlineData("SSL/TLS handshake failure (80090322)", "download.transfer.tls.hostname")]
     public void AriaBackendClassifiesTlsFailuresWithoutExposingRawMessages(
@@ -604,6 +663,17 @@ public sealed class DownloadRetryPolicyTests
         Assert.Equal(DownloadTransferFailureKind.Tls, result.FailureKind);
         Assert.Equal(expectedCode, result.ErrorCode);
         Assert.DoesNotContain(errorMessage, result.ErrorCode, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AriaBackendClassifiesCertificateFreeHandshakeFailureAsTransient()
+    {
+        var result = Aria2TransferFailureClassifier.Classify(
+            "1",
+            "SSL/TLS handshake failure");
+
+        Assert.Equal(DownloadTransferFailureKind.TransientNetwork, result.FailureKind);
+        Assert.Equal("download.transfer.aria2-1", result.ErrorCode);
     }
 
     [Theory]

--- a/tests/DownKyi.Tests/ImageSourceUriResolverTests.cs
+++ b/tests/DownKyi.Tests/ImageSourceUriResolverTests.cs
@@ -21,7 +21,9 @@ public sealed class ImageSourceUriResolverTests
         using var loader = new BaseWebImageLoader(httpClient, false);
 
         var bitmap = await loader
-            .ProvideImageAsync("//i0.hdslb.com/bfs/archive/cover.jpg")
+            .ProvideImageAsync(
+                "//i0.hdslb.com/bfs/archive/cover.jpg",
+                TestContext.Current.CancellationToken)
             .WaitAsync(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken);
 
         Assert.Null(bitmap);
@@ -35,10 +37,52 @@ public sealed class ImageSourceUriResolverTests
         using var httpClient = new HttpClient(handler, false);
         using var loader = new BaseWebImageLoader(httpClient, false);
 
-        var bitmap = await loader.ProvideImageAsync("images/missing-cover.png");
+        var bitmap = await loader.ProvideImageAsync(
+            "images/missing-cover.png",
+            TestContext.Current.CancellationToken);
 
         Assert.Null(bitmap);
         Assert.Null(handler.RequestUri);
+    }
+
+    [Fact]
+    public async Task ConcurrentRequestsForSameImageShareOneHttpTransfer()
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler, false);
+        using var loader = new BaseWebImageLoader(httpClient, false);
+
+        var first = loader.ProvideImageAsync(
+            "https://i0.hdslb.com/shared.jpg",
+            TestContext.Current.CancellationToken);
+        await handler.RequestStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        var second = loader.ProvideImageAsync(
+            "https://i0.hdslb.com/shared.jpg",
+            TestContext.Current.CancellationToken);
+
+        handler.Complete.TrySetResult();
+        await Task.WhenAll(first, second).WaitAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task CancelingLastWaiterCancelsUnderlyingImageTransfer()
+    {
+        using var handler = new BlockingHandler();
+        using var httpClient = new HttpClient(handler, false);
+        using var loader = new BaseWebImageLoader(httpClient, false);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            TestContext.Current.CancellationToken);
+
+        var load = loader.ProvideImageAsync(
+            "https://i0.hdslb.com/canceled.jpg",
+            cancellation.Token);
+        await handler.RequestStarted.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await cancellation.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => load);
+        await handler.RequestCanceled.Task.WaitAsync(TestContext.Current.CancellationToken);
     }
 
     private sealed class CapturingHandler : HttpMessageHandler
@@ -51,6 +95,40 @@ public sealed class ImageSourceUriResolverTests
         {
             RequestUri = request.RequestUri;
             return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound));
+        }
+    }
+
+    private sealed class BlockingHandler : HttpMessageHandler
+    {
+        private int _requestCount;
+
+        public TaskCompletionSource RequestStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Complete { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource RequestCanceled { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int RequestCount => Volatile.Read(ref _requestCount);
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref _requestCount);
+            RequestStarted.TrySetResult();
+            try
+            {
+                await Complete.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                return new HttpResponseMessage(HttpStatusCode.NotFound);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                RequestCanceled.TrySetResult();
+                throw;
+            }
         }
     }
 }


### PR DESCRIPTION
## Why

Application startup queried and projected the entire completed-download history. A real portable database with about 161,000 completed rows consequently delayed host startup, even though only unfinished downloads are needed to resume work. Opening list-heavy pages also launched duplicate, uncancellable image requests, so slow CDN responses kept stale work alive and made covers appear progressively over several seconds.

Long-running batch download preparation disabled only the clicked button and provided no progress or cancellation affordance. Related commands remained enabled, allowing a second click to silently cancel or overlap the active operation. TLS transport failures also needed a more precise boundary: certificate validation errors must remain fail-closed, while certificate-free handshake interruptions should remain retryable network failures instead of being reported as permanent certificate failures.

The DASH response model also permits `backup_url: null`; treating it as an always-present collection caused an avoidable exception while preparing media addresses.

## What Changed

- Restore only unfinished downloads during host startup and use a query rooted at `downloading`, avoiding a full completed-history scan.
- Load completed history on demand in 250-item pages through the existing infinite-scroll behavior, with navigation cancellation and duplicate-ID filtering.
- Add cancellation to asynchronous image loading, coalesce concurrent requests for the same URL, cap global image network concurrency, and dispose stale bitmap results deterministically.
- Distinguish explicit certificate validation failures from transient secure-connection interruptions across the built-in and aria2 transfer backends while keeping diagnostic URLs redacted.
- Add a shared async command gate for related UI operations. Batch download buttons now disable together, show an in-progress state, expose explicit cancellation, and recover consistently after success, failure, or cancellation.
- Apply the same mutual-exclusion rule to video-detail parsing/download actions and download-manager list mutations.
- Add batch-preparation lifecycle logging and treat a null DASH backup URL collection as empty.
- Add regression coverage for startup hydration, image request sharing and cancellation, TLS classification, command state, and UI feedback.

## Verification

- The startup regression verifies that bootstrap restores unfinished tasks without querying completed history.
- The unfinished-download query plan was checked against a database containing 161,146 completed rows; SQLite starts from `downloading` and performs keyed `download_base` lookups instead of scanning completed history.
- Image-loader regressions verify that concurrent requests for one URL share a single HTTP transfer and canceling the last waiter cancels the underlying transfer.
- Targeted UI tests verify sibling commands stay disabled during batch preparation, a second action is rejected, cancellation restores both actions, and the progress control follows command state.
- Targeted transfer tests verify certificate validation remains fail-closed while certificate-free handshake interruptions remain retryable.
- Strict Release build completed with zero warnings and zero errors on the rebased head.
- Review invariant gate passed 326 tests and its adversarial mutation proof; all 8 Windows-selected test projects passed.
