### PR TITLE
refactor: bind containment operation authorities

### DIFF
--- a/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
@@ -274,6 +274,20 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
     }
 
     [Fact]
+    public void UndefinedCleanupFailureCannotEnterOperationResult()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        var backendResult = operation.BackendResults.Succeeded(
+            "backend evidence");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => operation.FromBackend(
+            backendResult,
+            UndefinedCleanupFailures()));
+    }
+
+    [Fact]
     public void FailureFamiliesCannotRepresentContradictoryAuthorityKinds()
     {
         var clock = new ManualMonotonicTimeProvider();
@@ -379,6 +393,14 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
             kind,
             nameof(InvalidOperationException),
             detail);
+    }
+
+    private static IEnumerable<ProcessCleanupFailure> UndefinedCleanupFailures()
+    {
+        yield return new ProcessCleanupFailure(
+            (ProcessCleanupFailureKind)int.MaxValue,
+            nameof(InvalidOperationException),
+            "undefined cleanup failure");
     }
 
     private sealed class ManualMonotonicTimeProvider : TimeProvider

--- a/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
@@ -1,0 +1,276 @@
+using DownKyi.ProcessSupervision;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class ProcessContainmentOperationAuthorityBehaviorTests
+{
+    [Fact]
+    public void CallerFactsRequireTheirBoundAuthoritativeObservation()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            operation.Caller.PublishCancellation("caller canceled"));
+        Assert.Throws<InvalidOperationException>(() =>
+            operation.Caller.PublishDeadlineExceeded("caller deadline expired"));
+
+        cancellation.Cancel();
+        var canceled = operation.Caller.PublishCancellation("caller canceled");
+        clock.Advance(TimeSpan.FromSeconds(10));
+        var expired = operation.Caller.PublishDeadlineExceeded(
+            "caller deadline expired");
+
+        Assert.Same(operation.Identity, canceled.AuthorityIdentity);
+        Assert.Same(operation.Identity, expired.AuthorityIdentity);
+        Assert.Equal(nameof(OperationCanceledException), canceled.ErrorType);
+        Assert.Equal(nameof(TimeoutException), expired.ErrorType);
+        Assert.NotEqual(canceled.GetType(), expired.GetType());
+    }
+
+    [Fact]
+    public async Task CapturedBackendExceptionRemainsBackendFailureAfterDelay()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        var continuation = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var delayedResult = CaptureBackendFailureBeforeDelayAsync(
+            operation.BackendResults,
+            continuation.Task);
+
+        clock.Advance(TimeSpan.FromSeconds(10));
+        await cancellation.CancelAsync();
+        Assert.True(operation.Caller.Budget.Operation.IsExpired);
+        Assert.True(operation.Caller.CancellationToken.IsCancellationRequested);
+        continuation.SetResult();
+
+        var rejected = AssertRejected(operation.FromBackend(
+            await delayedResult.ConfigureAwait(true)));
+
+        Assert.IsAssignableFrom<ProcessContainmentBackendFailure>(
+            rejected.PrimaryFailure);
+        Assert.IsNotAssignableFrom<ProcessContainmentCallerFailure>(
+            rejected.PrimaryFailure);
+        Assert.IsNotAssignableFrom<ProcessContainmentContractFailure>(
+            rejected.PrimaryFailure);
+        Assert.Equal(
+            nameof(InvalidOperationException),
+            rejected.PrimaryFailure.ErrorType);
+    }
+
+    [Fact]
+    public void RootAuthorityRejectsCallerBackendAndGuardSubstitution()
+    {
+        var clockA = new ManualMonotonicTimeProvider();
+        var clockB = new ManualMonotonicTimeProvider();
+        using var cancellationA = new CancellationTokenSource();
+        using var cancellationB = new CancellationTokenSource();
+        var operationA = Operation(clockA, cancellationA.Token);
+        var operationB = Operation(clockB, cancellationB.Token);
+        var reboundA = ProcessContainmentOperationAuthority.Create(
+            operationA.Caller.Budget,
+            operationA.Caller.CancellationToken);
+        cancellationA.Cancel();
+        cancellationB.Cancel();
+
+        var ownCaller = operationA.Caller.PublishCancellation("caller A canceled");
+        var foreignCaller = operationB.Caller.PublishCancellation("caller B canceled");
+        var reboundCaller = reboundA.Caller.PublishCancellation("rebound A canceled");
+        var ownResult = AssertRejected(operationA.Rejected(ownCaller, []));
+        var foreignCallerResult = AssertRejected(
+            operationA.Rejected(foreignCaller, []));
+        var reboundCallerResult = AssertRejected(
+            operationA.Rejected(reboundCaller, []));
+        var foreignBackendResult = AssertRejected(operationA.FromBackend(
+            operationB.BackendResults.Failed(
+                new InvalidOperationException("fixture backend B failure"),
+                "backend B failed")));
+        var foreignGuardResult = AssertRejected(operationA.Rejected(
+            operationB.ContractGuard.IllegalTransition("guard B failure"),
+            []));
+
+        Assert.Same(operationA.Identity, ownCaller.AuthorityIdentity);
+        Assert.Same(ownCaller, ownResult.PrimaryFailure);
+        Assert.NotSame(operationA.Identity, operationB.Identity);
+        Assert.NotSame(operationA.Identity, reboundA.Identity);
+        Assert.All(
+        [
+            foreignCallerResult,
+            reboundCallerResult,
+            foreignBackendResult,
+            foreignGuardResult
+        ],
+            rejected =>
+            {
+                Assert.IsAssignableFrom<ProcessContainmentContractFailure>(
+                    rejected.PrimaryFailure);
+                Assert.Contains(
+                    "does not own this operation lifetime",
+                    rejected.PrimaryFailure.Detail,
+                    StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public void CleanupSnapshotCannotReplacePrimaryFailure()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        cancellation.Cancel();
+        var primary = operation.Caller.PublishCancellation("caller canceled");
+        var cleanup = new List<ProcessCleanupFailure>
+        {
+            Cleanup(
+                ProcessCleanupFailureKind.ResourceReleaseFailure,
+                "resource release failed")
+        };
+
+        var rejected = AssertRejected(operation.Rejected(primary, cleanup));
+        cleanup.Clear();
+        cleanup.Add(Cleanup(
+            ProcessCleanupFailureKind.StreamDrainFailure,
+            "replacement cleanup failure"));
+
+        Assert.Same(primary, rejected.PrimaryFailure);
+        Assert.IsAssignableFrom<ProcessContainmentCallerFailure>(
+            rejected.PrimaryFailure);
+        Assert.Equal(
+            ProcessCleanupFailureKind.ResourceReleaseFailure,
+            Assert.Single(rejected.CleanupFailures).Kind);
+    }
+
+    [Fact]
+    public void FailureFamiliesCannotRepresentContradictoryAuthorityKinds()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        cancellation.Cancel();
+        var caller = operation.Caller.PublishCancellation("caller canceled");
+        var backend = AssertRejected(operation.FromBackend(
+            operation.BackendResults.Failed(
+                new IOException("fixture backend failure"),
+                "backend failed"))).PrimaryFailure;
+        var contract = operation.ContractGuard.IllegalTransition(
+            "illegal transition");
+
+        Assert.IsAssignableFrom<ProcessContainmentCallerFailure>(caller);
+        Assert.IsNotAssignableFrom<ProcessContainmentBackendFailure>(caller);
+        Assert.IsNotAssignableFrom<ProcessContainmentContractFailure>(caller);
+        Assert.IsAssignableFrom<ProcessContainmentBackendFailure>(backend);
+        Assert.IsNotAssignableFrom<ProcessContainmentCallerFailure>(backend);
+        Assert.IsNotAssignableFrom<ProcessContainmentContractFailure>(backend);
+        Assert.IsAssignableFrom<ProcessContainmentContractFailure>(contract);
+        Assert.IsNotAssignableFrom<ProcessContainmentCallerFailure>(contract);
+        Assert.IsNotAssignableFrom<ProcessContainmentBackendFailure>(contract);
+    }
+
+    [Fact]
+    public async Task EnumerationAndSchedulerCannotMutatePublishedResult()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        await cancellation.CancelAsync();
+        var primary = operation.Caller.PublishCancellation("caller canceled");
+        var cleanup = new List<ProcessCleanupFailure>
+        {
+            Cleanup(
+                ProcessCleanupFailureKind.ResourceReleaseFailure,
+                "first cleanup failure"),
+            Cleanup(
+                ProcessCleanupFailureKind.StreamDrainFailure,
+                "second cleanup failure")
+        };
+        var rejected = AssertRejected(operation.Rejected(primary, cleanup));
+
+        cleanup.Reverse();
+        cleanup.Clear();
+        clock.Advance(TimeSpan.FromSeconds(20));
+        await Task.Yield();
+
+        Assert.Same(primary, rejected.PrimaryFailure);
+        Assert.Equal(
+            [
+                ProcessCleanupFailureKind.ResourceReleaseFailure,
+                ProcessCleanupFailureKind.StreamDrainFailure
+            ],
+            rejected.CleanupFailures.Select(failure => failure.Kind));
+    }
+
+    private static async Task<ProcessContainmentBackendResult>
+        CaptureBackendFailureBeforeDelayAsync(
+            ProcessContainmentBackendResultFactory factory,
+            Task continuation)
+    {
+        ProcessContainmentBackendResult captured;
+        try
+        {
+            throw new InvalidOperationException("fixture backend failure");
+        }
+        catch (InvalidOperationException failure)
+        {
+            captured = factory.Failed(failure, "backend failed");
+        }
+
+        await continuation.ConfigureAwait(false);
+        return captured;
+    }
+
+    private static ProcessContainmentOperationRejected AssertRejected(
+        ProcessContainmentOperationResult result)
+    {
+        return Assert.IsAssignableFrom<ProcessContainmentOperationRejected>(result);
+    }
+
+    private static ProcessContainmentOperationAuthority Operation(
+        ManualMonotonicTimeProvider clock,
+        CancellationToken cancellationToken)
+    {
+        var budget = TransitionBudget.StartForTesting(
+            TimeSpan.FromSeconds(10),
+            TimeSpan.FromSeconds(2),
+            clock);
+        return ProcessContainmentOperationAuthority.Create(
+            budget,
+            cancellationToken);
+    }
+
+    private static ProcessCleanupFailure Cleanup(
+        ProcessCleanupFailureKind kind,
+        string detail)
+    {
+        return new ProcessCleanupFailure(
+            kind,
+            nameof(InvalidOperationException),
+            detail);
+    }
+
+    private sealed class ManualMonotonicTimeProvider : TimeProvider
+    {
+        private long _timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            throw new InvalidOperationException(
+                "Operation authority contracts must not read wall-clock time.");
+        }
+
+        public override long GetTimestamp()
+        {
+            return _timestamp;
+        }
+
+        internal void Advance(TimeSpan elapsed)
+        {
+            ArgumentOutOfRangeException.ThrowIfLessThan(elapsed, TimeSpan.Zero);
+            _timestamp = checked(_timestamp + elapsed.Ticks);
+        }
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using DownKyi.ProcessSupervision;
 
 namespace DownKyi.Architecture.Tests;
@@ -22,11 +23,14 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
         var expired = operation.Caller.PublishDeadlineExceeded(
             "caller deadline expired");
 
-        Assert.Same(operation.Identity, canceled.AuthorityIdentity);
-        Assert.Same(operation.Identity, expired.AuthorityIdentity);
+        Assert.Equal(
+            ProcessContainmentCallerFailureKind.Cancellation,
+            canceled.Kind);
+        Assert.Equal(
+            ProcessContainmentCallerFailureKind.DeadlineExceeded,
+            expired.Kind);
         Assert.Equal(nameof(OperationCanceledException), canceled.ErrorType);
         Assert.Equal(nameof(TimeoutException), expired.ErrorType);
-        Assert.NotEqual(canceled.GetType(), expired.GetType());
     }
 
     [Fact]
