### PR TITLE
refactor: split central test runner responsibilities

### DIFF
--- a/tests/DownKyi.Architecture.Tests/CentralTestRunnerRecorderTests.cs
+++ b/tests/DownKyi.Architecture.Tests/CentralTestRunnerRecorderTests.cs
@@ -243,7 +243,7 @@ public sealed class CentralTestRunnerRecorderTests
         try
         {
             using var cancellation = new CancellationTokenSource();
-            var build = CentralTestCommand.RunBuildProcessAsync(
+            var build = BuildProcessRunner.RunAsync(
                 CreateFixtureStartInfo("fixture-hold-marker", markerPath),
                 cancellation.Token,
                 TimeSpan.FromSeconds(3));
@@ -300,7 +300,7 @@ public sealed class CentralTestRunnerRecorderTests
                 "<TestRun><ResultSummary><Counters executed=\"1\" failed=\"0\" /></ResultSummary></TestRun>",
                 TestContext.Current.CancellationToken);
 
-            var discovered = CentralTestCommand.DiscoverProjects(repositoryRoot);
+            var discovered = TestProjectCatalog.DiscoverProjects(repositoryRoot);
             var definition = Assert.Single(discovered);
             Assert.Equal("tests/Fixture.Tests/Fixture.Tests.csproj", definition.Project);
             Assert.Equal(["Windows", "Linux", "macOS"], definition.Platforms);
@@ -352,7 +352,7 @@ public sealed class CentralTestRunnerRecorderTests
                 TestContext.Current.CancellationToken);
 
             var exception = Assert.Throws<InvalidDataException>(
-                () => CentralTestCommand.DiscoverProjects(repositoryRoot));
+                () => TestProjectCatalog.DiscoverProjects(repositoryRoot));
             Assert.Contains("Linuz", exception.Message, StringComparison.Ordinal);
         }
         finally
@@ -391,7 +391,7 @@ public sealed class CentralTestRunnerRecorderTests
                 TestContext.Current.CancellationToken);
 
             var exception = Assert.Throws<InvalidDataException>(
-                () => CentralTestCommand.DiscoverProjects(repositoryRoot));
+                () => TestProjectCatalog.DiscoverProjects(repositoryRoot));
             Assert.Contains("unconditionally", exception.Message, StringComparison.Ordinal);
         }
         finally

