### PR TITLE
[197-R2.1b] Add process-supervision contracts and proof

### DIFF
--- a/DownKyi.sln
+++ b/DownKyi.sln
@@ -64,6 +64,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DownKyi.Windows.Tests", "te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DownKyi.Linux.Tests", "tests\DownKyi.Linux.Tests\DownKyi.Linux.Tests.csproj", "{AE63391B-6A4B-4FB3-9452-FE2C3D505FD8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DownKyi.ProcessSupervision", "tools\DownKyi.ProcessSupervision\DownKyi.ProcessSupervision.csproj", "{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -326,6 +328,18 @@ Global
 		{AE63391B-6A4B-4FB3-9452-FE2C3D505FD8}.Release|x64.Build.0 = Release|Any CPU
 		{AE63391B-6A4B-4FB3-9452-FE2C3D505FD8}.Release|x86.ActiveCfg = Release|Any CPU
 		{AE63391B-6A4B-4FB3-9452-FE2C3D505FD8}.Release|x86.Build.0 = Release|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Debug|x64.Build.0 = Debug|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Debug|x86.Build.0 = Debug|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Release|x64.ActiveCfg = Release|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Release|x64.Build.0 = Release|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Release|x86.ActiveCfg = Release|Any CPU
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -350,5 +364,6 @@ Global
 		{55B2C90F-9EF8-40BE-9156-EF7384B2601B} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{D1F36CA9-2EF9-433F-8AA6-0D89077B2458} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 		{AE63391B-6A4B-4FB3-9452-FE2C3D505FD8} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
+		{5A7D758A-BFD0-4E55-A037-9C63DC5A7751} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
 	EndGlobalSection
 EndGlobal

--- a/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
+++ b/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
@@ -20,4 +20,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\tools\DownKyi.ProcessSupervision\DownKyi.ProcessSupervision.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
@@ -1,0 +1,165 @@
+using System.Reflection;
+using System.Xml.Linq;
+using DownKyi.ProcessSupervision;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class ProcessSupervisionContractArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    public void ContractProjectIsAnInactiveDependencyFreeLibrary()
+    {
+        var projectPath = Path.Combine(
+            RepositoryRoot,
+            "tools",
+            "DownKyi.ProcessSupervision",
+            "DownKyi.ProcessSupervision.csproj");
+        var project = XDocument.Load(projectPath);
+
+        Assert.DoesNotContain(
+            project.Descendants("OutputType"),
+            element => string.Equals(
+                element.Value,
+                "Exe",
+                StringComparison.OrdinalIgnoreCase));
+        Assert.Empty(project.Descendants("PackageReference"));
+        Assert.Empty(project.Descendants("ProjectReference"));
+
+        var source = string.Join(
+            Environment.NewLine,
+            Directory.EnumerateFiles(
+                    Path.GetDirectoryName(projectPath)!,
+                    "*.cs",
+                    SearchOption.TopDirectoryOnly)
+                .Select(File.ReadAllText));
+        string[] forbiddenCapabilities =
+        [
+            "System.Diagnostics.Process",
+            "System.IO.Pipes",
+            "System.Runtime.InteropServices",
+            "OwnedProcessLease",
+            "ProcessStartInfo"
+        ];
+        foreach (var forbidden in forbiddenCapabilities)
+        {
+            Assert.DoesNotContain(forbidden, source, StringComparison.Ordinal);
+        }
+
+        var activeExecutionScripts = Directory.EnumerateFiles(
+                Path.Combine(RepositoryRoot, "script", "assembly-lifecycle"),
+                "*.ps1",
+                SearchOption.TopDirectoryOnly)
+            .Concat(
+            [
+                Path.Combine(
+                    RepositoryRoot,
+                    "script",
+                    "test-assembly-lifecycle.ps1"),
+                Path.Combine(
+                    RepositoryRoot,
+                    "script",
+                    "test-project-runner.ps1"),
+                Path.Combine(
+                    RepositoryRoot,
+                    "script",
+                    "audit-lifecycle-ownership.ps1")
+            ]);
+        foreach (var script in activeExecutionScripts)
+        {
+            Assert.DoesNotContain(
+                "DownKyi.ProcessSupervision",
+                File.ReadAllText(script),
+                StringComparison.Ordinal);
+        }
+
+        var supervisionProjectPath = Path.GetFullPath(projectPath);
+        var productionReferences = Directory.EnumerateFiles(
+                RepositoryRoot,
+                "*.csproj",
+                SearchOption.AllDirectories)
+            .Where(path => !IsUnderDirectory(path, "tests"))
+            .Where(path => !IsUnderDirectory(path, "benchmarks"))
+            .Where(path => !IsUnderDirectory(path, "bin"))
+            .Where(path => !IsUnderDirectory(path, "obj"))
+            .SelectMany(path => XDocument.Load(path)
+                .Descendants("ProjectReference")
+                .Select(reference => (string?)reference.Attribute("Include"))
+                .Where(reference => !string.IsNullOrWhiteSpace(reference))
+                .Select(reference => new
+                {
+                    Project = Path.GetRelativePath(RepositoryRoot, path),
+                    Reference = Path.GetFullPath(Path.Combine(
+                        Path.GetDirectoryName(path)!,
+                        reference!))
+                }))
+            .Where(reference => string.Equals(
+                reference.Reference,
+                supervisionProjectPath,
+                StringComparison.OrdinalIgnoreCase))
+            .Select(reference => reference.Project)
+            .ToArray();
+        Assert.Empty(productionReferences);
+    }
+
+    [Fact]
+    public void PublicProofAndOutcomeValuesCannotBeConstructedOrMutatedByCallers()
+    {
+        Type[] ownerCreatedTypes =
+        [
+            typeof(TransitionDeadline),
+            typeof(ProcessInvariantEvidence),
+            typeof(ProcessInvariantResult),
+            typeof(ProcessSupervisionProof),
+            typeof(ProcessPrimaryFailure),
+            typeof(ProcessCleanupFailure),
+            typeof(ProcessTerminalCandidate),
+            typeof(ProcessSupervisionOutcome)
+        ];
+
+        foreach (var type in ownerCreatedTypes)
+        {
+            Assert.Empty(type.GetConstructors());
+            Assert.All(
+                type.GetProperties(BindingFlags.Instance | BindingFlags.Public),
+                property => Assert.True(
+                    property.SetMethod is null || !property.SetMethod.IsPublic,
+                    $"{type.Name}.{property.Name} exposes a public setter."));
+        }
+    }
+
+    [Fact]
+    public void PrimaryTaxonomyCannotRepresentCleanupOrDisposeAsTerminal()
+    {
+        var terminalNames = Enum.GetNames<ProcessTerminalCandidateKind>();
+        Assert.DoesNotContain(terminalNames, name =>
+            name.Contains("Cleanup", StringComparison.Ordinal) ||
+            name.Contains("Dispose", StringComparison.Ordinal) ||
+            name.Contains("ResourceRelease", StringComparison.Ordinal));
+        Assert.Contains(
+            ProcessCleanupFailureKind.ResourceReleaseFailure,
+            Enum.GetValues<ProcessCleanupFailureKind>());
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null &&
+               !File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+               ?? throw new DirectoryNotFoundException(
+                   "Could not locate the DownKyi repository root.");
+    }
+
+    private static bool IsUnderDirectory(string path, string directoryName)
+    {
+        var marker = Path.DirectorySeparatorChar + directoryName +
+                     Path.DirectorySeparatorChar;
+        return path.Contains(marker, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractBehaviorTests.cs
@@ -1,0 +1,278 @@
+using DownKyi.ProcessSupervision;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class ProcessSupervisionContractBehaviorTests
+{
+    [Fact]
+    public void UnknownAndViolatedRequiredInvariantsFailClosed()
+    {
+        var unknownBuilder = ProveAllExcept(RequiredProcessInvariantKind.StreamDrain);
+        var unknown = unknownBuilder.Build();
+
+        var unknownStreamDrain = Assert.Single(
+            unknown.Invariants,
+            result => result.Kind == RequiredProcessInvariantKind.StreamDrain);
+        Assert.Equal(ProcessInvariantState.Unknown, unknownStreamDrain.State);
+        Assert.Empty(unknownStreamDrain.Evidence);
+        Assert.False(unknown.FormalGatePassed);
+
+        var violatedBuilder = ProveAll();
+        violatedBuilder.Violate(
+            RequiredProcessInvariantKind.TreeQuiescence,
+            "descendant membership remained");
+        violatedBuilder.Prove(
+            RequiredProcessInvariantKind.TreeQuiescence,
+            "late callback attempted to overwrite the violation");
+        var violated = violatedBuilder.Build();
+
+        var tree = Assert.Single(
+            violated.Invariants,
+            result => result.Kind == RequiredProcessInvariantKind.TreeQuiescence);
+        Assert.Equal(ProcessInvariantState.Violated, tree.State);
+        Assert.All(tree.Evidence, evidence =>
+            Assert.Equal(ProcessInvariantState.Violated, evidence.State));
+        Assert.False(violated.FormalGatePassed);
+    }
+
+    [Fact]
+    public void ProofAlwaysContainsEveryRequiredInvariantAndRejectsOmission()
+    {
+        var proof = new ProcessProofBuilder().Build();
+
+        Assert.Equal(
+            Enum.GetValues<RequiredProcessInvariantKind>(),
+            proof.Invariants.Select(result => result.Kind));
+        Assert.All(proof.Invariants, result =>
+            Assert.Equal(ProcessInvariantState.Unknown, result.State));
+        Assert.False(proof.FormalGatePassed);
+
+        Assert.Throws<ArgumentException>(() => new ProcessSupervisionProof(
+            proof.Invariants.Where(result =>
+                result.Kind != RequiredProcessInvariantKind.OwnershipLifetime)));
+    }
+
+    [Fact]
+    public void ProofSnapshotCannotBeChangedByLaterBuilderTransitions()
+    {
+        var builder = ProveAllExcept(RequiredProcessInvariantKind.StreamDrain);
+        var before = builder.Build();
+
+        builder.Prove(
+            RequiredProcessInvariantKind.StreamDrain,
+            "both streams reached EOF");
+        var after = builder.Build();
+
+        Assert.False(before.FormalGatePassed);
+        Assert.True(after.FormalGatePassed);
+        Assert.Equal(
+            ProcessInvariantState.Unknown,
+            Assert.Single(before.Invariants, result =>
+                result.Kind == RequiredProcessInvariantKind.StreamDrain).State);
+    }
+
+    [Fact]
+    public void ProvenResultRejectsAnyViolatedEvidence()
+    {
+        var kind = RequiredProcessInvariantKind.OperationBudget;
+        var proven = new ProcessInvariantEvidence(
+            kind,
+            ProcessInvariantState.Proven,
+            "one monotonic authority retained");
+        var violated = new ProcessInvariantEvidence(
+            kind,
+            ProcessInvariantState.Violated,
+            "independent deadline observed");
+
+        Assert.Throws<ArgumentException>(() => new ProcessInvariantResult(
+            kind,
+            ProcessInvariantState.Proven,
+            [proven, violated]));
+    }
+
+    [Fact]
+    public void TransitionBudgetDerivesBothDeadlinesFromOneMonotonicAuthority()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        var budget = TransitionBudget.StartForTesting(
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(5),
+            clock);
+
+        Assert.Same(budget, budget.Operation.Authority);
+        Assert.Same(budget, budget.Cleanup.Authority);
+        Assert.Equal(TimeSpan.FromSeconds(10), budget.Operation.Limit);
+        Assert.Equal(TimeSpan.FromSeconds(15), budget.Cleanup.Limit);
+
+        clock.Advance(TimeSpan.FromSeconds(4));
+
+        Assert.Equal(TimeSpan.FromSeconds(6), budget.Operation.Remaining);
+        Assert.Equal(TimeSpan.FromSeconds(11), budget.Cleanup.Remaining);
+        Assert.False(budget.Operation.IsExpired);
+        Assert.False(budget.Cleanup.IsExpired);
+
+        clock.Advance(TimeSpan.FromSeconds(6));
+
+        Assert.True(budget.Operation.IsExpired);
+        Assert.Equal(TimeSpan.FromSeconds(5), budget.Cleanup.Remaining);
+    }
+
+    [Fact]
+    public void SameAuthorityUsesAuthoritativeSequenceInsteadOfCandidateKind()
+    {
+        var laterContainmentFailure = Primary(
+            ProcessPrimaryFailureKind.ContainmentFailure,
+            authoritySequence: 2);
+        var earlierExecutionFailure = Primary(
+            ProcessPrimaryFailureKind.ExecutionFailure,
+            authoritySequence: 1);
+
+        var selected = ProcessTerminalSelectionPolicy.Select(
+            [laterContainmentFailure, earlierExecutionFailure]);
+
+        Assert.Same(earlierExecutionFailure, selected);
+    }
+
+    [Fact]
+    public void DifferentAuthoritiesUseFixedPrecedenceIndependentOfInputOrder()
+    {
+        var target = ProcessTerminalCandidateFactory.TargetTerminal(3, 0);
+        var execution = Primary(ProcessPrimaryFailureKind.ExecutionFailure, 2);
+        var cancellation = Primary(ProcessPrimaryFailureKind.CallerCancellation, 1);
+        var deadline = Primary(ProcessPrimaryFailureKind.DeadlineExceeded, 0);
+        ProcessTerminalCandidate[] reverseArrival =
+        [deadline, cancellation, execution, target];
+
+        var forward = ProcessTerminalSelectionPolicy.Select(
+            reverseArrival.Reverse());
+        var reverse = ProcessTerminalSelectionPolicy.Select(reverseArrival);
+
+        Assert.Same(target, forward);
+        Assert.Same(target, reverse);
+    }
+
+    [Fact]
+    public void AmbiguousSequenceWithinOneAuthorityFailsClosed()
+    {
+        var containment = Primary(
+            ProcessPrimaryFailureKind.ContainmentFailure,
+            authoritySequence: 7);
+        var execution = Primary(
+            ProcessPrimaryFailureKind.ExecutionFailure,
+            authoritySequence: 7);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ProcessTerminalSelectionPolicy.Select([containment, execution]));
+    }
+
+    [Fact]
+    public void LaterContradictionFailsClosedEvenWhenAuthorityHasEarlierWinner()
+    {
+        var earlier = Primary(
+            ProcessPrimaryFailureKind.ExecutionFailure,
+            authoritySequence: 1);
+        var laterContainment = Primary(
+            ProcessPrimaryFailureKind.ContainmentFailure,
+            authoritySequence: 2);
+        var laterExecution = Primary(
+            ProcessPrimaryFailureKind.ExecutionFailure,
+            authoritySequence: 2);
+        ProcessTerminalCandidate[] publications =
+        [earlier, laterContainment, laterExecution];
+
+        Assert.Throws<InvalidOperationException>(() =>
+            ProcessTerminalSelectionPolicy.Select(publications));
+        Assert.Throws<InvalidOperationException>(() =>
+            ProcessTerminalSelectionPolicy.Select(publications.Reverse()));
+    }
+
+    [Fact]
+    public void CleanupFailureCannotOverwritePrimaryTerminalChannel()
+    {
+        var primary = Primary(
+            ProcessPrimaryFailureKind.CallerCancellation,
+            authoritySequence: 1);
+        var cleanup = new List<ProcessCleanupFailure>
+        {
+            new(
+                ProcessCleanupFailureKind.ResourceReleaseFailure,
+                nameof(InvalidOperationException),
+                "dispose failed")
+        };
+
+        var outcome = new ProcessSupervisionOutcome(
+            primary,
+            ProveAll().Build(),
+            cleanup);
+        cleanup.Clear();
+
+        Assert.Same(primary, outcome.Terminal);
+        Assert.Same(primary.PrimaryFailure, outcome.PrimaryFailure);
+        Assert.Equal(
+            ProcessPrimaryFailureKind.CallerCancellation,
+            outcome.PrimaryFailure?.Kind);
+        Assert.Equal(
+            ProcessCleanupFailureKind.ResourceReleaseFailure,
+            Assert.Single(outcome.CleanupFailures).Kind);
+        Assert.True(outcome.Proof.FormalGatePassed);
+    }
+
+    private static ProcessTerminalCandidate Primary(
+        ProcessPrimaryFailureKind kind,
+        long authoritySequence)
+    {
+        return ProcessTerminalCandidateFactory.PrimaryFailure(
+            kind,
+            authoritySequence,
+            nameof(InvalidOperationException),
+            kind.ToString());
+    }
+
+    private static ProcessProofBuilder ProveAll()
+    {
+        var builder = new ProcessProofBuilder();
+        foreach (var kind in Enum.GetValues<RequiredProcessInvariantKind>())
+        {
+            builder.Prove(kind, $"{kind} evidence");
+        }
+
+        return builder;
+    }
+
+    private static ProcessProofBuilder ProveAllExcept(
+        RequiredProcessInvariantKind omitted)
+    {
+        var builder = new ProcessProofBuilder();
+        foreach (var kind in Enum.GetValues<RequiredProcessInvariantKind>()
+                     .Where(kind => kind != omitted))
+        {
+            builder.Prove(kind, $"{kind} evidence");
+        }
+
+        return builder;
+    }
+
+    private sealed class ManualMonotonicTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            throw new InvalidOperationException(
+                "TransitionBudget must not read wall-clock time.");
+        }
+
+        public override long GetTimestamp()
+        {
+            return _timestamp;
+        }
+
+        internal void Advance(TimeSpan elapsed)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(elapsed, TimeSpan.Zero);
+            _timestamp = checked(_timestamp + elapsed.Ticks);
+        }
+    }
+}