@@ -48,7 +52,8 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
         continuation.SetResult();
 
         var rejected = AssertRejected(operation.FromBackend(
-            await delayedResult.ConfigureAwait(true)));
+            await delayedResult.ConfigureAwait(true),
+            []));
 
         Assert.IsAssignableFrom<ProcessContainmentBackendFailure>(
             rejected.PrimaryFailure);
@@ -87,15 +92,13 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
         var foreignBackendResult = AssertRejected(operationA.FromBackend(
             operationB.BackendResults.Failed(
                 new InvalidOperationException("fixture backend B failure"),
-                "backend B failed")));
+                "backend B failed"),
+            []));
         var foreignGuardResult = AssertRejected(operationA.Rejected(
             operationB.ContractGuard.IllegalTransition("guard B failure"),
             []));
 
-        Assert.Same(operationA.Identity, ownCaller.AuthorityIdentity);
         Assert.Same(ownCaller, ownResult.PrimaryFailure);
-        Assert.NotSame(operationA.Identity, operationB.Identity);
-        Assert.NotSame(operationA.Identity, reboundA.Identity);
         Assert.All(
         [
             foreignCallerResult,
@@ -112,6 +115,57 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
                     rejected.PrimaryFailure.Detail,
                     StringComparison.Ordinal);
             });
+    }
+
+    [Fact]
+    public void NonPublicConstructionCannotForgeCallerAuthority()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        var constructor = typeof(ProcessContainmentCallerFailure)
+            .GetConstructors(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Single(candidate => candidate.GetParameters()
+                .Select(parameter => parameter.ParameterType)
+                .SequenceEqual(
+                [
+                    typeof(object),
+                    typeof(ProcessContainmentCallerFailureKind),
+                    typeof(string)
+                ]));
+        var forged = Assert.IsType<ProcessContainmentCallerFailure>(
+            constructor.Invoke(
+            [
+                new object(),
+                ProcessContainmentCallerFailureKind.Cancellation,
+                "reflected caller failure"
+            ]));
+        var foreignPublisher = new ProcessContainmentCallerFailure.Publisher();
+        var foreignPublished = foreignPublisher.PublishCancellation(
+            "foreign published caller failure");
+        var invalidKind = Assert.Throws<TargetInvocationException>(() =>
+            constructor.Invoke(
+            [
+                new object(),
+                (ProcessContainmentCallerFailureKind)int.MaxValue,
+                "invalid caller failure"
+            ]));
+
+        var rejected = AssertRejected(operation.Rejected(forged, []));
+        var foreignRejected = AssertRejected(operation.Rejected(
+            foreignPublished,
+            []));
+
+        Assert.All([rejected, foreignRejected], candidate =>
+        {
+            Assert.IsAssignableFrom<ProcessContainmentContractFailure>(
+                candidate.PrimaryFailure);
+            Assert.Contains(
+                "does not own this operation lifetime",
+                candidate.PrimaryFailure.Detail,
+                StringComparison.Ordinal);
+        });
+        Assert.IsType<ArgumentOutOfRangeException>(invalidKind.InnerException);
     }
 
     [Fact]
@@ -144,6 +198,82 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
     }
 
     [Fact]