--- a/tools/DownKyi.CentralTestRunner/BoundedOutputCapture.cs
+++ b/tools/DownKyi.CentralTestRunner/BoundedOutputCapture.cs
@@ -1,0 +1,94 @@
+using System.Text;
+
+namespace DownKyi.CentralTestRunner;
+
+internal static class BoundedOutputCapture
+{
+    private const int MaximumOutputLineCharacters = 8192;
+    private const string TruncatedOutputLine = "[output line exceeded 8192 characters and was discarded]";
+
+    internal static async Task CaptureAsync(
+        StreamReader reader,
+        TailBuffer tail,
+        TextWriter destination,
+        SensitiveEvidenceRedactor redactor,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var buffer = new char[4096];
+            var line = new StringBuilder(MaximumOutputLineCharacters);
+            var discardingLine = false;
+            var previousWasCarriageReturn = false;
+
+            async Task FlushLineAsync()
+            {
+                var redacted = discardingLine
+                    ? TruncatedOutputLine
+                    : redactor.Redact(line.ToString());
+                tail.Add(redacted);
+                await destination.WriteLineAsync(redacted).ConfigureAwait(false);
+                line.Clear();
+                discardingLine = false;
+            }
+
+            while (true)
+            {
+                var count = await reader.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
+                if (count == 0)
+                {
+                    break;
+                }
+
+                for (var index = 0; index < count; index++)
+                {
+                    var character = buffer[index];
+                    if (character == '\n')
+                    {
+                        if (!previousWasCarriageReturn)
+                        {
+                            await FlushLineAsync().ConfigureAwait(false);
+                        }
+                        previousWasCarriageReturn = false;
+                        continue;
+                    }
+
+                    if (character == '\r')
+                    {
+                        await FlushLineAsync().ConfigureAwait(false);
+                        previousWasCarriageReturn = true;
+                        continue;
+                    }
+
+                    previousWasCarriageReturn = false;
+                    if (discardingLine)
+                    {
+                        continue;
+                    }
+
+                    if (line.Length == MaximumOutputLineCharacters)
+                    {
+                        line.Clear();
+                        discardingLine = true;
+                        continue;
+                    }
+
+                    line.Append(character);
+                }
+            }
+
+            if (line.Length > 0 || discardingLine)
+            {
+                await FlushLineAsync().ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // The existing cleanup bound ended stream collection.
+        }
+        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Process disposal closes redirected streams after bounded cleanup.
+        }
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/BuildProcessRunner.cs
+++ b/tools/DownKyi.CentralTestRunner/BuildProcessRunner.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+
+namespace DownKyi.CentralTestRunner;
+
+internal static class BuildProcessRunner
+{
+    internal static async Task<int> BuildProjectAsync(
+        string projectPath,
+        string configuration,
+        bool noRestore,
+        CancellationToken cancellationToken)
+    {
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("build");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(configuration);
+        startInfo.ArgumentList.Add("-nodeReuse:false");
+        startInfo.ArgumentList.Add("-p:UseSharedCompilation=false");
+        if (noRestore)
+        {
+            startInfo.ArgumentList.Add("--no-restore");
+        }
+
+        return await RunAsync(startInfo, cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task<int> RunAsync(
+        ProcessStartInfo startInfo,
+        CancellationToken cancellationToken,
+        TimeSpan? cleanupTimeout = null)
+    {
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            var cleanupWindow = cleanupTimeout ?? TimeSpan.FromSeconds(5);
+            var ownedProcesses = await ProcessTreeSnapshot.CaptureAsync(process.Id, cleanupWindow)
+                .ConfigureAwait(false);
+            try
+            {
+                if (!process.HasExited)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+            }
+            catch (Exception exception) when (
+                (exception is InvalidOperationException or System.ComponentModel.Win32Exception) &&
+                process.HasExited)
+            {
+                // The build exited between the liveness check and the kill request.
+            }
+
+            await process.WaitForExitAsync()
+                .WaitAsync(cleanupWindow)
+                .ConfigureAwait(false);
+            await WaitForOwnedProcessesToExitAsync(ownedProcesses.Processes, cleanupWindow)
+                .ConfigureAwait(false);
+            throw;
+        }
+
+        return process.ExitCode;
+    }
+
+    private static async Task WaitForOwnedProcessesToExitAsync(
+        IReadOnlyList<ObservedProcess> ownedProcesses,
+        TimeSpan cleanupTimeout)
+    {
+        var waits = ownedProcesses.Select(WaitForObservedProcessExitAsync);
+        await Task.WhenAll(waits).WaitAsync(cleanupTimeout).ConfigureAwait(false);
+    }
+
+    private static async Task WaitForObservedProcessExitAsync(ObservedProcess observedProcess)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(observedProcess.Pid);
+            if (observedProcess.StartTimeUtc is { } expectedStartTime &&
+                process.StartTime.ToUniversalTime() != expectedStartTime)
+            {
+                return;
+            }
+
+            await process.WaitForExitAsync().ConfigureAwait(false);
+        }
+        catch (ArgumentException)
+        {
+            // The observed process exited before its identity could be opened.
+        }
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/CentralTestCommand.cs
+++ b/tools/DownKyi.CentralTestRunner/CentralTestCommand.cs
@@ -1,34 +1,7 @@
-using System.Diagnostics;
-using System.Runtime.InteropServices;
-using System.Text.Json;
-using System.Xml.Linq;
-
 namespace DownKyi.CentralTestRunner;
-
-internal sealed record TestProjectDefinition(
-    string Project,
-    string[] Platforms,
-    string? InProcessTargetFramework)
-{
-    public bool UseInProcessXunit => InProcessTargetFramework is not null;
-}
-
-internal sealed record TestRunnerPolicyDocument(
-    int SchemaVersion,
-    TestRunnerPolicyProject[] Projects);
-
-internal sealed record TestRunnerPolicyProject(
-    string Project,
-    string Runner,
-    string? TargetFramework);
 
 internal static class CentralTestCommand
 {
-    private static readonly JsonSerializerOptions PolicyJsonOptions = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
-
     public static async Task<int> RunAsync(string[] args, CancellationToken cancellationToken)
     {
         if (args.Length == 0)
@@ -50,13 +23,13 @@ internal static class CentralTestCommand
         CancellationToken cancellationToken)
     {
         var repositoryRoot = Path.GetFullPath(options.RepositoryRoot);
-        var projects = DiscoverProjects(repositoryRoot);
+        var projects = TestProjectCatalog.DiscoverProjects(repositoryRoot);
         if (projects.Length == 0)
         {
             throw new InvalidDataException("No runnable test projects were discovered.");
         }
 
-        var platform = GetCurrentPlatform();
+        var platform = TestProjectCatalog.GetCurrentPlatform();
         var selected = projects
             .Where(project => project.Platforms.Contains(platform, StringComparer.Ordinal))
             .ToArray();
@@ -67,12 +40,12 @@ internal static class CentralTestCommand
 
         foreach (var project in selected)
         {
-            var trxOutput = ResolveTrxOutput(
+            var trxOutput = TrxResultStore.ResolveOutput(
                 repositoryRoot,
                 options.ResultsDirectory,
                 $"{Path.GetFileNameWithoutExtension(project.Project)}.trx",
                 project.Project);
-            ClearStaleTrx(trxOutput);
+            TrxResultStore.ClearStale(trxOutput);
         }
 
         Console.WriteLine($"Selected {selected.Length} of {projects.Length} test projects for '{platform}'.");
@@ -106,15 +79,15 @@ internal static class CentralTestCommand
         }
 
         var repositoryRoot = Path.GetFullPath(options.RepositoryRoot);
-        var relativeProject = NormalizeProject(repositoryRoot, options.Project);
-        var definition = (discoveredProjects ?? DiscoverProjects(repositoryRoot)).SingleOrDefault(project =>
+        var relativeProject = TestProjectCatalog.NormalizeProject(repositoryRoot, options.Project);
+        var definition = (discoveredProjects ?? TestProjectCatalog.DiscoverProjects(repositoryRoot)).SingleOrDefault(project =>
             string.Equals(project.Project, relativeProject, StringComparison.Ordinal));
         if (definition is null)
         {
             throw new InvalidOperationException($"Test project is not allowlisted: {relativeProject}");
         }
 
-        var platform = GetCurrentPlatform();
+        var platform = TestProjectCatalog.GetCurrentPlatform();
         if (!definition.Platforms.Contains(platform, StringComparer.Ordinal))
         {
             throw new InvalidOperationException(
@@ -127,19 +100,19 @@ internal static class CentralTestCommand
             throw new FileNotFoundException("Allowlisted test project is missing.", relativeProject);
         }
 
-        var trxOutput = ResolveTrxOutput(
+        var trxOutput = TrxResultStore.ResolveOutput(
             repositoryRoot,
             options.ResultsDirectory,
             options.TrxName,
             relativeProject);
-        ClearStaleTrx(trxOutput);
+        TrxResultStore.ClearStale(trxOutput);
         var resultsDirectory = trxOutput.ResultsDirectory;
         var trxName = trxOutput.TrxName;
         var trxPath = trxOutput.TrxPath;
 
         if (!options.NoBuild)
         {
-            var buildExitCode = await BuildProjectAsync(
+            var buildExitCode = await BuildProcessRunner.BuildProjectAsync(
                 projectPath,
                 options.Configuration,
                 options.NoRestore,
@@ -151,12 +124,16 @@ internal static class CentralTestCommand
         }
 
         var startInfo = definition.UseInProcessXunit
-            ? CreateInProcessXunitStartInfo(
+            ? TestInvocationFactory.CreateInProcessXunitStartInfo(
                 projectPath,
                 definition.InProcessTargetFramework!,
                 options,
                 trxPath)
-            : CreateVstestStartInfo(projectPath, options, resultsDirectory, trxName);
+            : TestInvocationFactory.CreateVstestStartInfo(
+                projectPath,
+                options,
+                resultsDirectory,
+                trxName);
         startInfo.WorkingDirectory = repositoryRoot;
         var evidenceDirectory = string.IsNullOrWhiteSpace(options.EvidenceDirectory)
             ? Path.Combine(repositoryRoot, "artifacts", "test-flight-recorder")
@@ -185,7 +162,7 @@ internal static class CentralTestCommand
 
         try
         {
-            ValidateTrx(trxPath, $"{relativeProject}:{trxName}");
+            TrxResultStore.Validate(trxPath, $"{relativeProject}:{trxName}");
         }
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or System.Xml.XmlException or InvalidDataException)
         {
@@ -202,525 +179,5 @@ internal static class CentralTestCommand
 
         await FlightRecorderExecution.DiscardAsync(result).ConfigureAwait(false);
         return 0;
-    }
-
-    private static (string ResultsDirectory, string TrxName, string TrxPath) ResolveTrxOutput(
-        string repositoryRoot,
-        string? requestedResultsDirectory,
-        string? requestedTrxName,
-        string relativeProject)
-    {
-        var resultsDirectory = string.IsNullOrWhiteSpace(requestedResultsDirectory)
-            ? Path.Combine(repositoryRoot, "artifacts", "test-results")
-            : Path.GetFullPath(requestedResultsDirectory, repositoryRoot);
-        var trxName = string.IsNullOrWhiteSpace(requestedTrxName)
-            ? $"{Path.GetFileNameWithoutExtension(relativeProject)}.trx"
-            : ValidateTrxName(requestedTrxName);
-        return (resultsDirectory, trxName, Path.Combine(resultsDirectory, trxName));
-    }
-
-    private static void ClearStaleTrx(
-        (string ResultsDirectory, string TrxName, string TrxPath) trxOutput)
-    {
-        Directory.CreateDirectory(trxOutput.ResultsDirectory);
-        File.Delete(trxOutput.TrxPath);
-    }
-
-    private static async Task<int> BuildProjectAsync(
-        string projectPath,
-        string configuration,
-        bool noRestore,
-        CancellationToken cancellationToken)
-    {
-        var startInfo = new ProcessStartInfo("dotnet")
-        {
-            UseShellExecute = false
-        };
-        startInfo.ArgumentList.Add("build");
-        startInfo.ArgumentList.Add(projectPath);
-        startInfo.ArgumentList.Add("-c");
-        startInfo.ArgumentList.Add(configuration);
-        startInfo.ArgumentList.Add("-nodeReuse:false");
-        startInfo.ArgumentList.Add("-p:UseSharedCompilation=false");
-        if (noRestore)
-        {
-            startInfo.ArgumentList.Add("--no-restore");
-        }
-
-        return await RunBuildProcessAsync(startInfo, cancellationToken).ConfigureAwait(false);
-    }
-
-    internal static async Task<int> RunBuildProcessAsync(
-        ProcessStartInfo startInfo,
-        CancellationToken cancellationToken,
-        TimeSpan? cleanupTimeout = null)
-    {
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-        try
-        {
-            await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            var cleanupWindow = cleanupTimeout ?? TimeSpan.FromSeconds(5);
-            var ownedProcesses = await ProcessTreeSnapshot.CaptureAsync(process.Id, cleanupWindow)
-                .ConfigureAwait(false);
-            try
-            {
-                if (!process.HasExited)
-                {
-                    process.Kill(entireProcessTree: true);
-                }
-            }
-            catch (Exception exception) when (
-                (exception is InvalidOperationException or System.ComponentModel.Win32Exception) &&
-                process.HasExited)
-            {
-                // The build exited between the liveness check and the kill request.
-            }
-
-            await process.WaitForExitAsync()
-                .WaitAsync(cleanupWindow)
-                .ConfigureAwait(false);
-            await WaitForOwnedProcessesToExitAsync(ownedProcesses.Processes, cleanupWindow)
-                .ConfigureAwait(false);
-            throw;
-        }
-
-        return process.ExitCode;
-    }
-
-    private static async Task WaitForOwnedProcessesToExitAsync(
-        IReadOnlyList<ObservedProcess> ownedProcesses,
-        TimeSpan cleanupTimeout)
-    {
-        var waits = ownedProcesses.Select(WaitForObservedProcessExitAsync);
-        await Task.WhenAll(waits).WaitAsync(cleanupTimeout).ConfigureAwait(false);
-    }
-
-    private static async Task WaitForObservedProcessExitAsync(ObservedProcess observedProcess)
-    {
-        try
-        {
-            using var process = Process.GetProcessById(observedProcess.Pid);
-            if (observedProcess.StartTimeUtc is { } expectedStartTime &&
-                process.StartTime.ToUniversalTime() != expectedStartTime)
-            {
-                return;
-            }
-
-            await process.WaitForExitAsync().ConfigureAwait(false);
-        }
-        catch (ArgumentException)
-        {
-            // The observed process exited before its identity could be opened.
-        }
-    }
-
-    private static ProcessStartInfo CreateVstestStartInfo(
-        string projectPath,
-        CommandOptions options,
-        string? resultsDirectory,
-        string trxName)
-    {
-        var startInfo = CreateDotnetStartInfo();
-        startInfo.ArgumentList.Add("test");
-        startInfo.ArgumentList.Add(projectPath);
-        startInfo.ArgumentList.Add("-c");
-        startInfo.ArgumentList.Add(options.Configuration);
-        if (options.NoRestore)
-        {
-            startInfo.ArgumentList.Add("--no-restore");
-        }
-        startInfo.ArgumentList.Add("--no-build");
-
-        var filter = options.Filter;
-        if (string.IsNullOrWhiteSpace(filter) && options.Classes.Length > 0)
-        {
-            filter = string.Join(
-                '|',
-                options.Classes
-                    .Order(StringComparer.Ordinal)
-                    .Distinct(StringComparer.Ordinal)
-                    .Select(className => $"FullyQualifiedName~{className}"));
-        }
-        if (!string.IsNullOrWhiteSpace(filter))
-        {
-            startInfo.ArgumentList.Add("--filter");
-            startInfo.ArgumentList.Add(filter);
-        }
-        if (resultsDirectory is not null)
-        {
-            startInfo.ArgumentList.Add("--logger");
-            startInfo.ArgumentList.Add($"trx;LogFileName={trxName}");
-            startInfo.ArgumentList.Add("--results-directory");
-            startInfo.ArgumentList.Add(resultsDirectory);
-        }
-
-        return startInfo;
-    }
-
-    private static ProcessStartInfo CreateInProcessXunitStartInfo(
-        string projectPath,
-        string targetFramework,
-        CommandOptions options,
-        string? trxPath)
-    {
-        if (!string.IsNullOrWhiteSpace(options.Filter))
-        {
-            throw new InvalidOperationException(
-                "The xUnit in-process runner requires --class locators instead of a VSTest filter.");
-        }
-
-        var projectDirectory = Path.GetDirectoryName(projectPath)
-            ?? throw new InvalidOperationException("The test project directory is unavailable.");
-        var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
-        var assemblyPath = Path.Combine(
-            projectDirectory,
-            "bin",
-            options.Configuration,
-            targetFramework,
-            $"{assemblyName}.dll");
-        if (!File.Exists(assemblyPath))
-        {
-            throw new FileNotFoundException("The xUnit in-process test assembly is missing.", assemblyPath);
-        }
-
-        var startInfo = CreateDotnetStartInfo();
-        startInfo.ArgumentList.Add(assemblyPath);
-        startInfo.ArgumentList.Add("-noLogo");
-        startInfo.ArgumentList.Add("-noColor");
-        startInfo.ArgumentList.Add("-noAutoReporters");
-        startInfo.ArgumentList.Add("-reporter");
-        startInfo.ArgumentList.Add("quiet");
-        startInfo.ArgumentList.Add("-parallel");
-        startInfo.ArgumentList.Add("none");
-        foreach (var className in options.Classes.Order(StringComparer.Ordinal).Distinct(StringComparer.Ordinal))
-        {
-            startInfo.ArgumentList.Add("-class");
-            startInfo.ArgumentList.Add(className);
-        }
-        if (trxPath is not null)
-        {
-            startInfo.ArgumentList.Add("-trx");
-            startInfo.ArgumentList.Add(trxPath);
-        }
-
-        return startInfo;
-    }
-
-    private static ProcessStartInfo CreateDotnetStartInfo()
-    {
-        return new ProcessStartInfo("dotnet")
-        {
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-    }
-
-    private static string NormalizeProject(string repositoryRoot, string project)
-    {
-        var fullPath = Path.GetFullPath(project, repositoryRoot);
-        return Path.GetRelativePath(repositoryRoot, fullPath).Replace('\\', '/');
-    }
-
-    internal static TestProjectDefinition[] DiscoverProjects(string repositoryRoot)
-    {
-        var testsDirectory = Path.Combine(repositoryRoot, "tests");
-        if (!Directory.Exists(testsDirectory))
-        {
-            throw new DirectoryNotFoundException($"The repository test directory is missing: {testsDirectory}");
-        }
-
-        var policyPath = Path.Combine(repositoryRoot, "docs", "testing", "test-runner-policy.json");
-        if (!File.Exists(policyPath))
-        {
-            throw new FileNotFoundException("The test runner policy is missing.", policyPath);
-        }
-
-        var policy = JsonSerializer.Deserialize<TestRunnerPolicyDocument>(
-            File.ReadAllText(policyPath),
-            PolicyJsonOptions) ?? throw new InvalidDataException("The test runner policy is empty.");
-        if (policy.SchemaVersion != 1 || policy.Projects is null)
-        {
-            throw new InvalidDataException("The test runner policy schema is unsupported.");
-        }
-
-        var policies = new Dictionary<string, TestRunnerPolicyProject>(StringComparer.Ordinal);
-        foreach (var entry in policy.Projects)
-        {
-            var project = NormalizeProject(repositoryRoot, entry.Project);
-            if (!policies.TryAdd(project, entry))
-            {
-                throw new InvalidDataException($"The test runner policy contains duplicate project '{project}'.");
-            }
-        }
-
-        var projects = Directory.EnumerateFiles(
-                testsDirectory,
-                "*.Tests.csproj",
-                SearchOption.AllDirectories)
-            .Where(path => !IsBuildOutput(path))
-            .Order(StringComparer.Ordinal)
-            .Select(path =>
-            {
-                var project = NormalizeProject(repositoryRoot, path);
-                var platforms = ReadDeclaredPlatforms(path, project);
-                policies.TryGetValue(project, out var runnerPolicy);
-                if (runnerPolicy is not null &&
-                    !string.Equals(runnerPolicy.Runner, "xunit-in-process", StringComparison.Ordinal))
-                {
-                    throw new InvalidDataException(
-                        $"Test project '{project}' has unsupported runner '{runnerPolicy.Runner}'.");
-                }
-                if (runnerPolicy is not null && string.IsNullOrWhiteSpace(runnerPolicy.TargetFramework))
-                {
-                    throw new InvalidDataException(
-                        $"Test project '{project}' requires a target framework for xunit-in-process.");
-                }
-
-                policies.Remove(project);
-                return new TestProjectDefinition(
-                    project,
-                    platforms,
-                    runnerPolicy?.TargetFramework);
-            })
-            .ToArray();
-
-        if (policies.Count > 0)
-        {
-            throw new InvalidDataException(
-                $"The test runner policy references unknown project(s): {string.Join(", ", policies.Keys.Order(StringComparer.Ordinal))}");
-        }
-
-        return projects;
-    }
-
-    private static string[] ReadDeclaredPlatforms(string projectPath, string projectIdentity)
-    {
-        var document = XDocument.Load(projectPath);
-        var declarations = document
-            .Descendants()
-            .Where(element => string.Equals(
-                element.Name.LocalName,
-                "DownKyiTestPlatforms",
-                StringComparison.Ordinal))
-            .ToArray();
-        if (declarations.Length != 1)
-        {
-            throw new InvalidDataException(
-                $"Test project '{projectIdentity}' must declare exactly one DownKyiTestPlatforms value.");
-        }
-
-        var declaration = declarations[0];
-        if (declaration.AncestorsAndSelf().Any(element =>
-                element.Attributes().Any(attribute => string.Equals(
-                    attribute.Name.LocalName,
-                    "Condition",
-                    StringComparison.Ordinal))))
-        {
-            throw new InvalidDataException(
-                $"Test project '{projectIdentity}' must declare DownKyiTestPlatforms unconditionally.");
-        }
-
-        var platforms = declaration.Value.Split(';')
-            .Select(value => value.Trim())
-            .ToArray();
-        if (platforms.Length == 0 ||
-            platforms.Any(string.IsNullOrWhiteSpace) ||
-            platforms.Distinct(StringComparer.Ordinal).Count() != platforms.Length)
-        {
-            throw new InvalidDataException(
-                $"Test project '{projectIdentity}' has invalid DownKyiTestPlatforms metadata.");
-        }
-
-        var unknownPlatforms = platforms
-            .Where(platform => platform is not ("Windows" or "Linux" or "macOS"))
-            .ToArray();
-        if (unknownPlatforms.Length > 0)
-        {
-            throw new InvalidDataException(
-                $"Test project '{projectIdentity}' declares unknown platform(s): {string.Join(", ", unknownPlatforms)}.");
-        }
-
-        return platforms;
-    }
-
-    private static bool IsBuildOutput(string path)
-    {
-        return path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            .Any(segment => string.Equals(segment, "bin", StringComparison.OrdinalIgnoreCase) ||
-                            string.Equals(segment, "obj", StringComparison.OrdinalIgnoreCase));
-    }
-
-    private static string GetCurrentPlatform()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return "Windows";
-        }
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-        {
-            return "Linux";
-        }
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return "macOS";
-        }
-
-        throw new PlatformNotSupportedException("The current operating system has no allowlisted test platform.");
-    }
-
-    private static string ValidateTrxName(string trxName)
-    {
-        if (Path.IsPathRooted(trxName) ||
-            !string.Equals(Path.GetFileName(trxName), trxName, StringComparison.Ordinal) ||
-            trxName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
-        {
-            throw new ArgumentException("The TRX name must be a file name without directory components.", nameof(trxName));
-        }
-
-        return trxName;
-    }
-
-    private static void ValidateTrx(string trxPath, string trxIdentity)
-    {
-        var file = new FileInfo(trxPath);
-        if (!file.Exists || file.Length == 0)
-        {
-            throw new InvalidDataException($"The requested TRX is missing or empty: {trxIdentity}");
-        }
-
-        var document = XDocument.Load(trxPath);
-        if (!string.Equals(document.Root?.Name.LocalName, "TestRun", StringComparison.Ordinal))
-        {
-            throw new InvalidDataException(
-                $"The requested TRX has an unexpected root element: {trxIdentity}");
-        }
-
-        var counters = document
-            .Descendants()
-            .FirstOrDefault(element => string.Equals(
-                element.Name.LocalName,
-                "Counters",
-                StringComparison.Ordinal));
-        if (counters is null ||
-            !int.TryParse(counters.Attribute("executed")?.Value, out var executed) ||
-            !int.TryParse(counters.Attribute("failed")?.Value, out var failed) ||
-            executed < 1 ||
-            failed != 0)
-        {
-            throw new InvalidDataException(
-                $"The requested TRX does not prove a non-empty passing test run: {trxIdentity}");
-        }
-    }
-}
-
-internal sealed record CommandOptions(
-    string RepositoryRoot,
-    string? Project,
-    string Configuration,
-    bool NoRestore,
-    bool NoBuild,
-    string? ResultsDirectory,
-    string? TrxName,
-    string[] Classes,
-    string? Filter,
-    int TimeoutSeconds,
-    string? EvidenceDirectory)
-{
-    public static CommandOptions Parse(string[] args)
-    {
-        var repositoryRoot = Directory.GetCurrentDirectory();
-        string? project = null;
-        var configuration = "Release";
-        var noRestore = false;
-        var noBuild = false;
-        string? resultsDirectory = null;
-        string? trxName = null;
-        var classes = new List<string>();
-        string? filter = null;
-        var timeoutSeconds = 300;
-        string? evidenceDirectory = null;
-
-        for (var index = 0; index < args.Length; index++)
-        {
-            switch (args[index])
-            {
-                case "--repository-root":
-                    repositoryRoot = ReadValue(args, ref index);
-                    break;
-                case "--project":
-                    project = ReadValue(args, ref index);
-                    break;
-                case "--configuration":
-                    configuration = ReadValue(args, ref index);
-                    break;
-                case "--no-restore":
-                    noRestore = true;
-                    break;
-                case "--no-build":
-                    noBuild = true;
-                    break;
-                case "--results-directory":
-                    resultsDirectory = ReadValue(args, ref index);
-                    break;
-                case "--trx-name":
-                    trxName = ReadValue(args, ref index);
-                    break;
-                case "--class":
-                    classes.Add(ReadValue(args, ref index));
-                    break;
-                case "--filter":
-                    filter = ReadValue(args, ref index);
-                    break;
-                case "--timeout-seconds":
-                    timeoutSeconds = int.Parse(
-                        ReadValue(args, ref index),
-                        System.Globalization.CultureInfo.InvariantCulture);
-                    break;
-                case "--evidence-directory":
-                    evidenceDirectory = ReadValue(args, ref index);
-                    break;
-                default:
-                    throw new ArgumentException($"Unknown option: {args[index]}", nameof(args));
-            }
-        }
-
-        if (configuration is not ("Debug" or "Release"))
-        {
-            throw new ArgumentOutOfRangeException(nameof(args), "Configuration must be Debug or Release.");
-        }
-        if (timeoutSeconds is < 1 or > 3600)
-        {
-            throw new ArgumentOutOfRangeException(nameof(args), "Timeout must be between 1 and 3600 seconds.");
-        }
-
-        return new CommandOptions(
-            repositoryRoot,
-            project,
-            configuration,
-            noRestore,
-            noBuild,
-            resultsDirectory,
-            trxName,
-            classes.ToArray(),
-            filter,
-            timeoutSeconds,
-            evidenceDirectory);
-    }
-
-    private static string ReadValue(string[] args, ref int index)
-    {
-        index++;
-        if (index >= args.Length || string.IsNullOrWhiteSpace(args[index]))
-        {
-            throw new ArgumentException("A command option is missing its value.", nameof(args));
-        }
-
-        return args[index];
     }
 }

--- a/tools/DownKyi.CentralTestRunner/CommandOptions.cs
+++ b/tools/DownKyi.CentralTestRunner/CommandOptions.cs
@@ -1,0 +1,107 @@
+namespace DownKyi.CentralTestRunner;
+
+internal sealed record CommandOptions(
+    string RepositoryRoot,
+    string? Project,
+    string Configuration,
+    bool NoRestore,
+    bool NoBuild,
+    string? ResultsDirectory,
+    string? TrxName,
+    string[] Classes,
+    string? Filter,
+    int TimeoutSeconds,
+    string? EvidenceDirectory)
+{
+    public static CommandOptions Parse(string[] args)
+    {
+        var repositoryRoot = Directory.GetCurrentDirectory();
+        string? project = null;
+        var configuration = "Release";
+        var noRestore = false;
+        var noBuild = false;
+        string? resultsDirectory = null;
+        string? trxName = null;
+        var classes = new List<string>();
+        string? filter = null;
+        var timeoutSeconds = 300;
+        string? evidenceDirectory = null;
+
+        for (var index = 0; index < args.Length; index++)
+        {
+            switch (args[index])
+            {
+                case "--repository-root":
+                    repositoryRoot = ReadValue(args, ref index);
+                    break;
+                case "--project":
+                    project = ReadValue(args, ref index);
+                    break;
+                case "--configuration":
+                    configuration = ReadValue(args, ref index);
+                    break;
+                case "--no-restore":
+                    noRestore = true;
+                    break;
+                case "--no-build":
+                    noBuild = true;
+                    break;
+                case "--results-directory":
+                    resultsDirectory = ReadValue(args, ref index);
+                    break;
+                case "--trx-name":
+                    trxName = ReadValue(args, ref index);
+                    break;
+                case "--class":
+                    classes.Add(ReadValue(args, ref index));
+                    break;
+                case "--filter":
+                    filter = ReadValue(args, ref index);
+                    break;
+                case "--timeout-seconds":
+                    timeoutSeconds = int.Parse(
+                        ReadValue(args, ref index),
+                        System.Globalization.CultureInfo.InvariantCulture);
+                    break;
+                case "--evidence-directory":
+                    evidenceDirectory = ReadValue(args, ref index);
+                    break;
+                default:
+                    throw new ArgumentException($"Unknown option: {args[index]}", nameof(args));
+            }
+        }
+
+        if (configuration is not ("Debug" or "Release"))
+        {
+            throw new ArgumentOutOfRangeException(nameof(args), "Configuration must be Debug or Release.");
+        }
+        if (timeoutSeconds is < 1 or > 3600)
+        {
+            throw new ArgumentOutOfRangeException(nameof(args), "Timeout must be between 1 and 3600 seconds.");
+        }
+
+        return new CommandOptions(
+            repositoryRoot,
+            project,
+            configuration,
+            noRestore,
+            noBuild,
+            resultsDirectory,
+            trxName,
+            classes.ToArray(),
+            filter,
+            timeoutSeconds,
+            evidenceDirectory);
+    }
+
+    private static string ReadValue(string[] args, ref int index)
+    {
+        index++;
+        if (index >= args.Length || string.IsNullOrWhiteSpace(args[index]))
+        {
+            throw new ArgumentException("A command option is missing its value.", nameof(args));
+        }
+
+        return args[index];
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/FlightRecorder.cs
+++ b/tools/DownKyi.CentralTestRunner/FlightRecorder.cs
@@ -1,349 +1,7 @@
-using System.Diagnostics;
-using System.Globalization;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 
 namespace DownKyi.CentralTestRunner;
-
-internal sealed record ProcessExecutionRequest(
-    string SliceIdentity,
-    string TestIdentity,
-    ProcessStartInfo StartInfo,
-    TimeSpan Timeout,
-    TimeSpan CleanupTimeout,
-    string EvidenceDirectory,
-    Func<int, TimeSpan, Task<FinalProcessSnapshot>>? SnapshotCapture = null);
-
-internal sealed record ProcessExecutionResult(
-    int ExitCode,
-    int RootPid,
-    DateTimeOffset RootStartTimeUtc,
-    string EvidencePath,
-    FlightRecorder Recorder);
-
-internal static class FlightRecorderExecution
-{
-    private const int MaximumOutputLineCharacters = 8192;
-    private const string TruncatedOutputLine = "[output line exceeded 8192 characters and was discarded]";
-
-    public static async Task<ProcessExecutionResult> RunAsync(
-        ProcessExecutionRequest request,
-        CancellationToken cancellationToken)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.SliceIdentity);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.TestIdentity);
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.EvidenceDirectory);
-
-        var recorder = await FlightRecorder.CreateAsync(request).ConfigureAwait(false);
-        using var process = new Process { StartInfo = request.StartInfo };
-        var standardOutput = new TailBuffer(8192);
-        var standardError = new TailBuffer(8192);
-
-        try
-        {
-            process.Start();
-        }
-        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
-        {
-            await recorder.RecordAsync("process_start_failed", detail: exception.Message).ConfigureAwait(false);
-            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
-            await recorder.FinalizeFailureAsync("start_failed", standardOutput, standardError).ConfigureAwait(false);
-            return new ProcessExecutionResult(2, 0, default, recorder.EvidencePath, recorder);
-        }
-
-        var rootPid = process.Id;
-        DateTimeOffset rootStartTime;
-        try
-        {
-            rootStartTime = process.StartTime.ToUniversalTime();
-        }
-        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
-        {
-            await recorder.RecordAsync(
-                "root_identity_failed",
-                pid: rootPid,
-                detail: exception.Message).ConfigureAwait(false);
-            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
-            await StopAsync(process, request.CleanupTimeout, recorder).ConfigureAwait(false);
-            await recorder.FinalizeFailureAsync("root_identity_failed", standardOutput, standardError)
-                .ConfigureAwait(false);
-            return new ProcessExecutionResult(2, rootPid, default, recorder.EvidencePath, recorder);
-        }
-
-        recorder.SetRootIdentity(rootPid, rootStartTime);
-        await recorder.RecordAsync(
-            "process_start",
-            pid: rootPid,
-            startTimeUtc: rootStartTime).ConfigureAwait(false);
-
-        using var outputCapture = new CancellationTokenSource();
-        var outputTask = CaptureOutputAsync(
-            process.StandardOutput,
-            standardOutput,
-            Console.Out,
-            recorder,
-            outputCapture.Token);
-        var errorTask = CaptureOutputAsync(
-            process.StandardError,
-            standardError,
-            Console.Error,
-            recorder,
-            outputCapture.Token);
-        using var timeout = new CancellationTokenSource(request.Timeout);
-        using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(
-            cancellationToken,
-            timeout.Token);
-
-        try
-        {
-            await process.WaitForExitAsync(waitCancellation.Token).ConfigureAwait(false);
-        }
-        catch (OperationCanceledException)
-        {
-            var eventName = cancellationToken.IsCancellationRequested ? "cancellation" : "timeout";
-            await recorder.RecordAsync(eventName, pid: rootPid).ConfigureAwait(false);
-            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
-            await StopAsync(process, request.CleanupTimeout, recorder).ConfigureAwait(false);
-            await DrainOutputAsync(
-                outputTask,
-                errorTask,
-                outputCapture,
-                request.CleanupTimeout,
-                recorder,
-                rootPid).ConfigureAwait(false);
-            await recorder.FinalizeFailureAsync(eventName, standardOutput, standardError)
-                .ConfigureAwait(false);
-            var exitCode = string.Equals(eventName, "timeout", StringComparison.Ordinal) ? 124 : 130;
-            return new ProcessExecutionResult(
-                exitCode,
-                rootPid,
-                rootStartTime,
-                recorder.EvidencePath,
-                recorder);
-        }
-
-        var processExitCode = process.ExitCode;
-        await recorder.RecordAsync(
-            "process_exit",
-            pid: rootPid,
-            exitCode: processExitCode).ConfigureAwait(false);
-        if (processExitCode != 0)
-        {
-            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
-        }
-
-        var streamsDrained = await DrainOutputAsync(
-            outputTask,
-            errorTask,
-            outputCapture,
-            request.CleanupTimeout,
-            recorder,
-            rootPid).ConfigureAwait(false);
-        if (!streamsDrained)
-        {
-            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
-            await recorder.FinalizeFailureAsync("stream_drain_failed", standardOutput, standardError)
-                .ConfigureAwait(false);
-            processExitCode = 2;
-        }
-        else if (processExitCode != 0)
-        {
-            await recorder.RecordAsync(
-                "cleanup_completed",
-                pid: rootPid,
-                detail: "natural process exit and stream drain observed").ConfigureAwait(false);
-            await recorder.FinalizeFailureAsync("process_exit", standardOutput, standardError)
-                .ConfigureAwait(false);
-        }
-        else
-        {
-            recorder.SetOutputTails(standardOutput.Value, standardError.Value);
-            await recorder.RecordAsync("cleanup_completed", pid: rootPid, detail: "natural process exit observed")
-                .ConfigureAwait(false);
-        }
-
-        return new ProcessExecutionResult(
-            processExitCode,
-            rootPid,
-            rootStartTime,
-            recorder.EvidencePath,
-            recorder);
-    }
-
-    public static async Task PreservePostExitFailureAsync(
-        ProcessExecutionResult result,
-        string eventName,
-        string detail)
-    {
-        await result.Recorder.RecordAsync(
-            eventName,
-            pid: result.RootPid,
-            detail: detail).ConfigureAwait(false);
-        await result.Recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
-        await result.Recorder.FinalizeFailureAsync(
-            eventName,
-            new TailBuffer(1),
-            new TailBuffer(1)).ConfigureAwait(false);
-    }
-
-    public static Task DiscardAsync(ProcessExecutionResult result)
-    {
-        File.Delete(result.EvidencePath);
-        return Task.CompletedTask;
-    }
-
-    private static async Task StopAsync(
-        Process process,
-        TimeSpan cleanupTimeout,
-        FlightRecorder recorder)
-    {
-        await recorder.RecordAsync("bounded_stop_requested", pid: process.Id).ConfigureAwait(false);
-        try
-        {
-            if (!process.HasExited)
-            {
-                process.Kill(entireProcessTree: true);
-            }
-
-            using var cleanup = new CancellationTokenSource(cleanupTimeout);
-            await process.WaitForExitAsync(cleanup.Token).ConfigureAwait(false);
-            await recorder.RecordAsync(
-                "process_exit",
-                pid: process.Id,
-                exitCode: process.ExitCode).ConfigureAwait(false);
-            await recorder.RecordAsync("cleanup_completed", pid: process.Id).ConfigureAwait(false);
-        }
-        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception or OperationCanceledException)
-        {
-            await recorder.RecordAsync(
-                "cleanup_failed",
-                pid: process.Id,
-                detail: exception.Message).ConfigureAwait(false);
-        }
-    }
-
-    private static async Task CaptureOutputAsync(
-        StreamReader reader,
-        TailBuffer tail,
-        TextWriter destination,
-        FlightRecorder recorder,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            var buffer = new char[4096];
-            var line = new StringBuilder(MaximumOutputLineCharacters);
-            var discardingLine = false;
-            var previousWasCarriageReturn = false;
-
-            async Task FlushLineAsync()
-            {
-                var redacted = discardingLine
-                    ? TruncatedOutputLine
-                    : recorder.RedactSensitiveEvidence(line.ToString());
-                tail.Add(redacted);
-                await destination.WriteLineAsync(redacted).ConfigureAwait(false);
-                line.Clear();
-                discardingLine = false;
-            }
-
-            while (true)
-            {
-                var count = await reader.ReadAsync(buffer.AsMemory(), cancellationToken).ConfigureAwait(false);
-                if (count == 0)
-                {
-                    break;
-                }
-
-                for (var index = 0; index < count; index++)
-                {
-                    var character = buffer[index];
-                    if (character == '\n')
-                    {
-                        if (!previousWasCarriageReturn)
-                        {
-                            await FlushLineAsync().ConfigureAwait(false);
-                        }
-                        previousWasCarriageReturn = false;
-                        continue;
-                    }
-
-                    if (character == '\r')
-                    {
-                        await FlushLineAsync().ConfigureAwait(false);
-                        previousWasCarriageReturn = true;
-                        continue;
-                    }
-
-                    previousWasCarriageReturn = false;
-                    if (discardingLine)
-                    {
-                        continue;
-                    }
-
-                    if (line.Length == MaximumOutputLineCharacters)
-                    {
-                        line.Clear();
-                        discardingLine = true;
-                        continue;
-                    }
-
-                    line.Append(character);
-                }
-            }
-
-            if (line.Length > 0 || discardingLine)
-            {
-                await FlushLineAsync().ConfigureAwait(false);
-            }
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            // The existing cleanup bound ended stream collection.
-        }
-        catch (ObjectDisposedException) when (cancellationToken.IsCancellationRequested)
-        {
-            // Process disposal closes redirected streams after bounded cleanup.
-        }
-    }
-
-    private static async Task<bool> DrainOutputAsync(
-        Task outputTask,
-        Task errorTask,
-        CancellationTokenSource outputCapture,
-        TimeSpan cleanupTimeout,
-        FlightRecorder recorder,
-        int rootPid)
-    {
-        var drain = Task.WhenAll(outputTask, errorTask);
-        try
-        {
-            await drain.WaitAsync(cleanupTimeout).ConfigureAwait(false);
-            return true;
-        }
-        catch (TimeoutException)
-        {
-            await outputCapture.CancelAsync().ConfigureAwait(false);
-            await recorder.RecordAsync(
-                "cleanup_failed",
-                pid: rootPid,
-                detail: "stdout/stderr drain exceeded the bounded cleanup window")
-                .ConfigureAwait(false);
-            return false;
-        }
-        catch (Exception exception) when (exception is IOException or InvalidOperationException or ObjectDisposedException)
-        {
-            await recorder.RecordAsync(
-                "cleanup_failed",
-                pid: rootPid,
-                detail: $"stdout/stderr drain failed: {exception.Message}")
-                .ConfigureAwait(false);
-            return false;
-        }
-    }
-}
 
 internal sealed class FlightRecorder
 {
@@ -362,38 +20,27 @@ internal sealed class FlightRecorder
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
-    private static readonly Regex SensitiveHeaderPattern = new(
-        @"\b(?<name>authorization|proxy-authorization|cookie|set-cookie)\s*[:=]\s*[^\r\n]+",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-
-    private static readonly Regex SensitiveValuePattern = new(
-        @"\b(?<name>access[_-]?token|refresh[_-]?token|token|api[_-]?key|secret|password|sessdata|bili_jct|dedeuserid|account(?:id)?|user(?:id)?|uid|mid)\b(?<separator>\s*[:=]\s*)(?<value>[^&;\s,]+)",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-
-    private static readonly Regex UrlPattern = new(
-        "\\bhttps?://[^\\s\\\"'<>]+",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
-
     private readonly RecorderReport report;
     private readonly TimeSpan snapshotTimeout;
-    private readonly string workingDirectory;
     private readonly Func<int, TimeSpan, Task<FinalProcessSnapshot>> snapshotCapture;
 
     private FlightRecorder(
         string evidencePath,
         RecorderReport report,
         TimeSpan snapshotTimeout,
-        string workingDirectory,
-        Func<int, TimeSpan, Task<FinalProcessSnapshot>> snapshotCapture)
+        Func<int, TimeSpan, Task<FinalProcessSnapshot>> snapshotCapture,
+        SensitiveEvidenceRedactor redactor)
     {
         EvidencePath = evidencePath;
         this.report = report;
         this.snapshotTimeout = snapshotTimeout;
-        this.workingDirectory = workingDirectory;
         this.snapshotCapture = snapshotCapture;
+        Redactor = redactor;
     }
 
     public string EvidencePath { get; }
+
+    internal SensitiveEvidenceRedactor Redactor { get; }
 
     public static async Task<FlightRecorder> CreateAsync(ProcessExecutionRequest request)
     {
@@ -407,14 +54,11 @@ internal sealed class FlightRecorder
         var evidencePath = Path.Combine(
             request.EvidenceDirectory,
             $"{safeSlice}-{Guid.NewGuid():N}.json");
+        var redactor = new SensitiveEvidenceRedactor(request.StartInfo.WorkingDirectory);
         var report = new RecorderReport
         {
-            SliceIdentity = RedactSensitiveEvidence(
-                request.SliceIdentity,
-                request.StartInfo.WorkingDirectory),
-            TestIdentity = RedactSensitiveEvidence(
-                request.TestIdentity,
-                request.StartInfo.WorkingDirectory),
+            SliceIdentity = redactor.Redact(request.SliceIdentity),
+            TestIdentity = redactor.Redact(request.TestIdentity),
             RecorderStartedAtUtc = DateTimeOffset.UtcNow,
             Events = []
         };
@@ -422,8 +66,8 @@ internal sealed class FlightRecorder
             evidencePath,
             report,
             request.CleanupTimeout,
-            request.StartInfo.WorkingDirectory,
-            request.SnapshotCapture ?? ProcessTreeSnapshot.CaptureAsync);
+            request.SnapshotCapture ?? ProcessTreeSnapshot.CaptureAsync,
+            redactor);
         await recorder.RecordAsync("recorder_start").ConfigureAwait(false);
         return recorder;
     }
@@ -439,8 +83,8 @@ internal sealed class FlightRecorder
 
     public void SetOutputTails(string standardOutput, string standardError)
     {
-        report.StdoutTail = RedactSensitiveEvidence(standardOutput);
-        report.StderrTail = RedactSensitiveEvidence(standardError);
+        report.StdoutTail = Redactor.Redact(standardOutput);
+        report.StderrTail = Redactor.Redact(standardError);
     }
 
     public async Task RecordAsync(
@@ -457,7 +101,7 @@ internal sealed class FlightRecorder
             Pid = pid,
             StartTimeUtc = startTimeUtc,
             ExitCode = exitCode,
-            Detail = detail is null ? null : RedactSensitiveEvidence(detail)
+            Detail = detail is null ? null : Redactor.Redact(detail)
         });
         await PersistAsync().ConfigureAwait(false);
     }
@@ -479,7 +123,7 @@ internal sealed class FlightRecorder
                                           System.ComponentModel.Win32Exception or TimeoutException or
                                           UnauthorizedAccessException or NotSupportedException)
         {
-            var error = RedactSensitiveEvidence(exception.Message);
+            var error = Redactor.Redact(exception.Message);
             report.FinalSnapshot = new FinalProcessSnapshot
             {
                 CapturedAtUtc = DateTimeOffset.UtcNow,
@@ -504,49 +148,15 @@ internal sealed class FlightRecorder
         report.Outcome = outcome;
         if (standardOutput.Value.Length > 0 || report.StdoutTail is null)
         {
-            report.StdoutTail = RedactSensitiveEvidence(standardOutput.Value);
+            report.StdoutTail = Redactor.Redact(standardOutput.Value);
         }
         if (standardError.Value.Length > 0 || report.StderrTail is null)
         {
-            report.StderrTail = RedactSensitiveEvidence(standardError.Value);
+            report.StderrTail = Redactor.Redact(standardError.Value);
         }
 
         report.DiagnosticGuidance = DiagnosticGuidance;
         await PersistAsync().ConfigureAwait(false);
-    }
-
-    internal string RedactSensitiveEvidence(string value)
-    {
-        return RedactSensitiveEvidence(value, workingDirectory);
-    }
-
-    private static string RedactSensitiveEvidence(string value, string workingDirectory)
-    {
-        var redacted = ReplacePath(value, workingDirectory, "<repository-root>");
-        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-        redacted = ReplacePath(redacted, userProfile, "<user-profile>");
-        redacted = SensitiveHeaderPattern.Replace(
-            redacted,
-            match => $"{match.Groups["name"].Value}: <redacted>");
-        redacted = UrlPattern.Replace(redacted, "<redacted-url>");
-        return SensitiveValuePattern.Replace(
-            redacted,
-            match => $"{match.Groups["name"].Value}{match.Groups["separator"].Value}<redacted>");
-    }
-
-    private static string ReplacePath(string value, string path, string replacement)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-        {
-            return value;
-        }
-
-        var trimmed = Path.TrimEndingDirectorySeparator(path);
-        var redacted = value.Replace(trimmed, replacement, StringComparison.OrdinalIgnoreCase);
-        var alternate = trimmed.Contains('\\', StringComparison.Ordinal)
-            ? trimmed.Replace('\\', '/')
-            : trimmed.Replace('/', '\\');
-        return redacted.Replace(alternate, replacement, StringComparison.OrdinalIgnoreCase);
     }
 
     private Task PersistAsync()
@@ -554,261 +164,4 @@ internal sealed class FlightRecorder
         var json = JsonSerializer.Serialize(report, JsonOptions);
         return File.WriteAllTextAsync(EvidencePath, json);
     }
