### PR TITLE
refactor: centralize process terminal success authority

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
     <PackageVersion Include="Grpc.Tools" Version="2.82.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite.Core" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />

--- a/docs/testing/review-invariant-corpus.json
+++ b/docs/testing/review-invariant-corpus.json
@@ -30,6 +30,46 @@
       ]
     },
     {
+      "id": "process-terminal-success-authority",
+      "historicalRoots": ["PR #208", "PR #213"],
+      "guards": "ProcessSupervisionOutcome alone derives final success from target-terminal exit zero, formal proof and an empty cleanup-failure snapshot; proof and containment-operation facts cannot independently report final success or gain an active production consumer before OwnedProcessLease integration.",
+      "testClasses": [
+        { "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj", "class": "DownKyi.Architecture.Tests.ProcessSupervisionContractBehaviorTests" },
+        { "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj", "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests" }
+      ],
+      "proofRequirements": [
+        "deterministic-generative",
+        "semantic-architecture",
+        "adversarial-mutation"
+      ],
+      "adversarialProofs": [
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "direct-formal-gate",
+          "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "second-success-authority",
+          "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "operation-completed-final-success",
+          "expectedOutcome": "test-failure"
+        }
+      ]
+    },
+    {
       "id": "output-cleanup-ownership",
       "historicalRoots": ["PR #85", "PR #120"],
       "guards": "Task rows, transfer inputs, resume state, generated files and sidecars are changed through their existing owners; retry checkpoints survive every pre-commit failure and transfer inputs are cleaned only after durable completion.",

--- a/docs/testing/review-invariant-corpus.json
+++ b/docs/testing/review-invariant-corpus.json
@@ -66,6 +66,46 @@
           "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
           "environmentValue": "operation-completed-final-success",
           "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "target-typed-outcome-constructor",
+          "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "qualified-bool-success-authority",
+          "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "positional-record-success-authority",
+          "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "contract-operation-consumer",
+          "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "dynamic-success-access",
+          "expectedOutcome": "test-failure"
         }
       ]
     },

--- a/docs/testing/review-invariant-corpus.json
+++ b/docs/testing/review-invariant-corpus.json
@@ -64,6 +64,14 @@
           "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
           "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
           "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
+          "environmentValue": "subnamespace-record-success-authority",
+          "expectedOutcome": "test-failure"
+        },
+        {
+          "kind": "adversarial-mutation",
+          "project": "tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj",
+          "class": "DownKyi.Architecture.Tests.ProcessTerminalSuccessAuthorityArchitectureTests",
+          "environmentVariable": "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY",
           "environmentValue": "operation-completed-final-success",
           "expectedOutcome": "test-failure"
         },

--- a/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
+++ b/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs
@@ -56,14 +56,14 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
             []));
 
         Assert.IsAssignableFrom<ProcessContainmentBackendFailure>(
-            rejected.PrimaryFailure);
+            rejected.Failure);
         Assert.IsNotAssignableFrom<ProcessContainmentCallerFailure>(
-            rejected.PrimaryFailure);
+            rejected.Failure);
         Assert.IsNotAssignableFrom<ProcessContainmentContractFailure>(
-            rejected.PrimaryFailure);
+            rejected.Failure);
         Assert.Equal(
             nameof(InvalidOperationException),
-            rejected.PrimaryFailure.ErrorType);
+            rejected.Failure.ErrorType);
     }
 
     [Fact]
@@ -98,7 +98,7 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
             operationB.ContractGuard.IllegalTransition("guard B failure"),
             []));
 
-        Assert.Same(ownCaller, ownResult.PrimaryFailure);
+        Assert.Same(ownCaller, ownResult.Failure);
         Assert.All(
         [
             foreignCallerResult,
@@ -109,10 +109,10 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
             rejected =>
             {
                 Assert.IsAssignableFrom<ProcessContainmentContractFailure>(
-                    rejected.PrimaryFailure);
+                    rejected.Failure);
                 Assert.Contains(
                     "does not own this operation lifetime",
-                    rejected.PrimaryFailure.Detail,
+                    rejected.Failure.Detail,
                     StringComparison.Ordinal);
             });
     }
@@ -159,23 +159,23 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
         Assert.All([rejected, foreignRejected], candidate =>
         {
             Assert.IsAssignableFrom<ProcessContainmentContractFailure>(
-                candidate.PrimaryFailure);
+                candidate.Failure);
             Assert.Contains(
                 "does not own this operation lifetime",
-                candidate.PrimaryFailure.Detail,
+                candidate.Failure.Detail,
                 StringComparison.Ordinal);
         });
         Assert.IsType<ArgumentOutOfRangeException>(invalidKind.InnerException);
     }
 
     [Fact]
-    public void CleanupSnapshotCannotReplacePrimaryFailure()
+    public void CleanupSnapshotCannotReplaceOperationFailure()
     {
         var clock = new ManualMonotonicTimeProvider();
         using var cancellation = new CancellationTokenSource();
         var operation = Operation(clock, cancellation.Token);
         cancellation.Cancel();
-        var primary = operation.Caller.PublishCancellation("caller canceled");
+        var operationFailure = operation.Caller.PublishCancellation("caller canceled");
         var cleanup = new List<ProcessCleanupFailure>
         {
             Cleanup(
@@ -183,15 +183,15 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
                 "resource release failed")
         };
 
-        var rejected = AssertRejected(operation.Rejected(primary, cleanup));
+        var rejected = AssertRejected(operation.Rejected(operationFailure, cleanup));
         cleanup.Clear();
         cleanup.Add(Cleanup(
             ProcessCleanupFailureKind.StreamDrainFailure,
             "replacement cleanup failure"));
 
-        Assert.Same(primary, rejected.PrimaryFailure);
+        Assert.Same(operationFailure, rejected.Failure);
         Assert.IsAssignableFrom<ProcessContainmentCallerFailure>(
-            rejected.PrimaryFailure);
+            rejected.Failure);
         Assert.Equal(
             ProcessCleanupFailureKind.ResourceReleaseFailure,
             Assert.Single(rejected.CleanupFailures).Kind);
@@ -213,7 +213,7 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
         var backendResult = operation.BackendResults.Failed(
                 new IOException("fixture backend failure"),
                 "backend failed");
-        var publishedPrimary = Assert.IsAssignableFrom<
+        var publishedFailure = Assert.IsAssignableFrom<
             ProcessContainmentBackendFailure>(backendResult.GetType()
                 .GetProperty("Failure")!
                 .GetValue(backendResult));
@@ -225,8 +225,8 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
             ProcessCleanupFailureKind.StreamDrainFailure,
             "replacement cleanup failure"));
 
-        Assert.Same(publishedPrimary, rejected.PrimaryFailure);
-        Assert.Equal(nameof(IOException), publishedPrimary.ErrorType);
+        Assert.Same(publishedFailure, rejected.Failure);
+        Assert.Equal(nameof(IOException), publishedFailure.ErrorType);
         Assert.Equal(
             ProcessCleanupFailureKind.ResourceReleaseFailure,
             Assert.Single(rejected.CleanupFailures).Kind);
@@ -267,7 +267,7 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
             ProcessCleanupFailureKind.StreamDrainFailure,
             Assert.Single(completed.CleanupFailures).Kind);
         Assert.IsAssignableFrom<ProcessContainmentContractFailure>(
-            guarded.PrimaryFailure);
+            guarded.Failure);
         Assert.Equal(
             ProcessCleanupFailureKind.ResourceReleaseFailure,
             Assert.Single(guarded.CleanupFailures).Kind);
@@ -299,7 +299,7 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
             operation.BackendResults.Failed(
                 new IOException("fixture backend failure"),
                 "backend failed"),
-            [])).PrimaryFailure;
+            [])).Failure;
         var contract = operation.ContractGuard.IllegalTransition(
             "illegal transition");
 
@@ -321,7 +321,7 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
         using var cancellation = new CancellationTokenSource();
         var operation = Operation(clock, cancellation.Token);
         await cancellation.CancelAsync();
-        var primary = operation.Caller.PublishCancellation("caller canceled");
+        var operationFailure = operation.Caller.PublishCancellation("caller canceled");
         var cleanup = new List<ProcessCleanupFailure>
         {
             Cleanup(
@@ -331,14 +331,14 @@ public sealed class ProcessContainmentOperationAuthorityBehaviorTests
                 ProcessCleanupFailureKind.StreamDrainFailure,
                 "second cleanup failure")
         };
-        var rejected = AssertRejected(operation.Rejected(primary, cleanup));
+        var rejected = AssertRejected(operation.Rejected(operationFailure, cleanup));
 
         cleanup.Reverse();
         cleanup.Clear();
         clock.Advance(TimeSpan.FromSeconds(20));
         await Task.Yield();
 
-        Assert.Same(primary, rejected.PrimaryFailure);
+        Assert.Same(operationFailure, rejected.Failure);
         Assert.Equal(
             [
                 ProcessCleanupFailureKind.ResourceReleaseFailure,

--- a/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs
@@ -160,7 +160,7 @@ public sealed class ProcessSupervisionContractArchitectureTests
             typeof(ProcessCleanupFailure),
             typeof(ProcessTerminalCandidate),
             typeof(ProcessSupervisionOutcome),
-            typeof(ProcessContainmentPrimaryFailure),
+            typeof(ProcessContainmentOperationFailure),
             typeof(ProcessContainmentBackendResult),
             typeof(ProcessContainmentBackendFailure),
             typeof(ProcessContainmentCallerFailure),
@@ -296,7 +296,7 @@ public sealed class ProcessSupervisionContractArchitectureTests
                 .OrderBy(type => type.FullName, StringComparer.Ordinal));
         Assert.DoesNotContain(resultEntries, method =>
             method.GetParameters()[0].ParameterType ==
-                typeof(ProcessContainmentPrimaryFailure));
+                typeof(ProcessContainmentOperationFailure));
         Assert.All(resultEntries, method => Assert.Equal(
             typeof(IEnumerable<ProcessCleanupFailure>),
             method.GetParameters()[1].ParameterType));
@@ -305,6 +305,16 @@ public sealed class ProcessSupervisionContractArchitectureTests
             typeof(ProcessContainmentOperationResult)
                 .GetProperty(nameof(ProcessContainmentOperationResult.CleanupFailures))!
                 .PropertyType);