+    public void BackendFailurePublicationPreservesPrimaryAndCleanupSnapshot()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        var cleanup = new List<ProcessCleanupFailure>
+        {
+            Cleanup(
+                ProcessCleanupFailureKind.ResourceReleaseFailure,
+                "backend cleanup failed")
+        };
+
+        var backendResult = operation.BackendResults.Failed(
+                new IOException("fixture backend failure"),
+                "backend failed");
+        var publishedPrimary = Assert.IsAssignableFrom<
+            ProcessContainmentBackendFailure>(backendResult.GetType()
+                .GetProperty("Failure")!
+                .GetValue(backendResult));
+        var rejected = AssertRejected(operation.FromBackend(
+            backendResult,
+            cleanup));
+        cleanup.Clear();
+        cleanup.Add(Cleanup(
+            ProcessCleanupFailureKind.StreamDrainFailure,
+            "replacement cleanup failure"));
+
+        Assert.Same(publishedPrimary, rejected.PrimaryFailure);
+        Assert.Equal(nameof(IOException), publishedPrimary.ErrorType);
+        Assert.Equal(
+            ProcessCleanupFailureKind.ResourceReleaseFailure,
+            Assert.Single(rejected.CleanupFailures).Kind);
+    }
+
+    [Fact]
+    public void BackendSuccessAndGuardRejectionPreserveCleanupSnapshots()
+    {
+        var clock = new ManualMonotonicTimeProvider();
+        using var cancellation = new CancellationTokenSource();
+        var operation = Operation(clock, cancellation.Token);
+        var foreignOperation = Operation(clock, cancellation.Token);
+        var successCleanup = new List<ProcessCleanupFailure>
+        {
+            Cleanup(
+                ProcessCleanupFailureKind.StreamDrainFailure,
+                "success cleanup failed")
+        };
+        var guardCleanup = new List<ProcessCleanupFailure>
+        {
+            Cleanup(
+                ProcessCleanupFailureKind.ResourceReleaseFailure,
+                "guard cleanup failed")
+        };
+
+        var completed = Assert.IsAssignableFrom<
+            ProcessContainmentOperationCompleted>(operation.FromBackend(
+                operation.BackendResults.Succeeded("backend evidence"),
+                successCleanup));
+        var guarded = AssertRejected(operation.FromBackend(
+            foreignOperation.BackendResults.Succeeded("foreign evidence"),
+            guardCleanup));
+        successCleanup.Clear();
+        guardCleanup.Clear();
+
+        Assert.Equal("backend evidence", completed.Evidence);
+        Assert.Equal(
+            ProcessCleanupFailureKind.StreamDrainFailure,
+            Assert.Single(completed.CleanupFailures).Kind);
+        Assert.IsAssignableFrom<ProcessContainmentContractFailure>(
+            guarded.PrimaryFailure);
+        Assert.Equal(
+            ProcessCleanupFailureKind.ResourceReleaseFailure,
+            Assert.Single(guarded.CleanupFailures).Kind);
+    }
+
+    [Fact]
     public void FailureFamiliesCannotRepresentContradictoryAuthorityKinds()
     {
         var clock = new ManualMonotonicTimeProvider();
@@ -154,7 +284,8 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
         var backend = AssertRejected(operation.FromBackend(
             operation.BackendResults.Failed(
                 new IOException("fixture backend failure"),
-                "backend failed"))).PrimaryFailure;
+                "backend failed"),
+            [])).PrimaryFailure;
         var contract = operation.ContractGuard.IllegalTransition(
             "illegal transition");
 

--- a/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
@@ -168,7 +168,6 @@ public sealed class ProcessSupervisionContractArchitectureTests
             typeof(ProcessContainmentOperationResult),
             typeof(ProcessContainmentOperationCompleted),
             typeof(ProcessContainmentOperationRejected),
-            typeof(ProcessContainmentOperationAuthorityIdentity),
             typeof(ProcessContainmentCallerAuthority),
             typeof(ProcessContainmentBackendResultFactory),
             typeof(ProcessContainmentContractGuard),
@@ -279,8 +278,13 @@ public sealed class ProcessSupervisionContractArchitectureTests
             .ToArray();
         Assert.Equal(3, resultEntries.Length);
         Assert.Single(resultEntries, method => method.Name == "FromBackend" &&
-            method.GetParameters()[0].ParameterType ==
-                typeof(ProcessContainmentBackendResult));
+            method.GetParameters()
+                .Select(parameter => parameter.ParameterType)
+                .SequenceEqual(
+                [
+                    typeof(ProcessContainmentBackendResult),
+                    typeof(IEnumerable<ProcessCleanupFailure>)
+                ]));
         Assert.Equal(
             [
                 typeof(ProcessContainmentCallerFailure),
@@ -293,12 +297,19 @@ public sealed class ProcessSupervisionContractArchitectureTests
         Assert.DoesNotContain(resultEntries, method =>
             method.GetParameters()[0].ParameterType ==
                 typeof(ProcessContainmentPrimaryFailure));
+        Assert.All(resultEntries, method => Assert.Equal(
+            typeof(IEnumerable<ProcessCleanupFailure>),
+            method.GetParameters()[1].ParameterType));
+        Assert.Equal(
+            typeof(IReadOnlyList<ProcessCleanupFailure>),
+            typeof(ProcessContainmentOperationResult)
+                .GetProperty(nameof(ProcessContainmentOperationResult.CleanupFailures))!
+                .PropertyType);
         Assert.Equal(
             [
                 nameof(ProcessContainmentOperationAuthority.BackendResults),
                 nameof(ProcessContainmentOperationAuthority.Caller),
-                nameof(ProcessContainmentOperationAuthority.ContractGuard),
-                nameof(ProcessContainmentOperationAuthority.Identity)
+                nameof(ProcessContainmentOperationAuthority.ContractGuard)
             ],
             typeof(ProcessContainmentOperationAuthority)
                 .GetProperties(BindingFlags.Instance | BindingFlags.Public)
@@ -326,11 +337,58 @@ public sealed class ProcessSupervisionContractArchitectureTests
                                .IsAssignableFrom(type))
             .ToArray();
 
-        Assert.Equal(2, callerFailures.Length);
+        Assert.Empty(callerFailures);
         Assert.Single(backendFailures);
         Assert.Equal(3, contractFailures.Length);
+        Assert.True(typeof(ProcessContainmentCallerFailure).IsSealed);
+        Assert.False(typeof(ProcessContainmentCallerFailure).IsAbstract);
         Assert.All(
-            callerFailures.Concat(backendFailures).Concat(contractFailures),
+            typeof(ProcessContainmentCallerFailure).GetConstructors(
+                BindingFlags.Instance | BindingFlags.NonPublic),
+            constructor => Assert.True(constructor.IsPrivate));
+        Assert.Equal(
+            [
+                nameof(ProcessContainmentCallerFailureKind.Cancellation),
+                nameof(ProcessContainmentCallerFailureKind.DeadlineExceeded)
+            ],
+            Enum.GetNames<ProcessContainmentCallerFailureKind>());
+        Assert.DoesNotContain(
+            typeof(ProcessContainmentCallerFailure).GetProperties(
+                BindingFlags.Instance |
+                BindingFlags.Public |
+                BindingFlags.NonPublic),
+            property => property.Name.Contains(
+                "Authority",
+                StringComparison.Ordinal));
+        Assert.All(
+            typeof(ProcessContainmentCallerFailure)
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic)
+                .Where(field => field.Name.Contains(
+                    "authority",
+                    StringComparison.OrdinalIgnoreCase)),
+            field => Assert.True(field.IsPrivate));
+        Assert.All(
+            typeof(ProcessContainmentCallerFailure.Publisher)
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic),
+            field => Assert.True(field.IsPrivate));
+        Assert.DoesNotContain(
+            typeof(ProcessContainmentCallerAuthority).GetProperties(
+                BindingFlags.Instance |
+                BindingFlags.Public |
+                BindingFlags.NonPublic),
+            property => property.Name.Contains(
+                "Identity",
+                StringComparison.Ordinal));
+        Assert.DoesNotContain(
+            typeof(ProcessContainmentOperationAuthority).GetProperties(
+                BindingFlags.Instance |
+                BindingFlags.Public |
+                BindingFlags.NonPublic),
+            property => property.Name.Contains(
+                "Identity",
+                StringComparison.Ordinal));
+        Assert.All(
+            backendFailures.Concat(contractFailures),
             type =>
             {
                 Assert.True(type.IsSealed);
@@ -352,7 +410,6 @@ public sealed class ProcessSupervisionContractArchitectureTests
             typeof(ProcessContainmentOperationResult),
             typeof(ProcessContainmentOperationCompleted),
             typeof(ProcessContainmentOperationRejected),
-            typeof(ProcessContainmentOperationAuthorityIdentity),
             typeof(ProcessContainmentBackendResultFactory),
             typeof(ProcessContainmentContractGuard),
             typeof(ProcessContainmentOperationAuthority)

--- a/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
@@ -159,7 +159,20 @@ public sealed class ProcessSupervisionContractArchitectureTests
             typeof(ProcessPrimaryFailure),
             typeof(ProcessCleanupFailure),
             typeof(ProcessTerminalCandidate),
-            typeof(ProcessSupervisionOutcome)
+            typeof(ProcessSupervisionOutcome),
+            typeof(ProcessContainmentPrimaryFailure),
+            typeof(ProcessContainmentBackendResult),
+            typeof(ProcessContainmentBackendFailure),
+            typeof(ProcessContainmentCallerFailure),
+            typeof(ProcessContainmentContractFailure),
+            typeof(ProcessContainmentOperationResult),
+            typeof(ProcessContainmentOperationCompleted),
+            typeof(ProcessContainmentOperationRejected),
+            typeof(ProcessContainmentOperationAuthorityIdentity),
+            typeof(ProcessContainmentCallerAuthority),
+            typeof(ProcessContainmentBackendResultFactory),
+            typeof(ProcessContainmentContractGuard),
+            typeof(ProcessContainmentOperationAuthority)
         ];
 
         foreach (var type in ownerCreatedTypes)
@@ -171,6 +184,206 @@ public sealed class ProcessSupervisionContractArchitectureTests
                     property.SetMethod is null || !property.SetMethod.IsPublic,
                     $"{type.Name}.{property.Name} exposes a public setter."));
         }