-}
-
-internal sealed class TailBuffer
-{
-    private readonly int maximumCharacters;
-    private readonly Queue<string> lines = new();
-    private readonly object synchronization = new();
-    private int characters;
-
-    public TailBuffer(int maximumCharacters)
-    {
-        this.maximumCharacters = maximumCharacters;
-    }
-
-    public string Value
-    {
-        get
-        {
-            lock (synchronization)
-            {
-                return string.Join(Environment.NewLine, lines);
-            }
-        }
-    }
-
-    public void Add(string line)
-    {
-        lock (synchronization)
-        {
-            var retained = line.Length > maximumCharacters
-                ? line[^maximumCharacters..]
-                : line;
-            lines.Enqueue(retained);
-            characters += retained.Length + Environment.NewLine.Length;
-            while (characters > maximumCharacters && lines.Count > 1)
-            {
-                characters -= lines.Dequeue().Length + Environment.NewLine.Length;
-            }
-            if (characters > maximumCharacters && lines.Count == 1)
-            {
-                var onlyLine = lines.Dequeue();
-                var keep = Math.Max(0, maximumCharacters - Environment.NewLine.Length);
-                retained = keep == 0 ? string.Empty : onlyLine[^Math.Min(keep, onlyLine.Length)..];
-                lines.Enqueue(retained);
-                characters = retained.Length + Environment.NewLine.Length;
-            }
-        }
-    }
-}
-
-internal static class ProcessTreeSnapshot
-{
-    public static async Task<FinalProcessSnapshot> CaptureAsync(
-        int rootPid,
-        TimeSpan timeout)
-    {
-        var parentIds = await ReadParentIdsAsync(timeout).ConfigureAwait(false);
-        var included = new HashSet<int>();
-        if (rootPid > 0)
-        {
-            included.Add(rootPid);
-        }
-
-        var added = true;
-        while (added)
-        {
-            added = false;
-            foreach (var pair in parentIds)
-            {
-                if (included.Contains(pair.Value) && included.Add(pair.Key))
-                {
-                    added = true;
-                }
-            }
-        }
-
-        var processes = new List<ObservedProcess>();
-        foreach (var pid in included.Where(parentIds.ContainsKey).Order())
-        {
-            DateTimeOffset? startTimeUtc = null;
-            try
-            {
-                using var process = Process.GetProcessById(pid);
-                startTimeUtc = process.StartTime.ToUniversalTime();
-            }
-            catch (Exception exception) when (exception is ArgumentException or InvalidOperationException or System.ComponentModel.Win32Exception)
-            {
-                // The process may exit between the point-in-time relationship snapshot and identity read.
-            }
-
-            processes.Add(new ObservedProcess
-            {
-                Pid = pid,
-                ParentPid = parentIds[pid],
-                StartTimeUtc = startTimeUtc
-            });
-        }
-
-        return new FinalProcessSnapshot
-        {
-            CapturedAtUtc = DateTimeOffset.UtcNow,
-            Completeness = FlightRecorder.SnapshotNotice,
-            Processes = processes
-        };
-    }
-
-    private static async Task<Dictionary<int, int>> ReadParentIdsAsync(TimeSpan timeout)
-    {
-        var startInfo = OperatingSystem.IsWindows()
-            ? CreateWindowsSnapshotStartInfo()
-            : CreateUnixSnapshotStartInfo();
-        using var process = new Process { StartInfo = startInfo };
-        process.Start();
-        var outputTask = process.StandardOutput.ReadToEndAsync();
-        var errorTask = process.StandardError.ReadToEndAsync();
-        try
-        {
-            await process.WaitForExitAsync().WaitAsync(timeout).ConfigureAwait(false);
-        }
-        catch (TimeoutException)
-        {
-            try
-            {
-                process.Kill(entireProcessTree: true);
-            }
-            catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
-            {
-                // The snapshot helper may have exited while the bound elapsed.
-            }
-            throw new TimeoutException("Process relationship snapshot exceeded the bounded cleanup window.");
-        }
-        var output = await outputTask.ConfigureAwait(false);
-        var error = await errorTask.ConfigureAwait(false);
-        if (process.ExitCode != 0)
-        {
-            throw new InvalidOperationException($"Process relationship snapshot failed: {error.Trim()}");
-        }
-
-        return ParseParentIds(output);
-    }
-
-    internal static Dictionary<int, int> ParseParentIds(string output)
-    {
-        var result = new Dictionary<int, int>();
-        foreach (var line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
-        {
-            var values = line.Contains('|', StringComparison.Ordinal)
-                ? line.Split('|', StringSplitOptions.TrimEntries)
-                : line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
-            if (values.Length == 2 &&
-                int.TryParse(values[0], NumberStyles.None, CultureInfo.InvariantCulture, out var pid) &&
-                int.TryParse(values[1], NumberStyles.None, CultureInfo.InvariantCulture, out var parentPid) &&
-                pid > 0 &&
-                parentPid >= 0)
-            {
-                result[pid] = parentPid;
-            }
-        }
-
-        return result;
-    }
-
-    private static ProcessStartInfo CreateWindowsSnapshotStartInfo()
-    {
-        var startInfo = new ProcessStartInfo("powershell.exe")
-        {
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-        startInfo.ArgumentList.Add("-NoProfile");
-        startInfo.ArgumentList.Add("-NonInteractive");
-        startInfo.ArgumentList.Add("-Command");
-        startInfo.ArgumentList.Add(
-            "Get-CimInstance Win32_Process | ForEach-Object { '{0}|{1}' -f $_.ProcessId,$_.ParentProcessId }");
-        return startInfo;
-    }
-
-    private static ProcessStartInfo CreateUnixSnapshotStartInfo()
-    {
-        var startInfo = new ProcessStartInfo("/bin/ps")
-        {
-            UseShellExecute = false,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            CreateNoWindow = true
-        };
-        startInfo.ArgumentList.Add("-axo");
-        startInfo.ArgumentList.Add("pid=,ppid=");
-        return startInfo;
-    }
-}
-
-internal sealed class RecorderReport
-{
-    public required string SliceIdentity { get; init; }
-
-    public required string TestIdentity { get; init; }
-
-    public DateTimeOffset RecorderStartedAtUtc { get; init; }
-
-    public RootProcessIdentity? RootProcess { get; set; }
-
-    public string? Outcome { get; set; }
-
-    public required List<RecorderEvent> Events { get; init; }
-
-    public string? StdoutTail { get; set; }
-
-    public string? StderrTail { get; set; }
-
-    public FinalProcessSnapshot? FinalSnapshot { get; set; }
-
-    public string? DiagnosticGuidance { get; set; }
-}
-
-internal sealed class RootProcessIdentity
-{
-    public int Pid { get; init; }
-
-    public DateTimeOffset StartTimeUtc { get; init; }
-}
-
-internal sealed class RecorderEvent
-{
-    public DateTimeOffset TimestampUtc { get; init; }
-
-    public required string Event { get; init; }
-
-    public int? Pid { get; init; }
-
-    public DateTimeOffset? StartTimeUtc { get; init; }
-
-    public int? ExitCode { get; init; }
-
-    public string? Detail { get; init; }
-}
-
-internal sealed class FinalProcessSnapshot
-{
-    public DateTimeOffset CapturedAtUtc { get; init; }
-
-    public required string Completeness { get; init; }
-
-    public required IReadOnlyList<ObservedProcess> Processes { get; init; }
-
-    public string? Error { get; init; }
-}
-
-internal sealed class ObservedProcess
-{
-    public int Pid { get; init; }
-
-    public int ParentPid { get; init; }
-
-    public DateTimeOffset? StartTimeUtc { get; init; }
 }

--- a/tools/DownKyi.CentralTestRunner/FlightRecorderExecution.cs
+++ b/tools/DownKyi.CentralTestRunner/FlightRecorderExecution.cs
@@ -1,0 +1,253 @@
+using System.Diagnostics;
+
+namespace DownKyi.CentralTestRunner;
+
+internal sealed record ProcessExecutionRequest(
+    string SliceIdentity,
+    string TestIdentity,
+    ProcessStartInfo StartInfo,
+    TimeSpan Timeout,
+    TimeSpan CleanupTimeout,
+    string EvidenceDirectory,
+    Func<int, TimeSpan, Task<FinalProcessSnapshot>>? SnapshotCapture = null);
+
+internal sealed record ProcessExecutionResult(
+    int ExitCode,
+    int RootPid,
+    DateTimeOffset RootStartTimeUtc,
+    string EvidencePath,
+    FlightRecorder Recorder);
+
+internal static class FlightRecorderExecution
+{
+    public static async Task<ProcessExecutionResult> RunAsync(
+        ProcessExecutionRequest request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.SliceIdentity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TestIdentity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.EvidenceDirectory);
+
+        var recorder = await FlightRecorder.CreateAsync(request).ConfigureAwait(false);
+        using var process = new Process { StartInfo = request.StartInfo };
+        var standardOutput = new TailBuffer(8192);
+        var standardError = new TailBuffer(8192);
+
+        try
+        {
+            process.Start();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            await recorder.RecordAsync("process_start_failed", detail: exception.Message).ConfigureAwait(false);
+            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
+            await recorder.FinalizeFailureAsync("start_failed", standardOutput, standardError).ConfigureAwait(false);
+            return new ProcessExecutionResult(2, 0, default, recorder.EvidencePath, recorder);
+        }
+
+        var rootPid = process.Id;
+        DateTimeOffset rootStartTime;
+        try
+        {
+            rootStartTime = process.StartTime.ToUniversalTime();
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            await recorder.RecordAsync(
+                "root_identity_failed",
+                pid: rootPid,
+                detail: exception.Message).ConfigureAwait(false);
+            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
+            await StopAsync(process, request.CleanupTimeout, recorder).ConfigureAwait(false);
+            await recorder.FinalizeFailureAsync("root_identity_failed", standardOutput, standardError)
+                .ConfigureAwait(false);
+            return new ProcessExecutionResult(2, rootPid, default, recorder.EvidencePath, recorder);
+        }
+
+        recorder.SetRootIdentity(rootPid, rootStartTime);
+        await recorder.RecordAsync(
+            "process_start",
+            pid: rootPid,
+            startTimeUtc: rootStartTime).ConfigureAwait(false);
+
+        using var outputCapture = new CancellationTokenSource();
+        var outputTask = BoundedOutputCapture.CaptureAsync(
+            process.StandardOutput,
+            standardOutput,
+            Console.Out,
+            recorder.Redactor,
+            outputCapture.Token);
+        var errorTask = BoundedOutputCapture.CaptureAsync(
+            process.StandardError,
+            standardError,
+            Console.Error,
+            recorder.Redactor,
+            outputCapture.Token);
+        using var timeout = new CancellationTokenSource(request.Timeout);
+        using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(
+            cancellationToken,
+            timeout.Token);
+
+        try
+        {
+            await process.WaitForExitAsync(waitCancellation.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            var eventName = cancellationToken.IsCancellationRequested ? "cancellation" : "timeout";
+            await recorder.RecordAsync(eventName, pid: rootPid).ConfigureAwait(false);
+            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
+            await StopAsync(process, request.CleanupTimeout, recorder).ConfigureAwait(false);
+            await DrainOutputAsync(
+                outputTask,
+                errorTask,
+                outputCapture,
+                request.CleanupTimeout,
+                recorder,
+                rootPid).ConfigureAwait(false);
+            await recorder.FinalizeFailureAsync(eventName, standardOutput, standardError)
+                .ConfigureAwait(false);
+            var exitCode = string.Equals(eventName, "timeout", StringComparison.Ordinal) ? 124 : 130;
+            return new ProcessExecutionResult(
+                exitCode,
+                rootPid,
+                rootStartTime,
+                recorder.EvidencePath,
+                recorder);
+        }
+
+        var processExitCode = process.ExitCode;
+        await recorder.RecordAsync(
+            "process_exit",
+            pid: rootPid,
+            exitCode: processExitCode).ConfigureAwait(false);
+        if (processExitCode != 0)
+        {
+            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
+        }
+
+        var streamsDrained = await DrainOutputAsync(
+            outputTask,
+            errorTask,
+            outputCapture,
+            request.CleanupTimeout,
+            recorder,
+            rootPid).ConfigureAwait(false);
+        if (!streamsDrained)
+        {
+            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
+            await recorder.FinalizeFailureAsync("stream_drain_failed", standardOutput, standardError)
+                .ConfigureAwait(false);
+            processExitCode = 2;
+        }
+        else if (processExitCode != 0)
+        {
+            await recorder.RecordAsync(
+                "cleanup_completed",
+                pid: rootPid,
+                detail: "natural process exit and stream drain observed").ConfigureAwait(false);
+            await recorder.FinalizeFailureAsync("process_exit", standardOutput, standardError)
+                .ConfigureAwait(false);
+        }
+        else
+        {
+            recorder.SetOutputTails(standardOutput.Value, standardError.Value);
+            await recorder.RecordAsync("cleanup_completed", pid: rootPid, detail: "natural process exit observed")
+                .ConfigureAwait(false);
+        }
+
+        return new ProcessExecutionResult(
+            processExitCode,
+            rootPid,
+            rootStartTime,
+            recorder.EvidencePath,
+            recorder);
+    }
+
+    public static async Task PreservePostExitFailureAsync(
+        ProcessExecutionResult result,
+        string eventName,
+        string detail)
+    {
+        await result.Recorder.RecordAsync(
+            eventName,
+            pid: result.RootPid,
+            detail: detail).ConfigureAwait(false);
+        await result.Recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
+        await result.Recorder.FinalizeFailureAsync(
+            eventName,
+            new TailBuffer(1),
+            new TailBuffer(1)).ConfigureAwait(false);
+    }
+
+    public static Task DiscardAsync(ProcessExecutionResult result)
+    {
+        File.Delete(result.EvidencePath);
+        return Task.CompletedTask;
+    }
+
+    private static async Task StopAsync(
+        Process process,
+        TimeSpan cleanupTimeout,
+        FlightRecorder recorder)
+    {
+        await recorder.RecordAsync("bounded_stop_requested", pid: process.Id).ConfigureAwait(false);
+        try
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+
+            using var cleanup = new CancellationTokenSource(cleanupTimeout);
+            await process.WaitForExitAsync(cleanup.Token).ConfigureAwait(false);
+            await recorder.RecordAsync(
+                "process_exit",
+                pid: process.Id,
+                exitCode: process.ExitCode).ConfigureAwait(false);
+            await recorder.RecordAsync("cleanup_completed", pid: process.Id).ConfigureAwait(false);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception or OperationCanceledException)
+        {
+            await recorder.RecordAsync(
+                "cleanup_failed",
+                pid: process.Id,
+                detail: exception.Message).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<bool> DrainOutputAsync(
+        Task outputTask,
+        Task errorTask,
+        CancellationTokenSource outputCapture,
+        TimeSpan cleanupTimeout,
+        FlightRecorder recorder,
+        int rootPid)
+    {
+        var drain = Task.WhenAll(outputTask, errorTask);
+        try
+        {
+            await drain.WaitAsync(cleanupTimeout).ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            await outputCapture.CancelAsync().ConfigureAwait(false);
+            await recorder.RecordAsync(
+                "cleanup_failed",
+                pid: rootPid,
+                detail: "stdout/stderr drain exceeded the bounded cleanup window")
+                .ConfigureAwait(false);
+            return false;
+        }
+        catch (Exception exception) when (exception is IOException or InvalidOperationException or ObjectDisposedException)
+        {
+            await recorder.RecordAsync(
+                "cleanup_failed",
+                pid: rootPid,
+                detail: $"stdout/stderr drain failed: {exception.Message}")
+                .ConfigureAwait(false);
+            return false;
+        }
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/FlightRecorderReport.cs
+++ b/tools/DownKyi.CentralTestRunner/FlightRecorderReport.cs
@@ -1,0 +1,66 @@
+namespace DownKyi.CentralTestRunner;
+
+internal sealed class RecorderReport
+{
+    public required string SliceIdentity { get; init; }
+
+    public required string TestIdentity { get; init; }
+
+    public DateTimeOffset RecorderStartedAtUtc { get; init; }
+
+    public RootProcessIdentity? RootProcess { get; set; }
+
+    public string? Outcome { get; set; }
+
+    public required List<RecorderEvent> Events { get; init; }
+
+    public string? StdoutTail { get; set; }
+
+    public string? StderrTail { get; set; }
+
+    public FinalProcessSnapshot? FinalSnapshot { get; set; }
+
+    public string? DiagnosticGuidance { get; set; }
+}
+
+internal sealed class RootProcessIdentity
+{
+    public int Pid { get; init; }
+
+    public DateTimeOffset StartTimeUtc { get; init; }
+}
+
+internal sealed class RecorderEvent
+{
+    public DateTimeOffset TimestampUtc { get; init; }
+
+    public required string Event { get; init; }
+
+    public int? Pid { get; init; }
+
+    public DateTimeOffset? StartTimeUtc { get; init; }
+
+    public int? ExitCode { get; init; }
+
+    public string? Detail { get; init; }
+}
+
+internal sealed class FinalProcessSnapshot
+{
+    public DateTimeOffset CapturedAtUtc { get; init; }
+
+    public required string Completeness { get; init; }
+
+    public required IReadOnlyList<ObservedProcess> Processes { get; init; }
+
+    public string? Error { get; init; }
+}
+
+internal sealed class ObservedProcess
+{
+    public int Pid { get; init; }
+
+    public int ParentPid { get; init; }
+
+    public DateTimeOffset? StartTimeUtc { get; init; }
+}

--- a/tools/DownKyi.CentralTestRunner/ProcessTreeSnapshot.cs
+++ b/tools/DownKyi.CentralTestRunner/ProcessTreeSnapshot.cs
@@ -1,0 +1,148 @@
+using System.Diagnostics;
+using System.Globalization;
+
+namespace DownKyi.CentralTestRunner;
+
+internal static class ProcessTreeSnapshot
+{
+    public static async Task<FinalProcessSnapshot> CaptureAsync(
+        int rootPid,
+        TimeSpan timeout)
+    {
+        var parentIds = await ReadParentIdsAsync(timeout).ConfigureAwait(false);
+        var included = new HashSet<int>();
+        if (rootPid > 0)
+        {
+            included.Add(rootPid);
+        }
+
+        var added = true;
+        while (added)
+        {
+            added = false;
+            foreach (var pair in parentIds)
+            {
+                if (included.Contains(pair.Value) && included.Add(pair.Key))
+                {
+                    added = true;
+                }
+            }
+        }
+
+        var processes = new List<ObservedProcess>();
+        foreach (var pid in included.Where(parentIds.ContainsKey).Order())
+        {
+            DateTimeOffset? startTimeUtc = null;
+            try
+            {
+                using var process = Process.GetProcessById(pid);
+                startTimeUtc = process.StartTime.ToUniversalTime();
+            }
+            catch (Exception exception) when (exception is ArgumentException or InvalidOperationException or System.ComponentModel.Win32Exception)
+            {
+                // The process may exit between the point-in-time relationship snapshot and identity read.
+            }
+
+            processes.Add(new ObservedProcess
+            {
+                Pid = pid,
+                ParentPid = parentIds[pid],
+                StartTimeUtc = startTimeUtc
+            });
+        }
+
+        return new FinalProcessSnapshot
+        {
+            CapturedAtUtc = DateTimeOffset.UtcNow,
+            Completeness = FlightRecorder.SnapshotNotice,
+            Processes = processes
+        };
+    }
+
+    private static async Task<Dictionary<int, int>> ReadParentIdsAsync(TimeSpan timeout)
+    {
+        var startInfo = OperatingSystem.IsWindows()
+            ? CreateWindowsSnapshotStartInfo()
+            : CreateUnixSnapshotStartInfo();
+        using var process = new Process { StartInfo = startInfo };
+        process.Start();
+        var outputTask = process.StandardOutput.ReadToEndAsync();
+        var errorTask = process.StandardError.ReadToEndAsync();
+        try
+        {
+            await process.WaitForExitAsync().WaitAsync(timeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            try
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+            {
+                // The snapshot helper may have exited while the bound elapsed.
+            }
+            throw new TimeoutException("Process relationship snapshot exceeded the bounded cleanup window.");
+        }
+        var output = await outputTask.ConfigureAwait(false);
+        var error = await errorTask.ConfigureAwait(false);
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Process relationship snapshot failed: {error.Trim()}");
+        }
+
+        return ParseParentIds(output);
+    }
+
+    internal static Dictionary<int, int> ParseParentIds(string output)
+    {
+        var result = new Dictionary<int, int>();
+        foreach (var line in output.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var values = line.Contains('|', StringComparison.Ordinal)
+                ? line.Split('|', StringSplitOptions.TrimEntries)
+                : line.Split([' ', '\t'], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (values.Length == 2 &&
+                int.TryParse(values[0], NumberStyles.None, CultureInfo.InvariantCulture, out var pid) &&
+                int.TryParse(values[1], NumberStyles.None, CultureInfo.InvariantCulture, out var parentPid) &&
+                pid > 0 &&
+                parentPid >= 0)
+            {
+                result[pid] = parentPid;
+            }
+        }
+
+        return result;
+    }
+
+    private static ProcessStartInfo CreateWindowsSnapshotStartInfo()
+    {
+        var startInfo = new ProcessStartInfo("powershell.exe")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-NoProfile");
+        startInfo.ArgumentList.Add("-NonInteractive");
+        startInfo.ArgumentList.Add("-Command");
+        startInfo.ArgumentList.Add(
+            "Get-CimInstance Win32_Process | ForEach-Object { '{0}|{1}' -f $_.ProcessId,$_.ParentProcessId }");
+        return startInfo;
+    }
+
+    private static ProcessStartInfo CreateUnixSnapshotStartInfo()
+    {
+        var startInfo = new ProcessStartInfo("/bin/ps")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+        startInfo.ArgumentList.Add("-axo");
+        startInfo.ArgumentList.Add("pid=,ppid=");
+        return startInfo;
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/SensitiveEvidenceRedactor.cs
+++ b/tools/DownKyi.CentralTestRunner/SensitiveEvidenceRedactor.cs
@@ -1,0 +1,54 @@
+using System.Text.RegularExpressions;
+
+namespace DownKyi.CentralTestRunner;
+
+internal sealed class SensitiveEvidenceRedactor
+{
+    private static readonly Regex SensitiveHeaderPattern = new(
+        @"\b(?<name>authorization|proxy-authorization|cookie|set-cookie)\s*[:=]\s*[^\r\n]+",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex SensitiveValuePattern = new(
+        @"\b(?<name>access[_-]?token|refresh[_-]?token|token|api[_-]?key|secret|password|sessdata|bili_jct|dedeuserid|account(?:id)?|user(?:id)?|uid|mid)\b(?<separator>\s*[:=]\s*)(?<value>[^&;\s,]+)",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex UrlPattern = new(
+        "\\bhttps?://[^\\s\\\"'<>]+",
+        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private readonly string workingDirectory;
+
+    internal SensitiveEvidenceRedactor(string workingDirectory)
+    {
+        this.workingDirectory = workingDirectory;
+    }
+
+    internal string Redact(string value)
+    {
+        var redacted = ReplacePath(value, workingDirectory, "<repository-root>");
+        var userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        redacted = ReplacePath(redacted, userProfile, "<user-profile>");
+        redacted = SensitiveHeaderPattern.Replace(
+            redacted,
+            match => $"{match.Groups["name"].Value}: <redacted>");
+        redacted = UrlPattern.Replace(redacted, "<redacted-url>");
+        return SensitiveValuePattern.Replace(
+            redacted,
+            match => $"{match.Groups["name"].Value}{match.Groups["separator"].Value}<redacted>");
+    }
+
+    private static string ReplacePath(string value, string path, string replacement)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return value;
+        }
+
+        var trimmed = Path.TrimEndingDirectorySeparator(path);
+        var redacted = value.Replace(trimmed, replacement, StringComparison.OrdinalIgnoreCase);
+        var alternate = trimmed.Contains('\\', StringComparison.Ordinal)
+            ? trimmed.Replace('\\', '/')
+            : trimmed.Replace('/', '\\');
+        return redacted.Replace(alternate, replacement, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/TailBuffer.cs
+++ b/tools/DownKyi.CentralTestRunner/TailBuffer.cs
@@ -1,0 +1,49 @@
+namespace DownKyi.CentralTestRunner;
+
+internal sealed class TailBuffer
+{
+    private readonly int maximumCharacters;
+    private readonly Queue<string> lines = new();
+    private readonly object synchronization = new();
+    private int characters;
+
+    public TailBuffer(int maximumCharacters)
+    {
+        this.maximumCharacters = maximumCharacters;
+    }
+
+    public string Value
+    {
+        get
+        {
+            lock (synchronization)
+            {
+                return string.Join(Environment.NewLine, lines);
+            }
+        }
+    }
+
+    public void Add(string line)
+    {
+        lock (synchronization)
+        {
+            var retained = line.Length > maximumCharacters
+                ? line[^maximumCharacters..]
+                : line;
+            lines.Enqueue(retained);
+            characters += retained.Length + Environment.NewLine.Length;
+            while (characters > maximumCharacters && lines.Count > 1)
+            {
+                characters -= lines.Dequeue().Length + Environment.NewLine.Length;
+            }
+            if (characters > maximumCharacters && lines.Count == 1)
+            {
+                var onlyLine = lines.Dequeue();
+                var keep = Math.Max(0, maximumCharacters - Environment.NewLine.Length);
+                retained = keep == 0 ? string.Empty : onlyLine[^Math.Min(keep, onlyLine.Length)..];
+                lines.Enqueue(retained);
+                characters = retained.Length + Environment.NewLine.Length;
+            }
+        }
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/TestInvocationFactory.cs
+++ b/tools/DownKyi.CentralTestRunner/TestInvocationFactory.cs
@@ -1,0 +1,109 @@
+using System.Diagnostics;
+
+namespace DownKyi.CentralTestRunner;
+
+internal static class TestInvocationFactory
+{
+    internal static ProcessStartInfo CreateVstestStartInfo(
+        string projectPath,
+        CommandOptions options,
+        string? resultsDirectory,
+        string trxName)
+    {
+        var startInfo = CreateDotnetStartInfo();
+        startInfo.ArgumentList.Add("test");
+        startInfo.ArgumentList.Add(projectPath);
+        startInfo.ArgumentList.Add("-c");
+        startInfo.ArgumentList.Add(options.Configuration);
+        if (options.NoRestore)
+        {
+            startInfo.ArgumentList.Add("--no-restore");
+        }
+        startInfo.ArgumentList.Add("--no-build");
+
+        var filter = options.Filter;
+        if (string.IsNullOrWhiteSpace(filter) && options.Classes.Length > 0)
+        {
+            filter = string.Join(
+                '|',
+                options.Classes
+                    .Order(StringComparer.Ordinal)
+                    .Distinct(StringComparer.Ordinal)
+                    .Select(className => $"FullyQualifiedName~{className}"));
+        }
+        if (!string.IsNullOrWhiteSpace(filter))
+        {
+            startInfo.ArgumentList.Add("--filter");
+            startInfo.ArgumentList.Add(filter);
+        }
+        if (resultsDirectory is not null)
+        {
+            startInfo.ArgumentList.Add("--logger");
+            startInfo.ArgumentList.Add($"trx;LogFileName={trxName}");
+            startInfo.ArgumentList.Add("--results-directory");
+            startInfo.ArgumentList.Add(resultsDirectory);
+        }
+
+        return startInfo;
+    }
+
+    internal static ProcessStartInfo CreateInProcessXunitStartInfo(
+        string projectPath,
+        string targetFramework,
+        CommandOptions options,
+        string? trxPath)
+    {
+        if (!string.IsNullOrWhiteSpace(options.Filter))
+        {
+            throw new InvalidOperationException(
+                "The xUnit in-process runner requires --class locators instead of a VSTest filter.");
+        }
+
+        var projectDirectory = Path.GetDirectoryName(projectPath)
+            ?? throw new InvalidOperationException("The test project directory is unavailable.");
+        var assemblyName = Path.GetFileNameWithoutExtension(projectPath);
+        var assemblyPath = Path.Combine(
+            projectDirectory,
+            "bin",
+            options.Configuration,
+            targetFramework,
+            $"{assemblyName}.dll");
+        if (!File.Exists(assemblyPath))
+        {
+            throw new FileNotFoundException("The xUnit in-process test assembly is missing.", assemblyPath);
+        }
+
+        var startInfo = CreateDotnetStartInfo();
+        startInfo.ArgumentList.Add(assemblyPath);
+        startInfo.ArgumentList.Add("-noLogo");
+        startInfo.ArgumentList.Add("-noColor");
+        startInfo.ArgumentList.Add("-noAutoReporters");
+        startInfo.ArgumentList.Add("-reporter");
+        startInfo.ArgumentList.Add("quiet");
+        startInfo.ArgumentList.Add("-parallel");
+        startInfo.ArgumentList.Add("none");
+        foreach (var className in options.Classes.Order(StringComparer.Ordinal).Distinct(StringComparer.Ordinal))
+        {
+            startInfo.ArgumentList.Add("-class");
+            startInfo.ArgumentList.Add(className);
+        }
+        if (trxPath is not null)
+        {
+            startInfo.ArgumentList.Add("-trx");
+            startInfo.ArgumentList.Add(trxPath);
+        }
+
+        return startInfo;
+    }
+
+    private static ProcessStartInfo CreateDotnetStartInfo()
+    {
+        return new ProcessStartInfo("dotnet")
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true
+        };
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/TestProjectCatalog.cs
+++ b/tools/DownKyi.CentralTestRunner/TestProjectCatalog.cs
@@ -1,0 +1,183 @@
+using System.Runtime.InteropServices;
+using System.Text.Json;
+using System.Xml.Linq;
+
+namespace DownKyi.CentralTestRunner;
+
+internal sealed record TestProjectDefinition(
+    string Project,
+    string[] Platforms,
+    string? InProcessTargetFramework)
+{
+    public bool UseInProcessXunit => InProcessTargetFramework is not null;
+}
+
+internal sealed record TestRunnerPolicyDocument(
+    int SchemaVersion,
+    TestRunnerPolicyProject[] Projects);
+
+internal sealed record TestRunnerPolicyProject(
+    string Project,
+    string Runner,
+    string? TargetFramework);
+
+internal static class TestProjectCatalog
+{
+    private static readonly JsonSerializerOptions PolicyJsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    internal static string NormalizeProject(string repositoryRoot, string project)
+    {
+        var fullPath = Path.GetFullPath(project, repositoryRoot);
+        return Path.GetRelativePath(repositoryRoot, fullPath).Replace('\\', '/');
+    }
+
+    internal static TestProjectDefinition[] DiscoverProjects(string repositoryRoot)
+    {
+        var testsDirectory = Path.Combine(repositoryRoot, "tests");
+        if (!Directory.Exists(testsDirectory))
+        {
+            throw new DirectoryNotFoundException($"The repository test directory is missing: {testsDirectory}");
+        }
+
+        var policyPath = Path.Combine(repositoryRoot, "docs", "testing", "test-runner-policy.json");
+        if (!File.Exists(policyPath))
+        {
+            throw new FileNotFoundException("The test runner policy is missing.", policyPath);
+        }
+
+        var policy = JsonSerializer.Deserialize<TestRunnerPolicyDocument>(
+            File.ReadAllText(policyPath),
+            PolicyJsonOptions) ?? throw new InvalidDataException("The test runner policy is empty.");
+        if (policy.SchemaVersion != 1 || policy.Projects is null)
+        {
+            throw new InvalidDataException("The test runner policy schema is unsupported.");
+        }
+
+        var policies = new Dictionary<string, TestRunnerPolicyProject>(StringComparer.Ordinal);
+        foreach (var entry in policy.Projects)
+        {
+            var project = NormalizeProject(repositoryRoot, entry.Project);
+            if (!policies.TryAdd(project, entry))
+            {
+                throw new InvalidDataException($"The test runner policy contains duplicate project '{project}'.");
+            }
+        }
+
+        var projects = Directory.EnumerateFiles(
+                testsDirectory,
+                "*.Tests.csproj",
+                SearchOption.AllDirectories)
+            .Where(path => !IsBuildOutput(path))
+            .Order(StringComparer.Ordinal)
+            .Select(path =>
+            {
+                var project = NormalizeProject(repositoryRoot, path);
+                var platforms = ReadDeclaredPlatforms(path, project);
+                policies.TryGetValue(project, out var runnerPolicy);
+                if (runnerPolicy is not null &&
+                    !string.Equals(runnerPolicy.Runner, "xunit-in-process", StringComparison.Ordinal))
+                {
+                    throw new InvalidDataException(
+                        $"Test project '{project}' has unsupported runner '{runnerPolicy.Runner}'.");
+                }
+                if (runnerPolicy is not null && string.IsNullOrWhiteSpace(runnerPolicy.TargetFramework))
+                {
+                    throw new InvalidDataException(
+                        $"Test project '{project}' requires a target framework for xunit-in-process.");
+                }
+
+                policies.Remove(project);
+                return new TestProjectDefinition(
+                    project,
+                    platforms,
+                    runnerPolicy?.TargetFramework);
+            })
+            .ToArray();
+
+        if (policies.Count > 0)
+        {
+            throw new InvalidDataException(
+                $"The test runner policy references unknown project(s): {string.Join(", ", policies.Keys.Order(StringComparer.Ordinal))}");
+        }
+
+        return projects;
+    }
+
+    internal static string GetCurrentPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return "Windows";
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return "Linux";
+        }
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return "macOS";
+        }
+
+        throw new PlatformNotSupportedException("The current operating system has no allowlisted test platform.");
+    }
+
+    private static string[] ReadDeclaredPlatforms(string projectPath, string projectIdentity)
+    {
+        var document = XDocument.Load(projectPath);
+        var declarations = document
+            .Descendants()
+            .Where(element => string.Equals(
+                element.Name.LocalName,
+                "DownKyiTestPlatforms",
+                StringComparison.Ordinal))
+            .ToArray();
+        if (declarations.Length != 1)
+        {
+            throw new InvalidDataException(
+                $"Test project '{projectIdentity}' must declare exactly one DownKyiTestPlatforms value.");
+        }
+
+        var declaration = declarations[0];
+        if (declaration.AncestorsAndSelf().Any(element =>
+                element.Attributes().Any(attribute => string.Equals(
+                    attribute.Name.LocalName,
+                    "Condition",
+                    StringComparison.Ordinal))))
+        {
+            throw new InvalidDataException(
+                $"Test project '{projectIdentity}' must declare DownKyiTestPlatforms unconditionally.");
+        }
+
+        var platforms = declaration.Value.Split(';')
+            .Select(value => value.Trim())
+            .ToArray();
+        if (platforms.Length == 0 ||
+            platforms.Any(string.IsNullOrWhiteSpace) ||
+            platforms.Distinct(StringComparer.Ordinal).Count() != platforms.Length)
+        {
+            throw new InvalidDataException(
+                $"Test project '{projectIdentity}' has invalid DownKyiTestPlatforms metadata.");
+        }
+
+        var unknownPlatforms = platforms
+            .Where(platform => platform is not ("Windows" or "Linux" or "macOS"))
+            .ToArray();
+        if (unknownPlatforms.Length > 0)
+        {
+            throw new InvalidDataException(
+                $"Test project '{projectIdentity}' declares unknown platform(s): {string.Join(", ", unknownPlatforms)}.");
+        }
+
+        return platforms;
+    }
+
+    private static bool IsBuildOutput(string path)
+    {
+        return path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .Any(segment => string.Equals(segment, "bin", StringComparison.OrdinalIgnoreCase) ||
+                            string.Equals(segment, "obj", StringComparison.OrdinalIgnoreCase));
+    }
+}

--- a/tools/DownKyi.CentralTestRunner/TrxResultStore.cs
+++ b/tools/DownKyi.CentralTestRunner/TrxResultStore.cs
@@ -1,0 +1,72 @@
+using System.Xml.Linq;
+
+namespace DownKyi.CentralTestRunner;
+
+internal static class TrxResultStore
+{
+    internal static (string ResultsDirectory, string TrxName, string TrxPath) ResolveOutput(
+        string repositoryRoot,
+        string? requestedResultsDirectory,
+        string? requestedTrxName,
+        string relativeProject)
+    {
+        var resultsDirectory = string.IsNullOrWhiteSpace(requestedResultsDirectory)
+            ? Path.Combine(repositoryRoot, "artifacts", "test-results")
+            : Path.GetFullPath(requestedResultsDirectory, repositoryRoot);
+        var trxName = string.IsNullOrWhiteSpace(requestedTrxName)
+            ? $"{Path.GetFileNameWithoutExtension(relativeProject)}.trx"
+            : ValidateTrxName(requestedTrxName);
+        return (resultsDirectory, trxName, Path.Combine(resultsDirectory, trxName));
+    }
+
+    internal static void ClearStale(
+        (string ResultsDirectory, string TrxName, string TrxPath) trxOutput)
+    {
+        Directory.CreateDirectory(trxOutput.ResultsDirectory);
+        File.Delete(trxOutput.TrxPath);
+    }
+
+    internal static void Validate(string trxPath, string trxIdentity)
+    {
+        var file = new FileInfo(trxPath);
+        if (!file.Exists || file.Length == 0)
+        {
+            throw new InvalidDataException($"The requested TRX is missing or empty: {trxIdentity}");
+        }
+
+        var document = XDocument.Load(trxPath);
+        if (!string.Equals(document.Root?.Name.LocalName, "TestRun", StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"The requested TRX has an unexpected root element: {trxIdentity}");
+        }
+
+        var counters = document
+            .Descendants()
+            .FirstOrDefault(element => string.Equals(
+                element.Name.LocalName,
+                "Counters",
+                StringComparison.Ordinal));
+        if (counters is null ||
+            !int.TryParse(counters.Attribute("executed")?.Value, out var executed) ||
+            !int.TryParse(counters.Attribute("failed")?.Value, out var failed) ||
+            executed < 1 ||
+            failed != 0)
+        {
+            throw new InvalidDataException(
+                $"The requested TRX does not prove a non-empty passing test run: {trxIdentity}");
+        }
+    }
+
+    private static string ValidateTrxName(string trxName)
+    {
+        if (Path.IsPathRooted(trxName) ||
+            !string.Equals(Path.GetFileName(trxName), trxName, StringComparison.Ordinal) ||
+            trxName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+        {
+            throw new ArgumentException("The TRX name must be a file name without directory components.", nameof(trxName));
+        }
+
+        return trxName;
+    }
+}


### PR DESCRIPTION
## Summary

- split `CentralTestCommand.cs` into command orchestration, options, project catalog/policy, invocation construction, build ownership, and TRX storage
- split `FlightRecorder.cs` into execution ownership, recorder state/persistence, bounded capture, redaction, tail buffering, process snapshots, and report DTOs
- update only the internal test seams required by the type moves

This is separate from the merged #215 remediation and preserves its final build-cancellation cleanup semantics.

## Behavior-preserving guarantees

- CLI names, defaults, validation, and exit codes are unchanged
- TRX cleanup and acceptance criteria are unchanged
- timeout, cancellation, process-tree cleanup, and stream-drain behavior are unchanged
- `FlightRecorderExecution` remains the single owner of the test-process lifecycle
- evidence JSON DTOs and serialized property shape are unchanged
- bounded output capture still uses 4 KiB reads and an 8192-character logical-line cap

## Validation

- focused CentralTestRunner/recorder/output tests: 14/14 passed
- strict Release solution build with analyzers and warnings-as-errors: 0 warnings, 0 errors
- formal Windows solution run: 8/8 selected projects passed, 976 tests passed, 1 existing external-binary integration test skipped
- Windows platform tests: 2/2 passed
- Linux and macOS test assemblies compiled successfully; runtime coverage was not available on the Windows host
- `dotnet format ./DownKyi.sln --verify-no-changes --no-restore`
- `git diff --check`