--- a/tools/DownKyi.ProcessSupervision/DownKyi.ProcessSupervision.csproj
+++ b/tools/DownKyi.ProcessSupervision/DownKyi.ProcessSupervision.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="DownKyi.Architecture.Tests" />
+  </ItemGroup>
+
+</Project>

--- a/tools/DownKyi.ProcessSupervision/ProcessSupervisionProof.cs
+++ b/tools/DownKyi.ProcessSupervision/ProcessSupervisionProof.cs
@@ -1,0 +1,174 @@
+using System.Collections.ObjectModel;
+
+#pragma warning disable CA1515 // These immutable contracts are consumed outside this assembly.
+
+namespace DownKyi.ProcessSupervision;
+
+public enum RequiredProcessInvariantKind
+{
+    TargetTerminal,
+    RequiredContainment,
+    OperationCompletion,
+    OperationBudget,
+    TreeQuiescence,
+    BoundedCleanup,
+    StreamDrain,
+    OwnershipLifetime
+}
+
+public enum ProcessInvariantState
+{
+    Unknown,
+    Proven,
+    Violated
+}
+
+public sealed record ProcessInvariantEvidence
+{
+    internal ProcessInvariantEvidence(
+        RequiredProcessInvariantKind kind,
+        ProcessInvariantState state,
+        string detail)
+    {
+        if (state == ProcessInvariantState.Unknown)
+        {
+            throw new ArgumentException(
+                "Unknown invariant state cannot be represented as evidence.",
+                nameof(state));
+        }
+
+        ArgumentException.ThrowIfNullOrWhiteSpace(detail);
+        Kind = kind;
+        State = state;
+        Detail = detail;
+    }
+
+    public RequiredProcessInvariantKind Kind { get; }
+
+    public ProcessInvariantState State { get; }
+
+    public string Detail { get; }
+}
+
+public sealed record ProcessInvariantResult
+{
+    internal ProcessInvariantResult(
+        RequiredProcessInvariantKind kind,
+        ProcessInvariantState state,
+        IEnumerable<ProcessInvariantEvidence> evidence)
+    {
+        ArgumentNullException.ThrowIfNull(evidence);
+        var snapshot = evidence.ToArray();
+        if (!HasMatchingEvidence(kind, state, snapshot))
+        {
+            throw new ArgumentException(
+                "Invariant evidence kind and state must exactly match the result; unknown state forbids evidence.",
+                nameof(evidence));
+        }
+
+        Kind = kind;
+        State = state;
+        Evidence = new ReadOnlyCollection<ProcessInvariantEvidence>(snapshot);
+    }
+
+    public RequiredProcessInvariantKind Kind { get; }
+
+    public ProcessInvariantState State { get; }
+
+    public IReadOnlyList<ProcessInvariantEvidence> Evidence { get; }
+
+    internal bool HasConsistentEvidence => HasMatchingEvidence(
+        Kind,
+        State,
+        Evidence);
+
+    private static bool HasMatchingEvidence(
+        RequiredProcessInvariantKind kind,
+        ProcessInvariantState state,
+        IReadOnlyCollection<ProcessInvariantEvidence> evidence)
+    {
+        return state == ProcessInvariantState.Unknown
+            ? evidence.Count == 0
+            : evidence.Count > 0 && evidence.All(item =>
+                item.Kind == kind && item.State == state);
+    }
+}
+
+public sealed class ProcessSupervisionProof
+{
+    internal ProcessSupervisionProof(
+        IEnumerable<ProcessInvariantResult> invariantResults)
+    {
+        ArgumentNullException.ThrowIfNull(invariantResults);
+        var snapshot = invariantResults.ToArray();
+        var required = Enum.GetValues<RequiredProcessInvariantKind>();
+        if (snapshot.Any(result =>
+                result is null || !result.HasConsistentEvidence) ||
+            snapshot.Length != required.Length ||
+            required.Any(kind => snapshot.Count(result => result.Kind == kind) != 1))
+        {
+            throw new ArgumentException(
+                "Process proof requires consistent evidence and every required invariant exactly once.",
+                nameof(invariantResults));
+        }
+
+        Invariants = new ReadOnlyCollection<ProcessInvariantResult>(
+            snapshot.OrderBy(result => result.Kind).ToArray());
+    }
+
+    public IReadOnlyList<ProcessInvariantResult> Invariants { get; }
+
+    public bool FormalGatePassed => Invariants.All(result =>
+        result.State == ProcessInvariantState.Proven &&
+        result.HasConsistentEvidence);
+}
+
+internal sealed class ProcessProofBuilder
+{
+    private readonly Dictionary<RequiredProcessInvariantKind, ProcessInvariantState> _states =
+        Enum.GetValues<RequiredProcessInvariantKind>()
+            .ToDictionary(kind => kind, _ => ProcessInvariantState.Unknown);
+    private readonly Dictionary<RequiredProcessInvariantKind, List<ProcessInvariantEvidence>> _evidence =
+        Enum.GetValues<RequiredProcessInvariantKind>()
+            .ToDictionary(kind => kind, _ => new List<ProcessInvariantEvidence>());
+
+    internal void Prove(RequiredProcessInvariantKind kind, string detail)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(detail);
+        if (_states[kind] == ProcessInvariantState.Violated)
+        {
+            return;
+        }
+
+        _states[kind] = ProcessInvariantState.Proven;
+        _evidence[kind].Add(new ProcessInvariantEvidence(
+            kind,
+            ProcessInvariantState.Proven,
+            detail));
+    }
+
+    internal void Violate(RequiredProcessInvariantKind kind, string detail)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(detail);
+        if (_states[kind] != ProcessInvariantState.Violated)
+        {
+            _evidence[kind].Clear();
+        }
+
+        _states[kind] = ProcessInvariantState.Violated;
+        _evidence[kind].Add(new ProcessInvariantEvidence(
+            kind,
+            ProcessInvariantState.Violated,
+            detail));
+    }
+
+    internal ProcessSupervisionProof Build()
+    {
+        return new ProcessSupervisionProof(
+            Enum.GetValues<RequiredProcessInvariantKind>()
+                .Select(kind => new ProcessInvariantResult(
+                    kind,
+                    _states[kind],
+                    _evidence[kind])));
+    }
+}