+    }
+
+    [Fact]
+    public void OperationAuthorityTaxonomyCannotEscalateBackendResults()
+    {
+        Assert.False(typeof(ProcessContainmentBackendResult).IsAssignableFrom(
+            typeof(ProcessContainmentCallerFailure)));
+        Assert.False(typeof(ProcessContainmentBackendResult).IsAssignableFrom(
+            typeof(ProcessContainmentContractFailure)));
+        Assert.False(typeof(ProcessContainmentBackendResult).IsAssignableFrom(
+            typeof(ProcessCleanupFailure)));
+        Assert.False(typeof(ProcessContainmentCallerFailure).IsAssignableFrom(
+            typeof(ProcessContainmentBackendFailure)));
+        Assert.False(typeof(ProcessContainmentContractFailure).IsAssignableFrom(
+            typeof(ProcessContainmentBackendFailure)));
+
+        var backendFactoryMethods = typeof(ProcessContainmentBackendResultFactory)
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(method => method.DeclaringType ==
+                             typeof(ProcessContainmentBackendResultFactory) &&
+                             method.ReturnType ==
+                                 typeof(ProcessContainmentBackendResult))
+            .ToArray();
+        Assert.Equal(
+            ["Failed", "Succeeded"],
+            backendFactoryMethods
+                .Select(method => method.Name)
+                .Order(StringComparer.Ordinal));
+        Assert.All(backendFactoryMethods, method =>
+        {
+            Assert.Equal(
+                typeof(ProcessContainmentBackendResult),
+                method.ReturnType);
+            Assert.DoesNotContain(method.GetParameters(), parameter =>
+                parameter.ParameterType == typeof(TransitionBudget) ||
+                parameter.ParameterType == typeof(CancellationToken) ||
+                parameter.ParameterType ==
+                    typeof(ProcessContainmentCallerAuthority) ||
+                typeof(ProcessContainmentCallerFailure).IsAssignableFrom(
+                    parameter.ParameterType) ||
+                typeof(ProcessContainmentContractFailure).IsAssignableFrom(
+                    parameter.ParameterType));
+        });
+
+        var callerFactoryMethods = typeof(ProcessContainmentCallerAuthority)
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(method => method.DeclaringType ==
+                             typeof(ProcessContainmentCallerAuthority) &&
+                             method.ReturnType ==
+                                 typeof(ProcessContainmentCallerFailure))
+            .ToArray();
+        Assert.Equal(
+            ["PublishCancellation", "PublishDeadlineExceeded"],
+            callerFactoryMethods
+                .Select(method => method.Name)
+                .Order(StringComparer.Ordinal));
+        Assert.All(callerFactoryMethods, method => Assert.Equal(
+            typeof(ProcessContainmentCallerFailure),
+            method.ReturnType));
+
+        var rootFactory = typeof(ProcessContainmentOperationAuthority).GetMethod(
+            "Create",
+            BindingFlags.Static | BindingFlags.NonPublic);
+        Assert.NotNull(rootFactory);
+        Assert.Equal(
+            [typeof(TransitionBudget), typeof(CancellationToken)],
+            rootFactory.GetParameters()
+                .Select(parameter => parameter.ParameterType));
+
+        var guardFactories = typeof(ProcessContainmentContractGuard)
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(method => method.DeclaringType ==
+                             typeof(ProcessContainmentContractGuard) &&
+                             method.ReturnType ==
+                                 typeof(ProcessContainmentContractFailure))
+            .ToDictionary(method => method.Name, StringComparer.Ordinal);
+        Assert.Equal(
+            ["AuthoritySubstitution", "IllegalTransition", "InvalidBackendResult"],
+            guardFactories.Keys.Order(StringComparer.Ordinal));
+        Assert.Equal(
+            typeof(ProcessContainmentContractFailure),
+            guardFactories["IllegalTransition"].ReturnType);
+        Assert.Equal(
+            typeof(ProcessContainmentContractFailure),
+            guardFactories["InvalidBackendResult"].ReturnType);
+
+        var resultEntries = typeof(ProcessContainmentOperationAuthority)
+            .GetMethods(BindingFlags.Instance | BindingFlags.NonPublic)
+            .Where(method => method.DeclaringType ==
+                             typeof(ProcessContainmentOperationAuthority) &&
+                             method.ReturnType ==
+                                 typeof(ProcessContainmentOperationResult))
+            .ToArray();
+        Assert.Equal(3, resultEntries.Length);
+        Assert.Single(resultEntries, method => method.Name == "FromBackend" &&
+            method.GetParameters()[0].ParameterType ==
+                typeof(ProcessContainmentBackendResult));
+        Assert.Equal(
+            [
+                typeof(ProcessContainmentCallerFailure),
+                typeof(ProcessContainmentContractFailure)
+            ],
+            resultEntries
+                .Where(method => method.Name == "Rejected")
+                .Select(method => method.GetParameters()[0].ParameterType)
+                .OrderBy(type => type.FullName, StringComparer.Ordinal));
+        Assert.DoesNotContain(resultEntries, method =>
+            method.GetParameters()[0].ParameterType ==
+                typeof(ProcessContainmentPrimaryFailure));
+        Assert.Equal(
+            [
+                nameof(ProcessContainmentOperationAuthority.BackendResults),
+                nameof(ProcessContainmentOperationAuthority.Caller),
+                nameof(ProcessContainmentOperationAuthority.ContractGuard),
+                nameof(ProcessContainmentOperationAuthority.Identity)
+            ],
+            typeof(ProcessContainmentOperationAuthority)
+                .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+                .Select(property => property.Name)
+                .Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void OperationAuthorityContractsRemainInertAndAreNotRuntimeProof()
+    {
+        var assembly = typeof(ProcessContainmentPrimaryFailure).Assembly;
+        var callerFailures = assembly.GetTypes()
+            .Where(type => type != typeof(ProcessContainmentCallerFailure) &&
+                           typeof(ProcessContainmentCallerFailure)
+                               .IsAssignableFrom(type))
+            .ToArray();
+        var backendFailures = assembly.GetTypes()
+            .Where(type => type != typeof(ProcessContainmentBackendFailure) &&
+                           typeof(ProcessContainmentBackendFailure)
+                               .IsAssignableFrom(type))
+            .ToArray();
+        var contractFailures = assembly.GetTypes()
+            .Where(type => type != typeof(ProcessContainmentContractFailure) &&
+                           typeof(ProcessContainmentContractFailure)
+                               .IsAssignableFrom(type))
+            .ToArray();
+
+        Assert.Equal(2, callerFailures.Length);
+        Assert.Single(backendFailures);
+        Assert.Equal(3, contractFailures.Length);
+        Assert.All(
+            callerFailures.Concat(backendFailures).Concat(contractFailures),
+            type =>
+            {
+                Assert.True(type.IsSealed);
+                Assert.False(type.IsPublic || type.IsNestedPublic);
+                Assert.Empty(type.GetConstructors());
+                Assert.False(typeof(ProcessSupervisionProof).IsAssignableFrom(type));
+                Assert.False(typeof(EstablishedProcessContainmentFact)
+                    .IsAssignableFrom(type));
+            });
+
+        Type[] authorityContractTypes =
+        [
+            typeof(ProcessContainmentCallerAuthority),
+            typeof(ProcessContainmentPrimaryFailure),
+            typeof(ProcessContainmentBackendResult),
+            typeof(ProcessContainmentBackendFailure),
+            typeof(ProcessContainmentCallerFailure),
+            typeof(ProcessContainmentContractFailure),
+            typeof(ProcessContainmentOperationResult),
+            typeof(ProcessContainmentOperationCompleted),
+            typeof(ProcessContainmentOperationRejected),
+            typeof(ProcessContainmentOperationAuthorityIdentity),
+            typeof(ProcessContainmentBackendResultFactory),
+            typeof(ProcessContainmentContractGuard),
+            typeof(ProcessContainmentOperationAuthority)
+        ];
+        string[] forbiddenRuntimeOwners =
+        [
+            "Lease",
+            "StateMachine",
+            "Coordinator",
+            "Executor",
+            "Host"
+        ];
+        Assert.DoesNotContain(authorityContractTypes, type =>
+            forbiddenRuntimeOwners.Any(fragment =>
+                type.Name.Contains(fragment, StringComparison.Ordinal)));
+        Assert.DoesNotContain(
+            authorityContractTypes.SelectMany(type => type.GetMethods(
+                BindingFlags.Instance |
+                BindingFlags.Static |
+                BindingFlags.Public |
+                BindingFlags.NonPublic |
+                BindingFlags.DeclaredOnly)),
+            method => method.Name is "Execute" or "ExecuteAsync" or
+                "Start" or "StartAsync" or "Transition");
+        Assert.All(authorityContractTypes, type =>
+        {
+            Assert.False(typeof(ProcessSupervisionProof).IsAssignableFrom(type));
+            Assert.False(typeof(EstablishedProcessContainmentFact)
+                .IsAssignableFrom(type));
+            Assert.False(typeof(IProcessContainmentBackend).IsAssignableFrom(type));
+        });
     }
 
     [Fact]

--- a/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractBehaviorTests.cs
@@ -217,6 +217,20 @@ public sealed class ProcessSupervisionContractBehaviorTests
         Assert.True(outcome.Proof.FormalGatePassed);
     }
 
+    [Fact]
+    public void UndefinedCleanupFailureCannotEnterSupervisionOutcome()
+    {
+        var primary = Primary(
+            ProcessPrimaryFailureKind.ExecutionFailure,
+            authoritySequence: 1);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ProcessSupervisionOutcome(
+                primary,
+                ProveAll().Build(),
+                UndefinedCleanupFailures()));
+    }
+
     private static ProcessTerminalCandidate Primary(
         ProcessPrimaryFailureKind kind,
         long authoritySequence)
