### PR TITLE
[197-R2.1c] Add supervisor protocol framing seam

### DIFF
--- a/tests/DownKyi.Architecture.Tests/SupervisorProtocolBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SupervisorProtocolBehaviorTests.cs
@@ -1,0 +1,579 @@
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Text;
+using DownKyi.ProcessSupervision;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class SupervisorProtocolBehaviorTests
+{
+    public static TheoryData<byte[], int> StructuralFailures =>
+        new()
+        {
+            { [], (int)SupervisorProtocolFailureKind.EndOfStream },
+            {
+                new byte[SupervisorProtocol.HeaderLength - 1],
+                (int)SupervisorProtocolFailureKind.TruncatedHeader
+            },
+            {
+                CreateFrame(
+                    SupervisorProtocolEnvelopeKind.Command,
+                    ValidCommandPayload,
+                    magic: 0),
+                (int)SupervisorProtocolFailureKind.InvalidMagic
+            },
+            {
+                CreateFrame(
+                    SupervisorProtocolEnvelopeKind.Command,
+                    ValidCommandPayload,
+                    version: checked((ushort)(SupervisorProtocol.Version + 1))),
+                (int)SupervisorProtocolFailureKind.UnsupportedVersion
+            },
+            {
+                CreateFrame(
+                    SupervisorProtocolEnvelopeKind.Command,
+                    ValidCommandPayload,
+                    rawEnvelopeKind: ushort.MaxValue),
+                (int)SupervisorProtocolFailureKind.UnknownEnvelopeKind
+            },
+            {
+                CreateFrame(
+                    SupervisorProtocolEnvelopeKind.Command,
+                    [],
+                    declaredPayloadLength: -1),
+                (int)SupervisorProtocolFailureKind.InvalidPayloadLength
+            },
+            {
+                CreateFrame(SupervisorProtocolEnvelopeKind.Command, []),
+                (int)SupervisorProtocolFailureKind.InvalidPayloadLength
+            },
+            {
+                CreateFrame(
+                    SupervisorProtocolEnvelopeKind.Command,
+                    [],
+                    declaredPayloadLength: SupervisorProtocol.MaximumPayloadLength + 1),
+                (int)SupervisorProtocolFailureKind.PayloadTooLarge
+            },
+            {
+                CreateFrame(
+                    SupervisorProtocolEnvelopeKind.Command,
+                    [0x7b, 0x7d],
+                    declaredPayloadLength: 10),
+                (int)SupervisorProtocolFailureKind.TruncatedPayload
+            }
+        };
+
+    public static TheoryData<string, int, byte[]> InvalidNumericFields
+    {
+        get
+        {
+            var data = new TheoryData<string, int, byte[]>();
+            (string Name, string Json)[] invalidNumbers =
+            [
+                ("null", "null"),
+                ("string", "\"1\""),
+                ("bool", "true"),
+                ("array", "[1]"),
+                ("object", "{\"value\":1}"),
+                ("overflow", "9223372036854775808")
+            ];
+            foreach (var invalid in invalidNumbers)
+            {
+                data.Add(
+                    $"telemetrySequence-{invalid.Name}",
+                    (int)SupervisorProtocolEnvelopeKind.Command,
+                    Utf8($"{{\"telemetrySequence\":{invalid.Json},\"command\":1}}"));
+                data.Add(
+                    $"command-{invalid.Name}",
+                    (int)SupervisorProtocolEnvelopeKind.Command,
+                    Utf8($"{{\"telemetrySequence\":0,\"command\":{invalid.Json}}}"));
+                data.Add(
+                    $"status-{invalid.Name}",
+                    (int)SupervisorProtocolEnvelopeKind.Status,
+                    Utf8($"{{\"telemetrySequence\":0,\"status\":{invalid.Json}}}"));
+                data.Add(
+                    $"invariant-{invalid.Name}",
+                    (int)SupervisorProtocolEnvelopeKind.Evidence,
+                    Utf8(
+                        $"{{\"telemetrySequence\":0,\"invariant\":{invalid.Json}," +
+                        "\"state\":1,\"detail\":\"evidence\"}"));
+                data.Add(
+                    $"state-{invalid.Name}",
+                    (int)SupervisorProtocolEnvelopeKind.Evidence,
+                    Utf8(
+                        "{\"telemetrySequence\":0,\"invariant\":0," +
+                        $"\"state\":{invalid.Json},\"detail\":\"evidence\"}}"));
+            }
+
+            return data;
+        }
+    }
+
+    public static TheoryData<int, byte[], int>
+        InvalidPayloads =>
+        new()
+        {
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                [0xc3, 0x28],
+                (int)SupervisorProtocolFailureKind.MalformedPayload
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                Utf8("{\"telemetrySequence\":0,\"command\":1} trailing"),
+                (int)SupervisorProtocolFailureKind.MalformedPayload
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                Utf8("[0,1]"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                Utf8("{\"telemetrySequence\":0,\"telemetrySequence\":1,\"command\":1}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                Utf8("{\"telemetrySequence\":0,\"command\":1,\"extra\":true}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                Utf8("{\"telemetrySequence\":0,\"status\":1}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                Utf8("{\"telemetrySequence\":-1,\"command\":1}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Command,
+                Utf8("{\"telemetrySequence\":0,\"command\":999}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Status,
+                Utf8("{\"TelemetrySequence\":0,\"status\":1}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Evidence,
+                Utf8("{\"telemetrySequence\":0,\"invariant\":0,\"state\":0,\"detail\":\"unknown\"}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Evidence,
+                Utf8("{\"telemetrySequence\":0,\"invariant\":0,\"state\":1,\"detail\":\"   \"}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Evidence,
+                Utf8(
+                    "{\"telemetrySequence\":0,\"invariant\":0,\"state\":1,\"detail\":\"" +
+                    new string('x', SupervisorProtocol.MaximumEvidenceDetailLength + 1) +
+                    "\"}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Evidence,
+                Utf8(
+                    "{\"telemetrySequence\":0,\"invariant\":0,\"state\":1," +
+                    "\"detail\":\"\\uD800\"}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            },
+            {
+                (int)SupervisorProtocolEnvelopeKind.Evidence,
+                Utf8(
+                    "{\"telemetrySequence\":0,\"invariant\":0,\"state\":1," +
+                    "\"detail\":\"\\uDC00\"}"),
+                (int)SupervisorProtocolFailureKind.InvalidMessage
+            }
+        };
+
+    private static readonly byte[] ValidCommandPayload =
+        Utf8("{\"telemetrySequence\":0,\"command\":1}");
+
+    [Fact]
+    public async Task CommandStatusAndEvidenceUseOneFramedCodec()
+    {
+        SupervisorProtocolMessage[] expected =
+        [
+            new SupervisorCommandMessage(1, SupervisorCommandKind.Begin),
+            new SupervisorStatusMessage(2, SupervisorStatusKind.Accepted),
+            new SupervisorEvidenceMessage(
+                3,
+                RequiredProcessInvariantKind.StreamDrain,
+                ProcessInvariantState.Proven,
+                "both streams reached EOF")
+        ];
+        using var stream = new MemoryStream();
+        foreach (var message in expected)
+        {
+            Assert.IsType<SupervisorProtocolMessageWritten>(
+                await SupervisorProtocolFramer.WriteAsync(
+                        stream,
+                        message,
+                        TestContext.Current.CancellationToken)
+                    .ConfigureAwait(true));
+        }
+
+        stream.Position = 0;
+        foreach (var message in expected)
+        {
+            var read = await SupervisorProtocolFramer.ReadAsync(
+                    stream,
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+            Assert.Equal(
+                message,
+                Assert.IsType<SupervisorProtocolMessageRead>(read).Message);
+        }
+
+        AssertFailure(
+            await SupervisorProtocolFramer.ReadAsync(
+                    stream,
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(true),
+            SupervisorProtocolFailureKind.EndOfStream);
+    }
+
+    [Fact]
+    public async Task FragmentedReadsDoNotChangeFrameMeaning()
+    {
+        var expected = new SupervisorStatusMessage(7, SupervisorStatusKind.Ready);
+        using var encoded = new MemoryStream();
+        Assert.IsType<SupervisorProtocolMessageWritten>(
+            await SupervisorProtocolFramer.WriteAsync(
+                    encoded,
+                    expected,
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(true));
+        using var fragmented = new FragmentedReadStream(
+            encoded.ToArray(),
+            maximumReadSize: 1);
+
+        var read = await SupervisorProtocolFramer.ReadAsync(
+                fragmented,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(
+            expected,
+            Assert.IsType<SupervisorProtocolMessageRead>(read).Message);
+    }
+
+    [Theory]
+    [MemberData(nameof(StructuralFailures))]
+    public async Task StructuralFailuresAreTyped(
+        byte[] bytes,
+        int expected)
+    {
+        using var stream = new FragmentedReadStream(bytes, maximumReadSize: 2);
+
+        var read = await SupervisorProtocolFramer.ReadAsync(
+                stream,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        AssertFailure(read, (SupervisorProtocolFailureKind)expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidPayloads))]
+    public async Task PayloadMustBeOneExactTypedShape(
+        int envelopeKind,
+        byte[] payload,
+        int expected)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        using var stream = new MemoryStream(
+            CreateFrame((SupervisorProtocolEnvelopeKind)envelopeKind, payload),
+            writable: false);
+
+        var read = await SupervisorProtocolFramer.ReadAsync(
+                stream,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        AssertFailure(read, (SupervisorProtocolFailureKind)expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidNumericFields))]
+    public async Task EveryNumericFieldRejectsWrongKindsAndOverflow(
+        string caseName,
+        int envelopeKind,
+        byte[] payload)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(caseName);
+        ArgumentNullException.ThrowIfNull(payload);
+        using var stream = new MemoryStream(
+            CreateFrame((SupervisorProtocolEnvelopeKind)envelopeKind, payload),
+            writable: false);
+
+        var read = await SupervisorProtocolFramer.ReadAsync(
+                stream,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        AssertFailure(read, SupervisorProtocolFailureKind.InvalidMessage);
+    }
+
+    [Fact]
+    public async Task OversizeLengthIsRejectedBeforePayloadRead()
+    {
+        var bytes = CreateFrame(
+            SupervisorProtocolEnvelopeKind.Command,
+            [1, 2, 3],
+            declaredPayloadLength: SupervisorProtocol.MaximumPayloadLength + 1);
+        using var stream = new MemoryStream(bytes, writable: false);
+
+        var read = await SupervisorProtocolFramer.ReadAsync(
+                stream,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        AssertFailure(read, SupervisorProtocolFailureKind.PayloadTooLarge);
+        Assert.Equal(SupervisorProtocol.HeaderLength, stream.Position);
+    }
+
+    [Fact]
+    public async Task InvalidTypedMessageIsRejectedBeforeStreamWrite()
+    {
+        using var stream = new MemoryStream();
+        var invalid = new SupervisorCommandMessage(
+            0,
+            (SupervisorCommandKind)int.MaxValue);
+
+        var result = await SupervisorProtocolFramer.WriteAsync(
+                stream,
+                invalid,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(
+            SupervisorProtocolFailureKind.InvalidMessage,
+            Assert.IsType<SupervisorProtocolWriteRejected>(result).Failure.Kind);
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Theory]
+    [InlineData(0xd800)]
+    [InlineData(0xdc00)]
+    public async Task OutboundLoneSurrogateIsRejectedBeforeStreamWrite(
+        int surrogate)
+    {
+        using var stream = new MemoryStream();
+        var invalid = new SupervisorEvidenceMessage(
+            0,
+            RequiredProcessInvariantKind.StreamDrain,
+            ProcessInvariantState.Proven,
+            new string((char)surrogate, 1));
+
+        var result = await SupervisorProtocolFramer.WriteAsync(
+                stream,
+                invalid,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(
+            SupervisorProtocolFailureKind.InvalidMessage,
+            Assert.IsType<SupervisorProtocolWriteRejected>(result).Failure.Kind);
+        Assert.Equal(0, stream.Length);
+    }
+
+    [Fact]
+    public async Task ValidSurrogatePairRoundTripsWithoutReplacement()
+    {
+        using var stream = new MemoryStream();
+        var expected = new SupervisorEvidenceMessage(
+            0,
+            RequiredProcessInvariantKind.StreamDrain,
+            ProcessInvariantState.Proven,
+            $"captured {char.ConvertFromUtf32(0x1f600)} evidence");
+        Assert.IsType<SupervisorProtocolMessageWritten>(
+            await SupervisorProtocolFramer.WriteAsync(
+                    stream,
+                    expected,
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(true));
+        stream.Position = 0;
+
+        var read = await SupervisorProtocolFramer.ReadAsync(
+                stream,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(
+            expected,
+            Assert.IsType<SupervisorProtocolMessageRead>(read).Message);
+    }
+
+    [Fact]
+    public async Task CancellationOnlyEndsIo()
+    {
+        using var stream = new CancellationStream();
+        using var cancellation = new CancellationTokenSource();
+        await cancellation.CancelAsync().ConfigureAwait(true);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await SupervisorProtocolFramer.ReadAsync(stream, cancellation.Token)
+                .ConfigureAwait(true));
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await SupervisorProtocolFramer.WriteAsync(
+                    stream,
+                    new SupervisorCommandMessage(0, SupervisorCommandKind.Cancel),
+                    cancellation.Token)
+                .ConfigureAwait(true));
+    }
+
+    [Fact]
+    public void ProtocolAssemblyHasNoHostAndExposesNoProtocolAuthority()
+    {
+        var assembly = typeof(SupervisorProtocolFramer).Assembly;
+        var types = assembly.GetTypes();
+        Assert.Null(assembly.EntryPoint);
+        Assert.DoesNotContain(types, type => type.Name is
+            "SupervisorHost" or
+            "OwnedProcessLease" or
+            "OwnedProcessCompletion");
+
+        var protocolTypes = types.Where(type =>
+            type.Name.StartsWith("SupervisorProtocol", StringComparison.Ordinal) ||
+            type.Name.StartsWith("SupervisorCommand", StringComparison.Ordinal) ||
+            type.Name.StartsWith("SupervisorStatus", StringComparison.Ordinal) ||
+            type.Name.StartsWith("SupervisorEvidence", StringComparison.Ordinal))
+            .ToArray();
+        Assert.NotEmpty(protocolTypes);
+        Assert.All(protocolTypes, type =>
+            Assert.False(type.IsPublic || type.IsNestedPublic, type.FullName));
+
+        var codecOwners = protocolTypes.Where(type =>
+                type.GetMethods(
+                        BindingFlags.Static |
+                        BindingFlags.Public |
+                        BindingFlags.NonPublic |
+                        BindingFlags.DeclaredOnly)
+                    .Any(method => method.Name is "ReadAsync" or "WriteAsync"))
+            .ToArray();
+        Assert.Equal(typeof(SupervisorProtocolFramer), Assert.Single(codecOwners));
+        Assert.All(
+            protocolTypes.Where(type => typeof(SupervisorProtocolMessage).IsAssignableFrom(type)),
+            type => Assert.Null(type.GetProperty("AuthoritySequence")));
+    }
+
+    private static byte[] CreateFrame(
+        SupervisorProtocolEnvelopeKind envelopeKind,
+        byte[] payload,
+        uint? magic = null,
+        ushort? version = null,
+        ushort? rawEnvelopeKind = null,
+        int? declaredPayloadLength = null)
+    {
+        var bytes = new byte[SupervisorProtocol.HeaderLength + payload.Length];
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            bytes,
+            magic ?? SupervisorProtocol.Magic);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            bytes.AsSpan(sizeof(uint)),
+            version ?? SupervisorProtocol.Version);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            bytes.AsSpan(sizeof(uint) + sizeof(ushort)),
+            rawEnvelopeKind ?? (ushort)envelopeKind);
+        BinaryPrimitives.WriteInt32LittleEndian(
+            bytes.AsSpan(sizeof(uint) + sizeof(ushort) + sizeof(ushort)),
+            declaredPayloadLength ?? payload.Length);
+        payload.CopyTo(bytes.AsSpan(SupervisorProtocol.HeaderLength));
+        return bytes;
+    }
+
+    private static byte[] Utf8(string value)
+    {
+        return Encoding.UTF8.GetBytes(value);
+    }
+
+    private static void AssertFailure(
+        SupervisorProtocolReadResult read,
+        SupervisorProtocolFailureKind expected)
+    {
+        Assert.Equal(
+            expected,
+            Assert.IsType<SupervisorProtocolReadRejected>(read).Failure.Kind);
+    }
+
+    private sealed class FragmentedReadStream : MemoryStream
+    {
+        private readonly int _maximumReadSize;
+
+        internal FragmentedReadStream(byte[] bytes, int maximumReadSize)
+            : base(bytes, writable: false)
+        {
+            _maximumReadSize = maximumReadSize;
+        }
+
+        public override ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            return base.ReadAsync(
+                buffer[..Math.Min(buffer.Length, _maximumReadSize)],
+                cancellationToken);
+        }
+    }
+
+    private sealed class CancellationStream : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override async ValueTask<int> ReadAsync(
+            Memory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                .ConfigureAwait(false);
+            return 0;
+        }
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/tools/DownKyi.ProcessSupervision/ProtocolContracts.cs
+++ b/tools/DownKyi.ProcessSupervision/ProtocolContracts.cs
@@ -1,0 +1,103 @@
+namespace DownKyi.ProcessSupervision;
+
+internal static class SupervisorProtocol
+{
+    internal const uint Magic = 0x31505344; // DSP1 in little-endian byte order.
+    internal const ushort Version = 1;
+    internal const int HeaderLength =
+        sizeof(uint) + sizeof(ushort) + sizeof(ushort) + sizeof(int);
+    internal const int MaximumPayloadLength = 64 * 1024;
+    internal const int MaximumEvidenceDetailLength = 1024;
+}
+
+internal enum SupervisorProtocolEnvelopeKind : ushort
+{
+    Command = 1,
+    Status = 2,
+    Evidence = 3
+}
+
+internal enum SupervisorCommandKind
+{
+    Begin = 1,
+    Cancel = 2,
+    Finalize = 3
+}
+
+internal enum SupervisorStatusKind
+{
+    Ready = 1,
+    Accepted = 2,
+    Rejected = 3,
+    Finished = 4
+}
+
+internal abstract record SupervisorProtocolMessage(long TelemetrySequence)
+{
+    // Transport telemetry only. Lifecycle arbitration remains with the future
+    // process owner and its AuthoritySequence contract.
+}
+
+internal sealed record SupervisorCommandMessage(
+    long TelemetrySequence,
+    SupervisorCommandKind Command)
+    : SupervisorProtocolMessage(TelemetrySequence);
+
+internal sealed record SupervisorStatusMessage(
+    long TelemetrySequence,
+    SupervisorStatusKind Status)
+    : SupervisorProtocolMessage(TelemetrySequence);
+
+internal sealed record SupervisorEvidenceMessage(
+    long TelemetrySequence,
+    RequiredProcessInvariantKind Invariant,
+    ProcessInvariantState State,
+    string Detail)
+    : SupervisorProtocolMessage(TelemetrySequence);
+
+internal enum SupervisorProtocolFailureKind
+{
+    EndOfStream,
+    TruncatedHeader,
+    InvalidMagic,
+    UnsupportedVersion,
+    UnknownEnvelopeKind,
+    InvalidPayloadLength,
+    PayloadTooLarge,
+    TruncatedPayload,
+    MalformedPayload,
+    InvalidMessage,
+    TransportFailure
+}
+
+internal sealed record SupervisorProtocolFailure(
+    SupervisorProtocolFailureKind Kind,
+    string Detail);
+
+internal abstract record SupervisorProtocolReadResult;
+
+internal sealed record SupervisorProtocolMessageRead(
+    SupervisorProtocolMessage Message)
+    : SupervisorProtocolReadResult;
+
+internal sealed record SupervisorProtocolReadRejected(
+    SupervisorProtocolFailure Failure)
+    : SupervisorProtocolReadResult;
+
+internal abstract record SupervisorProtocolWriteResult;
+
+internal sealed record SupervisorProtocolMessageWritten()
+    : SupervisorProtocolWriteResult;
+
+internal sealed record SupervisorProtocolWriteRejected(
+    SupervisorProtocolFailure Failure)
+    : SupervisorProtocolWriteResult;
+
+internal sealed record SupervisorProtocolEncodeResult(
+    SupervisorProtocolEnvelopeKind? EnvelopeKind,
+    byte[]? Payload,
+    SupervisorProtocolFailure? Failure)
+{
+    internal bool Succeeded =>
+        EnvelopeKind.HasValue && Payload is not null && Failure is null;
+}

--- a/tools/DownKyi.ProcessSupervision/SupervisorProtocolFramer.cs
+++ b/tools/DownKyi.ProcessSupervision/SupervisorProtocolFramer.cs
@@ -1,0 +1,348 @@
+using System.Buffers;
+using System.Buffers.Binary;
+using System.Text.Json;
+
+namespace DownKyi.ProcessSupervision;
+
+internal static class SupervisorProtocolFramer
+{
+    internal static async ValueTask<SupervisorProtocolWriteResult> WriteAsync(
+        Stream stream,
+        SupervisorProtocolMessage message,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(message);
+        var encoded = Encode(message);
+        if (!encoded.Succeeded)
+        {
+            return new SupervisorProtocolWriteRejected(encoded.Failure!);
+        }
+
+        var header = CreateHeader(
+            encoded.EnvelopeKind!.Value,
+            encoded.Payload!.Length);
+        try
+        {
+            await stream.WriteAsync(header, cancellationToken).ConfigureAwait(false);
+            await stream.WriteAsync(encoded.Payload, cancellationToken).ConfigureAwait(false);
+            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+            return new SupervisorProtocolMessageWritten();
+        }
+        catch (IOException exception)
+        {
+            return RejectWriteTransport(exception);
+        }
+        catch (ObjectDisposedException exception)
+        {
+            return RejectWriteTransport(exception);
+        }
+        catch (NotSupportedException exception)
+        {
+            return RejectWriteTransport(exception);
+        }
+    }
+
+    internal static async ValueTask<SupervisorProtocolReadResult> ReadAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        try
+        {
+            var header = new byte[SupervisorProtocol.HeaderLength];
+            var headerBytes = await ReadExactOrEofAsync(
+                    stream,
+                    header,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (headerBytes == 0)
+            {
+                return RejectRead(
+                    SupervisorProtocolFailureKind.EndOfStream,
+                    "The stream ended before the next frame header.");
+            }
+
+            if (headerBytes != header.Length)
+            {
+                return RejectRead(
+                    SupervisorProtocolFailureKind.TruncatedHeader,
+                    "The stream ended during a frame header.");
+            }
+
+            var headerFailure = ValidateHeader(
+                header,
+                out var envelopeKind,
+                out var payloadLength);
+            if (headerFailure is not null)
+            {
+                return new SupervisorProtocolReadRejected(headerFailure);
+            }
+
+            var payload = new byte[payloadLength];
+            var payloadBytes = await ReadExactOrEofAsync(
+                    stream,
+                    payload,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (payloadBytes != payloadLength)
+            {
+                return RejectRead(
+                    SupervisorProtocolFailureKind.TruncatedPayload,
+                    "The stream ended during a frame payload.");
+            }
+
+            return Decode(envelopeKind, payload);
+        }
+        catch (IOException exception)
+        {
+            return RejectReadTransport(exception);
+        }
+        catch (ObjectDisposedException exception)
+        {
+            return RejectReadTransport(exception);
+        }
+        catch (NotSupportedException exception)
+        {
+            return RejectReadTransport(exception);
+        }
+    }
+
+    private static byte[] CreateHeader(
+        SupervisorProtocolEnvelopeKind envelopeKind,
+        int payloadLength)
+    {
+        var header = new byte[SupervisorProtocol.HeaderLength];
+        BinaryPrimitives.WriteUInt32LittleEndian(header, SupervisorProtocol.Magic);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            header.AsSpan(sizeof(uint)),
+            SupervisorProtocol.Version);
+        BinaryPrimitives.WriteUInt16LittleEndian(
+            header.AsSpan(sizeof(uint) + sizeof(ushort)),
+            (ushort)envelopeKind);
+        BinaryPrimitives.WriteInt32LittleEndian(
+            header.AsSpan(sizeof(uint) + sizeof(ushort) + sizeof(ushort)),
+            payloadLength);
+        return header;
+    }
+
+    private static SupervisorProtocolFailure? ValidateHeader(
+        byte[] header,
+        out SupervisorProtocolEnvelopeKind envelopeKind,
+        out int payloadLength)
+    {
+        envelopeKind = default;
+        payloadLength = 0;
+        if (BinaryPrimitives.ReadUInt32LittleEndian(header) != SupervisorProtocol.Magic)
+        {
+            return Failure(
+                SupervisorProtocolFailureKind.InvalidMagic,
+                "The frame magic is invalid.");
+        }
+
+        var version = BinaryPrimitives.ReadUInt16LittleEndian(
+            header.AsSpan(sizeof(uint)));
+        if (version != SupervisorProtocol.Version)
+        {
+            return Failure(
+                SupervisorProtocolFailureKind.UnsupportedVersion,
+                "The frame version is unsupported.");
+        }
+
+        var rawEnvelopeKind = BinaryPrimitives.ReadUInt16LittleEndian(
+            header.AsSpan(sizeof(uint) + sizeof(ushort)));
+        if (!Enum.IsDefined(typeof(SupervisorProtocolEnvelopeKind), rawEnvelopeKind))
+        {
+            return Failure(
+                SupervisorProtocolFailureKind.UnknownEnvelopeKind,
+                "The frame envelope kind is unknown.");
+        }
+
+        payloadLength = BinaryPrimitives.ReadInt32LittleEndian(
+            header.AsSpan(sizeof(uint) + sizeof(ushort) + sizeof(ushort)));
+        if (payloadLength < 0)
+        {
+            return Failure(
+                SupervisorProtocolFailureKind.InvalidPayloadLength,
+                "The frame payload length is negative.");
+        }
+
+        if (payloadLength == 0)
+        {
+            return Failure(
+                SupervisorProtocolFailureKind.InvalidPayloadLength,
+                "The frame payload length must be positive.");
+        }
+
+        if (payloadLength > SupervisorProtocol.MaximumPayloadLength)
+        {
+            return Failure(
+                SupervisorProtocolFailureKind.PayloadTooLarge,
+                "The frame payload exceeds the protocol limit.");
+        }
+
+        envelopeKind = (SupervisorProtocolEnvelopeKind)rawEnvelopeKind;
+        return null;
+    }
+
+    private static SupervisorProtocolEncodeResult Encode(
+        SupervisorProtocolMessage message)
+    {
+        var failure = SupervisorProtocolValidator.ValidateForWrite(message);
+        if (failure is not null)
+        {
+            return new SupervisorProtocolEncodeResult(null, null, failure);
+        }
+
+        var output = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(output))
+        {
+            writer.WriteStartObject();
+            writer.WriteNumber(
+                SupervisorProtocolValidator.TelemetrySequenceProperty,
+                message.TelemetrySequence);
+            WriteMessageBody(writer, message);
+            writer.WriteEndObject();
+        }
+
+        var payload = output.WrittenSpan.ToArray();
+        if (payload.Length > SupervisorProtocol.MaximumPayloadLength)
+        {
+            return new SupervisorProtocolEncodeResult(
+                null,
+                null,
+                Failure(
+                    SupervisorProtocolFailureKind.PayloadTooLarge,
+                    "The encoded payload exceeds the protocol limit."));
+        }
+
+        return new SupervisorProtocolEncodeResult(
+            SupervisorProtocolValidator.GetEnvelopeKind(message),
+            payload,
+            null);
+    }
+
+    private static void WriteMessageBody(
+        Utf8JsonWriter writer,
+        SupervisorProtocolMessage message)
+    {
+        switch (message)
+        {
+            case SupervisorCommandMessage command:
+                writer.WriteNumber(
+                    SupervisorProtocolValidator.CommandProperty,
+                    (int)command.Command);
+                break;
+            case SupervisorStatusMessage status:
+                writer.WriteNumber(
+                    SupervisorProtocolValidator.StatusProperty,
+                    (int)status.Status);
+                break;
+            case SupervisorEvidenceMessage evidence:
+                writer.WriteNumber(
+                    SupervisorProtocolValidator.InvariantProperty,
+                    (int)evidence.Invariant);
+                writer.WriteNumber(
+                    SupervisorProtocolValidator.StateProperty,
+                    (int)evidence.State);
+                writer.WriteString(
+                    SupervisorProtocolValidator.DetailProperty,
+                    evidence.Detail);
+                break;
+            default:
+                throw new InvalidOperationException(
+                    "The validated supervisor message type is unsupported.");
+        }
+    }
+
+    private static SupervisorProtocolReadResult Decode(
+        SupervisorProtocolEnvelopeKind envelopeKind,
+        byte[] payload)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(
+                payload,
+                new JsonDocumentOptions
+                {
+                    AllowTrailingCommas = false,
+                    CommentHandling = JsonCommentHandling.Disallow,
+                    MaxDepth = 8
+                });
+            return SupervisorProtocolValidator.Decode(
+                envelopeKind,
+                document.RootElement);
+        }
+        catch (JsonException)
+        {
+            return RejectRead(
+                SupervisorProtocolFailureKind.MalformedPayload,
+                "The payload is not one complete UTF-8 JSON value.");
+        }
+        catch (InvalidOperationException)
+        {
+            return RejectRead(
+                SupervisorProtocolFailureKind.InvalidMessage,
+                "The payload cannot be projected to the declared message shape.");
+        }
+        catch (ArgumentException)
+        {
+            return RejectRead(
+                SupervisorProtocolFailureKind.InvalidMessage,
+                "The payload contains an invalid typed value.");
+        }
+    }
+
+    private static async ValueTask<int> ReadExactOrEofAsync(
+        Stream stream,
+        byte[] buffer,
+        CancellationToken cancellationToken)
+    {
+        var offset = 0;
+        while (offset < buffer.Length)
+        {
+            var read = await stream.ReadAsync(
+                    buffer.AsMemory(offset),
+                    cancellationToken)
+                .ConfigureAwait(false);
+            if (read == 0)
+            {
+                break;
+            }
+
+            offset += read;
+        }
+
+        return offset;
+    }
+
+    private static SupervisorProtocolFailure Failure(
+        SupervisorProtocolFailureKind kind,
+        string detail)
+    {
+        return new SupervisorProtocolFailure(kind, detail);
+    }
+
+    private static SupervisorProtocolReadRejected RejectRead(
+        SupervisorProtocolFailureKind kind,
+        string detail)
+    {
+        return new SupervisorProtocolReadRejected(Failure(kind, detail));
+    }
+
+    private static SupervisorProtocolReadRejected RejectReadTransport(
+        Exception exception)
+    {
+        return RejectRead(
+            SupervisorProtocolFailureKind.TransportFailure,
+            $"The transport failed with {exception.GetType().Name}.");
+    }
+
+    private static SupervisorProtocolWriteRejected RejectWriteTransport(
+        Exception exception)
+    {
+        return new SupervisorProtocolWriteRejected(Failure(
+            SupervisorProtocolFailureKind.TransportFailure,
+            $"The transport failed with {exception.GetType().Name}."));
+    }
+}

--- a/tools/DownKyi.ProcessSupervision/SupervisorProtocolValidator.cs
+++ b/tools/DownKyi.ProcessSupervision/SupervisorProtocolValidator.cs
@@ -1,0 +1,244 @@
+using System.Text.Json;
+
+namespace DownKyi.ProcessSupervision;
+
+internal static class SupervisorProtocolValidator
+{
+    internal const string TelemetrySequenceProperty = "telemetrySequence";
+    internal const string CommandProperty = "command";
+    internal const string StatusProperty = "status";
+    internal const string InvariantProperty = "invariant";
+    internal const string StateProperty = "state";
+    internal const string DetailProperty = "detail";
+
+    internal static SupervisorProtocolFailure? ValidateForWrite(
+        SupervisorProtocolMessage message)
+    {
+        ArgumentNullException.ThrowIfNull(message);
+        if (message.TelemetrySequence < 0)
+        {
+            return Invalid("Telemetry sequence must be non-negative.");
+        }
+
+        return message switch
+        {
+            SupervisorCommandMessage command when Enum.IsDefined(command.Command) => null,
+            SupervisorStatusMessage status when Enum.IsDefined(status.Status) => null,
+            SupervisorEvidenceMessage evidence when
+                Enum.IsDefined(evidence.Invariant) &&
+                evidence.State is ProcessInvariantState.Proven or
+                    ProcessInvariantState.Violated &&
+                !string.IsNullOrWhiteSpace(evidence.Detail) &&
+                evidence.Detail.Length <= SupervisorProtocol.MaximumEvidenceDetailLength &&
+                HasValidSurrogatePairs(evidence.Detail) => null,
+            _ => Invalid(
+                "The message contains an unknown kind or invalid evidence value.")
+        };
+    }
+
+    internal static SupervisorProtocolEnvelopeKind GetEnvelopeKind(
+        SupervisorProtocolMessage message)
+    {
+        return message switch
+        {
+            SupervisorCommandMessage => SupervisorProtocolEnvelopeKind.Command,
+            SupervisorStatusMessage => SupervisorProtocolEnvelopeKind.Status,
+            SupervisorEvidenceMessage => SupervisorProtocolEnvelopeKind.Evidence,
+            _ => throw new InvalidOperationException(
+                "The validated supervisor message type is unsupported.")
+        };
+    }
+
+    internal static SupervisorProtocolReadResult Decode(
+        SupervisorProtocolEnvelopeKind envelopeKind,
+        JsonElement root)
+    {
+        return envelopeKind switch
+        {
+            SupervisorProtocolEnvelopeKind.Command => DecodeCommand(root),
+            SupervisorProtocolEnvelopeKind.Status => DecodeStatus(root),
+            SupervisorProtocolEnvelopeKind.Evidence => DecodeEvidence(root),
+            _ => Reject(
+                SupervisorProtocolFailureKind.UnknownEnvelopeKind,
+                "The envelope kind is not defined by this protocol version.")
+        };
+    }
+
+    private static SupervisorProtocolReadResult DecodeCommand(JsonElement root)
+    {
+        if (!HasExactProperties(root, TelemetrySequenceProperty, CommandProperty) ||
+            !TryReadTelemetrySequence(root, out var sequence) ||
+            !TryReadDefinedEnum(root, CommandProperty, out SupervisorCommandKind command))
+        {
+            return InvalidMessage(
+                "A command requires exactly telemetrySequence and command.");
+        }
+
+        return Accept(new SupervisorCommandMessage(sequence, command));
+    }
+
+    private static SupervisorProtocolReadResult DecodeStatus(JsonElement root)
+    {
+        if (!HasExactProperties(root, TelemetrySequenceProperty, StatusProperty) ||
+            !TryReadTelemetrySequence(root, out var sequence) ||
+            !TryReadDefinedEnum(root, StatusProperty, out SupervisorStatusKind status))
+        {
+            return InvalidMessage(
+                "A status requires exactly telemetrySequence and status.");
+        }
+
+        return Accept(new SupervisorStatusMessage(sequence, status));
+    }
+
+    private static SupervisorProtocolReadResult DecodeEvidence(JsonElement root)
+    {
+        if (!HasExactProperties(
+                root,
+                TelemetrySequenceProperty,
+                InvariantProperty,
+                StateProperty,
+                DetailProperty) ||
+            !TryReadTelemetrySequence(root, out var sequence) ||
+            !TryReadDefinedEnum(
+                root,
+                InvariantProperty,
+                out RequiredProcessInvariantKind invariant) ||
+            !TryReadDefinedEnum(root, StateProperty, out ProcessInvariantState state) ||
+            !TryReadDetail(root, out var detail))
+        {
+            return InvalidMessage(
+                "Evidence requires exactly telemetrySequence, invariant, state, and detail.");
+        }
+
+        var message = new SupervisorEvidenceMessage(
+            sequence,
+            invariant,
+            state,
+            detail);
+        var failure = ValidateForWrite(message);
+        return failure is null
+            ? Accept(message)
+            : new SupervisorProtocolReadRejected(failure);
+    }
+
+    private static bool HasExactProperties(
+        JsonElement root,
+        params string[] expectedProperties)
+    {
+        if (root.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        var expected = expectedProperties.ToHashSet(StringComparer.Ordinal);
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var property in root.EnumerateObject())
+        {
+            if (!expected.Contains(property.Name) || !seen.Add(property.Name))
+            {
+                return false;
+            }
+        }
+
+        return seen.SetEquals(expected);
+    }
+
+    private static bool TryReadTelemetrySequence(
+        JsonElement root,
+        out long sequence)
+    {
+        var property = root.GetProperty(TelemetrySequenceProperty);
+        sequence = default;
+        return property.ValueKind == JsonValueKind.Number &&
+               property.TryGetInt64(out sequence) &&
+               sequence >= 0;
+    }
+
+    private static bool TryReadDefinedEnum<TEnum>(
+        JsonElement root,
+        string propertyName,
+        out TEnum value)
+        where TEnum : struct, Enum
+    {
+        value = default;
+        var property = root.GetProperty(propertyName);
+        if (property.ValueKind != JsonValueKind.Number ||
+            !property.TryGetInt32(out var raw))
+        {
+            return false;
+        }
+
+        var candidate = (TEnum)Enum.ToObject(typeof(TEnum), raw);
+        if (!Enum.IsDefined(candidate))
+        {
+            return false;
+        }
+
+        value = candidate;
+        return true;
+    }
+
+    private static bool TryReadDetail(
+        JsonElement root,
+        out string detail)
+    {
+        var property = root.GetProperty(DetailProperty);
+        detail = property.ValueKind == JsonValueKind.String
+            ? property.GetString() ?? string.Empty
+            : string.Empty;
+        return !string.IsNullOrWhiteSpace(detail) &&
+               detail.Length <= SupervisorProtocol.MaximumEvidenceDetailLength;
+    }
+
+    private static bool HasValidSurrogatePairs(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (char.IsLowSurrogate(value[index]))
+            {
+                return false;
+            }
+
+            if (!char.IsHighSurrogate(value[index]))
+            {
+                continue;
+            }
+
+            if (index + 1 >= value.Length ||
+                !char.IsLowSurrogate(value[index + 1]))
+            {
+                return false;
+            }
+
+            index++;
+        }
+
+        return true;
+    }
+
+    private static SupervisorProtocolMessageRead Accept(
+        SupervisorProtocolMessage message)
+    {
+        return new SupervisorProtocolMessageRead(message);
+    }
+
+    private static SupervisorProtocolReadRejected InvalidMessage(string detail)
+    {
+        return new SupervisorProtocolReadRejected(Invalid(detail));
+    }
+
+    private static SupervisorProtocolFailure Invalid(string detail)
+    {
+        return new SupervisorProtocolFailure(
+            SupervisorProtocolFailureKind.InvalidMessage,
+            detail);
+    }
+
+    private static SupervisorProtocolReadRejected Reject(
+        SupervisorProtocolFailureKind kind,
+        string detail)
+    {
+        return new SupervisorProtocolReadRejected(
+            new SupervisorProtocolFailure(kind, detail));
+    }
+}


### PR DESCRIPTION
## Summary

- add one internal versioned length-prefixed supervisor protocol format
- keep command, status, and evidence as distinct typed envelope kinds on the same framed stream
- bound payload allocation before reading attacker-controlled lengths
- reject EOF, truncation, zero/negative/oversize length, unknown version/kind, malformed UTF-8/JSON, duplicate/extra/cross-shape fields, wrong-kind/overflow numeric fields, invalid enum values, and invalid UTF-16 evidence with typed protocol failures
- keep async cancellation as I/O cancellation only; it does not create a lifecycle primary
- keep the library inert: no executable, host loop, Process, pipe/socket, native handle, owner/completion state, deadline, or active production caller

## Closure Gate

- WHO: `SupervisorProtocolFramer` is the sole wire owner; `SupervisorProtocolValidator` owns exact message shape
- WHAT: one versioned length-prefix frame and one exact JSON payload shape per envelope kind
- ENTRY: a caller supplies an existing `Stream`, one internal typed message, and a cancellation token
- EXIT: typed protocol read/write result only; never a lifecycle outcome
- STATE: no host, owner, completion, or lifecycle state
- FAILURE: wire and payload failures are typed; cancellation only ends I/O
- CAPABILITY: caller-owned `Stream` only; the protocol creates no OS capability
- CLOCK: no clock or deadline; `TelemetrySequence` is explicitly non-authoritative
- RACE: no ordering, arbitration, retry, or lifecycle-cause selection
- FACT: the protocol proves bytes to typed message only; future owner/host direct facts remain lifecycle truth

## Validation

- focused protocol behavior/adversarial tests: 62/62
- existing ProcessSupervision contract tests: 13/13
- full `DownKyi.Architecture.Tests`: 341/341
- static lifecycle-ownership audit: 564 matches, 0 violations
- strict Release solution build with analyzers and warnings-as-errors: 0 warnings, 0 errors
- current-platform solution gate: 8/8 Windows-applicable test projects passed; the existing packaged aria2 TLS case remained environment-skipped
- review-invariant gate: 11 invariants, 7 projects, 320 positive tests, 1 adversarial mutation proof
- release-version contract, full-solution format verification, module-boundary audit, and `git diff --check` passed
- the first natural CI run on the superseded SHA found one deterministic static-initialization ownership violation; the amended head removes that state and the local ownership audit is clean

## Scope exclusions

No supervisor executable, `Program`/`Main`, host loop, process launch, pipe/socket/OS handle creation, `OwnedProcessLease`, completion/arbitration engine, containment backend, PowerShell lifecycle/runner/CentralTestRunner/workflow/rehearsal/docs change, lifecycle rounds, merge, or release.

Base: `804985f245df0370cf87d9a2eaac2a77609afd4f`
Head: `78a4e03c5b29c522d1a5a6c53232a9b2a50d5616`