--- a/tools/DownKyi.ProcessSupervision/TerminalOutcomeContracts.cs
+++ b/tools/DownKyi.ProcessSupervision/TerminalOutcomeContracts.cs
@@ -1,0 +1,286 @@
+using System.Collections.ObjectModel;
+
+#pragma warning disable CA1515 // These immutable contracts are consumed outside this assembly.
+
+namespace DownKyi.ProcessSupervision;
+
+public enum ProcessTerminalCandidateKind
+{
+    TargetTerminal,
+    ContainmentFailure,
+    ExecutionFailure,
+    CallerCancellation,
+    DeadlineExceeded
+}
+
+public enum ProcessTerminalAuthorityKind
+{
+    Target,
+    ContainmentOrExecution,
+    CallerCancellation,
+    TransitionBudget
+}
+
+public enum ProcessPrimaryFailureKind
+{
+    ContainmentFailure,
+    ExecutionFailure,
+    CallerCancellation,
+    DeadlineExceeded
+}
+
+public sealed record ProcessPrimaryFailure
+{
+    internal ProcessPrimaryFailure(
+        ProcessPrimaryFailureKind kind,
+        string errorType,
+        string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        Kind = kind;
+        ErrorType = errorType;
+        Message = message;
+    }
+
+    public ProcessPrimaryFailureKind Kind { get; }
+
+    public string ErrorType { get; }
+
+    public string Message { get; }
+}
+
+public enum ProcessCleanupFailureKind
+{
+    TerminationFailure,
+    ReapFailure,
+    TreeQuiescenceFailure,
+    StreamDrainFailure,
+    CleanupDeadlineExceeded,
+    ResourceReleaseFailure
+}
+
+public sealed record ProcessCleanupFailure
+{
+    internal ProcessCleanupFailure(
+        ProcessCleanupFailureKind kind,
+        string errorType,
+        string message)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(message);
+        Kind = kind;
+        ErrorType = errorType;
+        Message = message;
+    }
+
+    public ProcessCleanupFailureKind Kind { get; }
+
+    public string ErrorType { get; }
+
+    public string Message { get; }
+}
+
+public sealed record ProcessTerminalCandidate
+{
+    internal ProcessTerminalCandidate(
+        ProcessTerminalCandidateKind kind,
+        long authoritySequence,
+        int? exitCode,
+        ProcessPrimaryFailure? primaryFailure)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(authoritySequence);
+        var isTarget = kind == ProcessTerminalCandidateKind.TargetTerminal;
+        if (isTarget != exitCode.HasValue || isTarget == (primaryFailure is not null))
+        {
+            throw new ArgumentException(
+                "Target terminal candidates require an exit code; failure candidates require a primary failure.");
+        }
+
+        if (primaryFailure is not null && !Matches(kind, primaryFailure.Kind))
+        {
+            throw new ArgumentException(
+                "Terminal candidate kind must match the primary failure kind.",
+                nameof(primaryFailure));
+        }
+
+        Kind = kind;
+        Authority = GetAuthority(kind);
+        AuthoritySequence = authoritySequence;
+        ExitCode = exitCode;
+        PrimaryFailure = primaryFailure;
+    }
+
+    public ProcessTerminalCandidateKind Kind { get; }
+
+    public ProcessTerminalAuthorityKind Authority { get; }
+
+    public long AuthoritySequence { get; }
+
+    public int? ExitCode { get; }
+
+    public ProcessPrimaryFailure? PrimaryFailure { get; }
+
+    private static ProcessTerminalAuthorityKind GetAuthority(
+        ProcessTerminalCandidateKind kind)
+    {
+        return kind switch
+        {
+            ProcessTerminalCandidateKind.TargetTerminal =>
+                ProcessTerminalAuthorityKind.Target,
+            ProcessTerminalCandidateKind.ContainmentFailure or
+                ProcessTerminalCandidateKind.ExecutionFailure =>
+                ProcessTerminalAuthorityKind.ContainmentOrExecution,
+            ProcessTerminalCandidateKind.CallerCancellation =>
+                ProcessTerminalAuthorityKind.CallerCancellation,
+            ProcessTerminalCandidateKind.DeadlineExceeded =>
+                ProcessTerminalAuthorityKind.TransitionBudget,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
+    }
+
+    private static bool Matches(
+        ProcessTerminalCandidateKind candidate,
+        ProcessPrimaryFailureKind failure)
+    {
+        return (candidate, failure) switch
+        {
+            (ProcessTerminalCandidateKind.ContainmentFailure,
+                ProcessPrimaryFailureKind.ContainmentFailure) => true,
+            (ProcessTerminalCandidateKind.ExecutionFailure,
+                ProcessPrimaryFailureKind.ExecutionFailure) => true,
+            (ProcessTerminalCandidateKind.CallerCancellation,
+                ProcessPrimaryFailureKind.CallerCancellation) => true,
+            (ProcessTerminalCandidateKind.DeadlineExceeded,
+                ProcessPrimaryFailureKind.DeadlineExceeded) => true,
+            _ => false
+        };
+    }
+}
+
+public sealed class ProcessSupervisionOutcome
+{
+    internal ProcessSupervisionOutcome(
+        ProcessTerminalCandidate terminal,
+        ProcessSupervisionProof proof,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+    {
+        ArgumentNullException.ThrowIfNull(terminal);
+        ArgumentNullException.ThrowIfNull(proof);
+        ArgumentNullException.ThrowIfNull(cleanupFailures);
+        Terminal = terminal;
+        Proof = proof;
+        CleanupFailures = new ReadOnlyCollection<ProcessCleanupFailure>(
+            cleanupFailures.ToArray());
+    }
+
+    public ProcessTerminalCandidate Terminal { get; }
+
+    public ProcessPrimaryFailure? PrimaryFailure => Terminal.PrimaryFailure;
+
+    public ProcessSupervisionProof Proof { get; }
+
+    public IReadOnlyList<ProcessCleanupFailure> CleanupFailures { get; }
+}
+
+internal static class ProcessTerminalCandidateFactory
+{
+    internal static ProcessTerminalCandidate TargetTerminal(
+        long authoritySequence,
+        int exitCode)
+    {
+        return new ProcessTerminalCandidate(
+            ProcessTerminalCandidateKind.TargetTerminal,
+            authoritySequence,
+            exitCode,
+            null);
+    }
+
+    internal static ProcessTerminalCandidate PrimaryFailure(
+        ProcessPrimaryFailureKind kind,
+        long authoritySequence,
+        string errorType,
+        string message)
+    {
+        var candidateKind = kind switch
+        {
+            ProcessPrimaryFailureKind.ContainmentFailure =>
+                ProcessTerminalCandidateKind.ContainmentFailure,
+            ProcessPrimaryFailureKind.ExecutionFailure =>
+                ProcessTerminalCandidateKind.ExecutionFailure,
+            ProcessPrimaryFailureKind.CallerCancellation =>
+                ProcessTerminalCandidateKind.CallerCancellation,
+            ProcessPrimaryFailureKind.DeadlineExceeded =>
+                ProcessTerminalCandidateKind.DeadlineExceeded,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
+        return new ProcessTerminalCandidate(
+            candidateKind,
+            authoritySequence,
+            null,
+            new ProcessPrimaryFailure(kind, errorType, message));
+    }
+}
+
+internal static class ProcessTerminalSelectionPolicy
+{
+    internal static ProcessTerminalCandidate Select(
+        IEnumerable<ProcessTerminalCandidate> candidates)
+    {
+        ArgumentNullException.ThrowIfNull(candidates);
+        var snapshot = candidates.ToArray();
+        if (snapshot.Length == 0)
+        {
+            throw new ArgumentException(
+                "At least one terminal candidate is required.",
+                nameof(candidates));
+        }
+
+        var consistentCandidates = snapshot
+            .GroupBy(candidate => (
+                candidate.Authority,
+                candidate.AuthoritySequence))
+            .Select(RequireConsistentPublication)
+            .ToArray();
+        var authoritativeCandidates = consistentCandidates
+            .GroupBy(candidate => candidate.Authority)
+            .Select(SelectFirstFromAuthority)
+            .OrderBy(candidate => Precedence(candidate.Authority))
+            .ToArray();
+        return authoritativeCandidates[0];
+    }
+
+    private static ProcessTerminalCandidate RequireConsistentPublication(
+        IGrouping<
+            (ProcessTerminalAuthorityKind Authority, long AuthoritySequence),
+            ProcessTerminalCandidate> publications)
+    {
+        var distinct = publications.Distinct().ToArray();
+        if (distinct.Length != 1)
+        {
+            throw new InvalidOperationException(
+                $"Authority {publications.Key.Authority} published contradictory candidates " +
+                $"at sequence {publications.Key.AuthoritySequence}.");
+        }
+
+        return distinct[0];
+    }
+
+    private static ProcessTerminalCandidate SelectFirstFromAuthority(
+        IGrouping<ProcessTerminalAuthorityKind, ProcessTerminalCandidate> candidates)
+    {
+        return candidates.OrderBy(candidate => candidate.AuthoritySequence).First();
+    }
+
+    private static int Precedence(ProcessTerminalAuthorityKind authority)
+    {
+        return authority switch
+        {
+            ProcessTerminalAuthorityKind.Target => 0,
+            ProcessTerminalAuthorityKind.ContainmentOrExecution => 1,
+            ProcessTerminalAuthorityKind.CallerCancellation => 2,
+            ProcessTerminalAuthorityKind.TransitionBudget => 3,
+            _ => throw new ArgumentOutOfRangeException(nameof(authority), authority, null)
+        };
+    }
+}

--- a/tools/DownKyi.ProcessSupervision/TransitionBudget.cs
+++ b/tools/DownKyi.ProcessSupervision/TransitionBudget.cs
@@ -1,0 +1,95 @@
+#pragma warning disable CA1515 // This contract is intentionally public for the future process owner.
+
+namespace DownKyi.ProcessSupervision;
+
+public enum TransitionDeadlineKind
+{
+    Operation,
+    Cleanup
+}
+
+public sealed class TransitionBudget
+{
+    private readonly TimeProvider _timeProvider;
+    private readonly long _startedAt;
+
+    private TransitionBudget(
+        TimeSpan operationDuration,
+        TimeSpan cleanupGrace,
+        TimeProvider timeProvider)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThanOrEqual(
+            operationDuration,
+            TimeSpan.Zero);
+        ArgumentOutOfRangeException.ThrowIfLessThan(cleanupGrace, TimeSpan.Zero);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        _timeProvider = timeProvider;
+        _startedAt = timeProvider.GetTimestamp();
+        Operation = new TransitionDeadline(
+            this,
+            TransitionDeadlineKind.Operation,
+            operationDuration);
+        Cleanup = new TransitionDeadline(
+            this,
+            TransitionDeadlineKind.Cleanup,
+            checked(operationDuration + cleanupGrace));
+    }
+
+    public TransitionDeadline Operation { get; }
+
+    public TransitionDeadline Cleanup { get; }
+
+    public static TransitionBudget Start(
+        TimeSpan operationDuration,
+        TimeSpan cleanupGrace)
+    {
+        return new TransitionBudget(
+            operationDuration,
+            cleanupGrace,
+            TimeProvider.System);
+    }
+
+    internal static TransitionBudget StartForTesting(
+        TimeSpan operationDuration,
+        TimeSpan cleanupGrace,
+        TimeProvider timeProvider)
+    {
+        return new TransitionBudget(
+            operationDuration,
+            cleanupGrace,
+            timeProvider);
+    }
+
+    internal TimeSpan Remaining(TimeSpan limit)
+    {
+        var elapsed = _timeProvider.GetElapsedTime(
+            _startedAt,
+            _timeProvider.GetTimestamp());
+        var remaining = limit - elapsed;
+        return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+    }
+}
+
+public sealed class TransitionDeadline
+{
+    internal TransitionDeadline(
+        TransitionBudget authority,
+        TransitionDeadlineKind kind,
+        TimeSpan limit)
+    {
+        Authority = authority;
+        Kind = kind;
+        Limit = limit;
+    }
+
+    public TransitionBudget Authority { get; }
+
+    public TransitionDeadlineKind Kind { get; }
+
+    public TimeSpan Limit { get; }
+
+    public TimeSpan Remaining => Authority.Remaining(Limit);
+
+    public bool IsExpired => Remaining == TimeSpan.Zero;
+}


### PR DESCRIPTION
## Summary

- add an inactive, dependency-free `DownKyi.ProcessSupervision` contract library
- define immutable terminal candidate/outcome and required-invariant proof/evidence values
- keep primary failure and cleanup failure channels structurally separate
- derive operation and cleanup deadlines from one caller-created monotonic `TransitionBudget`
- freeze deterministic terminal selection semantics without adding an owner, completion loop, transport, backend, or active execution path
- reject contradictory same-authority publications at every sequence and mixed-state invariant evidence
- verify the active PowerShell and production project graphs cannot consume the inactive contract library

## Closure Gate

- WHO: future sole correctness owner is `OwnedProcessLease`; it is not implemented or enabled here
- WHAT: this PR owns types, immutable proof construction, terminal selection policy, and deadline semantics only
- ENTRY: caller creates one budget; owner-side factories in the same assembly create candidates and evidence
- EXIT: callers receive immutable `ProcessSupervisionOutcome` and cannot construct proof-bearing values
- STATE: every required invariant exists exactly once, starts Unknown, and Violated absorbs later Proven
- FAILURE: primary is terminal; cleanup is supplemental and cannot overwrite it; disposal is cleanup only
- CAPABILITY: no Process, PID authority, native handle, containment, protocol, callback, lock, kill, reap, or stream authority
- CLOCK: operation and cleanup deadlines share one TimeProvider and one origin timestamp
- RACE: same authority uses its sequence; otherwise target > containment/execution > cancellation > deadline; ambiguous same-authority sequence fails closed
- FACT: the existing PowerShell lifecycle path is unchanged; only tests reference the new library

## Validation

- focused process-supervision contract behavior: 10/10
- full `DownKyi.Architecture.Tests`: 279/279, including PR #209 lifecycle alarm parity
- strict Release solution build with all analyzers and warnings-as-errors: 0 warnings, 0 errors
- Windows-applicable solution tests: 8/8 projects passed
- review invariant gate: 11 invariants, 7 projects, 320 tests, 1 adversarial proof
- `dotnet format DownKyi.sln --verify-no-changes --no-restore`
- `git diff --check`

## Scope exclusions

No `OwnedProcessLease` engine, supervisor protocol/host, platform containment backend, PowerShell lifecycle change, CentralTestRunner change, workflow change, rehearsal, merge, or release.

Exact base: `6c662eda4b746babfe37f056f040a03064c16c45`
Exact head: `158069acea901aa536f35e6d54054d1294579653`