@@ -250,6 +264,14 @@ public sealed class ProcessSupervisionContractBehaviorTests
         }
 
         return builder;
+    }
+
+    private static IEnumerable<ProcessCleanupFailure> UndefinedCleanupFailures()
+    {
+        yield return new ProcessCleanupFailure(
+            (ProcessCleanupFailureKind)int.MaxValue,
+            nameof(InvalidOperationException),
+            "undefined cleanup failure");
     }
 
     private sealed class ManualMonotonicTimeProvider : TimeProvider

--- a/tools/DownKyi.ProcessSupervision/ProcessContainmentOperationAuthorityContracts.cs
+++ b/tools/DownKyi.ProcessSupervision/ProcessContainmentOperationAuthorityContracts.cs
@@ -2,7 +2,7 @@ using System.Collections.ObjectModel;
 
 namespace DownKyi.ProcessSupervision;
 
-internal abstract record ProcessContainmentPrimaryFailure
+internal abstract class ProcessContainmentPrimaryFailure
 {
     private protected ProcessContainmentPrimaryFailure(
         string errorType,
@@ -19,7 +19,7 @@ internal abstract record ProcessContainmentPrimaryFailure
     public string Detail { get; }
 }
 
-internal abstract record ProcessContainmentBackendFailure
+internal abstract class ProcessContainmentBackendFailure
     : ProcessContainmentPrimaryFailure
 {
     private protected ProcessContainmentBackendFailure(
@@ -35,23 +35,78 @@ internal abstract record ProcessContainmentBackendFailure
     internal object AuthorityIdentity { get; }
 }
 
-internal abstract record ProcessContainmentCallerFailure
-    : ProcessContainmentPrimaryFailure
+internal enum ProcessContainmentCallerFailureKind
 {
-    private protected ProcessContainmentCallerFailure(
-        ProcessContainmentOperationAuthorityIdentity authorityIdentity,
-        string errorType,
-        string detail)
-        : base(errorType, detail)
-    {
-        ArgumentNullException.ThrowIfNull(authorityIdentity);
-        AuthorityIdentity = authorityIdentity;
-    }
-
-    public ProcessContainmentOperationAuthorityIdentity AuthorityIdentity { get; }
+    Cancellation,
+    DeadlineExceeded
 }
 
-internal abstract record ProcessContainmentContractFailure
+internal sealed class ProcessContainmentCallerFailure
+    : ProcessContainmentPrimaryFailure
+{
+    private readonly object _authorityIdentity;
+
+    private ProcessContainmentCallerFailure(
+        object authorityIdentity,
+        ProcessContainmentCallerFailureKind kind,
+        string detail)
+        : base(ErrorTypeFor(kind), detail)
+    {
+        ArgumentNullException.ThrowIfNull(authorityIdentity);
+        _authorityIdentity = authorityIdentity;
+        Kind = kind;
+    }
+
+    public ProcessContainmentCallerFailureKind Kind { get; }
+
+    private bool IsOwnedBy(object authorityIdentity)
+    {
+        return ReferenceEquals(_authorityIdentity, authorityIdentity);
+    }
+
+    private static string ErrorTypeFor(ProcessContainmentCallerFailureKind kind)
+    {
+        return kind switch
+        {
+            ProcessContainmentCallerFailureKind.Cancellation =>
+                nameof(OperationCanceledException),
+            ProcessContainmentCallerFailureKind.DeadlineExceeded =>
+                nameof(TimeoutException),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null)
+        };
+    }
+
+    internal sealed class Publisher
+    {
+        private readonly object _authorityIdentity = new();
+
+        internal ProcessContainmentCallerFailure PublishCancellation(
+            string detail)
+        {
+            return new ProcessContainmentCallerFailure(
+                _authorityIdentity,
+                ProcessContainmentCallerFailureKind.Cancellation,
+                detail);
+        }
+
+        internal ProcessContainmentCallerFailure PublishDeadlineExceeded(
+            string detail)
+        {
+            return new ProcessContainmentCallerFailure(
+                _authorityIdentity,
+                ProcessContainmentCallerFailureKind.DeadlineExceeded,
+                detail);
+        }
+
+        internal bool Owns(ProcessContainmentCallerFailure failure)
+        {
+            ArgumentNullException.ThrowIfNull(failure);
+            return failure.IsOwnedBy(_authorityIdentity);
+        }
+    }
+}
+
+internal abstract class ProcessContainmentContractFailure
     : ProcessContainmentPrimaryFailure
 {
     private protected ProcessContainmentContractFailure(
@@ -67,26 +122,18 @@ internal abstract record ProcessContainmentContractFailure
     internal object AuthorityIdentity { get; }
 }
 
-internal sealed class ProcessContainmentOperationAuthorityIdentity
-{
-    internal ProcessContainmentOperationAuthorityIdentity()
-    {
-    }
-}
-
 internal sealed class ProcessContainmentCallerAuthority
 {
+    private readonly ProcessContainmentCallerFailure.Publisher _publisher = new();
+
     internal ProcessContainmentCallerAuthority(
         TransitionBudget budget,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(budget);
-        Identity = new ProcessContainmentOperationAuthorityIdentity();
         Budget = budget;
         CancellationToken = cancellationToken;
     }
-
-    public ProcessContainmentOperationAuthorityIdentity Identity { get; }
 
     public TransitionBudget Budget { get; }
 
@@ -100,7 +147,7 @@ internal sealed class ProcessContainmentCallerAuthority
                 "Caller cancellation cannot be published before its bound capability is canceled.");
         }
 
-        return new PublishedCallerCancellationFailure(Identity, detail);
+        return _publisher.PublishCancellation(detail);
     }
 
     internal ProcessContainmentCallerFailure PublishDeadlineExceeded(string detail)