+        Assert.Equal(
+            typeof(ProcessContainmentOperationFailure),
+            typeof(ProcessContainmentOperationRejected)
+                .GetProperty(nameof(ProcessContainmentOperationRejected.Failure))!
+                .PropertyType);
+        Assert.Null(typeof(ProcessContainmentOperationRejected).GetProperty(
+            "PrimaryFailure",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic));
+        Assert.Null(typeof(ProcessContainmentOperationFailure).Assembly.GetType(
+            "DownKyi.ProcessSupervision.ProcessContainmentPrimaryFailure"));
         Assert.Equal(
             [
                 nameof(ProcessContainmentOperationAuthority.BackendResults),
@@ -320,7 +330,7 @@ public sealed class ProcessSupervisionContractArchitectureTests
     [Fact]
     public void OperationAuthorityContractsRemainInertAndAreNotRuntimeProof()
     {
-        var assembly = typeof(ProcessContainmentPrimaryFailure).Assembly;
+        var assembly = typeof(ProcessContainmentOperationFailure).Assembly;
         var callerFailures = assembly.GetTypes()
             .Where(type => type != typeof(ProcessContainmentCallerFailure) &&
                            typeof(ProcessContainmentCallerFailure)
@@ -402,7 +412,7 @@ public sealed class ProcessSupervisionContractArchitectureTests
         Type[] authorityContractTypes =
         [
             typeof(ProcessContainmentCallerAuthority),
-            typeof(ProcessContainmentPrimaryFailure),
+            typeof(ProcessContainmentOperationFailure),
             typeof(ProcessContainmentBackendResult),
             typeof(ProcessContainmentBackendFailure),
             typeof(ProcessContainmentCallerFailure),

--- a/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractBehaviorTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessSupervisionContractBehaviorTests.cs
@@ -4,6 +4,52 @@ namespace DownKyi.Architecture.Tests;
 
 public sealed class ProcessSupervisionContractBehaviorTests
 {
+    public static TheoryData<
+        ProcessTerminalCandidateKind,
+        int,
+        ProcessInvariantState,
+        bool,
+        bool> SuccessMatrix
+    {
+        get
+        {
+            var data = new TheoryData<
+                ProcessTerminalCandidateKind,
+                int,
+                ProcessInvariantState,
+                bool,
+                bool>();
+            (ProcessTerminalCandidateKind Kind, int ExitCode)[] terminals =
+            [
+                (ProcessTerminalCandidateKind.TargetTerminal, 0),
+                (ProcessTerminalCandidateKind.TargetTerminal, 7),
+                (ProcessTerminalCandidateKind.ExecutionFailure, 0)
+            ];
+            foreach (var terminal in terminals)
+            {
+                foreach (var proofState in Enum.GetValues<ProcessInvariantState>())
+                {
+                    foreach (var hasCleanupFailure in new[] { false, true })
+                    {
+                        var expected =
+                            terminal.Kind == ProcessTerminalCandidateKind.TargetTerminal &&
+                            terminal.ExitCode == 0 &&
+                            proofState == ProcessInvariantState.Proven &&
+                            !hasCleanupFailure;
+                        data.Add(
+                            terminal.Kind,
+                            terminal.ExitCode,
+                            proofState,
+                            hasCleanupFailure,
+                            expected);
+                    }
+                }
+            }
+
+            return data;
+        }
+    }
+
     [Fact]
     public void UnknownAndViolatedRequiredInvariantsFailClosed()
     {
@@ -186,6 +232,36 @@ public sealed class ProcessSupervisionContractBehaviorTests
             ProcessTerminalSelectionPolicy.Select(publications.Reverse()));
     }
 
+    [Theory]
+    [MemberData(nameof(SuccessMatrix))]
+    public void SucceededRequiresTargetZeroFormalProofAndCleanCleanup(
+        ProcessTerminalCandidateKind terminalKind,
+        int exitCode,
+        ProcessInvariantState proofState,
+        bool hasCleanupFailure,
+        bool expected)
+    {
+        var terminal = terminalKind == ProcessTerminalCandidateKind.TargetTerminal
+            ? ProcessTerminalCandidateFactory.TargetTerminal(1, exitCode)
+            : Primary(ProcessPrimaryFailureKind.ExecutionFailure, 1);
+        ProcessCleanupFailure[] cleanupFailures = hasCleanupFailure
+            ?
+            [
+                new ProcessCleanupFailure(
+                    ProcessCleanupFailureKind.ResourceReleaseFailure,
+                    nameof(InvalidOperationException),
+                    "fixture cleanup failure")
+            ]
+            : [];
+
+        var outcome = new ProcessSupervisionOutcome(
+            terminal,
+            ProofInState(proofState),
+            cleanupFailures);
+
+        Assert.Equal(expected, outcome.Succeeded);
+    }
+
     [Fact]
     public void CleanupFailureCannotOverwritePrimaryTerminalChannel()
     {
@@ -264,6 +340,28 @@ public sealed class ProcessSupervisionContractBehaviorTests
         }
 
         return builder;
+    }
+
+    private static ProcessSupervisionProof ProofInState(
+        ProcessInvariantState state)
+    {
+        return state switch
+        {
+            ProcessInvariantState.Proven => ProveAll().Build(),
+            ProcessInvariantState.Unknown =>
+                ProveAllExcept(RequiredProcessInvariantKind.StreamDrain).Build(),
+            ProcessInvariantState.Violated => ViolatedProof(),
+            _ => throw new ArgumentOutOfRangeException(nameof(state), state, null)
+        };
+    }
+
+    private static ProcessSupervisionProof ViolatedProof()
+    {
+        var builder = ProveAll();
+        builder.Violate(
+            RequiredProcessInvariantKind.StreamDrain,
+            "stream drain violated");
+        return builder.Build();
     }
 
     private static IEnumerable<ProcessCleanupFailure> UndefinedCleanupFailures()

--- a/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessAuthorityArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessAuthorityArchitectureTests.cs
@@ -1,8 +1,5 @@
 using System.Reflection;
 using DownKyi.ProcessSupervision;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace DownKyi.Architecture.Tests;
 
@@ -53,14 +50,29 @@ public sealed class ProcessTerminalSuccessAuthorityArchitectureTests
     [Fact]
     public void SemanticGateKeepsProofAndOperationFactsOutOfProduction()
     {
-        var contractCompilation = CreateContractCompilation();
-        AssertNoCompilationErrors(contractCompilation);
-        AssertFormalGateIsConsumedOnlyBySucceeded(contractCompilation);
-        AssertNoOutcomeConstructionConsumer(contractCompilation);
+        var mutation = Environment.GetEnvironmentVariable(
+            MutationEnvironmentVariable);
+        var contract = ProcessTerminalSuccessSemanticGate.AnalyzeContract(
+            RepositoryRoot,
+            mutation);
 
-        var violations = FindProductionAuthorityViolations();
+        AssertNoFindings(contract.CompilationErrors);
+        AssertNoFindings(contract.AuthorityViolations);
 
-        Assert.Empty(violations);
+        var production = ProcessTerminalSuccessSemanticGate.AnalyzeProduction(
+            RepositoryRoot,
+            mutation);
+
+        AssertNoFindings(production.CompilationErrors);
+        AssertNoFindings(production.AuthorityViolations);
+    }
+
+    private static void AssertNoFindings(IReadOnlyList<string> findings)
+    {
+        Assert.True(
+            findings.Count == 0,
+            $"Unexpected semantic-gate findings:{Environment.NewLine}" +
+            string.Join(Environment.NewLine, findings));
     }
 
     private static IEnumerable<MemberInfo> SuccessBooleanMembers(Type type)
@@ -90,365 +102,6 @@ public sealed class ProcessTerminalSuccessAuthorityArchitectureTests
     {
         return name.Contains("Success", StringComparison.Ordinal) ||
                name.Contains("Succeed", StringComparison.Ordinal);
-    }
-
-    private static CSharpCompilation CreateContractCompilation()
-    {
-        var contractDirectory = Path.Combine(
-            RepositoryRoot,
-            "tools",
-            "DownKyi.ProcessSupervision");
-        var syntaxTrees = Directory.EnumerateFiles(
-                contractDirectory,
-                "*.cs",
-                SearchOption.TopDirectoryOnly)
-            .Order(StringComparer.Ordinal)
-            .Select(ParseFile)
-            .Prepend(CSharpSyntaxTree.ParseText(
-                """
-                global using System;
-                global using System.Collections.Generic;
-                global using System.IO;
-                global using System.Linq;
-                global using System.Net.Http;
-                global using System.Threading;
-                global using System.Threading.Tasks;
-                """,
-                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
-                path: "__architecture__/ImplicitUsings.g.cs"));
-        return CSharpCompilation.Create(
-            "DownKyi.ProcessSupervision.ArchitectureInspection",
-            syntaxTrees,
-            TrustedPlatformReferences(),
-            new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-    }
-
-    private static void AssertNoCompilationErrors(CSharpCompilation compilation)
-    {
-        var errors = compilation.GetDiagnostics()
-            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
-            .Select(diagnostic => diagnostic.ToString())
-            .ToArray();
-
-        Assert.Empty(errors);
-    }
-
-    private static void AssertFormalGateIsConsumedOnlyBySucceeded(
-        CSharpCompilation compilation)
-    {
-        var references = compilation.SyntaxTrees
-            .SelectMany(tree =>
-            {
-                var model = compilation.GetSemanticModel(tree);
-                return tree.GetRoot()
-                    .DescendantNodes()
-                    .OfType<SimpleNameSyntax>()
-                    .Where(name => name.Identifier.ValueText ==
-                                   nameof(ProcessSupervisionProof.FormalGatePassed))
-                    .Select(name => new
-                    {
-                        Symbol = ReferencedSymbol(model, name),
-                        Enclosing = EnclosingMember(model, name.SpanStart)
-                    });
-            })
-            .Where(reference => reference.Symbol is IPropertySymbol property &&
-                                property.ContainingType.Name ==
-                                    nameof(ProcessSupervisionProof))
-            .ToArray();
-
-        var reference = Assert.Single(references);
-        var property = Assert.IsAssignableFrom<IPropertySymbol>(reference.Enclosing);
-        Assert.Equal(nameof(ProcessSupervisionOutcome.Succeeded), property.Name);
-        Assert.Equal(nameof(ProcessSupervisionOutcome), property.ContainingType.Name);
-    }
-
-    private static void AssertNoOutcomeConstructionConsumer(
-        CSharpCompilation compilation)
-    {
-        var consumers = compilation.SyntaxTrees
-            .SelectMany(tree =>
-            {
-                var model = compilation.GetSemanticModel(tree);
-                return tree.GetRoot()
-                    .DescendantNodes()
-                    .OfType<ObjectCreationExpressionSyntax>()
-                    .Select(creation => ReferencedSymbol(model, creation));
-            })
-            .OfType<IMethodSymbol>()
-            .Where(method => method.MethodKind == MethodKind.Constructor &&
-                             method.ContainingType.Name ==
-                                 nameof(ProcessSupervisionOutcome))
-            .ToArray();
-
-        Assert.Empty(consumers);
-    }
-
-    private static List<string> FindProductionAuthorityViolations()
-    {
-        var syntaxTrees = EnumerateProductionSourcePaths()
-            .Select(ParseFile)
-            .ToList();
-        var mutationTree = CreateMutationTree();
-        if (mutationTree is not null)
-        {
-            syntaxTrees.Add(mutationTree);
-        }
-
-        var references = TrustedPlatformReferences()
-            .Append(MetadataReference.CreateFromFile(
-                typeof(ProcessSupervisionOutcome).Assembly.Location));
-        var compilation = CSharpCompilation.Create(
-            "DownKyi.Architecture.Tests",
-            syntaxTrees,
-            references,
-            new CSharpCompilationOptions(
-                OutputKind.DynamicallyLinkedLibrary,
-                nullableContextOptions: NullableContextOptions.Enable));
-        if (mutationTree is not null)
-        {
-            var mutationErrors = compilation.GetDiagnostics()
-                .Where(diagnostic =>
-                    diagnostic.Severity == DiagnosticSeverity.Error &&
-                    diagnostic.Location.SourceTree == mutationTree)
-                .Select(diagnostic => diagnostic.ToString())
-                .ToArray();
-            Assert.Empty(mutationErrors);
-        }
-
-        var trackedNames = TrackedAuthoritySymbolNames();
-        var contractAssemblyName =
-            typeof(ProcessSupervisionOutcome).Assembly.GetName().Name;
-        var violations = new List<string>();
-        foreach (var tree in syntaxTrees)
-        {
-            var model = compilation.GetSemanticModel(tree);
-            foreach (var name in tree.GetRoot()
-                         .DescendantNodes()
-                         .OfType<SimpleNameSyntax>()
-                         .Where(name => trackedNames.Contains(
-                             name.Identifier.ValueText)))
-            {
-                var symbol = ReferencedSymbol(model, name);
-                if (symbol is not null &&
-                    string.Equals(
-                        symbol.ContainingAssembly?.Name,
-                        contractAssemblyName,
-                        StringComparison.Ordinal))
-                {
-                    violations.Add(DescribeViolation(
-                        tree,
-                        name,
-                        $"references {symbol.ToDisplayString()}"));
-                }
-            }
-
-            foreach (var member in tree.GetRoot()
-                         .DescendantNodes()
-                         .OfType<MemberDeclarationSyntax>()
-                         .Where(IsCompetingSuccessDeclaration))
-            {
-                var symbol = model.GetDeclaredSymbol(member);
-                if (symbol?.ContainingNamespace?.ToDisplayString() ==
-                    "DownKyi.ProcessSupervision")
-                {
-                    violations.Add(DescribeViolation(
-                        tree,
-                        member,
-                        $"declares competing success member {symbol.ToDisplayString()}"));
-                }
-            }
-        }
-
-        return violations;
-    }
-
-    private static IEnumerable<string> EnumerateProductionSourcePaths()
-    {
-        var contractDirectory = Path.GetFullPath(Path.Combine(
-            RepositoryRoot,
-            "tools",
-            "DownKyi.ProcessSupervision"));
-        return Directory.EnumerateFiles(
-                RepositoryRoot,
-                "*.cs",
-                SearchOption.AllDirectories)
-            .Where(path => !Path.GetFullPath(path).StartsWith(
-                contractDirectory + Path.DirectorySeparatorChar,
-                StringComparison.OrdinalIgnoreCase))
-            .Where(path => IsProductionPath(
-                Path.GetRelativePath(RepositoryRoot, path)))
-            .Order(StringComparer.Ordinal);
-    }
-
-    private static bool IsProductionPath(string relativePath)
-    {
-        var segments = relativePath.Split(
-            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
-            StringSplitOptions.RemoveEmptyEntries);
-        string[] excludedSegments =
-        [
-            ".git",
-            ".tools",
-            "artifacts",
-            "benchmarks",
-            "bin",
-            "obj",
-            "tests"
-        ];
-        return !segments.Any(segment => excludedSegments.Contains(
-            segment,
-            StringComparer.OrdinalIgnoreCase));
-    }
-
-    private static HashSet<string> TrackedAuthoritySymbolNames()
-    {
-        Type[] operationTypes =
-        [
-            typeof(ProcessContainmentOperationAuthority),
-            typeof(ProcessContainmentOperationResult),
-            typeof(ProcessContainmentOperationCompleted),
-            typeof(ProcessContainmentOperationRejected),
-            typeof(ProcessContainmentOperationFailure),
-            typeof(ProcessContainmentBackendResult),
-            typeof(ProcessContainmentBackendFailure),
-            typeof(ProcessContainmentCallerFailure),
-            typeof(ProcessContainmentContractFailure)
-        ];
-        return operationTypes
-            .Select(type => type.Name)
-            .Append(nameof(ProcessSupervisionOutcome))
-            .Append(nameof(ProcessSupervisionOutcome.Succeeded))
-            .Append(nameof(ProcessSupervisionProof.FormalGatePassed))
-            .ToHashSet(StringComparer.Ordinal);
-    }
-
-    private static bool IsCompetingSuccessDeclaration(
-        MemberDeclarationSyntax declaration)
-    {
-        return declaration switch
-        {
-            PropertyDeclarationSyntax property =>
-                IsBooleanType(property.Type) &&
-                IsSuccessName(property.Identifier.ValueText),
-            MethodDeclarationSyntax method =>
-                IsBooleanType(method.ReturnType) &&
-                IsSuccessName(method.Identifier.ValueText),
-            FieldDeclarationSyntax field =>
-                IsBooleanType(field.Declaration.Type) &&
-                field.Declaration.Variables.Any(variable =>
-                    IsSuccessName(variable.Identifier.ValueText)),
-            _ => false
-        };
-    }
-
-    private static bool IsBooleanType(TypeSyntax type)
-    {
-        return type is PredefinedTypeSyntax predefined &&
-               predefined.Keyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.BoolKeyword);
-    }
-
-    private static SyntaxTree? CreateMutationTree()
-    {
-        var mutation = Environment.GetEnvironmentVariable(
-            MutationEnvironmentVariable);
-        var source = mutation switch
-        {
-            null or "" => null,
-            "direct-formal-gate" =>
-                """
-                using DownKyi.ProcessSupervision;
-                namespace MutatedProduction;
-                public static class DirectFormalGateConsumer
-                {
-                    public static bool FinalSuccess(ProcessSupervisionProof proof) =>
-                        proof.FormalGatePassed;
-                }
-                """,
-            "second-success-authority" =>
-                """
-                namespace DownKyi.ProcessSupervision;
-                public sealed class InjectedSecondSuccessAuthority
-                {
-                    public bool Succeeded => true;
-                }
-                """,
-            "operation-completed-final-success" =>
-                """
-                using DownKyi.ProcessSupervision;
-                namespace MutatedProduction;
-                internal static class OperationCompletedConsumer
-                {
-                    internal static bool FinalSuccess(
-                        ProcessContainmentOperationResult result) =>
-                        result is ProcessContainmentOperationCompleted;
-                }
-                """,
-            _ => throw new InvalidOperationException(
-                $"Unsupported terminal-success mutation: {mutation}")
-        };
-        return source is null
-            ? null
-            : CSharpSyntaxTree.ParseText(
-                source,
-                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
-                path: $"__mutation__/{mutation}.cs");
-    }
-
-    private static SyntaxTree ParseFile(string path)
-    {
-        return CSharpSyntaxTree.ParseText(
-            File.ReadAllText(path),
-            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
-            path);
-    }
-
-    private static IEnumerable<MetadataReference> TrustedPlatformReferences()
-    {
-        var trustedAssemblies = AppContext.GetData(
-            "TRUSTED_PLATFORM_ASSEMBLIES") as string;
-        if (string.IsNullOrWhiteSpace(trustedAssemblies))
-        {
-            throw new InvalidOperationException(
-                "Trusted platform assembly metadata is unavailable.");
-        }
-
-        return trustedAssemblies.Split(Path.PathSeparator)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Select(path => MetadataReference.CreateFromFile(path));
-    }
-
-    private static ISymbol? ReferencedSymbol(
-        SemanticModel model,
-        SyntaxNode node)
-    {
-        var symbolInfo = model.GetSymbolInfo(node);
-        return symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.SingleOrDefault();
-    }
-
-    private static ISymbol? EnclosingMember(
-        SemanticModel model,
-        int position)
-    {
-        var enclosing = model.GetEnclosingSymbol(position);
-        return enclosing is IMethodSymbol { AssociatedSymbol: not null } method
-            ? method.AssociatedSymbol
-            : enclosing;
-    }
-
-    private static string DescribeViolation(
-        SyntaxTree tree,
-        SyntaxNode node,
-        string detail)
-    {
-        var line = tree.GetLineSpan(node.Span).StartLinePosition.Line + 1;
-        var path = string.IsNullOrWhiteSpace(tree.FilePath)
-            ? "<source>"
-            : tree.FilePath.StartsWith("__mutation__", StringComparison.Ordinal)
-                ? tree.FilePath
-                : Path.GetRelativePath(RepositoryRoot, tree.FilePath);
-        return $"{path}:{line} {detail}";
     }
 
     private static string FindRepositoryRoot()

--- a/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessAuthorityArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessAuthorityArchitectureTests.cs
@@ -1,0 +1,467 @@
+using System.Reflection;
+using DownKyi.ProcessSupervision;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DownKyi.Architecture.Tests;
+
+public sealed class ProcessTerminalSuccessAuthorityArchitectureTests
+{
+    private const string MutationEnvironmentVariable =
+        "DOWNKYI_TEST_MUTATE_TERMINAL_SUCCESS_AUTHORITY";
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    public void CompiledContractHasOneDerivedFinalSuccessMember()
+    {
+        var contractAssembly = typeof(ProcessSupervisionOutcome).Assembly;
+        var successMembers = contractAssembly.GetTypes()
+            .SelectMany(SuccessBooleanMembers)
+            .ToArray();
+
+        Assert.Equal(
+            [
+                "DownKyi.ProcessSupervision.ProcessSupervisionOutcome.Succeeded",
+                "DownKyi.ProcessSupervision.SupervisorProtocolEncodeResult.Succeeded"
+            ],
+            successMembers
+                .Select(member =>
+                    $"{member.DeclaringType?.FullName}.{member.Name}")
+                .Order(StringComparer.Ordinal));
+        var succeeded = Assert.IsAssignableFrom<PropertyInfo>(Assert.Single(
+            successMembers,
+            member => member.DeclaringType == typeof(ProcessSupervisionOutcome)));
+        Assert.Equal(nameof(ProcessSupervisionOutcome.Succeeded), succeeded.Name);
+        Assert.Equal(typeof(ProcessSupervisionOutcome), succeeded.DeclaringType);
+        Assert.True(succeeded.GetMethod?.IsPublic);
+
+        var constructor = Assert.Single(
+            typeof(ProcessSupervisionOutcome).GetConstructors(
+                BindingFlags.Instance | BindingFlags.NonPublic));
+        Assert.True(constructor.IsAssembly);
+        Assert.Equal(
+            [
+                typeof(ProcessTerminalCandidate),
+                typeof(ProcessSupervisionProof),
+                typeof(IEnumerable<ProcessCleanupFailure>)
+            ],
+            constructor.GetParameters()
+                .Select(parameter => parameter.ParameterType));
+    }
+
+    [Fact]
+    public void SemanticGateKeepsProofAndOperationFactsOutOfProduction()
+    {
+        var contractCompilation = CreateContractCompilation();
+        AssertNoCompilationErrors(contractCompilation);
+        AssertFormalGateIsConsumedOnlyBySucceeded(contractCompilation);
+        AssertNoOutcomeConstructionConsumer(contractCompilation);
+
+        var violations = FindProductionAuthorityViolations();
+
+        Assert.Empty(violations);
+    }
+
+    private static IEnumerable<MemberInfo> SuccessBooleanMembers(Type type)
+    {
+        const BindingFlags flags = BindingFlags.Instance |
+                                   BindingFlags.Static |
+                                   BindingFlags.Public |
+                                   BindingFlags.NonPublic |
+                                   BindingFlags.DeclaredOnly;
+        return type.GetProperties(flags)
+            .Where(property =>
+                property.PropertyType == typeof(bool) &&
+                IsSuccessName(property.Name))
+            .Cast<MemberInfo>()
+            .Concat(type.GetMethods(flags)
+                .Where(method =>
+                    !method.IsSpecialName &&
+                    method.ReturnType == typeof(bool) &&
+                    IsSuccessName(method.Name)))
+            .Concat(type.GetFields(flags)
+                .Where(field =>
+                    field.FieldType == typeof(bool) &&
+                    IsSuccessName(field.Name)));
+    }
+
+    private static bool IsSuccessName(string name)
+    {
+        return name.Contains("Success", StringComparison.Ordinal) ||
+               name.Contains("Succeed", StringComparison.Ordinal);
+    }
+
+    private static CSharpCompilation CreateContractCompilation()
+    {
+        var contractDirectory = Path.Combine(
+            RepositoryRoot,
+            "tools",
+            "DownKyi.ProcessSupervision");
+        var syntaxTrees = Directory.EnumerateFiles(
+                contractDirectory,
+                "*.cs",
+                SearchOption.TopDirectoryOnly)
+            .Order(StringComparer.Ordinal)
+            .Select(ParseFile)
+            .Prepend(CSharpSyntaxTree.ParseText(
+                """
+                global using System;
+                global using System.Collections.Generic;
+                global using System.IO;
+                global using System.Linq;
+                global using System.Net.Http;
+                global using System.Threading;
+                global using System.Threading.Tasks;
+                """,
+                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
+                path: "__architecture__/ImplicitUsings.g.cs"));
+        return CSharpCompilation.Create(
+            "DownKyi.ProcessSupervision.ArchitectureInspection",
+            syntaxTrees,
+            TrustedPlatformReferences(),
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+    }
+
+    private static void AssertNoCompilationErrors(CSharpCompilation compilation)
+    {
+        var errors = compilation.GetDiagnostics()
+            .Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)
+            .Select(diagnostic => diagnostic.ToString())
+            .ToArray();
+
+        Assert.Empty(errors);
+    }
+
+    private static void AssertFormalGateIsConsumedOnlyBySucceeded(
+        CSharpCompilation compilation)
+    {
+        var references = compilation.SyntaxTrees
+            .SelectMany(tree =>
+            {
+                var model = compilation.GetSemanticModel(tree);
+                return tree.GetRoot()
+                    .DescendantNodes()
+                    .OfType<SimpleNameSyntax>()
+                    .Where(name => name.Identifier.ValueText ==
+                                   nameof(ProcessSupervisionProof.FormalGatePassed))
+                    .Select(name => new
+                    {
+                        Symbol = ReferencedSymbol(model, name),
+                        Enclosing = EnclosingMember(model, name.SpanStart)
+                    });
+            })
+            .Where(reference => reference.Symbol is IPropertySymbol property &&
+                                property.ContainingType.Name ==
+                                    nameof(ProcessSupervisionProof))
+            .ToArray();
+
+        var reference = Assert.Single(references);
+        var property = Assert.IsAssignableFrom<IPropertySymbol>(reference.Enclosing);
+        Assert.Equal(nameof(ProcessSupervisionOutcome.Succeeded), property.Name);
+        Assert.Equal(nameof(ProcessSupervisionOutcome), property.ContainingType.Name);
+    }
+
+    private static void AssertNoOutcomeConstructionConsumer(
+        CSharpCompilation compilation)
+    {
+        var consumers = compilation.SyntaxTrees
+            .SelectMany(tree =>
+            {
+                var model = compilation.GetSemanticModel(tree);
+                return tree.GetRoot()
+                    .DescendantNodes()
+                    .OfType<ObjectCreationExpressionSyntax>()
+                    .Select(creation => ReferencedSymbol(model, creation));
+            })
+            .OfType<IMethodSymbol>()
+            .Where(method => method.MethodKind == MethodKind.Constructor &&
+                             method.ContainingType.Name ==
+                                 nameof(ProcessSupervisionOutcome))
+            .ToArray();
+
+        Assert.Empty(consumers);
+    }
+
+    private static List<string> FindProductionAuthorityViolations()
+    {
+        var syntaxTrees = EnumerateProductionSourcePaths()
+            .Select(ParseFile)
+            .ToList();
+        var mutationTree = CreateMutationTree();
+        if (mutationTree is not null)
+        {
+            syntaxTrees.Add(mutationTree);
+        }
+
+        var references = TrustedPlatformReferences()
+            .Append(MetadataReference.CreateFromFile(
+                typeof(ProcessSupervisionOutcome).Assembly.Location));
+        var compilation = CSharpCompilation.Create(
+            "DownKyi.Architecture.Tests",
+            syntaxTrees,
+            references,
+            new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+        if (mutationTree is not null)
+        {
+            var mutationErrors = compilation.GetDiagnostics()
+                .Where(diagnostic =>
+                    diagnostic.Severity == DiagnosticSeverity.Error &&
+                    diagnostic.Location.SourceTree == mutationTree)
+                .Select(diagnostic => diagnostic.ToString())
+                .ToArray();
+            Assert.Empty(mutationErrors);
+        }
+
+        var trackedNames = TrackedAuthoritySymbolNames();
+        var contractAssemblyName =
+            typeof(ProcessSupervisionOutcome).Assembly.GetName().Name;
+        var violations = new List<string>();
+        foreach (var tree in syntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var name in tree.GetRoot()
+                         .DescendantNodes()
+                         .OfType<SimpleNameSyntax>()
+                         .Where(name => trackedNames.Contains(
+                             name.Identifier.ValueText)))
+            {
+                var symbol = ReferencedSymbol(model, name);
+                if (symbol is not null &&
+                    string.Equals(
+                        symbol.ContainingAssembly?.Name,
+                        contractAssemblyName,
+                        StringComparison.Ordinal))
+                {
+                    violations.Add(DescribeViolation(
+                        tree,
+                        name,
+                        $"references {symbol.ToDisplayString()}"));
+                }
+            }
+
+            foreach (var member in tree.GetRoot()
+                         .DescendantNodes()
+                         .OfType<MemberDeclarationSyntax>()
+                         .Where(IsCompetingSuccessDeclaration))
+            {
+                var symbol = model.GetDeclaredSymbol(member);
+                if (symbol?.ContainingNamespace?.ToDisplayString() ==
+                    "DownKyi.ProcessSupervision")
+                {
+                    violations.Add(DescribeViolation(
+                        tree,
+                        member,
+                        $"declares competing success member {symbol.ToDisplayString()}"));
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    private static IEnumerable<string> EnumerateProductionSourcePaths()
+    {
+        var contractDirectory = Path.GetFullPath(Path.Combine(
+            RepositoryRoot,
+            "tools",
+            "DownKyi.ProcessSupervision"));
+        return Directory.EnumerateFiles(
+                RepositoryRoot,
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => !Path.GetFullPath(path).StartsWith(
+                contractDirectory + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(path => IsProductionPath(
+                Path.GetRelativePath(RepositoryRoot, path)))
+            .Order(StringComparer.Ordinal);
+    }
+
+    private static bool IsProductionPath(string relativePath)
+    {
+        var segments = relativePath.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        string[] excludedSegments =
+        [
+            ".git",
+            ".tools",
+            "artifacts",
+            "benchmarks",
+            "bin",
+            "obj",
+            "tests"
+        ];
+        return !segments.Any(segment => excludedSegments.Contains(
+            segment,
+            StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static HashSet<string> TrackedAuthoritySymbolNames()
+    {
+        Type[] operationTypes =
+        [
+            typeof(ProcessContainmentOperationAuthority),
+            typeof(ProcessContainmentOperationResult),
+            typeof(ProcessContainmentOperationCompleted),
+            typeof(ProcessContainmentOperationRejected),
+            typeof(ProcessContainmentOperationFailure),
+            typeof(ProcessContainmentBackendResult),
+            typeof(ProcessContainmentBackendFailure),
+            typeof(ProcessContainmentCallerFailure),
+            typeof(ProcessContainmentContractFailure)
+        ];
+        return operationTypes
+            .Select(type => type.Name)
+            .Append(nameof(ProcessSupervisionOutcome))
+            .Append(nameof(ProcessSupervisionOutcome.Succeeded))
+            .Append(nameof(ProcessSupervisionProof.FormalGatePassed))
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static bool IsCompetingSuccessDeclaration(
+        MemberDeclarationSyntax declaration)
+    {
+        return declaration switch
+        {
+            PropertyDeclarationSyntax property =>
+                IsBooleanType(property.Type) &&
+                IsSuccessName(property.Identifier.ValueText),
+            MethodDeclarationSyntax method =>
+                IsBooleanType(method.ReturnType) &&
+                IsSuccessName(method.Identifier.ValueText),
+            FieldDeclarationSyntax field =>
+                IsBooleanType(field.Declaration.Type) &&
+                field.Declaration.Variables.Any(variable =>
+                    IsSuccessName(variable.Identifier.ValueText)),
+            _ => false
+        };
+    }
+
+    private static bool IsBooleanType(TypeSyntax type)
+    {
+        return type is PredefinedTypeSyntax predefined &&
+               predefined.Keyword.IsKind(Microsoft.CodeAnalysis.CSharp.SyntaxKind.BoolKeyword);
+    }
+
+    private static SyntaxTree? CreateMutationTree()
+    {
+        var mutation = Environment.GetEnvironmentVariable(
+            MutationEnvironmentVariable);
+        var source = mutation switch
+        {
+            null or "" => null,
+            "direct-formal-gate" =>
+                """
+                using DownKyi.ProcessSupervision;
+                namespace MutatedProduction;
+                public static class DirectFormalGateConsumer
+                {
+                    public static bool FinalSuccess(ProcessSupervisionProof proof) =>
+                        proof.FormalGatePassed;
+                }
+                """,
+            "second-success-authority" =>
+                """
+                namespace DownKyi.ProcessSupervision;
+                public sealed class InjectedSecondSuccessAuthority
+                {
+                    public bool Succeeded => true;
+                }
+                """,
+            "operation-completed-final-success" =>
+                """
+                using DownKyi.ProcessSupervision;
+                namespace MutatedProduction;
+                internal static class OperationCompletedConsumer
+                {
+                    internal static bool FinalSuccess(
+                        ProcessContainmentOperationResult result) =>
+                        result is ProcessContainmentOperationCompleted;
+                }
+                """,
+            _ => throw new InvalidOperationException(
+                $"Unsupported terminal-success mutation: {mutation}")
+        };
+        return source is null
+            ? null
+            : CSharpSyntaxTree.ParseText(
+                source,
+                CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
+                path: $"__mutation__/{mutation}.cs");
+    }
+
+    private static SyntaxTree ParseFile(string path)
+    {
+        return CSharpSyntaxTree.ParseText(
+            File.ReadAllText(path),
+            CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest),
+            path);
+    }
+
+    private static IEnumerable<MetadataReference> TrustedPlatformReferences()
+    {
+        var trustedAssemblies = AppContext.GetData(
+            "TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrWhiteSpace(trustedAssemblies))
+        {
+            throw new InvalidOperationException(
+                "Trusted platform assembly metadata is unavailable.");
+        }
+
+        return trustedAssemblies.Split(Path.PathSeparator)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path => MetadataReference.CreateFromFile(path));
+    }
+
+    private static ISymbol? ReferencedSymbol(
+        SemanticModel model,
+        SyntaxNode node)
+    {
+        var symbolInfo = model.GetSymbolInfo(node);
+        return symbolInfo.Symbol ?? symbolInfo.CandidateSymbols.SingleOrDefault();
+    }
+
+    private static ISymbol? EnclosingMember(
+        SemanticModel model,
+        int position)
+    {
+        var enclosing = model.GetEnclosingSymbol(position);
+        return enclosing is IMethodSymbol { AssociatedSymbol: not null } method
+            ? method.AssociatedSymbol
+            : enclosing;
+    }
+
+    private static string DescribeViolation(
+        SyntaxTree tree,
+        SyntaxNode node,
+        string detail)
+    {
+        var line = tree.GetLineSpan(node.Span).StartLinePosition.Line + 1;
+        var path = string.IsNullOrWhiteSpace(tree.FilePath)
+            ? "<source>"
+            : tree.FilePath.StartsWith("__mutation__", StringComparison.Ordinal)
+                ? tree.FilePath
+                : Path.GetRelativePath(RepositoryRoot, tree.FilePath);
+        return $"{path}:{line} {detail}";
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null &&
+               !File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+               ?? throw new DirectoryNotFoundException(
+                   "Could not locate the DownKyi repository root.");
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticCompilation.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticCompilation.cs
@@ -1,0 +1,249 @@
+using DownKyi.ProcessSupervision;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace DownKyi.Architecture.Tests;
+
+internal static class ProcessTerminalSuccessSemanticCompilation
+{
+    internal static CSharpCompilation CreateContract(
+        string repositoryRoot,
+        string? mutation)
+    {
+        ValidateMutation(mutation);
+        var contractDirectory = Path.Combine(
+            repositoryRoot,
+            "tools",
+            "DownKyi.ProcessSupervision");
+        var syntaxTrees = Directory.EnumerateFiles(
+                contractDirectory,
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => IsSourcePath(Path.GetRelativePath(
+                contractDirectory,
+                path)))
+            .Order(StringComparer.Ordinal)
+            .Select(ParseFile)
+            .Prepend(ImplicitUsings())
+            .ToList();
+        var mutationTree = CreateContractMutationTree(mutation);
+        if (mutationTree is not null)
+        {
+            syntaxTrees.Add(mutationTree);
+        }
+
+        return CSharpCompilation.Create(
+            "DownKyi.ProcessSupervision.ArchitectureInspection",
+            syntaxTrees,
+            TrustedPlatformReferences(),
+            CompilationOptions());
+    }
+
+    internal static (CSharpCompilation Compilation, SyntaxTree? MutationTree)
+        CreateProduction(
+            string repositoryRoot,
+            string? mutation)
+    {
+        ValidateMutation(mutation);
+        var syntaxTrees = EnumerateProductionSourcePaths(repositoryRoot)
+            .Select(ParseFile)
+            .ToList();
+        var mutationTree = CreateProductionMutationTree(mutation);
+        if (mutationTree is not null)
+        {
+            syntaxTrees.Add(mutationTree);
+        }
+
+        var references = TrustedPlatformReferences()
+            .Append(MetadataReference.CreateFromFile(
+                typeof(ProcessSupervisionOutcome).Assembly.Location));
+        var compilation = CSharpCompilation.Create(
+            "DownKyi.Architecture.Tests",
+            syntaxTrees,
+            references,
+            CompilationOptions());
+        return (compilation, mutationTree);
+    }
+
+    internal static IReadOnlyList<string> CompilationErrors(
+        CSharpCompilation compilation,
+        SyntaxTree? tree = null)
+    {
+        return compilation.GetDiagnostics()
+            .Where(diagnostic =>
+                diagnostic.Severity == DiagnosticSeverity.Error &&
+                (tree is null || diagnostic.Location.SourceTree == tree))
+            .Select(diagnostic => diagnostic.ToString())
+            .ToArray();
+    }
+
+    private static IEnumerable<string> EnumerateProductionSourcePaths(
+        string repositoryRoot)
+    {
+        var contractDirectory = Path.GetFullPath(Path.Combine(
+            repositoryRoot,
+            "tools",
+            "DownKyi.ProcessSupervision"));
+        return Directory.EnumerateFiles(
+                repositoryRoot,
+                "*.cs",
+                SearchOption.AllDirectories)
+            .Where(path => !Path.GetFullPath(path).StartsWith(
+                contractDirectory + Path.DirectorySeparatorChar,
+                StringComparison.OrdinalIgnoreCase))
+            .Where(path => IsProductionPath(
+                Path.GetRelativePath(repositoryRoot, path)))
+            .Order(StringComparer.Ordinal);
+    }
+
+    private static bool IsProductionPath(string relativePath)
+    {
+        return IsSourcePath(relativePath) &&
+               !relativePath.Split(
+                       [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                       StringSplitOptions.RemoveEmptyEntries)
+                   .Any(segment => segment.Equals(
+                       "tests",
+                       StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static bool IsSourcePath(string relativePath)
+    {
+        var segments = relativePath.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+        string[] excludedSegments =
+        [
+            ".git",
+            ".tools",
+            "artifacts",
+            "benchmarks",
+            "bin",
+            "obj"
+        ];
+        return !segments.Any(segment => excludedSegments.Contains(
+            segment,
+            StringComparer.OrdinalIgnoreCase));
+    }
+
+    private static SyntaxTree? CreateProductionMutationTree(string? mutation)
+    {
+        var source = mutation switch
+        {
+            "direct-formal-gate" =>
+                "using DownKyi.ProcessSupervision; namespace MutatedProduction; " +
+                "public static class DirectFormalGateConsumer { public static bool " +
+                "FinalSuccess(ProcessSupervisionProof proof) => proof.FormalGatePassed; }",
+            "second-success-authority" =>
+                "namespace DownKyi.ProcessSupervision; public sealed class " +
+                "InjectedSecondSuccessAuthority { public bool Succeeded => true; }",
+            "operation-completed-final-success" =>
+                "using DownKyi.ProcessSupervision; namespace MutatedProduction; " +
+                "internal static class OperationCompletedConsumer { internal static bool " +
+                "FinalSuccess(ProcessContainmentOperationResult result) => " +
+                "result is ProcessContainmentOperationCompleted; }",
+            _ => null
+        };
+        return MutationTree(source, mutation);
+    }
+
+    private static SyntaxTree? CreateContractMutationTree(string? mutation)
+    {
+        var source = mutation switch
+        {
+            "target-typed-outcome-constructor" =>
+                "namespace DownKyi.ProcessSupervision; internal static class " +
+                "InjectedOutcomeConstructorConsumer { internal static " +
+                "ProcessSupervisionOutcome Construct(ProcessTerminalCandidate terminal, " +
+                "ProcessSupervisionProof proof, IEnumerable<ProcessCleanupFailure> cleanup) " +
+                "=> new(terminal, proof, cleanup); }",
+            "qualified-bool-success-authority" =>
+                "namespace DownKyi.ProcessSupervision; public static class " +
+                "InjectedQualifiedBooleanAuthority { public static System.Boolean " +
+                "Succeeded => true; }",
+            "positional-record-success-authority" =>
+                "namespace DownKyi.ProcessSupervision; public sealed record " +
+                "InjectedPositionalAuthority(System.Boolean Succeeded);",
+            "contract-operation-consumer" =>
+                "namespace DownKyi.ProcessSupervision; internal static class " +
+                "InjectedOperationConsumer { internal static bool Accept(" +
+                "ProcessContainmentOperationResult result) => " +
+                "result is ProcessContainmentOperationCompleted; }",
+            "dynamic-success-access" =>
+                "namespace DownKyi.ProcessSupervision; internal static class " +
+                "InjectedDynamicSuccessConsumer { internal static bool Accept(" +
+                "object outcome) => ((dynamic)outcome).Succeeded; }",
+            _ => null
+        };
+        return MutationTree(source, mutation);
+    }
+
+    private static void ValidateMutation(string? mutation)
+    {
+        if (string.IsNullOrEmpty(mutation) ||
+            CreateProductionMutationTree(mutation) is not null ||
+            CreateContractMutationTree(mutation) is not null)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            $"Unsupported terminal-success mutation: {mutation}");
+    }
+
+    private static SyntaxTree? MutationTree(string? source, string? mutation)
+    {
+        return source is null
+            ? null
+            : CSharpSyntaxTree.ParseText(
+                source,
+                ParseOptions(),
+                path: $"__mutation__/{mutation}.cs");
+    }
+
+    private static SyntaxTree ImplicitUsings()
+    {
+        return CSharpSyntaxTree.ParseText(
+            "global using System; global using System.Collections.Generic; " +
+            "global using System.IO; global using System.Linq; " +
+            "global using System.Net.Http; global using System.Threading; " +
+            "global using System.Threading.Tasks;",
+            ParseOptions(),
+            path: "__architecture__/ImplicitUsings.g.cs");
+    }
+
+    private static SyntaxTree ParseFile(string path)
+    {
+        return CSharpSyntaxTree.ParseText(
+            File.ReadAllText(path),
+            ParseOptions(),
+            path);
+    }
+
+    private static CSharpParseOptions ParseOptions()
+    {
+        return CSharpParseOptions.Default.WithLanguageVersion(LanguageVersion.Latest);
+    }
+
+    private static CSharpCompilationOptions CompilationOptions()
+    {
+        return new CSharpCompilationOptions(
+            OutputKind.DynamicallyLinkedLibrary,
+            nullableContextOptions: NullableContextOptions.Enable);
+    }
+
+    private static IEnumerable<MetadataReference> TrustedPlatformReferences()
+    {
+        var trustedAssemblies = AppContext.GetData(
+            "TRUSTED_PLATFORM_ASSEMBLIES") as string;
+        if (string.IsNullOrWhiteSpace(trustedAssemblies))
+        {
+            throw new InvalidOperationException(
+                "Trusted platform assembly metadata is unavailable.");
+        }
+
+        return trustedAssemblies.Split(Path.PathSeparator)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Select(path => MetadataReference.CreateFromFile(path));
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticCompilation.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticCompilation.cs
@@ -137,6 +137,9 @@ internal static class ProcessTerminalSuccessSemanticCompilation
             "second-success-authority" =>
                 "namespace DownKyi.ProcessSupervision; public sealed class " +
                 "InjectedSecondSuccessAuthority { public bool Succeeded => true; }",
+            "subnamespace-record-success-authority" =>
+                "namespace DownKyi.ProcessSupervision.Terminal; public sealed record " +
+                "InjectedSubnamespaceAuthority(System.Boolean Succeeded);",
             "operation-completed-final-success" =>
                 "using DownKyi.ProcessSupervision; namespace MutatedProduction; " +
                 "internal static class OperationCompletedConsumer { internal static bool " +

--- a/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticGate.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticGate.cs
@@ -133,8 +133,9 @@ internal static class ProcessTerminalSuccessSemanticGate
     {
         var successMembers = AllTypes(compilation.Assembly.GlobalNamespace)
             .Where(type => allowContractMembers ||
-                           type.ContainingNamespace.ToDisplayString() ==
-                           ContractNamespace)
+                           (type.ContainingNamespace.ToDisplayString() + ".")
+                           .StartsWith(
+                               ContractNamespace + ".", StringComparison.Ordinal))
             .SelectMany(type => type.GetMembers())
             .Where(IsBooleanSuccessMember)
             .ToArray();
@@ -492,7 +493,6 @@ internal static class ProcessTerminalSuccessSemanticGate
             : Path.GetRelativePath(repositoryRoot, tree.FilePath);
         return $"{path}:{line} {detail}";
     }
-
     private sealed record SemanticReference(
         SyntaxNode Node,
         ISymbol? Symbol,

--- a/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticGate.cs
+++ b/tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticGate.cs
@@ -1,0 +1,500 @@
+using DownKyi.ProcessSupervision;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace DownKyi.Architecture.Tests;
+
+internal sealed record ProcessTerminalSuccessSemanticGateResult(
+    IReadOnlyList<string> CompilationErrors,
+    IReadOnlyList<string> AuthorityViolations);
+
+internal static class ProcessTerminalSuccessSemanticGate
+{
+    private const string ContractNamespace = "DownKyi.ProcessSupervision";
+
+    internal static ProcessTerminalSuccessSemanticGateResult AnalyzeContract(
+        string repositoryRoot,
+        string? mutation)
+    {
+        var compilation = ProcessTerminalSuccessSemanticCompilation
+            .CreateContract(repositoryRoot, mutation);
+        var violations = new List<string>();
+        violations.AddRange(FindFormalGateViolations(compilation, repositoryRoot));
+        violations.AddRange(FindOutcomeConstructionConsumers(
+            compilation,
+            repositoryRoot));
+        violations.AddRange(FindSuccessAuthorityViolations(
+            compilation,
+            repositoryRoot,
+            allowContractMembers: true));
+        violations.AddRange(FindContractOperationConsumerViolations(
+            compilation,
+            repositoryRoot));
+        violations.AddRange(FindDynamicViolations(compilation, repositoryRoot));
+        return new ProcessTerminalSuccessSemanticGateResult(
+            ProcessTerminalSuccessSemanticCompilation.CompilationErrors(
+                compilation),
+            violations.Distinct(StringComparer.Ordinal).ToArray());
+    }
+
+    internal static ProcessTerminalSuccessSemanticGateResult AnalyzeProduction(
+        string repositoryRoot,
+        string? mutation)
+    {
+        var (compilation, mutationTree) = ProcessTerminalSuccessSemanticCompilation
+            .CreateProduction(repositoryRoot, mutation);
+        var violations = FindProductionContractReferences(
+            compilation,
+            repositoryRoot);
+        violations.AddRange(FindOutcomeConstructionConsumers(
+            compilation,
+            repositoryRoot));
+        violations.AddRange(FindSuccessAuthorityViolations(
+            compilation,
+            repositoryRoot,
+            allowContractMembers: false));
+        violations.AddRange(FindDynamicViolations(compilation, repositoryRoot));
+        return new ProcessTerminalSuccessSemanticGateResult(
+            mutationTree is null
+                ? []
+                : ProcessTerminalSuccessSemanticCompilation.CompilationErrors(
+                    compilation,
+                    mutationTree),
+            violations.Distinct(StringComparer.Ordinal).ToArray());
+    }
+
+    private static List<string> FindFormalGateViolations(
+        CSharpCompilation compilation,
+        string repositoryRoot)
+    {
+        var references = FindSimpleNameReferences(
+                compilation,
+                nameof(ProcessSupervisionProof.FormalGatePassed))
+            .Where(reference =>
+                reference.Symbol is IPropertySymbol property &&
+                IsContractType(
+                    property.ContainingType,
+                    nameof(ProcessSupervisionProof)))
+            .ToArray();
+        var violations = references
+            .Where(reference => reference.Enclosing is not IPropertySymbol property ||
+                                !IsFinalSuccessMember(property))
+            .Select(reference => Describe(
+                repositoryRoot,
+                reference.Node,
+                "FormalGatePassed is consumed outside ProcessSupervisionOutcome.Succeeded"))
+            .ToList();
+        if (references.Length != 1)
+        {
+            violations.Add(
+                $"FormalGatePassed must have exactly one contract consumer; actual={references.Length}.");
+        }
+
+        return violations;
+    }
+
+    private static List<string> FindOutcomeConstructionConsumers(
+        CSharpCompilation compilation,
+        string repositoryRoot)
+    {
+        var violations = new List<string>();
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var creation in tree.GetRoot()
+                         .DescendantNodes()
+                         .OfType<ExpressionSyntax>()
+                         .Where(node => node is ObjectCreationExpressionSyntax or
+                             ImplicitObjectCreationExpressionSyntax))
+            {
+                if (model.GetOperation(creation) is IObjectCreationOperation
+                    { Constructor.ContainingType: { } containingType } &&
+                    IsContractType(
+                        containingType,
+                        nameof(ProcessSupervisionOutcome)))
+                {
+                    violations.Add(Describe(
+                        repositoryRoot,
+                        creation,
+                        "constructs ProcessSupervisionOutcome outside its future owner"));
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    private static List<string> FindSuccessAuthorityViolations(
+        CSharpCompilation compilation,
+        string repositoryRoot,
+        bool allowContractMembers)
+    {
+        var successMembers = AllTypes(compilation.Assembly.GlobalNamespace)
+            .Where(type => allowContractMembers ||
+                           type.ContainingNamespace.ToDisplayString() ==
+                           ContractNamespace)
+            .SelectMany(type => type.GetMembers())
+            .Where(IsBooleanSuccessMember)
+            .ToArray();
+        var violations = new List<string>();
+        foreach (var member in successMembers)
+        {
+            if (allowContractMembers && IsAllowedContractSuccessMember(member))
+            {
+                continue;
+            }
+
+            var syntax = member.DeclaringSyntaxReferences.FirstOrDefault()?
+                .GetSyntax();
+            violations.Add(syntax is null
+                ? $"declares competing success member {member.ToDisplayString()}"
+                : Describe(
+                    repositoryRoot,
+                    syntax,
+                    $"declares competing success member {member.ToDisplayString()}"));
+        }
+
+        if (allowContractMembers && successMembers.Count(IsFinalSuccessMember) != 1)
+        {
+            violations.Add(
+                "ProcessSupervisionOutcome.Succeeded must be the single final-success member.");
+        }
+
+        return violations;
+    }
+
+    private static List<string> FindContractOperationConsumerViolations(
+        CSharpCompilation compilation,
+        string repositoryRoot)
+    {
+        var trackedTypes = new HashSet<string>(
+        [
+            nameof(ProcessContainmentOperationResult),
+            nameof(ProcessContainmentOperationCompleted),
+            nameof(ProcessContainmentOperationRejected)
+        ], StringComparer.Ordinal);
+        var violations = new List<string>();
+        foreach (var reference in FindSimpleNameReferences(compilation))
+        {
+            if (reference.Symbol is INamedTypeSymbol type &&
+                trackedTypes.Contains(type.Name) &&
+                IsContractType(type, type.Name) &&
+                !IsAllowedContractOperationUsage(type, reference))
+            {
+                violations.Add(Describe(
+                    repositoryRoot,
+                    reference.Node,
+                    $"operation fact {type.Name} is consumed by " +
+                    $"{reference.Enclosing?.ToDisplayString() ?? "<unknown>"}"));
+            }
+        }
+
+        return violations;
+    }
+
+    private static List<string> FindDynamicViolations(
+        CSharpCompilation compilation,
+        string repositoryRoot)
+    {
+        var violations = new List<string>();
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var type in tree.GetRoot().DescendantNodes().OfType<TypeSyntax>())
+            {
+                if (model.GetTypeInfo(type).Type?.TypeKind == TypeKind.Dynamic)
+                {
+                    violations.Add(Describe(
+                        repositoryRoot,
+                        type,
+                        "uses dynamic in the process-supervision contract boundary"));
+                }
+            }
+
+            foreach (var expression in tree.GetRoot()
+                         .DescendantNodes()
+                         .OfType<ExpressionSyntax>())
+            {
+                if (model.GetOperation(expression) is
+                    IDynamicMemberReferenceOperation or
+                    IDynamicInvocationOperation or
+                    IDynamicIndexerAccessOperation or
+                    IDynamicObjectCreationOperation)
+                {
+                    violations.Add(Describe(
+                        repositoryRoot,
+                        expression,
+                        "uses dynamic member or object access"));
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    private static List<string> FindProductionContractReferences(
+        CSharpCompilation compilation,
+        string repositoryRoot)
+    {
+        var trackedNames = TrackedAuthoritySymbolNames();
+        var contractAssemblyName =
+            typeof(ProcessSupervisionOutcome).Assembly.GetName().Name;
+        var violations = new List<string>();
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var name in tree.GetRoot()
+                         .DescendantNodes()
+                         .OfType<SimpleNameSyntax>())
+            {
+                var symbol = ReferencedSymbol(model, name);
+                if (symbol is not null &&
+                    (trackedNames.Contains(symbol.Name) ||
+                     trackedNames.Contains(symbol.ContainingType?.Name ?? "")) &&
+                    string.Equals(
+                        symbol.ContainingAssembly?.Name,
+                        contractAssemblyName,
+                        StringComparison.Ordinal))
+                {
+                    violations.Add(Describe(
+                        repositoryRoot,
+                        name,
+                        $"references {symbol.ToDisplayString()}"));
+                }
+            }
+        }
+
+        return violations;
+    }
+
+    private static IEnumerable<SemanticReference> FindSimpleNameReferences(
+        CSharpCompilation compilation,
+        string? name = null)
+    {
+        foreach (var tree in compilation.SyntaxTrees)
+        {
+            var model = compilation.GetSemanticModel(tree);
+            foreach (var node in tree.GetRoot()
+                         .DescendantNodes()
+                         .OfType<SimpleNameSyntax>()
+                         .Where(candidate => name is null ||
+                             candidate.Identifier.ValueText == name))
+            {
+                yield return new SemanticReference(
+                    node,
+                    ReferencedSymbol(model, node),
+                    EnclosingMember(model, node));
+            }
+        }
+    }
+
+    private static bool IsAllowedContractSuccessMember(ISymbol member)
+    {
+        return IsFinalSuccessMember(member) ||
+               member is IPropertySymbol
+               { Name: "Succeeded" } && IsContractType(
+                   member.ContainingType,
+                   "SupervisorProtocolEncodeResult");
+    }
+
+    private static bool IsFinalSuccessMember(ISymbol member)
+    {
+        return member is IPropertySymbol
+        { Name: nameof(ProcessSupervisionOutcome.Succeeded) } && IsContractType(
+            member.ContainingType,
+            nameof(ProcessSupervisionOutcome));
+    }
+
+    private static bool IsBooleanSuccessMember(ISymbol member)
+    {
+        if (!IsSuccessName(member.Name))
+        {
+            return false;
+        }
+
+        return member switch
+        {
+            IPropertySymbol property => IsBoolean(property.Type),
+            IFieldSymbol field => IsBoolean(field.Type),
+            IMethodSymbol method when method.MethodKind is not
+                MethodKind.PropertyGet and not MethodKind.PropertySet and not
+                MethodKind.EventAdd and not MethodKind.EventRemove =>
+                IsBoolean(method.ReturnType),
+            IEventSymbol eventSymbol when eventSymbol.Type is INamedTypeSymbol type =>
+                IsBoolean(type.DelegateInvokeMethod?.ReturnType),
+            _ => false
+        };
+    }
+
+    private static bool IsBoolean(ITypeSymbol? type) =>
+        type is { SpecialType: SpecialType.System_Boolean };
+    private static bool IsSuccessName(string name)
+        => name.Contains("Success", StringComparison.Ordinal) ||
+           name.Contains("Succeed", StringComparison.Ordinal);
+
+    private static bool IsAllowedContractOperationUsage(
+        INamedTypeSymbol referencedType,
+        SemanticReference reference)
+    {
+        if (reference.Enclosing is INamedTypeSymbol type &&
+            IsContractType(type, type.Name) &&
+            reference.Node.AncestorsAndSelf().Any(node => node is BaseTypeSyntax))
+        {
+            return (type.Name, referencedType.Name) is
+                (nameof(ProcessContainmentOperationCompleted),
+                    nameof(ProcessContainmentOperationResult)) or
+                (nameof(ProcessContainmentOperationRejected),
+                    nameof(ProcessContainmentOperationResult)) or
+                ("PublishedOperationCompleted",
+                    nameof(ProcessContainmentOperationCompleted)) or
+                ("PublishedOperationRejected",
+                    nameof(ProcessContainmentOperationRejected));
+        }
+
+        return reference.Enclosing is IMethodSymbol method &&
+               IsContractType(
+                   method.ContainingType,
+                   nameof(ProcessContainmentOperationAuthority)) &&
+               IsMethodReturnTypeReference(method, reference.Node) &&
+               referencedType.Name == nameof(ProcessContainmentOperationResult) &&
+               HasAllowedOperationFactorySignature(method);
+    }
+
+    private static bool HasAllowedOperationFactorySignature(IMethodSymbol method)
+    {
+        var parameterTypes = method.Parameters
+            .Select(parameter => parameter.Type.ToDisplayString())
+            .ToArray();
+        if (method.Name == "FromBackend")
+        {
+            return parameterTypes.SequenceEqual(
+                [
+                    $"{ContractNamespace}.ProcessContainmentBackendResult",
+                    "System.Collections.Generic.IEnumerable<" +
+                    $"{ContractNamespace}.ProcessCleanupFailure>"
+                ],
+                StringComparer.Ordinal);
+        }
+
+        return method.Name == "Rejected" &&
+               parameterTypes.Length == 2 &&
+               parameterTypes[0] is
+                   $"{ContractNamespace}.ProcessContainmentCallerFailure" or
+                   $"{ContractNamespace}.ProcessContainmentContractFailure" &&
+               parameterTypes[1] ==
+                   "System.Collections.Generic.IEnumerable<" +
+                   $"{ContractNamespace}.ProcessCleanupFailure>";
+    }
+
+    private static bool IsMethodReturnTypeReference(
+        IMethodSymbol method,
+        SyntaxNode node)
+    {
+        var declaration = method.DeclaringSyntaxReferences
+            .Select(reference => reference.GetSyntax())
+            .OfType<MethodDeclarationSyntax>()
+            .SingleOrDefault();
+        return declaration?.ReturnType.Span.Contains(node.Span) is true;
+    }
+
+    private static bool IsContractType(INamedTypeSymbol type, string name)
+    {
+        return type.Name == name &&
+               type.ContainingType is null &&
+               type.ContainingNamespace.ToDisplayString() == ContractNamespace;
+    }
+
+    private static IEnumerable<INamedTypeSymbol> AllTypes(
+        INamespaceOrTypeSymbol root)
+    {
+        foreach (var type in root.GetTypeMembers())
+        {
+            yield return type;
+            foreach (var nested in AllTypes(type))
+            {
+                yield return nested;
+            }
+        }
+
+        if (root is not INamespaceSymbol namespaceSymbol)
+        {
+            yield break;
+        }
+
+        foreach (var child in namespaceSymbol.GetNamespaceMembers())
+        {
+            foreach (var type in AllTypes(child))
+            {
+                yield return type;
+            }
+        }
+    }
+
+    private static HashSet<string> TrackedAuthoritySymbolNames()
+    {
+        Type[] operationTypes =
+        [
+            typeof(ProcessContainmentOperationAuthority),
+            typeof(ProcessContainmentOperationResult),
+            typeof(ProcessContainmentOperationCompleted),
+            typeof(ProcessContainmentOperationRejected),
+            typeof(ProcessContainmentOperationFailure),
+            typeof(ProcessContainmentBackendResult),
+            typeof(ProcessContainmentBackendFailure),
+            typeof(ProcessContainmentCallerFailure),
+            typeof(ProcessContainmentContractFailure)
+        ];
+        return operationTypes
+            .Select(type => type.Name)
+            .Append(nameof(ProcessSupervisionOutcome))
+            .Append(nameof(ProcessSupervisionOutcome.Succeeded))
+            .Append(nameof(ProcessSupervisionProof.FormalGatePassed))
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static ISymbol? ReferencedSymbol(
+        SemanticModel model,
+        SyntaxNode node)
+    {
+        var symbolInfo = model.GetSymbolInfo(node);
+        var symbol = symbolInfo.Symbol ?? (symbolInfo.CandidateSymbols.Length == 1
+            ? symbolInfo.CandidateSymbols[0]
+            : null);
+        return symbol is IAliasSymbol alias ? alias.Target : symbol;
+    }
+
+    private static ISymbol? EnclosingMember(
+        SemanticModel model,
+        SyntaxNode node)
+    {
+        var declaration = node.AncestorsAndSelf()
+            .OfType<MemberDeclarationSyntax>()
+            .FirstOrDefault();
+        var enclosing = declaration is null
+            ? model.GetEnclosingSymbol(node.SpanStart)
+            : model.GetDeclaredSymbol(declaration);
+        return enclosing is IMethodSymbol { AssociatedSymbol: not null } method
+            ? method.AssociatedSymbol
+            : enclosing;
+    }
+
+    private static string Describe(
+        string repositoryRoot,
+        SyntaxNode node,
+        string detail)
+    {
+        var tree = node.SyntaxTree;
+        var line = tree.GetLineSpan(node.Span).StartLinePosition.Line + 1;
+        var path = tree.FilePath.StartsWith("__", StringComparison.Ordinal)
+            ? tree.FilePath
+            : Path.GetRelativePath(repositoryRoot, tree.FilePath);
+        return $"{path}:{line} {detail}";
+    }
+
+    private sealed record SemanticReference(
+        SyntaxNode Node,
+        ISymbol? Symbol,
+        ISymbol? Enclosing);
+}

--- a/tools/DownKyi.ProcessSupervision/ProcessContainmentOperationAuthorityContracts.cs
+++ b/tools/DownKyi.ProcessSupervision/ProcessContainmentOperationAuthorityContracts.cs
@@ -2,9 +2,9 @@ using System.Collections.ObjectModel;
 
 namespace DownKyi.ProcessSupervision;
 
-internal abstract class ProcessContainmentPrimaryFailure
+internal abstract class ProcessContainmentOperationFailure
 {
-    private protected ProcessContainmentPrimaryFailure(
+    private protected ProcessContainmentOperationFailure(
         string errorType,
         string detail)
     {
@@ -20,7 +20,7 @@ internal abstract class ProcessContainmentPrimaryFailure
 }
 
 internal abstract class ProcessContainmentBackendFailure
-    : ProcessContainmentPrimaryFailure
+    : ProcessContainmentOperationFailure
 {
     private protected ProcessContainmentBackendFailure(
         object authorityIdentity,
@@ -42,7 +42,7 @@ internal enum ProcessContainmentCallerFailureKind
 }
 
 internal sealed class ProcessContainmentCallerFailure
-    : ProcessContainmentPrimaryFailure
+    : ProcessContainmentOperationFailure
 {
     private readonly object _authorityIdentity;
 
@@ -107,7 +107,7 @@ internal sealed class ProcessContainmentCallerFailure
 }
 
 internal abstract class ProcessContainmentContractFailure
-    : ProcessContainmentPrimaryFailure
+    : ProcessContainmentOperationFailure
 {
     private protected ProcessContainmentContractFailure(
         object authorityIdentity,
@@ -291,15 +291,15 @@ internal abstract record ProcessContainmentOperationRejected
     : ProcessContainmentOperationResult
 {
     private protected ProcessContainmentOperationRejected(
-        ProcessContainmentPrimaryFailure primaryFailure,
+        ProcessContainmentOperationFailure failure,
         IEnumerable<ProcessCleanupFailure> cleanupFailures)
         : base(cleanupFailures)
     {
-        ArgumentNullException.ThrowIfNull(primaryFailure);
-        PrimaryFailure = primaryFailure;
+        ArgumentNullException.ThrowIfNull(failure);
+        Failure = failure;
     }
 
-    public ProcessContainmentPrimaryFailure PrimaryFailure { get; }
+    public ProcessContainmentOperationFailure Failure { get; }
 }
 
 internal sealed class ProcessContainmentOperationAuthority
@@ -361,24 +361,24 @@ internal sealed class ProcessContainmentOperationAuthority
     }
 
     internal ProcessContainmentOperationResult Rejected(
-        ProcessContainmentCallerFailure primaryFailure,
+        ProcessContainmentCallerFailure failure,
         IEnumerable<ProcessCleanupFailure> cleanupFailures)
     {
-        ArgumentNullException.ThrowIfNull(primaryFailure);
-        return Caller.Owns(primaryFailure)
-            ? new PublishedOperationRejected(primaryFailure, cleanupFailures)
+        ArgumentNullException.ThrowIfNull(failure);
+        return Caller.Owns(failure)
+            ? new PublishedOperationRejected(failure, cleanupFailures)
             : new PublishedOperationRejected(
                 ContractGuard.AuthoritySubstitution(),
                 cleanupFailures);
     }
 
     internal ProcessContainmentOperationResult Rejected(
-        ProcessContainmentContractFailure primaryFailure,
+        ProcessContainmentContractFailure failure,
         IEnumerable<ProcessCleanupFailure> cleanupFailures)
     {
-        ArgumentNullException.ThrowIfNull(primaryFailure);
-        return ContractGuard.Owns(primaryFailure)
-            ? new PublishedOperationRejected(primaryFailure, cleanupFailures)
+        ArgumentNullException.ThrowIfNull(failure);
+        return ContractGuard.Owns(failure)
+            ? new PublishedOperationRejected(failure, cleanupFailures)
             : new PublishedOperationRejected(
                 ContractGuard.AuthoritySubstitution(),
                 cleanupFailures);
@@ -472,9 +472,9 @@ file sealed record PublishedOperationRejected
     : ProcessContainmentOperationRejected
 {
     internal PublishedOperationRejected(
-        ProcessContainmentPrimaryFailure primaryFailure,
+        ProcessContainmentOperationFailure failure,
         IEnumerable<ProcessCleanupFailure> cleanupFailures)
-        : base(primaryFailure, cleanupFailures)
+        : base(failure, cleanupFailures)
     {
     }
 }

--- a/tools/DownKyi.ProcessSupervision/TerminalOutcomeContracts.cs
+++ b/tools/DownKyi.ProcessSupervision/TerminalOutcomeContracts.cs
@@ -186,6 +186,12 @@ public sealed class ProcessSupervisionOutcome
     public ProcessSupervisionProof Proof { get; }
 
     public IReadOnlyList<ProcessCleanupFailure> CleanupFailures { get; }
+
+    public bool Succeeded =>
+        Terminal.Kind == ProcessTerminalCandidateKind.TargetTerminal &&
+        Terminal.ExitCode == 0 &&
+        Proof.FormalGatePassed &&
+        CleanupFailures.Count == 0;
 }
 
 internal static class ProcessTerminalCandidateFactory


### PR DESCRIPTION
## Summary

- Add the sole final-success predicate, `ProcessSupervisionOutcome.Succeeded`, derived exactly from target terminal, exit code 0, `Proof.FormalGatePassed`, and an empty cleanup-failure snapshot.
- Keep `FormalGatePassed` as proof fact only. A compiled Roslyn semantic gate rejects direct production use, explicit and target-typed outcome construction, competing Boolean success members (including qualified/aliased types and record-generated properties), non-whitelisted contract-local containment-operation consumers, aliases, and dynamic member/object access.
- Rename containment operation-local `ProcessContainmentPrimaryFailure` / `PrimaryFailure` to `ProcessContainmentOperationFailure` / `Failure` without changing immutable failure or cleanup behavior.
- Add an exhaustive 18-case success matrix and six deterministic follow-up regression profiles, bringing this invariant to nine executable mutations.

## Exact provenance

- Base: `7397d32e704b8d35a08ccba919be77e299a672be`
- Head: `70886b4e1b3de59317e7eb73b042742841ed5518`
- Branch: `refactor/terminal-success-authority`
- Production callers of `DownKyi.ProcessSupervision`: zero.
- Active consumers of `ProcessContainmentOperationResult`: zero.
- Production contract reflection APIs added by this PR: zero. Arbitrary full-trust non-public reflection remains outside this gate's threat model.

## Files

- `tools/DownKyi.ProcessSupervision/TerminalOutcomeContracts.cs`
- `tools/DownKyi.ProcessSupervision/ProcessContainmentOperationAuthorityContracts.cs`
- `tests/DownKyi.Architecture.Tests/ProcessSupervisionContractBehaviorTests.cs`
- `tests/DownKyi.Architecture.Tests/ProcessSupervisionContractArchitectureTests.cs`
- `tests/DownKyi.Architecture.Tests/ProcessContainmentOperationAuthorityBehaviorTests.cs`
- `tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessAuthorityArchitectureTests.cs`
- `tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticCompilation.cs`
- `tests/DownKyi.Architecture.Tests/ProcessTerminalSuccessSemanticGate.cs`
- `tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj`
- `Directory.Packages.props`
- `docs/testing/review-invariant-corpus.json`

## Validation

- Focused exact-head contract/architecture classes: 47 passed, 0 failed.
- Full Architecture exact head: 398 passed, 0 failed.
- Strict Release build exact head: 0 warnings, 0 errors.
- Review invariant gate exact head: 12 invariants, 351 positive tests, 10 executable profiles passed. All nine terminal-success regression mutations produced real failed TRX tests as required.
- Lifecycle ownership audit: 566 matches, 0 violations.
- Module-boundary audit: passed.
- `dotnet format --verify-no-changes` and `git diff --check`: passed.
- Windows-eligible solution tests on parent implementation head `9991329bfda49d72c4b026fcb29a629e15b10d60`: 1,120 passed, 0 failed, 1 skipped because `DOWNKYI_ARIA2_BINARY` was not supplied. The follow-up commit changes only Architecture tests and the executable review corpus.
- Natural CI for head `70886b4e1b3de59317e7eb73b042742841ed5518`: 15/15 checks passed without rerun (CodeQL, Protobuf, Format, Package audit, Windows/Linux/macOS build-test, assembly lifecycle, and six aria2 TLS jobs).

## Not implemented

- No `OwnedProcessLease` or executor implementation.
- No operation-to-terminal mapper and no `ProcessSupervisionOutcome` construction consumer.
- No runtime/project/script integration and no production reference to the contract assembly.
- No change to `ProcessTerminalSelectionPolicy.Select`.
- No process launch/kill/reap, containment backend, quiescence, stream-drain, CentralRunner, PowerShell lifecycle, workflow, release, or documentation expansion.

## Next integration boundary

`OwnedProcessLease` is the only permitted future owner of the operation-to-terminal mapper and the only permitted constructor consumer of `ProcessSupervisionOutcome`. That integration is intentionally deferred from this PR.

Rollback before merge requires reverting `70886b4e1b3de59317e7eb73b042742841ed5518`, then `c78a311cbb2b0c46e015e39cb8d9a0681e1ecf52`, then implementation commit `9991329bfda49d72c4b026fcb29a629e15b10d60`.