@@ -111,13 +158,13 @@ internal sealed class ProcessContainmentCallerAuthority
                 "Caller deadline cannot be published before the bound root budget observes expiry.");
         }
 
-        return new PublishedCallerDeadlineExceededFailure(Identity, detail);
+        return _publisher.PublishDeadlineExceeded(detail);
     }
 
     internal bool Owns(ProcessContainmentCallerFailure failure)
     {
         ArgumentNullException.ThrowIfNull(failure);
-        return ReferenceEquals(Identity, failure.AuthorityIdentity);
+        return _publisher.Owns(failure);
     }
 }
 
@@ -205,12 +252,33 @@ internal sealed class ProcessContainmentContractGuard
     }
 }
 
-internal abstract record ProcessContainmentOperationResult;
+internal abstract record ProcessContainmentOperationResult
+{
+    private protected ProcessContainmentOperationResult(
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+    {
+        ArgumentNullException.ThrowIfNull(cleanupFailures);
+        var snapshot = cleanupFailures.ToArray();
+        if (snapshot.Any(failure => failure is null))
+        {
+            throw new ArgumentException(
+                "Cleanup failures cannot contain a null item.",
+                nameof(cleanupFailures));
+        }
+
+        CleanupFailures = new ReadOnlyCollection<ProcessCleanupFailure>(snapshot);
+    }
+
+    public IReadOnlyList<ProcessCleanupFailure> CleanupFailures { get; }
+}
 
 internal abstract record ProcessContainmentOperationCompleted
     : ProcessContainmentOperationResult
 {
-    private protected ProcessContainmentOperationCompleted(string evidence)
+    private protected ProcessContainmentOperationCompleted(
+        string evidence,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+        : base(cleanupFailures)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(evidence);
         Evidence = evidence;
@@ -225,24 +293,13 @@ internal abstract record ProcessContainmentOperationRejected
     private protected ProcessContainmentOperationRejected(
         ProcessContainmentPrimaryFailure primaryFailure,
         IEnumerable<ProcessCleanupFailure> cleanupFailures)
+        : base(cleanupFailures)
     {
         ArgumentNullException.ThrowIfNull(primaryFailure);
-        ArgumentNullException.ThrowIfNull(cleanupFailures);
-        var snapshot = cleanupFailures.ToArray();
-        if (snapshot.Any(failure => failure is null))
-        {
-            throw new ArgumentException(
-                "Cleanup failures cannot contain a null item.",
-                nameof(cleanupFailures));
-        }
-
         PrimaryFailure = primaryFailure;
-        CleanupFailures = new ReadOnlyCollection<ProcessCleanupFailure>(snapshot);
     }
 
     public ProcessContainmentPrimaryFailure PrimaryFailure { get; }
-
-    public IReadOnlyList<ProcessCleanupFailure> CleanupFailures { get; }
 }
 
 internal sealed class ProcessContainmentOperationAuthority
@@ -257,8 +314,6 @@ internal sealed class ProcessContainmentOperationAuthority
         BackendResults = new ProcessContainmentBackendResultFactory();
         ContractGuard = new ProcessContainmentContractGuard();
     }
-
-    public ProcessContainmentOperationAuthorityIdentity Identity => Caller.Identity;
 
     public ProcessContainmentCallerAuthority Caller { get; }
 
@@ -276,26 +331,32 @@ internal sealed class ProcessContainmentOperationAuthority
     }
 
     internal ProcessContainmentOperationResult FromBackend(
-        ProcessContainmentBackendResult backendResult)
+        ProcessContainmentBackendResult backendResult,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
     {
         ArgumentNullException.ThrowIfNull(backendResult);
+        ArgumentNullException.ThrowIfNull(cleanupFailures);
         if (!BackendResults.Owns(backendResult))
         {
             return new PublishedOperationRejected(
                 ContractGuard.AuthoritySubstitution(),
-                []);
+                cleanupFailures);
         }
 
         return backendResult switch
         {
             PublishedBackendSucceeded succeeded =>
-                new PublishedOperationCompleted(succeeded.Evidence),
+                new PublishedOperationCompleted(
+                    succeeded.Evidence,
+                    cleanupFailures),
             PublishedBackendFailed failed when BackendResults.Owns(failed.Failure) =>
-                new PublishedOperationRejected(failed.Failure, []),
+                new PublishedOperationRejected(
+                    failed.Failure,
+                    cleanupFailures),
             _ => new PublishedOperationRejected(
                 ContractGuard.InvalidBackendResult(
                     "The backend returned an unsupported result type."),
-                [])
+                cleanupFailures)
         };
     }
 
@@ -324,7 +385,7 @@ internal sealed class ProcessContainmentOperationAuthority
     }
 }
 
-file sealed record PublishedBackendOperationFailure
+file sealed class PublishedBackendOperationFailure
     : ProcessContainmentBackendFailure
 {
     internal PublishedBackendOperationFailure(
@@ -336,32 +397,7 @@ file sealed record PublishedBackendOperationFailure
     }
 }
 
-file sealed record PublishedCallerCancellationFailure
-    : ProcessContainmentCallerFailure
-{
-    internal PublishedCallerCancellationFailure(
-        ProcessContainmentOperationAuthorityIdentity authorityIdentity,
-        string detail)
-        : base(
-            authorityIdentity,
-            nameof(OperationCanceledException),
-            detail)
-    {
-    }
-}
-
-file sealed record PublishedCallerDeadlineExceededFailure
-    : ProcessContainmentCallerFailure
-{
-    internal PublishedCallerDeadlineExceededFailure(
-        ProcessContainmentOperationAuthorityIdentity authorityIdentity,
-        string detail)
-        : base(authorityIdentity, nameof(TimeoutException), detail)
-    {
-    }
-}
-
-file sealed record PublishedIllegalTransitionFailure
+file sealed class PublishedIllegalTransitionFailure
     : ProcessContainmentContractFailure
 {
     internal PublishedIllegalTransitionFailure(
@@ -372,7 +408,7 @@ file sealed record PublishedIllegalTransitionFailure
     }
 }
 
-file sealed record PublishedInvalidBackendResultFailure
+file sealed class PublishedInvalidBackendResultFailure
     : ProcessContainmentContractFailure
 {
     internal PublishedInvalidBackendResultFailure(
@@ -383,7 +419,7 @@ file sealed record PublishedInvalidBackendResultFailure
     }
 }
 
-file sealed record PublishedAuthoritySubstitutionFailure
+file sealed class PublishedAuthoritySubstitutionFailure
     : ProcessContainmentContractFailure
 {
     internal PublishedAuthoritySubstitutionFailure(object authorityIdentity)
@@ -424,8 +460,10 @@ file sealed record PublishedBackendFailed : ProcessContainmentBackendResult
 file sealed record PublishedOperationCompleted
     : ProcessContainmentOperationCompleted
 {
-    internal PublishedOperationCompleted(string evidence)
-        : base(evidence)
+    internal PublishedOperationCompleted(
+        string evidence,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+        : base(evidence, cleanupFailures)
     {
     }
 }

--- a/tools/DownKyi.ProcessSupervision/ProcessContainmentOperationAuthorityContracts.cs
+++ b/tools/DownKyi.ProcessSupervision/ProcessContainmentOperationAuthorityContracts.cs
@@ -1,0 +1,442 @@
+using System.Collections.ObjectModel;
+
+namespace DownKyi.ProcessSupervision;
+
+internal abstract record ProcessContainmentPrimaryFailure
+{
+    private protected ProcessContainmentPrimaryFailure(
+        string errorType,
+        string detail)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(errorType);
+        ArgumentException.ThrowIfNullOrWhiteSpace(detail);
+        ErrorType = errorType;
+        Detail = detail;
+    }
+
+    public string ErrorType { get; }
+
+    public string Detail { get; }
+}
+
+internal abstract record ProcessContainmentBackendFailure
+    : ProcessContainmentPrimaryFailure
+{
+    private protected ProcessContainmentBackendFailure(
+        object authorityIdentity,
+        string errorType,
+        string detail)
+        : base(errorType, detail)
+    {
+        ArgumentNullException.ThrowIfNull(authorityIdentity);
+        AuthorityIdentity = authorityIdentity;
+    }
+
+    internal object AuthorityIdentity { get; }
+}
+
+internal abstract record ProcessContainmentCallerFailure
+    : ProcessContainmentPrimaryFailure
+{
+    private protected ProcessContainmentCallerFailure(
+        ProcessContainmentOperationAuthorityIdentity authorityIdentity,
+        string errorType,
+        string detail)
+        : base(errorType, detail)
+    {
+        ArgumentNullException.ThrowIfNull(authorityIdentity);
+        AuthorityIdentity = authorityIdentity;
+    }
+
+    public ProcessContainmentOperationAuthorityIdentity AuthorityIdentity { get; }
+}
+
+internal abstract record ProcessContainmentContractFailure
+    : ProcessContainmentPrimaryFailure
+{
+    private protected ProcessContainmentContractFailure(
+        object authorityIdentity,
+        string errorType,
+        string detail)
+        : base(errorType, detail)
+    {
+        ArgumentNullException.ThrowIfNull(authorityIdentity);
+        AuthorityIdentity = authorityIdentity;
+    }
+
+    internal object AuthorityIdentity { get; }
+}
+
+internal sealed class ProcessContainmentOperationAuthorityIdentity
+{
+    internal ProcessContainmentOperationAuthorityIdentity()
+    {
+    }
+}
+
+internal sealed class ProcessContainmentCallerAuthority
+{
+    internal ProcessContainmentCallerAuthority(
+        TransitionBudget budget,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(budget);
+        Identity = new ProcessContainmentOperationAuthorityIdentity();
+        Budget = budget;
+        CancellationToken = cancellationToken;
+    }
+
+    public ProcessContainmentOperationAuthorityIdentity Identity { get; }
+
+    public TransitionBudget Budget { get; }
+
+    public CancellationToken CancellationToken { get; }
+
+    internal ProcessContainmentCallerFailure PublishCancellation(string detail)
+    {
+        if (!CancellationToken.IsCancellationRequested)
+        {
+            throw new InvalidOperationException(
+                "Caller cancellation cannot be published before its bound capability is canceled.");
+        }
+
+        return new PublishedCallerCancellationFailure(Identity, detail);
+    }
+
+    internal ProcessContainmentCallerFailure PublishDeadlineExceeded(string detail)
+    {
+        if (!Budget.Operation.IsExpired)
+        {
+            throw new InvalidOperationException(
+                "Caller deadline cannot be published before the bound root budget observes expiry.");
+        }
+
+        return new PublishedCallerDeadlineExceededFailure(Identity, detail);
+    }
+
+    internal bool Owns(ProcessContainmentCallerFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return ReferenceEquals(Identity, failure.AuthorityIdentity);
+    }
+}
+
+internal abstract record ProcessContainmentBackendResult
+{
+    private protected ProcessContainmentBackendResult(object authorityIdentity)
+    {
+        ArgumentNullException.ThrowIfNull(authorityIdentity);
+        AuthorityIdentity = authorityIdentity;
+    }
+
+    internal object AuthorityIdentity { get; }
+}
+
+internal sealed class ProcessContainmentBackendResultFactory
+{
+    private readonly object _authorityIdentity = new();
+
+    internal ProcessContainmentBackendResultFactory()
+    {
+    }
+
+    internal ProcessContainmentBackendResult Succeeded(string evidence)
+    {
+        return new PublishedBackendSucceeded(_authorityIdentity, evidence);
+    }
+
+    internal ProcessContainmentBackendResult Failed(
+        Exception failure,
+        string detail)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new PublishedBackendFailed(
+            _authorityIdentity,
+            new PublishedBackendOperationFailure(
+                _authorityIdentity,
+                failure.GetType().Name,
+                detail));
+    }
+
+    internal bool Owns(ProcessContainmentBackendResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+        return ReferenceEquals(_authorityIdentity, result.AuthorityIdentity);
+    }
+
+    internal bool Owns(ProcessContainmentBackendFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return ReferenceEquals(_authorityIdentity, failure.AuthorityIdentity);
+    }
+}
+
+internal sealed class ProcessContainmentContractGuard
+{
+    private readonly object _authorityIdentity = new();
+
+    internal ProcessContainmentContractGuard()
+    {
+    }
+
+    internal ProcessContainmentContractFailure IllegalTransition(string detail)
+    {
+        return new PublishedIllegalTransitionFailure(
+            _authorityIdentity,
+            detail);
+    }
+
+    internal ProcessContainmentContractFailure InvalidBackendResult(string detail)
+    {
+        return new PublishedInvalidBackendResultFailure(
+            _authorityIdentity,
+            detail);
+    }
+
+    internal ProcessContainmentContractFailure AuthoritySubstitution()
+    {
+        return new PublishedAuthoritySubstitutionFailure(_authorityIdentity);
+    }
+
+    internal bool Owns(ProcessContainmentContractFailure failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return ReferenceEquals(_authorityIdentity, failure.AuthorityIdentity);
+    }
+}
+
+internal abstract record ProcessContainmentOperationResult;
+
+internal abstract record ProcessContainmentOperationCompleted
+    : ProcessContainmentOperationResult
+{
+    private protected ProcessContainmentOperationCompleted(string evidence)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(evidence);
+        Evidence = evidence;
+    }
+
+    public string Evidence { get; }
+}
+
+internal abstract record ProcessContainmentOperationRejected
+    : ProcessContainmentOperationResult
+{
+    private protected ProcessContainmentOperationRejected(
+        ProcessContainmentPrimaryFailure primaryFailure,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+    {
+        ArgumentNullException.ThrowIfNull(primaryFailure);
+        ArgumentNullException.ThrowIfNull(cleanupFailures);
+        var snapshot = cleanupFailures.ToArray();
+        if (snapshot.Any(failure => failure is null))
+        {
+            throw new ArgumentException(
+                "Cleanup failures cannot contain a null item.",
+                nameof(cleanupFailures));
+        }
+
+        PrimaryFailure = primaryFailure;
+        CleanupFailures = new ReadOnlyCollection<ProcessCleanupFailure>(snapshot);
+    }
+
+    public ProcessContainmentPrimaryFailure PrimaryFailure { get; }
+
+    public IReadOnlyList<ProcessCleanupFailure> CleanupFailures { get; }
+}
+
+internal sealed class ProcessContainmentOperationAuthority
+{
+    private ProcessContainmentOperationAuthority(
+        TransitionBudget budget,
+        CancellationToken cancellationToken)
+    {
+        Caller = new ProcessContainmentCallerAuthority(
+            budget,
+            cancellationToken);
+        BackendResults = new ProcessContainmentBackendResultFactory();
+        ContractGuard = new ProcessContainmentContractGuard();
+    }
+
+    public ProcessContainmentOperationAuthorityIdentity Identity => Caller.Identity;
+
+    public ProcessContainmentCallerAuthority Caller { get; }
+
+    public ProcessContainmentBackendResultFactory BackendResults { get; }
+
+    public ProcessContainmentContractGuard ContractGuard { get; }
+
+    internal static ProcessContainmentOperationAuthority Create(
+        TransitionBudget budget,
+        CancellationToken cancellationToken)
+    {
+        return new ProcessContainmentOperationAuthority(
+            budget,
+            cancellationToken);
+    }
+
+    internal ProcessContainmentOperationResult FromBackend(
+        ProcessContainmentBackendResult backendResult)
+    {
+        ArgumentNullException.ThrowIfNull(backendResult);
+        if (!BackendResults.Owns(backendResult))
+        {
+            return new PublishedOperationRejected(
+                ContractGuard.AuthoritySubstitution(),
+                []);
+        }
+
+        return backendResult switch
+        {
+            PublishedBackendSucceeded succeeded =>
+                new PublishedOperationCompleted(succeeded.Evidence),
+            PublishedBackendFailed failed when BackendResults.Owns(failed.Failure) =>
+                new PublishedOperationRejected(failed.Failure, []),
+            _ => new PublishedOperationRejected(
+                ContractGuard.InvalidBackendResult(
+                    "The backend returned an unsupported result type."),
+                [])
+        };
+    }
+
+    internal ProcessContainmentOperationResult Rejected(
+        ProcessContainmentCallerFailure primaryFailure,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+    {
+        ArgumentNullException.ThrowIfNull(primaryFailure);
+        return Caller.Owns(primaryFailure)
+            ? new PublishedOperationRejected(primaryFailure, cleanupFailures)
+            : new PublishedOperationRejected(
+                ContractGuard.AuthoritySubstitution(),
+                cleanupFailures);
+    }
+
+    internal ProcessContainmentOperationResult Rejected(
+        ProcessContainmentContractFailure primaryFailure,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+    {
+        ArgumentNullException.ThrowIfNull(primaryFailure);
+        return ContractGuard.Owns(primaryFailure)
+            ? new PublishedOperationRejected(primaryFailure, cleanupFailures)
+            : new PublishedOperationRejected(
+                ContractGuard.AuthoritySubstitution(),
+                cleanupFailures);
+    }
+}
+
+file sealed record PublishedBackendOperationFailure
+    : ProcessContainmentBackendFailure
+{
+    internal PublishedBackendOperationFailure(
+        object authorityIdentity,
+        string errorType,
+        string detail)
+        : base(authorityIdentity, errorType, detail)
+    {
+    }
+}
+
+file sealed record PublishedCallerCancellationFailure
+    : ProcessContainmentCallerFailure
+{
+    internal PublishedCallerCancellationFailure(
+        ProcessContainmentOperationAuthorityIdentity authorityIdentity,
+        string detail)
+        : base(
+            authorityIdentity,
+            nameof(OperationCanceledException),
+            detail)
+    {
+    }
+}
+
+file sealed record PublishedCallerDeadlineExceededFailure
+    : ProcessContainmentCallerFailure
+{
+    internal PublishedCallerDeadlineExceededFailure(
+        ProcessContainmentOperationAuthorityIdentity authorityIdentity,
+        string detail)
+        : base(authorityIdentity, nameof(TimeoutException), detail)
+    {
+    }
+}
+
+file sealed record PublishedIllegalTransitionFailure
+    : ProcessContainmentContractFailure
+{
+    internal PublishedIllegalTransitionFailure(
+        object authorityIdentity,
+        string detail)
+        : base(authorityIdentity, nameof(InvalidOperationException), detail)
+    {
+    }
+}
+
+file sealed record PublishedInvalidBackendResultFailure
+    : ProcessContainmentContractFailure
+{
+    internal PublishedInvalidBackendResultFailure(
+        object authorityIdentity,
+        string detail)
+        : base(authorityIdentity, nameof(InvalidOperationException), detail)
+    {
+    }
+}
+
+file sealed record PublishedAuthoritySubstitutionFailure
+    : ProcessContainmentContractFailure
+{
+    internal PublishedAuthoritySubstitutionFailure(object authorityIdentity)
+        : base(
+            authorityIdentity,
+            nameof(InvalidOperationException),
+            "The candidate authority does not own this operation lifetime.")
+    {
+    }
+}
+
+file sealed record PublishedBackendSucceeded : ProcessContainmentBackendResult
+{
+    internal PublishedBackendSucceeded(object authorityIdentity, string evidence)
+        : base(authorityIdentity)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(evidence);
+        Evidence = evidence;
+    }
+
+    public string Evidence { get; }
+}
+
+file sealed record PublishedBackendFailed : ProcessContainmentBackendResult
+{
+    internal PublishedBackendFailed(
+        object authorityIdentity,
+        ProcessContainmentBackendFailure failure)
+        : base(authorityIdentity)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        Failure = failure;
+    }
+
+    public ProcessContainmentBackendFailure Failure { get; }
+}
+
+file sealed record PublishedOperationCompleted
+    : ProcessContainmentOperationCompleted
+{
+    internal PublishedOperationCompleted(string evidence)
+        : base(evidence)
+    {
+    }
+}
+
+file sealed record PublishedOperationRejected
+    : ProcessContainmentOperationRejected
+{
+    internal PublishedOperationRejected(
+        ProcessContainmentPrimaryFailure primaryFailure,
+        IEnumerable<ProcessCleanupFailure> cleanupFailures)
+        : base(primaryFailure, cleanupFailures)
+    {
+    }
+}

--- a/tools/DownKyi.ProcessSupervision/TerminalOutcomeContracts.cs
+++ b/tools/DownKyi.ProcessSupervision/TerminalOutcomeContracts.cs
@@ -67,6 +67,11 @@ public sealed record ProcessCleanupFailure
         string errorType,
         string message)
     {
+        if (!Enum.IsDefined(kind))
+        {
+            throw new ArgumentOutOfRangeException(nameof(kind), kind, null);
+        }
+
         ArgumentException.ThrowIfNullOrWhiteSpace(errorType);
         ArgumentException.ThrowIfNullOrWhiteSpace(message);
         Kind = kind;


### PR DESCRIPTION
## Summary

- bind caller deadline/cancellation publication, backend-result publication, and contract-guard publication to one immutable operation authority bundle
- keep caller, backend, contract, and cleanup failure families structurally separate; validate foreign and rebound authority facts at the operation result entry seams
- add focused adversarial behavior tests and Architecture reflection gates while leaving `TransitionBudget` clock semantics and every runtime ownership path unchanged

Base: `259a3c65c0936ac29024930b8823c81c00001093`
Head: `9b5e84aa35d11e7614eb2cda6dc0630f1fdca8a8`

## Scope and non-goals

This is Task 2.1e replacement slice 1/4 only. The contracts are inert and have no active production caller. This PR does not add a state machine, lease, prepare/rollback flow, launch prerequisite, OS backend, host, process start, new timeline/deadline, sleep, retry, or PID logic. It does not modify `TransitionBudget` or claim a runtime containment proof.

`ProcessContainmentOperationResult` is operation-specific. A later slice must define one explicit one-way mapping into the existing `ProcessSupervisionOutcome` taxonomy; the two taxonomies must never become parallel primary arbiters.

## Closure Gate

- WHO: `ProcessContainmentOperationAuthority` owns one caller authority identity plus private backend-result and contract-guard publication capabilities.
- WHAT: immutable operation result facts only: backend completion/failure, caller failure, contract rejection, and cleanup side-channel facts.
- ENTRY: `Create(TransitionBudget, CancellationToken)` binds the root pair once; capability-specific factories publish facts; operation entry seams validate their owning authority.
- EXIT: immutable completed or rejected snapshots; rejected results retain exactly one primary failure plus an ordered cleanup snapshot.
- STATE: no lifecycle state or transition machine is introduced.
- FAILURE: caller cancellation/deadline, backend operation failure, contract/guard rejection, and cleanup failure remain disjoint typed families.
- CAPABILITY: cross-operation, same-budget/token rebound, foreign backend, and foreign guard facts are rejected as receiving-operation contract failures.
- CLOCK: the existing monotonic `TransitionBudget.Operation.IsExpired` observation is unchanged and is read only by caller deadline publication; there is no catch-time reclassification.
- RACE: a backend exception captured before a delayed continuation remains backend failure; input cleanup enumeration and scheduler progress cannot mutate a published result.
- FACT: the authority contract does not implement or produce `ProcessSupervisionProof` or `EstablishedProcessContainmentFact`, and there is no active runtime caller.

## Review remediation

- caller failures are now sealed and privately constructed; the operation no longer exposes a reusable caller identity, and receiving authority validation rejects reflected or independently published foreign facts
- cleanup publication is owned by the common operation-result boundary; completion, backend failure, and guard rejection all retain the same immutable ordered cleanup snapshot without replacing the primary failure
- the common ProcessCleanupFailure fact owner rejects undefined enum values before either the existing supervision outcome or the operation result can snapshot them
## Validation

- focused operation-authority and terminal-contract tests: 27 passed, 0 failed, 0 skipped
- full `DownKyi.Architecture.Tests`: 378 passed, 0 failed, 0 skipped
- strict Release solution build with all analyzers and warnings-as-errors: passed, 0 warnings, 0 errors
- review invariant gate: 7 projects, 320 tests, 1 adversarial mutation proof; passed
- lifecycle ownership audit: 565 matches, 0 violations
- module boundary audit: passed
- `dotnet format DownKyi.sln --verify-no-changes --no-restore`: passed
- `git diff --check`: passed

Lifecycle and 100-round suites were intentionally not run because this slice has no runtime lifecycle caller and the task explicitly excludes them.