### PR TITLE
test: isolate aria2 TLS lifecycle failures

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -123,14 +123,6 @@ jobs:
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.x'
-      - name: Fetch and verify Windows aria2 asset
-        if: startsWith(matrix.rid, 'win-')
-        shell: pwsh
-        run: ./script/aria2.ps1 '${{ matrix.asset-argument }}'
-      - name: Fetch and verify Unix aria2 asset
-        if: ${{ !startsWith(matrix.rid, 'win-') }}
-        shell: bash
-        run: bash ./script/aria2.sh '${{ matrix.asset-argument }}'
       - name: Restore
         run: dotnet restore ${{ env.SOLUTION_FILE }}
       - name: Install ARM64 protobuf compiler
@@ -152,12 +144,8 @@ jobs:
           -p:AnalysisMode=All
           -p:EnforceCodeStyleInBuild=true
           -p:UseSharedCompilation=false
-      - name: Verify packaged aria2 TLS behavior
+      - name: Verify focused aria2 TLS harness lifecycle
         shell: pwsh
-        env:
-          DOWNKYI_ARIA2_BINARY: ${{ github.workspace }}/${{ matrix.binary }}
-          DOWNKYI_ARIA2_RID: ${{ matrix.rid }}
-          DOWNKYI_ARIA2_TLS_REPORT: ${{ github.workspace }}/artifacts/aria2-tls/${{ matrix.rid }}.json
         run: |
           . ./script/test-project-runner.ps1
           $result = Invoke-DownKyiTestProject `
@@ -166,8 +154,47 @@ jobs:
             -Configuration Release `
             -NoRestore `
             -NoBuild `
-            -ResultsDirectory ./artifacts/test-results/aria2-${{ matrix.rid }} `
-            -ClassNames DownKyi.Tests.Aria2TlsIntegrationTests
+            -ResultsDirectory ./artifacts/test-results/aria2-tls-focused-${{ matrix.rid }} `
+            -TrxName aria2-tls-focused-${{ matrix.rid }}.trx `
+            -EvidenceDirectory ./artifacts/test-flight-recorder/aria2-tls-focused-${{ matrix.rid }} `
+            -ClassNames @(
+              'DownKyi.Tests.Aria2TlsFailurePreservationTests'
+              'DownKyi.Tests.Aria2TlsReportWriterTests'
+              'DownKyi.Tests.Aria2TlsRuntimeLifecycleTests'
+              'DownKyi.Tests.LoopbackTlsFileServerLifecycleTests'
+            )
+          if ($result.ExitCode -ne 0) {
+            throw "Focused aria2 TLS harness tests failed."
+          }
+      - name: Fetch and verify Windows aria2 asset
+        if: startsWith(matrix.rid, 'win-')
+        shell: pwsh
+        run: ./script/aria2.ps1 '${{ matrix.asset-argument }}'
+      - name: Fetch and verify Unix aria2 asset
+        if: ${{ !startsWith(matrix.rid, 'win-') }}
+        shell: bash
+        run: bash ./script/aria2.sh '${{ matrix.asset-argument }}'
+      - name: Verify packaged aria2 TLS families and end-to-end behavior
+        shell: pwsh
+        env:
+          DOWNKYI_ARIA2_BINARY: ${{ github.workspace }}/${{ matrix.binary }}
+          DOWNKYI_ARIA2_RID: ${{ matrix.rid }}
+          DOWNKYI_ARIA2_TLS_REPORT: ${{ github.workspace }}/artifacts/aria2-tls/${{ matrix.rid }}
+        run: |
+          . ./script/test-project-runner.ps1
+          $result = Invoke-DownKyiTestProject `
+            -RepositoryRoot (Get-Location).Path `
+            -ProjectPath ./tests/DownKyi.Tests/DownKyi.Tests.csproj `
+            -Configuration Release `
+            -NoRestore `
+            -NoBuild `
+            -ResultsDirectory ./artifacts/test-results/aria2-tls-e2e-${{ matrix.rid }} `
+            -TrxName aria2-tls-e2e-${{ matrix.rid }}.trx `
+            -EvidenceDirectory ./artifacts/test-flight-recorder/aria2-tls-e2e-${{ matrix.rid }} `
+            -ClassNames @(
+              'DownKyi.Tests.Aria2RpcLifecycleIntegrationTests'
+              'DownKyi.Tests.Aria2TlsIntegrationTests'
+            )
           if ($result.ExitCode -ne 0) {
             throw "Packaged aria2 TLS integration tests failed."
           }
@@ -177,9 +204,11 @@ jobs:
         with:
           name: aria2-tls-${{ matrix.rid }}
           path: |
-            artifacts/aria2-tls/${{ matrix.rid }}.json
-            artifacts/test-results/aria2-${{ matrix.rid }}
-            artifacts/test-flight-recorder
+            artifacts/aria2-tls/${{ matrix.rid }}
+            artifacts/test-results/aria2-tls-focused-${{ matrix.rid }}
+            artifacts/test-results/aria2-tls-e2e-${{ matrix.rid }}
+            artifacts/test-flight-recorder/aria2-tls-focused-${{ matrix.rid }}
+            artifacts/test-flight-recorder/aria2-tls-e2e-${{ matrix.rid }}
           if-no-files-found: warn
 
   package-audit:

--- a/docs/operations/aria2-security.md
+++ b/docs/operations/aria2-security.md
@@ -109,8 +109,9 @@ LocalMachine Root; a non-elevated runner selects CurrentUser Root before any
 store write. Both are Windows system trust stores used by WinTLS. macOS uses
 the System keychain. Each registration is removed during test teardown.
 
-The report contains only environment metadata, backend, aria2 version, case
-names and pass/fail diagnostics. Header names may identify the tested policy;
+Each independently discoverable case writes one report fragment containing only
+environment metadata, backend, aria2 version, its case name and pass/fail
+diagnostics. Header names may identify the tested policy;
 header values, request URLs, filesystem paths, Cookie values, RPC tokens and
 account identifiers are forbidden.
 
@@ -119,11 +120,14 @@ For a local packaged binary:
 ```powershell
 $env:DOWNKYI_ARIA2_BINARY = '<absolute aria2c path>'
 $env:DOWNKYI_ARIA2_RID = 'win-x64'
-$env:DOWNKYI_ARIA2_TLS_REPORT = './artifacts/aria2-tls/win-x64.json'
+$env:DOWNKYI_ARIA2_TLS_REPORT = './artifacts/aria2-tls/win-x64'
 pwsh ./script/test-project.ps1 `
   -ProjectPath ./tests/DownKyi.Tests/DownKyi.Tests.csproj `
   -Configuration Release `
-  -ClassName DownKyi.Tests.Aria2TlsIntegrationTests `
+  -ClassName @(
+    'DownKyi.Tests.Aria2RpcLifecycleIntegrationTests'
+    'DownKyi.Tests.Aria2TlsIntegrationTests'
+  ) `
   -ResultsDirectory ./artifacts/test-results/aria2-local
 ```
 

--- a/tests/DownKyi.Tests/Aria2TlsFailurePreservation.cs
+++ b/tests/DownKyi.Tests/Aria2TlsFailurePreservation.cs
@@ -1,0 +1,125 @@
+using System.Runtime.ExceptionServices;
+
+namespace DownKyi.Tests;
+
+internal sealed record Aria2TlsStageFailure(
+    string Stage,
+    ExceptionDispatchInfo DispatchInfo)
+{
+    public Exception Exception => DispatchInfo.SourceException;
+}
+
+internal sealed class Aria2TlsMultipleFailuresException : AggregateException
+{
+    public Aria2TlsMultipleFailuresException()
+    {
+        Failures = [];
+    }
+
+    public Aria2TlsMultipleFailuresException(string message)
+        : base(message)
+    {
+        Failures = [];
+    }
+
+    public Aria2TlsMultipleFailuresException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+        Failures =
+        [
+            new Aria2TlsStageFailure(
+                "unspecified",
+                ExceptionDispatchInfo.Capture(innerException))
+        ];
+    }
+
+    public Aria2TlsMultipleFailuresException(IReadOnlyList<Aria2TlsStageFailure> failures)
+        : base(CreateMessage(failures), GetExceptions(failures))
+    {
+        Failures = failures.ToArray();
+    }
+
+    public IReadOnlyList<Aria2TlsStageFailure> Failures { get; }
+
+    public Aria2TlsStageFailure PrimaryFailure => Failures[0];
+
+    private static string CreateMessage(IReadOnlyList<Aria2TlsStageFailure> failures)
+    {
+        ArgumentNullException.ThrowIfNull(failures);
+        if (failures.Count < 2)
+        {
+            throw new ArgumentException(
+                "Multiple aria2 TLS failures require at least two stage failures.",
+                nameof(failures));
+        }
+
+        return $"Multiple aria2 TLS test stages failed. Primary stage: '{failures[0].Stage}'. "
+               + $"Failure stages: {string.Join(", ", failures.Select(failure => failure.Stage))}.";
+    }
+
+    private static Exception[] GetExceptions(
+        IReadOnlyList<Aria2TlsStageFailure> failures)
+    {
+        ArgumentNullException.ThrowIfNull(failures);
+        return failures.Select(failure => failure.Exception).ToArray();
+    }
+}
+
+internal sealed class Aria2TlsFailureCollector
+{
+    private readonly List<Aria2TlsStageFailure> _failures = [];
+
+    public IReadOnlyList<Aria2TlsStageFailure> Failures => _failures;
+
+    public void Capture(string stage, Exception exception)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stage);
+        ArgumentNullException.ThrowIfNull(exception);
+        if (exception is Aria2TlsMultipleFailuresException multipleFailures)
+        {
+            _failures.AddRange(multipleFailures.Failures);
+            return;
+        }
+
+        _failures.Add(new Aria2TlsStageFailure(
+            stage,
+            ExceptionDispatchInfo.Capture(exception)));
+    }
+
+    public void Run(string stage, Action action)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stage);
+        ArgumentNullException.ThrowIfNull(action);
+        var exception = Record.Exception(action);
+        if (exception != null)
+        {
+            Capture(stage, exception);
+        }
+    }
+
+    public async Task RunAsync(string stage, Func<Task> action)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stage);
+        ArgumentNullException.ThrowIfNull(action);
+        var exception = await Record.ExceptionAsync(action).ConfigureAwait(false);
+        if (exception != null)
+        {
+            Capture(stage, exception);
+        }
+    }
+
+    public void ThrowIfAny()
+    {
+        if (_failures.Count == 0)
+        {
+            return;
+        }
+
+        if (_failures.Count == 1)
+        {
+            _failures[0].DispatchInfo.Throw();
+        }
+
+        throw new Aria2TlsMultipleFailuresException(_failures);
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsFailurePreservationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsFailurePreservationTests.cs
@@ -1,0 +1,133 @@
+namespace DownKyi.Tests;
+
+public sealed class Aria2TlsFailurePreservationTests
+{
+    [Fact]
+    public void SingleFailureIsRethrownWithItsOriginalIdentityAndStack()
+    {
+        var collector = new Aria2TlsFailureCollector();
+        var primary = new InvalidOperationException("primary TLS failure");
+
+        collector.Run("primary-test", () => ThrowFromPrimarySite(primary));
+
+        var actual = Assert.Throws<InvalidOperationException>(collector.ThrowIfAny);
+        Assert.Same(primary, actual);
+        Assert.Contains(
+            nameof(ThrowFromPrimarySite),
+            actual.StackTrace,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task FiveFailuresAllRunAndRemainVisibleInPrimaryFirstOrder()
+    {
+        var collector = new Aria2TlsFailureCollector();
+        var executed = new List<string>();
+        var failures = new Exception[]
+        {
+            new InvalidOperationException("primary TLS failure"),
+            new IOException("report failure"),
+            new TimeoutException("runtime disposal failure"),
+            new InvalidOperationException("trusted-root cleanup failure"),
+            new UnauthorizedAccessException("filesystem cleanup failure")
+        };
+        string[] stages =
+        [
+            "primary-test",
+            "report",
+            "runtime-disposal",
+            "trusted-root-cleanup",
+            "filesystem-cleanup"
+        ];
+
+        for (var index = 0; index < stages.Length; index++)
+        {
+            var stage = stages[index];
+            var failure = failures[index];
+            await collector.RunAsync(
+                stage,
+                () => RecordAndFailAsync(executed, stage, failure)).ConfigureAwait(true);
+        }
+
+        Assert.Equal(stages, executed);
+        var aggregate = Assert.Throws<Aria2TlsMultipleFailuresException>(collector.ThrowIfAny);
+        Assert.Equal(stages, aggregate.Failures.Select(failure => failure.Stage));
+        Assert.Same(failures[0], aggregate.PrimaryFailure.Exception);
+        Assert.Equal(failures, aggregate.InnerExceptions);
+        Assert.Equal(
+            failures.Select(failure => failure.GetType()),
+            aggregate.Failures.Select(failure => failure.Exception.GetType()));
+        Assert.All(
+            aggregate.Failures,
+            failure =>
+            {
+                Assert.Same(failure.Exception, failure.DispatchInfo.SourceException);
+                Assert.Contains(
+                    nameof(RecordAndFailAsync),
+                    failure.Exception.StackTrace,
+                    StringComparison.Ordinal);
+            });
+    }
+
+    [Fact]
+    public async Task FailedStageDoesNotPreventLaterSuccessfulStage()
+    {
+        var collector = new Aria2TlsFailureCollector();
+        var laterStageRan = false;
+
+        await collector.RunAsync(
+            "report",
+            () => Task.FromException(new IOException("report failure"))).ConfigureAwait(true);
+        await collector.RunAsync(
+            "runtime-disposal",
+            () =>
+            {
+                laterStageRan = true;
+                return Task.CompletedTask;
+            }).ConfigureAwait(true);
+
+        Assert.True(laterStageRan);
+        Assert.Throws<IOException>(collector.ThrowIfAny);
+    }
+
+    [Fact]
+    public void NestedMultipleFailuresMergeWithoutHidingTheirNamedStages()
+    {
+        var nestedCollector = new Aria2TlsFailureCollector();
+        nestedCollector.Run(
+            "runtime-disposal",
+            () => throw new TimeoutException("runtime disposal failure"));
+        nestedCollector.Run(
+            "trusted-root-cleanup",
+            () => throw new InvalidOperationException("trusted-root cleanup failure"));
+        var nested = Assert.Throws<Aria2TlsMultipleFailuresException>(
+            nestedCollector.ThrowIfAny);
+        var outerCollector = new Aria2TlsFailureCollector();
+
+        outerCollector.Run("runtime", () => throw nested);
+
+        var actual = Assert.Throws<Aria2TlsMultipleFailuresException>(
+            outerCollector.ThrowIfAny);
+        Assert.Equal(
+            ["runtime-disposal", "trusted-root-cleanup"],
+            actual.Failures.Select(failure => failure.Stage));
+        Assert.Same(
+            nested.PrimaryFailure.DispatchInfo,
+            actual.PrimaryFailure.DispatchInfo);
+    }
+
+    private static void ThrowFromPrimarySite(Exception exception)
+    {
+        throw exception;
+    }
+
+    private static async Task RecordAndFailAsync(
+        List<string> executed,
+        string stage,
+        Exception failure)
+    {
+        executed.Add(stage);
+        await Task.Yield();
+        throw failure;
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsIntegrationTests.cs
@@ -1,26 +1,190 @@
+using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Text.Json;
 using DownKyi.Core.Aria2cNet.Client.Entity;
 using DownKyi.Services.Download;
 using DownKyi.TestInfrastructure;
 
 namespace DownKyi.Tests;
 
+[Collection("Aria2 packaged integration")]
 public sealed partial class Aria2TlsIntegrationTests
 {
-    private const int ExpectedCaseCount = 26;
+    private const int ExpectedReportCaseCount = 1;
     private static readonly TimeSpan DownloadTimeout = TimeSpan.FromSeconds(20);
-    private static readonly JsonSerializerOptions ReportJsonOptions = new()
-    {
-        WriteIndented = true
-    };
 
     [Fact]
     [Trait("Category", "Aria2TlsIntegration")]
-    public async Task PackagedAria2EnforcesCertificateValidationAcrossTransferFlows()
+    [Trait("Aria2TlsFamily", "trusted-transfer")]
+    public async Task PackagedAria2CompletesTrustedSplitDownload()
     {
+        await RunPackagedCaseAsync(
+            "trusted-split",
+            context => RunTrustedSplitDownloadAsync(
+                context.Runtime,
+                context.TrustedCertificate,
+                context.Payload,
+                context.Results,
+                context.LoopbackCleanupFailures,
+                context.CancellationToken)).ConfigureAwait(true);
+    }
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "connect-proxy")]
+    public async Task PackagedAria2CompletesTrustedConnectProxyDownload()
+    {
+        await RunPackagedCaseAsync(
+            "trusted-local-connect-proxy",
+            context => RunTrustedConnectProxyDownloadAsync(
+                context.Runtime,
+                context.TrustedCertificate,
+                context.Payload,
+                context.Results,
+                context.LoopbackCleanupFailures,
+                context.CancellationToken)).ConfigureAwait(true);
+    }
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "connect-proxy")]
+    public async Task PackagedAria2RejectsUntrustedConnectProxyInterception()
+    {
+        await RunPackagedCaseAsync(
+            "proxy-untrusted-interception",
+            async context =>
+            {
+                using var unknownAuthority = new TestCertificateAuthority(
+                    $"DownKyi Unknown TLS Test {Guid.NewGuid():N}");
+                using var unknownCertificate = unknownAuthority.IssueServerCertificate();
+                await RunProxyInterceptionRejectedAsync(
+                    context.Runtime,
+                    unknownCertificate,
+                    context.Payload,
+                    context.Results,
+                    context.CancellationToken).ConfigureAwait(false);
+            }).ConfigureAwait(true);
+    }
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "trusted-resume")]
+    public async Task PackagedAria2CompletesTrustedResume()
+    {
+        await RunPackagedCaseAsync(
+            "trusted-resume",
+            context => RunTrustedResumeAsync(
+                context.Runtime,
+                context.TrustedCertificate,
+                context.Payload,
+                context.Results,
+                context.LoopbackCleanupFailures,
+                context.CancellationToken)).ConfigureAwait(true);
+    }
+
+    [Theory]
+    [InlineData("unknown-ca")]
+    [InlineData("self-signed")]
+    [InlineData("expired")]
+    [InlineData("not-yet-valid")]
+    [InlineData("hostname-mismatch")]
+    [InlineData("missing-san-wrong-common-name")]
+    [InlineData("incomplete-chain")]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "certificate-rejection")]
+    public async Task PackagedAria2RejectsInvalidCertificate(string caseName)
+    {
+        await RunPackagedCaseAsync(
+            caseName,
+            async context =>
+            {
+                using var unknownAuthority = new TestCertificateAuthority(
+                    $"DownKyi Unknown TLS Test {Guid.NewGuid():N}");
+                using var intermediateCertificate = context.TrustedAuthority
+                    .IssueIntermediateCertificate("DownKyi Test Intermediate");
+                using var certificate = CreateRejectedCertificate(
+                    caseName,
+                    context.TrustedAuthority,
+                    unknownAuthority,
+                    intermediateCertificate);
+                await RunRejectedCertificateAsync(
+                    context.Runtime,
+                    caseName,
+                    certificate,
+                    context.Payload,
+                    GetAcceptedCertificateErrorCodes(caseName),
+                    context.Results,
+                    context.LoopbackCleanupFailures,
+                    context.CancellationToken).ConfigureAwait(false);
+            }).ConfigureAwait(true);
+    }
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "trust-transition")]
+    public async Task PackagedAria2RevalidatesCertificateAfterRedirect()
+    {
+        await RunPackagedCaseAsync(
+            "trusted-redirect-to-untrusted",
+            async context =>
+            {
+                using var unknownAuthority = new TestCertificateAuthority(
+                    $"DownKyi Unknown TLS Test {Guid.NewGuid():N}");
+                using var unknownCertificate = unknownAuthority.IssueServerCertificate();
+                await RunRedirectToUntrustedAsync(
+                    context.Runtime,
+                    context.TrustedCertificate,
+                    unknownCertificate,
+                    context.Payload,
+                    context.Results,
+                    context.LoopbackCleanupFailures,
+                    context.CancellationToken).ConfigureAwait(false);
+            }).ConfigureAwait(true);
+    }
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "trust-transition")]
+    public async Task PackagedAria2RevalidatesCertificateAfterApplicationRetry()
+    {
+        await RunPackagedCaseAsync(
+            "application-retry-resumes-to-untrusted",
+            async context =>
+            {
+                using var unknownAuthority = new TestCertificateAuthority(
+                    $"DownKyi Unknown TLS Test {Guid.NewGuid():N}");
+                using var unknownCertificate = unknownAuthority.IssueServerCertificate();
+                await RunResumeToUntrustedAsync(
+                    context.Runtime,
+                    context.TrustedCertificate,
+                    unknownCertificate,
+                    context.Payload,
+                    context.Results,
+                    context.LoopbackCleanupFailures,
+                    context.CancellationToken).ConfigureAwait(false);
+            }).ConfigureAwait(true);
+    }
+
+    internal static async Task RunRpcLifecycleCaseAsync()
+    {
+        await RunPackagedCaseAsync(
+            "rpc-add-query-remove",
+            context => RunRpcRemovalAsync(
+                context.Runtime,
+                context.TrustedCertificate,
+                context.Payload,
+                context.Results,
+                context.LoopbackCleanupFailures,
+                context.CancellationToken)).ConfigureAwait(false);
+    }
+
+    private static async Task RunPackagedCaseAsync(
+        string reportCaseName,
+        Func<Aria2TlsCaseContext, Task> runCaseAsync)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reportCaseName);
+        ArgumentNullException.ThrowIfNull(runCaseAsync);
         var binaryPath = Environment.GetEnvironmentVariable("DOWNKYI_ARIA2_BINARY");
         if (string.IsNullOrWhiteSpace(binaryPath))
         {
@@ -31,225 +195,131 @@ public sealed partial class Aria2TlsIntegrationTests
         var payload = CreatePayload(4 * 1024 * 1024 + 257);
         using var trustedAuthority = new TestCertificateAuthority(
             $"DownKyi TLS Test {Guid.NewGuid():N}");
-        using var unknownAuthority = new TestCertificateAuthority(
-            $"DownKyi Unknown TLS Test {Guid.NewGuid():N}");
         using var trustedCertificate = trustedAuthority.IssueServerCertificate();
-        using var unknownCertificate = unknownAuthority.IssueServerCertificate();
-        using var selfSignedCertificate =
-            TestCertificateAuthority.CreateSelfSignedServerCertificate();
-        using var expiredCertificate = trustedAuthority.IssueServerCertificate(
-            notBefore: DateTimeOffset.UtcNow.AddHours(-12),
-            notAfter: DateTimeOffset.UtcNow.AddHours(-6));
-        using var notYetValidCertificate = trustedAuthority.IssueServerCertificate(
-            notBefore: DateTimeOffset.UtcNow.AddHours(6),
-            notAfter: DateTimeOffset.UtcNow.AddHours(18));
-        using var hostnameMismatchCertificate = trustedAuthority.IssueServerCertificate(
-            dnsSubjectAlternativeName: "wrong.invalid");
-        using var missingSanCertificate = trustedAuthority.IssueServerCertificate(
-            commonName: "wrong.invalid",
-            dnsSubjectAlternativeName: null);
-        using var intermediateCertificate =
-            trustedAuthority.IssueIntermediateCertificate("DownKyi Test Intermediate");
-        using var incompleteChainCertificate = trustedAuthority.IssueServerCertificate(
-            issuer: intermediateCertificate);
-
-        var runtime = await Aria2TlsTestRuntime.StartAsync(
+        var failures = new Aria2TlsFailureCollector();
+        var loopbackCleanupFailures = new ConcurrentQueue<LoopbackTlsCleanupFailure>();
+        Aria2TlsTestRuntime? runtime = await Aria2TlsTestRuntime.StartAsync(
             binaryPath,
             trustedAuthority.RootCertificate,
-            cancellationToken).ConfigureAwait(true);
-        await using var runtimeLifetime = runtime.ConfigureAwait(false);
+            cancellationToken).ConfigureAwait(false);
         var results = new List<Aria2TlsCaseResult>();
-        try
-        {
-            await RunTrustedSplitDownloadAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunHttpsRedirectToHttpRejectedAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunPreflightThenActualDowngradeRejectedAsync(
-                runtime,
-                trustedCertificate,
-                trustedAuthority.RootCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunHeadSafeGetDowngradeRejectedAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRangeDowngradeRejectedAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunSecondRoundDowngradeRejectedAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunSensitiveCrossOriginRedirectsRejectedAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunSameOriginHttpsRedirectAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunCrossOriginHttpsRedirectAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunTrustedConnectProxyDownloadAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunProxyInterceptionRejectedAsync(
-                runtime,
-                unknownCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunTrustedResumeAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRpcRemovalAsync(
-                runtime,
-                trustedCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
+        var context = new Aria2TlsCaseContext(
+            runtime,
+            trustedAuthority,
+            trustedCertificate,
+            payload,
+            results,
+            loopbackCleanupFailures,
+            cancellationToken);
+        await failures.RunAsync(
+            "primary-test",
+            async () =>
+            {
+                await runCaseAsync(context).ConfigureAwait(false);
+                var result = Assert.Single(results);
+                Assert.Equal(reportCaseName, result.Name);
+                Assert.True(result.Passed, result.Name);
+            }).ConfigureAwait(false);
+        CaptureLoopbackCleanupFailures(loopbackCleanupFailures, failures);
+        await failures.RunAsync(
+                "report",
+                () => WriteReportFragmentAsync(
+                    runtime,
+                    reportCaseName,
+                    results,
+                    CancellationToken.None)).ConfigureAwait(false);
+        var runtimeDisposal = runtime.DisposeAsync().AsTask();
+        runtime = null;
+        await failures.RunAsync(
+            "runtime-disposal",
+            () => runtimeDisposal).ConfigureAwait(false);
+        CaptureLoopbackCleanupFailures(loopbackCleanupFailures, failures);
 
-            await RunRejectedCertificateAsync(
-                runtime,
-                "unknown-ca",
-                unknownCertificate,
-                payload,
-                [
-                    "download.transfer.tls.untrusted",
-                    "download.transfer.tls.handshake",
-                    "download.transfer.tls.chain"
-                ],
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRejectedCertificateAsync(
-                runtime,
-                "self-signed",
-                selfSignedCertificate,
-                payload,
-                [
-                    "download.transfer.tls.untrusted",
-                    "download.transfer.tls.handshake",
-                    "download.transfer.tls.chain"
-                ],
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRejectedCertificateAsync(
-                runtime,
-                "expired",
-                expiredCertificate,
-                payload,
-                [
-                    "download.transfer.tls.expired",
-                    "download.transfer.tls.handshake",
-                    "download.transfer.tls.chain"
-                ],
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRejectedCertificateAsync(
-                runtime,
-                "not-yet-valid",
-                notYetValidCertificate,
-                payload,
-                [
-                    "download.transfer.tls.not-yet-valid",
-                    "download.transfer.tls.expired",
-                    "download.transfer.tls.handshake",
-                    "download.transfer.tls.chain"
-                ],
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRejectedCertificateAsync(
-                runtime,
-                "hostname-mismatch",
-                hostnameMismatchCertificate,
-                payload,
-                [
-                    "download.transfer.tls.hostname",
-                    "download.transfer.tls.handshake",
-                    "download.transfer.tls.chain"
-                ],
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRejectedCertificateAsync(
-                runtime,
-                "missing-san-wrong-common-name",
-                missingSanCertificate,
-                payload,
-                [
-                    "download.transfer.tls.hostname",
-                    "download.transfer.tls.handshake",
-                    "download.transfer.tls.chain"
-                ],
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRejectedCertificateAsync(
-                runtime,
-                "incomplete-chain",
-                incompleteChainCertificate,
-                payload,
-                [
-                    "download.transfer.tls.chain",
-                    "download.transfer.tls.untrusted",
-                    "download.transfer.tls.handshake"
-                ],
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunRedirectToUntrustedAsync(
-                runtime,
-                trustedCertificate,
-                unknownCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
-            await RunResumeToUntrustedAsync(
-                runtime,
-                trustedCertificate,
-                unknownCertificate,
-                payload,
-                results,
-                cancellationToken).ConfigureAwait(true);
+        failures.ThrowIfAny();
+    }
 
-            Assert.All(results, result => Assert.True(result.Passed, result.Name));
-        }
-        finally
+    private static void CaptureLoopbackCleanupFailures(
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
+        Aria2TlsFailureCollector failures)
+    {
+        while (cleanupFailures.TryDequeue(out var cleanupFailure))
         {
-            await WriteReportAsync(
-                runtime,
-                results,
-                CancellationToken.None).ConfigureAwait(true);
+            failures.Capture(
+                $"loopback-tls/{cleanupFailure.Operation}",
+                cleanupFailure.Exception);
         }
+    }
+
+    private static X509Certificate2 CreateRejectedCertificate(
+        string caseName,
+        TestCertificateAuthority trustedAuthority,
+        TestCertificateAuthority unknownAuthority,
+        X509Certificate2 intermediateCertificate)
+    {
+        return caseName switch
+        {
+            "unknown-ca" => unknownAuthority.IssueServerCertificate(),
+            "self-signed" => TestCertificateAuthority.CreateSelfSignedServerCertificate(),
+            "expired" => trustedAuthority.IssueServerCertificate(
+                notBefore: DateTimeOffset.UtcNow.AddHours(-12),
+                notAfter: DateTimeOffset.UtcNow.AddHours(-6)),
+            "not-yet-valid" => trustedAuthority.IssueServerCertificate(
+                notBefore: DateTimeOffset.UtcNow.AddHours(6),
+                notAfter: DateTimeOffset.UtcNow.AddHours(18)),
+            "hostname-mismatch" => trustedAuthority.IssueServerCertificate(
+                dnsSubjectAlternativeName: "wrong.invalid"),
+            "missing-san-wrong-common-name" => trustedAuthority.IssueServerCertificate(
+                commonName: "wrong.invalid",
+                dnsSubjectAlternativeName: null),
+            "incomplete-chain" => trustedAuthority.IssueServerCertificate(
+                issuer: intermediateCertificate),
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(caseName),
+                caseName,
+                "Unknown rejected-certificate integration case.")
+        };
+    }
+
+    private static IReadOnlyList<string> GetAcceptedCertificateErrorCodes(string caseName)
+    {
+        return caseName switch
+        {
+            "unknown-ca" or "self-signed" =>
+            [
+                "download.transfer.tls.untrusted",
+                "download.transfer.tls.handshake",
+                "download.transfer.tls.chain"
+            ],
+            "expired" =>
+            [
+                "download.transfer.tls.expired",
+                "download.transfer.tls.handshake",
+                "download.transfer.tls.chain"
+            ],
+            "not-yet-valid" =>
+            [
+                "download.transfer.tls.not-yet-valid",
+                "download.transfer.tls.expired",
+                "download.transfer.tls.handshake",
+                "download.transfer.tls.chain"
+            ],
+            "hostname-mismatch" or "missing-san-wrong-common-name" =>
+            [
+                "download.transfer.tls.hostname",
+                "download.transfer.tls.handshake",
+                "download.transfer.tls.chain"
+            ],
+            "incomplete-chain" =>
+            [
+                "download.transfer.tls.chain",
+                "download.transfer.tls.untrusted",
+                "download.transfer.tls.handshake"
+            ],
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(caseName),
+                caseName,
+                "Unknown rejected-certificate integration case.")
+        };
     }
 
     private static async Task RunTrustedSplitDownloadAsync(
@@ -257,12 +327,14 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var server = new LoopbackTlsFileServer(
             _ => certificate,
             payload,
-            chunkDelay: TimeSpan.FromMilliseconds(10));
+            chunkDelay: TimeSpan.FromMilliseconds(10),
+            cleanupFailureSink: cleanupFailures);
         await using var serverLifetime = server.ConfigureAwait(false);
         const string outputName = "trusted-split.bin";
         var gid = await runtime.AddDownloadAsync(
@@ -294,47 +366,61 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
-        var server = new LoopbackTlsFileServer(_ => certificate, payload);
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            cleanupFailureSink: cleanupFailures);
         await using var serverLifetime = server.ConfigureAwait(false);
         var proxy = new LoopbackHttpConnectProxy();
-        await using var proxyLifetime = proxy.ConfigureAwait(false);
-        const string outputName = "trusted-connect-proxy.bin";
-        var url = new UriBuilder(server.Url)
-        {
-            Query = "signature=fixture"
-        }.Uri;
-        var gid = await runtime.AddDownloadAsync(
-            url,
-            outputName,
-            split: 1,
-            maximumTries: 1,
-            headers: ["Cookie: test-session=fixture"],
-            httpsProxy: proxy.Address.AbsoluteUri,
-            cancellationToken).ConfigureAwait(false);
-        var status = await runtime.WaitForTerminalStatusAsync(
-            gid,
-            DownloadTimeout,
-            cancellationToken).ConfigureAwait(false);
+        var proxyFailures = new Aria2TlsFailureCollector();
+        await proxyFailures.RunAsync(
+            "primary-test",
+            async () =>
+            {
+                const string outputName = "trusted-connect-proxy.bin";
+                var url = new UriBuilder(server.Url)
+                {
+                    Query = "signature=fixture"
+                }.Uri;
+                var gid = await runtime.AddDownloadAsync(
+                    url,
+                    outputName,
+                    split: 1,
+                    maximumTries: 1,
+                    headers: ["Cookie: test-session=fixture"],
+                    httpsProxy: proxy.Address.AbsoluteUri,
+                    cancellationToken).ConfigureAwait(false);
+                var status = await runtime.WaitForTerminalStatusAsync(
+                    gid,
+                    DownloadTimeout,
+                    cancellationToken).ConfigureAwait(false);
 
-        AssertCompleted(status, "trusted-local-connect-proxy", server.Failures);
-        AssertPayload(payload, runtime.GetOutputPath(outputName));
-        Assert.NotEmpty(proxy.ConnectAuthorities);
-        Assert.All(
-            proxy.ConnectAuthorities,
-            authority => Assert.Equal($"localhost:{server.Url.Port}", authority));
-        Assert.Equal(0, proxy.AbsoluteUriRequestCount);
-        Assert.Equal(0, proxy.CookieHeaderCount);
-        Assert.Equal(0, proxy.ProxyAuthorizationHeaderCount);
-        Assert.Equal(0, proxy.NonConnectRequestCount);
-        Assert.Contains(
-            server.Requests,
-            request => request.Headers.ContainsKey("Cookie"));
-        results.Add(new Aria2TlsCaseResult(
-            "trusted-local-connect-proxy",
-            true,
-            "connect-authority-only"));
+                AssertCompleted(status, "trusted-local-connect-proxy", server.Failures);
+                AssertPayload(payload, runtime.GetOutputPath(outputName));
+                Assert.NotEmpty(proxy.ConnectAuthorities);
+                Assert.All(
+                    proxy.ConnectAuthorities,
+                    authority => Assert.Equal($"localhost:{server.Url.Port}", authority));
+                Assert.Equal(0, proxy.AbsoluteUriRequestCount);
+                Assert.Equal(0, proxy.CookieHeaderCount);
+                Assert.Equal(0, proxy.ProxyAuthorizationHeaderCount);
+                Assert.Equal(0, proxy.NonConnectRequestCount);
+                Assert.Contains(
+                    server.Requests,
+                    request => request.Headers.ContainsKey("Cookie"));
+                results.Add(new Aria2TlsCaseResult(
+                    "trusted-local-connect-proxy",
+                    true,
+                    "connect-authority-only"));
+            }).ConfigureAwait(false);
+        var proxyDisposal = proxy.DisposeAsync().AsTask();
+        await proxyFailures.RunAsync(
+            "connect-proxy-cleanup",
+            () => proxyDisposal).ConfigureAwait(false);
+        proxyFailures.ThrowIfAny();
     }
 
     private static async Task RunProxyInterceptionRejectedAsync(
@@ -345,39 +431,49 @@ public sealed partial class Aria2TlsIntegrationTests
         CancellationToken cancellationToken)
     {
         var proxy = new LoopbackHttpConnectProxy(unknownCertificate);
-        await using var proxyLifetime = proxy.ConfigureAwait(false);
-        const string outputName = "proxy-untrusted-interception.bin";
-        var gid = await runtime.AddDownloadAsync(
-            new Uri("https://localhost:443/media.bin"),
-            outputName,
-            split: 1,
-            maximumTries: 1,
-            headers: ["Cookie: test-session=fixture"],
-            httpsProxy: proxy.Address.AbsoluteUri,
-            cancellationToken).ConfigureAwait(false);
-        var status = await runtime.WaitForTerminalStatusAsync(
-            gid,
-            DownloadTimeout,
-            cancellationToken).ConfigureAwait(false);
-        var classification = AssertRejectedTlsStatus(
-            status,
-            runtime.GetOutputPath(outputName),
-            payload,
-            [
-                "download.transfer.tls.untrusted",
-                "download.transfer.tls.handshake",
-                "download.transfer.tls.chain"
-            ]);
+        var proxyFailures = new Aria2TlsFailureCollector();
+        await proxyFailures.RunAsync(
+            "primary-test",
+            async () =>
+            {
+                const string outputName = "proxy-untrusted-interception.bin";
+                var gid = await runtime.AddDownloadAsync(
+                    new Uri("https://localhost:443/media.bin"),
+                    outputName,
+                    split: 1,
+                    maximumTries: 1,
+                    headers: ["Cookie: test-session=fixture"],
+                    httpsProxy: proxy.Address.AbsoluteUri,
+                    cancellationToken).ConfigureAwait(false);
+                var status = await runtime.WaitForTerminalStatusAsync(
+                    gid,
+                    DownloadTimeout,
+                    cancellationToken).ConfigureAwait(false);
+                var classification = AssertRejectedTlsStatus(
+                    status,
+                    runtime.GetOutputPath(outputName),
+                    payload,
+                    [
+                        "download.transfer.tls.untrusted",
+                        "download.transfer.tls.handshake",
+                        "download.transfer.tls.chain"
+                    ]);
 
-        Assert.Contains("localhost:443", proxy.ConnectAuthorities);
-        Assert.Equal(0, proxy.AbsoluteUriRequestCount);
-        Assert.Equal(0, proxy.CookieHeaderCount);
-        Assert.Equal(0, proxy.ProxyAuthorizationHeaderCount);
-        Assert.Equal(0, proxy.NonConnectRequestCount);
-        results.Add(new Aria2TlsCaseResult(
-            "proxy-untrusted-interception",
-            true,
-            classification));
+                Assert.Contains("localhost:443", proxy.ConnectAuthorities);
+                Assert.Equal(0, proxy.AbsoluteUriRequestCount);
+                Assert.Equal(0, proxy.CookieHeaderCount);
+                Assert.Equal(0, proxy.ProxyAuthorizationHeaderCount);
+                Assert.Equal(0, proxy.NonConnectRequestCount);
+                results.Add(new Aria2TlsCaseResult(
+                    "proxy-untrusted-interception",
+                    true,
+                    classification));
+            }).ConfigureAwait(false);
+        var proxyDisposal = proxy.DisposeAsync().AsTask();
+        await proxyFailures.RunAsync(
+            "connect-proxy-cleanup",
+            () => proxyDisposal).ConfigureAwait(false);
+        proxyFailures.ThrowIfAny();
     }
 
     private static async Task RunTrustedResumeAsync(
@@ -385,12 +481,14 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var server = new LoopbackTlsFileServer(
             _ => certificate,
             payload,
-            truncateFirstResponse: true);
+            truncateFirstResponse: true,
+            cleanupFailureSink: cleanupFailures);
         await using var serverLifetime = server.ConfigureAwait(false);
         const string outputName = "trusted-resume.bin";
         var gid = await runtime.AddDownloadAsync(
@@ -415,12 +513,14 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var server = new LoopbackTlsFileServer(
             _ => certificate,
             payload,
-            chunkDelay: TimeSpan.FromMilliseconds(100));
+            chunkDelay: TimeSpan.FromMilliseconds(100),
+            cleanupFailureSink: cleanupFailures);
         await using var serverLifetime = server.ConfigureAwait(false);
         var gid = await runtime.AddDownloadAsync(
             server.Url,
@@ -449,9 +549,13 @@ public sealed partial class Aria2TlsIntegrationTests
         byte[] payload,
         IReadOnlyList<string> acceptedErrorCodes,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
-        var server = new LoopbackTlsFileServer(_ => certificate, payload);
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            cleanupFailureSink: cleanupFailures);
         await using var serverLifetime = server.ConfigureAwait(false);
         var outputName = $"rejected-{name}.bin";
         var gid = await runtime.AddDownloadAsync(
@@ -479,14 +583,19 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 unknownCertificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
-        var target = new LoopbackTlsFileServer(_ => unknownCertificate, payload);
+        var target = new LoopbackTlsFileServer(
+            _ => unknownCertificate,
+            payload,
+            cleanupFailureSink: cleanupFailures);
         await using var targetLifetime = target.ConfigureAwait(false);
         var redirect = new LoopbackTlsFileServer(
             _ => trustedCertificate,
             [],
-            redirectTarget: target.Url);
+            redirectTarget: target.Url,
+            cleanupFailureSink: cleanupFailures);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
         const string outputName = "redirect-to-untrusted.bin";
         var gid = await runtime.AddDownloadAsync(
@@ -522,12 +631,14 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 unknownCertificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var server = new LoopbackTlsFileServer(
             connection => connection == 1 ? trustedCertificate : unknownCertificate,
             payload,
-            truncateFirstResponse: true);
+            truncateFirstResponse: true,
+            cleanupFailureSink: cleanupFailures);
         await using var serverLifetime = server.ConfigureAwait(false);
         const string outputName = "resume-to-untrusted.bin";
         var gid = await runtime.AddDownloadAsync(
@@ -652,27 +763,26 @@ public sealed partial class Aria2TlsIntegrationTests
         return payload;
     }
 
-    private static async Task WriteReportAsync(
+    private static async Task WriteReportFragmentAsync(
         Aria2TlsTestRuntime runtime,
-        List<Aria2TlsCaseResult> results,
+        string reportCaseName,
+        IReadOnlyCollection<Aria2TlsCaseResult> results,
         CancellationToken cancellationToken)
     {
-        var reportPath = Environment.GetEnvironmentVariable("DOWNKYI_ARIA2_TLS_REPORT");
-        if (string.IsNullOrWhiteSpace(reportPath))
+        var reportDirectory = Environment.GetEnvironmentVariable("DOWNKYI_ARIA2_TLS_REPORT");
+        if (string.IsNullOrWhiteSpace(reportDirectory))
         {
             return;
         }
 
-        var directory = Path.GetDirectoryName(Path.GetFullPath(reportPath));
-        if (directory != null)
+        if (reportCaseName.Any(character =>
+                !char.IsAsciiLetterOrDigit(character) && character is not '-' and not '_'))
         {
-            Directory.CreateDirectory(directory);
+            throw new InvalidDataException(
+                "The aria2 TLS report case name is not safe for use as a file name.");
         }
 
-        var report = new Aria2TlsReport(
-            SchemaVersion: 2,
-            Complete: results.Count == ExpectedCaseCount,
-            Passed: results.Count == ExpectedCaseCount && results.All(result => result.Passed),
+        var context = new Aria2TlsReportContext(
             Runtime: RuntimeInformation.FrameworkDescription,
             OperatingSystem: RuntimeInformation.OSDescription,
             Architecture: RuntimeInformation.ProcessArchitecture.ToString(),
@@ -684,41 +794,18 @@ public sealed partial class Aria2TlsIntegrationTests
             BinarySha256: runtime.BinarySha256,
             RequiredFeature: Aria2TlsTestRuntime.SecureRedirectFeature,
             TlsBackend: GetTlsBackend(),
-            CertificateAuthoritySource: runtime.CertificateAuthoritySource,
-            Cases: results);
-        var reportJson = JsonSerializer.Serialize(report, ReportJsonOptions);
-        AssertSanitizedReport(reportJson);
-        await File.WriteAllTextAsync(
+            CertificateAuthoritySource: runtime.CertificateAuthoritySource);
+        var report = Aria2TlsReportWriter.Build(
+            ExpectedReportCaseCount,
+            results,
+            context);
+        var reportJson = Aria2TlsReportWriter.EnsureSanitized(
+            Aria2TlsReportWriter.Serialize(report));
+        var reportPath = Path.Combine(reportDirectory, $"{reportCaseName}.json");
+        await Aria2TlsReportWriter.WriteAsync(
             reportPath,
             reportJson,
             cancellationToken).ConfigureAwait(false);
-    }
-
-    private static void AssertSanitizedReport(string reportJson)
-    {
-        string[] forbiddenTerms =
-        {
-            "test-session=fixture",
-            "Bearer fixture",
-            "Basic Zml4dHVyZQ==",
-            "X-Access-Token: fixture",
-            "X-API-Key: fixture",
-            "sessdata",
-            "bili_jct",
-            "dedeuserid",
-            "http://",
-            "https://",
-            "C:\\Users\\",
-            "/Users/",
-            "/home/"
-        };
-        foreach (var forbiddenTerm in forbiddenTerms)
-        {
-            Assert.DoesNotContain(
-                forbiddenTerm,
-                reportJson,
-                StringComparison.OrdinalIgnoreCase);
-        }
     }
 
     private static string GetTlsBackend()
@@ -734,6 +821,27 @@ public sealed partial class Aria2TlsIntegrationTests
         }
 
         return "OpenSSL";
+    }
+
+    private sealed record Aria2TlsCaseContext(
+        Aria2TlsTestRuntime Runtime,
+        TestCertificateAuthority TrustedAuthority,
+        X509Certificate2 TrustedCertificate,
+        byte[] Payload,
+        List<Aria2TlsCaseResult> Results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> LoopbackCleanupFailures,
+        CancellationToken CancellationToken);
+}
+
+[Collection("Aria2 packaged integration")]
+public sealed class Aria2RpcLifecycleIntegrationTests
+{
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "rpc-lifecycle")]
+    public async Task PackagedAria2SupportsRpcAddQueryAndRemove()
+    {
+        await Aria2TlsIntegrationTests.RunRpcLifecycleCaseAsync().ConfigureAwait(true);
     }
 }
 

--- a/tests/DownKyi.Tests/Aria2TlsProcessLifetime.cs
+++ b/tests/DownKyi.Tests/Aria2TlsProcessLifetime.cs
@@ -1,0 +1,298 @@
+using System.Diagnostics;
+
+namespace DownKyi.Tests;
+
+internal interface IAria2TlsProcessHandle : IDisposable
+{
+    bool HasExited { get; }
+
+    void KillEntireTree();
+
+    Task WaitForExitAsync(CancellationToken cancellationToken);
+}
+
+internal sealed class Aria2TlsProcessLifetime : IAsyncDisposable
+{
+    private readonly TimeSpan _cleanupTimeout;
+    private readonly Func<Task> _forceShutdown;
+    private readonly CancellationTokenSource _outputCaptureCancellation;
+    private readonly IAria2TlsProcessHandle _process;
+    private readonly TimeSpan _shutdownTimeout;
+    private readonly Task<string> _standardError;
+    private readonly Task<string> _standardOutput;
+    private int _cleanupStarted;
+    private Task? _forceShutdownTask;
+    private bool _forceShutdownTimedOut;
+
+    internal Aria2TlsProcessLifetime(
+        IAria2TlsProcessHandle process,
+        Task<string> standardOutput,
+        Task<string> standardError,
+        CancellationTokenSource outputCaptureCancellation,
+        Func<Task> forceShutdown,
+        TimeSpan shutdownTimeout,
+        TimeSpan cleanupTimeout)
+    {
+        _process = process ?? throw new ArgumentNullException(nameof(process));
+        _standardOutput = standardOutput ?? throw new ArgumentNullException(nameof(standardOutput));
+        _standardError = standardError ?? throw new ArgumentNullException(nameof(standardError));
+        _outputCaptureCancellation = outputCaptureCancellation
+            ?? throw new ArgumentNullException(nameof(outputCaptureCancellation));
+        _forceShutdown = forceShutdown ?? throw new ArgumentNullException(nameof(forceShutdown));
+        _shutdownTimeout = shutdownTimeout;
+        _cleanupTimeout = cleanupTimeout;
+    }
+
+    public static async Task<Aria2TlsProcessLifetime> CreateAsync(
+        Process process,
+        Func<Task> forceShutdown,
+        TimeSpan shutdownTimeout,
+        TimeSpan cleanupTimeout)
+    {
+        ArgumentNullException.ThrowIfNull(process);
+        var outputCancellation = new CancellationTokenSource();
+        Task<string>? standardOutput = null;
+        Task<string>? standardError = null;
+        var initializationFailure = Record.Exception(() =>
+        {
+            standardOutput = process.StandardOutput.ReadToEndAsync(outputCancellation.Token);
+            standardError = process.StandardError.ReadToEndAsync(outputCancellation.Token);
+        });
+        if (initializationFailure == null)
+        {
+            return new Aria2TlsProcessLifetime(
+                new SystemAria2TlsProcessHandle(process),
+                standardOutput!,
+                standardError!,
+                outputCancellation,
+                forceShutdown,
+                shutdownTimeout,
+                cleanupTimeout);
+        }
+
+        var failedLifetime = new Aria2TlsProcessLifetime(
+            new SystemAria2TlsProcessHandle(process),
+            standardOutput ?? Task.FromResult(string.Empty),
+            standardError ?? Task.FromResult(string.Empty),
+            outputCancellation,
+            forceShutdown,
+            shutdownTimeout,
+            cleanupTimeout);
+        var failures = new Aria2TlsFailureCollector();
+        failures.Capture("runtime-startup/output-capture", initializationFailure);
+        await failedLifetime.CleanupAsync(failures).ConfigureAwait(false);
+        failures.ThrowIfAny();
+        throw new InvalidOperationException("Unreachable output-capture startup failure path.");
+    }
+
+    internal async Task CleanupAsync(Aria2TlsFailureCollector failures)
+    {
+        ArgumentNullException.ThrowIfNull(failures);
+        if (Interlocked.Exchange(ref _cleanupStarted, 1) != 0)
+        {
+            return;
+        }
+
+        var hasExited = TryHasExited(failures);
+        if (!hasExited)
+        {
+            await failures.RunAsync(
+                "runtime-disposal",
+                ForceShutdownWithinDeadlineAsync).ConfigureAwait(false);
+            hasExited = await WaitForExitAsync(
+                _shutdownTimeout,
+                "process-wait",
+                recordTimeout: false,
+                failures).ConfigureAwait(false);
+        }
+
+        if (!hasExited)
+        {
+            if (!TryHasExited(failures))
+            {
+                failures.Run("process-kill", _process.KillEntireTree);
+            }
+
+            await WaitForExitAsync(
+                _cleanupTimeout,
+                "process-reap",
+                recordTimeout: true,
+                failures).ConfigureAwait(false);
+        }
+
+        if (_forceShutdownTimedOut)
+        {
+            await ObserveTimedOutShutdownAsync(failures).ConfigureAwait(false);
+        }
+
+        await DrainOutputAsync(failures).ConfigureAwait(false);
+        failures.Run("process-dispose", _process.Dispose);
+        await failures.RunAsync(
+            "output-cancellation",
+            () => _outputCaptureCancellation.CancelAsync()).ConfigureAwait(false);
+        failures.Run("output-cancellation-dispose", _outputCaptureCancellation.Dispose);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        var failures = new Aria2TlsFailureCollector();
+        await CleanupAsync(failures).ConfigureAwait(false);
+        failures.ThrowIfAny();
+    }
+
+    private async Task ForceShutdownWithinDeadlineAsync()
+    {
+        using var deadline = new CancellationTokenSource(_shutdownTimeout);
+        _forceShutdownTask = _forceShutdown();
+        try
+        {
+            await _forceShutdownTask.WaitAsync(deadline.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException exception) when (deadline.IsCancellationRequested)
+        {
+            _forceShutdownTimedOut = true;
+            throw new TimeoutException(
+                "The aria2 RPC shutdown call did not complete before its cleanup deadline.",
+                exception);
+        }
+    }
+
+    private async Task ObserveTimedOutShutdownAsync(Aria2TlsFailureCollector failures)
+    {
+        if (_forceShutdownTask == null)
+        {
+            return;
+        }
+
+        using var deadline = new CancellationTokenSource(_cleanupTimeout);
+        var exception = await Record.ExceptionAsync(
+            () => _forceShutdownTask.WaitAsync(deadline.Token)).ConfigureAwait(false);
+        if (exception is OperationCanceledException && deadline.IsCancellationRequested)
+        {
+            ObserveLateFault(_forceShutdownTask);
+            return;
+        }
+
+        if (exception != null)
+        {
+            failures.Capture("runtime-disposal/late-completion", exception);
+        }
+    }
+
+    private static void ObserveLateFault(Task task)
+    {
+        _ = task.ContinueWith(
+            completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+    }
+
+    private bool TryHasExited(Aria2TlsFailureCollector failures)
+    {
+        var hasExited = false;
+        var exception = Record.Exception(() => hasExited = _process.HasExited);
+        if (exception != null)
+        {
+            failures.Capture("process-state", exception);
+            return false;
+        }
+
+        return hasExited;
+    }
+
+    private async Task<bool> WaitForExitAsync(
+        TimeSpan timeout,
+        string failureStage,
+        bool recordTimeout,
+        Aria2TlsFailureCollector failures)
+    {
+        using var deadline = new CancellationTokenSource(timeout);
+        var exception = await Record.ExceptionAsync(
+            () => _process.WaitForExitAsync(deadline.Token)).ConfigureAwait(false);
+        if (exception == null)
+        {
+            return true;
+        }
+
+        if (exception is OperationCanceledException && deadline.IsCancellationRequested)
+        {
+            if (recordTimeout)
+            {
+                failures.Capture(
+                    failureStage,
+                    new TimeoutException($"aria2 did not exit within the {failureStage} deadline."));
+            }
+
+            return false;
+        }
+
+        failures.Capture(failureStage, exception);
+        return false;
+    }
+
+    private async Task DrainOutputAsync(Aria2TlsFailureCollector failures)
+    {
+        using var deadline = new CancellationTokenSource(_cleanupTimeout);
+        var standardOutput = ObserveOutputAsync(
+            _standardOutput,
+            "stdout-drain",
+            deadline.Token);
+        var standardError = ObserveOutputAsync(
+            _standardError,
+            "stderr-drain",
+            deadline.Token);
+        var observations = await Task.WhenAll(standardOutput, standardError).ConfigureAwait(false);
+        foreach (var observation in observations)
+        {
+            if (observation.Exception != null)
+            {
+                failures.Capture(observation.Stage, observation.Exception);
+            }
+        }
+    }
+
+    private static async Task<OutputObservation> ObserveOutputAsync(
+        Task<string> output,
+        string stage,
+        CancellationToken cancellationToken)
+    {
+        var exception = await Record.ExceptionAsync(
+            () => output.WaitAsync(cancellationToken)).ConfigureAwait(false);
+        if (exception == null)
+        {
+            return new OutputObservation(stage, null);
+        }
+
+        if (exception is OperationCanceledException && cancellationToken.IsCancellationRequested)
+        {
+            return new OutputObservation(
+                stage,
+                new TimeoutException($"{stage} did not complete before the cleanup deadline."));
+        }
+
+        return new OutputObservation(stage, exception);
+    }
+
+    private sealed record OutputObservation(string Stage, Exception? Exception);
+
+    private sealed class SystemAria2TlsProcessHandle(Process process) : IAria2TlsProcessHandle
+    {
+        public bool HasExited => process.HasExited;
+
+        public void KillEntireTree()
+        {
+            process.Kill(entireProcessTree: true);
+        }
+
+        public Task WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            return process.WaitForExitAsync(cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            process.Dispose();
+        }
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsRedirectIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using DownKyi.Core.Aria2cNet.Client.Entity;
@@ -8,11 +9,129 @@ namespace DownKyi.Tests;
 
 public sealed partial class Aria2TlsIntegrationTests
 {
+    [Theory]
+    [InlineData("https-to-http-redirect")]
+    [InlineData("preflight-safe-actual-downgrade")]
+    [InlineData("head-safe-get-downgrade")]
+    [InlineData("range-downgrade")]
+    [InlineData("second-round-downgrade")]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "insecure-redirect")]
+    public async Task PackagedAria2RejectsInsecureRedirect(string caseName)
+    {
+        await RunPackagedCaseAsync(
+            caseName,
+            context => caseName switch
+            {
+                "https-to-http-redirect" => RunHttpsRedirectToHttpRejectedAsync(
+                    context.Runtime,
+                    context.TrustedCertificate,
+                    context.Payload,
+                    context.Results,
+                    context.LoopbackCleanupFailures,
+                    context.CancellationToken),
+                "preflight-safe-actual-downgrade" =>
+                    RunPreflightThenActualDowngradeRejectedAsync(
+                        context.Runtime,
+                        context.TrustedCertificate,
+                        context.TrustedAuthority.RootCertificate,
+                        context.Payload,
+                        context.Results,
+                        context.LoopbackCleanupFailures,
+                        context.CancellationToken),
+                "head-safe-get-downgrade" => RunHeadSafeGetDowngradeRejectedAsync(
+                    context.Runtime,
+                    context.TrustedCertificate,
+                    context.Payload,
+                    context.Results,
+                    context.LoopbackCleanupFailures,
+                    context.CancellationToken),
+                "range-downgrade" => RunRangeDowngradeRejectedAsync(
+                    context.Runtime,
+                    context.TrustedCertificate,
+                    context.Payload,
+                    context.Results,
+                    context.LoopbackCleanupFailures,
+                    context.CancellationToken),
+                "second-round-downgrade" => RunSecondRoundDowngradeRejectedAsync(
+                    context.Runtime,
+                    context.TrustedCertificate,
+                    context.Payload,
+                    context.Results,
+                    context.LoopbackCleanupFailures,
+                    context.CancellationToken),
+                _ => throw new ArgumentOutOfRangeException(
+                    nameof(caseName),
+                    caseName,
+                    "Unknown insecure-redirect integration case.")
+            }).ConfigureAwait(true);
+    }
+
+    [Theory]
+    [InlineData("sensitive-cross-origin-cookie", "Cookie: test-session=fixture")]
+    [InlineData("sensitive-cross-origin-authorization", "Authorization: Bearer fixture")]
+    [InlineData(
+        "sensitive-cross-origin-proxy-authorization",
+        "Proxy-Authorization: Basic Zml4dHVyZQ==")]
+    [InlineData("sensitive-cross-origin-token", "X-Access-Token: fixture")]
+    [InlineData("sensitive-cross-origin-api-key", "X-API-Key: fixture")]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "credential-redirect")]
+    public async Task PackagedAria2RejectsSensitiveCrossOriginRedirect(
+        string caseName,
+        string header)
+    {
+        await RunPackagedCaseAsync(
+            caseName,
+            context => RunSensitiveCrossOriginRedirectRejectedAsync(
+                context.Runtime,
+                context.TrustedCertificate,
+                context.Payload,
+                caseName,
+                header,
+                context.Results,
+                context.LoopbackCleanupFailures,
+                context.CancellationToken)).ConfigureAwait(true);
+    }
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "https-redirect")]
+    public async Task PackagedAria2AllowsSameOriginHttpsRedirectWithCredentials()
+    {
+        await RunPackagedCaseAsync(
+            "same-origin-https-redirect",
+            context => RunSameOriginHttpsRedirectAsync(
+                context.Runtime,
+                context.TrustedCertificate,
+                context.Payload,
+                context.Results,
+                context.LoopbackCleanupFailures,
+                context.CancellationToken)).ConfigureAwait(true);
+    }
+
+    [Fact]
+    [Trait("Category", "Aria2TlsIntegration")]
+    [Trait("Aria2TlsFamily", "https-redirect")]
+    public async Task PackagedAria2AllowsCredentiallessCrossOriginHttpsRedirect()
+    {
+        await RunPackagedCaseAsync(
+            "cross-origin-https-redirect",
+            context => RunCrossOriginHttpsRedirectAsync(
+                context.Runtime,
+                context.TrustedCertificate,
+                context.Payload,
+                context.Results,
+                context.LoopbackCleanupFailures,
+                context.CancellationToken)).ConfigureAwait(true);
+    }
+
     private static async Task RunHttpsRedirectToHttpRejectedAsync(
         Aria2TlsTestRuntime runtime,
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var target = CreatePlainHttpTarget();
@@ -20,7 +139,8 @@ public sealed partial class Aria2TlsIntegrationTests
         var redirect = new LoopbackTlsFileServer(
             _ => certificate,
             [],
-            redirectTarget: target.Url);
+            redirectTarget: target.Url,
+            cleanupFailureSink: cleanupFailures);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
 
         const string outputName = "https-to-http-redirect.bin";
@@ -47,9 +167,10 @@ public sealed partial class Aria2TlsIntegrationTests
     private static async Task RunPreflightThenActualDowngradeRejectedAsync(
         Aria2TlsTestRuntime runtime,
         X509Certificate2 certificate,
-        X509Certificate2 trustedRoot,
+        X509Certificate2 rootCertificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var target = CreatePlainHttpTarget();
@@ -57,9 +178,10 @@ public sealed partial class Aria2TlsIntegrationTests
         var redirect = new LoopbackTlsFileServer(
             _ => certificate,
             payload,
-            redirectFactory: (connection, _) => connection > 1 ? target.Url : null);
+            redirectFactory: (connection, _) => connection > 1 ? target.Url : null,
+            cleanupFailureSink: cleanupFailures);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
-        using var resolver = CreateTrustedAddressResolver(trustedRoot);
+        using var resolver = CreateTrustedAddressResolver(rootCertificate);
         var resolution = await resolver.ResolveAsync(
             redirect.Url.AbsoluteUri,
             "DownKyi-TLS-Test",
@@ -128,6 +250,7 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var target = CreatePlainHttpTarget();
@@ -138,7 +261,8 @@ public sealed partial class Aria2TlsIntegrationTests
             redirectFactory: (_, request) =>
                 string.Equals(request.Method, "GET", StringComparison.OrdinalIgnoreCase)
                     ? target.Url
-                    : null);
+                    : null,
+            cleanupFailureSink: cleanupFailures);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
 
         using (var handler = new HttpClientHandler { AllowAutoRedirect = false })
@@ -192,6 +316,7 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var target = CreatePlainHttpTarget();
@@ -199,7 +324,8 @@ public sealed partial class Aria2TlsIntegrationTests
         var redirect = new LoopbackTlsFileServer(
             _ => certificate,
             payload,
-            redirectFactory: (_, request) => request.RangeStart is > 0 ? target.Url : null);
+            redirectFactory: (_, request) => request.RangeStart is > 0 ? target.Url : null,
+            cleanupFailureSink: cleanupFailures);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
 
         const string outputName = "range-downgrade.bin";
@@ -234,6 +360,7 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         var target = CreatePlainHttpTarget();
@@ -242,7 +369,8 @@ public sealed partial class Aria2TlsIntegrationTests
             _ => certificate,
             payload,
             truncateFirstResponse: true,
-            redirectFactory: (connection, _) => connection > 1 ? target.Url : null);
+            redirectFactory: (connection, _) => connection > 1 ? target.Url : null,
+            cleanupFailureSink: cleanupFailures);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
         const string outputName = "second-round-downgrade.bin";
         var firstGid = await runtime.AddDownloadAsync(
@@ -282,52 +410,47 @@ public sealed partial class Aria2TlsIntegrationTests
             "zero-http-requests"));
     }
 
-    private static async Task RunSensitiveCrossOriginRedirectsRejectedAsync(
+    private static async Task RunSensitiveCrossOriginRedirectRejectedAsync(
         Aria2TlsTestRuntime runtime,
         X509Certificate2 certificate,
         byte[] payload,
+        string reportName,
+        string header,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
-        var cases = new (string ReportName, string Header)[]
-        {
-            ("sensitive-cross-origin-cookie", "Cookie: test-session=fixture"),
-            ("sensitive-cross-origin-authorization", "Authorization: Bearer fixture"),
-            ("sensitive-cross-origin-proxy-authorization", "Proxy-Authorization: Basic Zml4dHVyZQ=="),
-            ("sensitive-cross-origin-token", "X-Access-Token: fixture"),
-            ("sensitive-cross-origin-api-key", "X-API-Key: fixture")
-        };
+        var target = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            cleanupFailureSink: cleanupFailures);
+        await using var targetLifetime = target.ConfigureAwait(false);
+        var redirect = new LoopbackTlsFileServer(
+            _ => certificate,
+            [],
+            redirectTarget: target.Url,
+            cleanupFailureSink: cleanupFailures);
+        await using var redirectLifetime = redirect.ConfigureAwait(false);
+        var outputName = $"{reportName}.bin";
+        var status = await DownloadToTerminalStatusAsync(
+            runtime,
+            redirect.Url,
+            outputName,
+            maximumTries: 1,
+            headers: [header],
+            cancellationToken).ConfigureAwait(false);
 
-        foreach (var testCase in cases)
-        {
-            var target = new LoopbackTlsFileServer(_ => certificate, payload);
-            await using var targetLifetime = target.ConfigureAwait(false);
-            var redirect = new LoopbackTlsFileServer(
-                _ => certificate,
-                [],
-                redirectTarget: target.Url);
-            await using var redirectLifetime = redirect.ConfigureAwait(false);
-            var outputName = $"{testCase.ReportName}.bin";
-            var status = await DownloadToTerminalStatusAsync(
-                runtime,
-                redirect.Url,
-                outputName,
-                maximumTries: 1,
-                headers: [testCase.Header],
-                cancellationToken).ConfigureAwait(false);
-
-            AssertRedirectRejected(
-                status,
-                runtime.GetOutputPath(outputName),
-                payload,
-                "download.transfer.credentialed-redirect");
-            Assert.Equal(0, target.ConnectionCount);
-            Assert.Empty(target.Requests);
-            results.Add(new Aria2TlsCaseResult(
-                testCase.ReportName,
-                true,
-                "zero-cross-origin-requests"));
-        }
+        AssertRedirectRejected(
+            status,
+            runtime.GetOutputPath(outputName),
+            payload,
+            "download.transfer.credentialed-redirect");
+        Assert.Equal(0, target.ConnectionCount);
+        Assert.Empty(target.Requests);
+        results.Add(new Aria2TlsCaseResult(
+            reportName,
+            true,
+            "zero-cross-origin-requests"));
     }
 
     private static async Task RunSameOriginHttpsRedirectAsync(
@@ -335,6 +458,7 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
         Uri? finalAddress = null;
@@ -344,7 +468,8 @@ public sealed partial class Aria2TlsIntegrationTests
             redirectFactory: (_, request) =>
                 request.RequestTarget.StartsWith("/media.bin", StringComparison.Ordinal)
                     ? finalAddress
-                    : null);
+                    : null,
+            cleanupFailureSink: cleanupFailures);
         await using var serverLifetime = server.ConfigureAwait(false);
         finalAddress = new Uri(server.Url, "/final.bin");
 
@@ -381,14 +506,19 @@ public sealed partial class Aria2TlsIntegrationTests
         X509Certificate2 certificate,
         byte[] payload,
         List<Aria2TlsCaseResult> results,
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
         CancellationToken cancellationToken)
     {
-        var target = new LoopbackTlsFileServer(_ => certificate, payload);
+        var target = new LoopbackTlsFileServer(
+            _ => certificate,
+            payload,
+            cleanupFailureSink: cleanupFailures);
         await using var targetLifetime = target.ConfigureAwait(false);
         var redirect = new LoopbackTlsFileServer(
             _ => certificate,
             [],
-            redirectTarget: target.Url);
+            redirectTarget: target.Url,
+            cleanupFailureSink: cleanupFailures);
         await using var redirectLifetime = redirect.ConfigureAwait(false);
 
         const string outputName = "cross-origin-https-redirect.bin";

--- a/tests/DownKyi.Tests/Aria2TlsReportWriter.cs
+++ b/tests/DownKyi.Tests/Aria2TlsReportWriter.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+
+namespace DownKyi.Tests;
+
+internal sealed record Aria2TlsReportContext(
+    string Runtime,
+    string OperatingSystem,
+    string Architecture,
+    string RuntimeIdentifier,
+    string AssetRuntimeIdentifier,
+    string CommitSha,
+    string AriaVersion,
+    string BinarySha256,
+    string RequiredFeature,
+    string TlsBackend,
+    string CertificateAuthoritySource);
+
+internal static class Aria2TlsReportWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private static readonly IReadOnlyList<string> ForbiddenTerms =
+    [
+        "test-session=fixture",
+        "Bearer fixture",
+        "Basic Zml4dHVyZQ==",
+        "X-Access-Token: fixture",
+        "X-API-Key: fixture",
+        "sessdata",
+        "bili_jct",
+        "dedeuserid",
+        "http://",
+        "https://",
+        "C:\\Users\\",
+        "/Users/",
+        "/home/"
+    ];
+
+    public static Aria2TlsReport Build(
+        int expectedCaseCount,
+        IReadOnlyCollection<Aria2TlsCaseResult> cases,
+        Aria2TlsReportContext context)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(expectedCaseCount);
+        ArgumentNullException.ThrowIfNull(cases);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var complete = cases.Count == expectedCaseCount;
+        return new Aria2TlsReport(
+            SchemaVersion: 2,
+            Complete: complete,
+            Passed: complete && cases.All(result => result.Passed),
+            context.Runtime,
+            context.OperatingSystem,
+            context.Architecture,
+            context.RuntimeIdentifier,
+            context.AssetRuntimeIdentifier,
+            context.CommitSha,
+            context.AriaVersion,
+            context.BinarySha256,
+            context.RequiredFeature,
+            context.TlsBackend,
+            context.CertificateAuthoritySource,
+            Cases: cases);
+    }
+
+    public static string Serialize(Aria2TlsReport report)
+    {
+        return Serialize(
+            report,
+            value => JsonSerializer.Serialize(value, JsonOptions));
+    }
+
+    internal static string Serialize(
+        Aria2TlsReport report,
+        Func<Aria2TlsReport, string> serialize)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        ArgumentNullException.ThrowIfNull(serialize);
+        return serialize(report);
+    }
+
+    public static string EnsureSanitized(string reportJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reportJson);
+        if (ForbiddenTerms.Any(term => reportJson.Contains(
+                term,
+                StringComparison.OrdinalIgnoreCase)))
+        {
+            throw new InvalidDataException(
+                "The aria2 TLS report contains evidence that is not safe to persist.");
+        }
+
+        return reportJson;
+    }
+
+    public static async Task WriteAsync(
+        string reportPath,
+        string reportJson,
+        CancellationToken cancellationToken)
+    {
+        await WriteAsync(
+            reportPath,
+            reportJson,
+            directory => _ = Directory.CreateDirectory(directory),
+            File.WriteAllTextAsync,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    internal static async Task WriteAsync(
+        string reportPath,
+        string reportJson,
+        Action<string> createDirectory,
+        Func<string, string, CancellationToken, Task> writeAllTextAsync,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(reportPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(reportJson);
+        ArgumentNullException.ThrowIfNull(createDirectory);
+        ArgumentNullException.ThrowIfNull(writeAllTextAsync);
+
+        var fullPath = Path.GetFullPath(reportPath);
+        var directory = Path.GetDirectoryName(fullPath);
+        if (directory != null)
+        {
+            createDirectory(directory);
+        }
+
+        await writeAllTextAsync(
+            fullPath,
+            reportJson,
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsReportWriterTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsReportWriterTests.cs
@@ -1,0 +1,161 @@
+namespace DownKyi.Tests;
+
+public sealed class Aria2TlsReportWriterTests
+{
+    [Fact]
+    public void BuildSeparatesCompletePassingEvidenceFromPartialEvidence()
+    {
+        Aria2TlsCaseResult[] cases =
+        [
+            new("trusted", true, "complete"),
+            new("untrusted", true, "rejected")
+        ];
+        var context = CreateContext();
+
+        var complete = Aria2TlsReportWriter.Build(2, cases, context);
+        var partial = Aria2TlsReportWriter.Build(3, cases, context);
+
+        Assert.True(complete.Complete);
+        Assert.True(complete.Passed);
+        Assert.False(partial.Complete);
+        Assert.False(partial.Passed);
+        Assert.Same(cases, complete.Cases);
+    }
+
+    [Fact]
+    public void SerializeThenSanitizeReturnsSafeJsonUnchanged()
+    {
+        var report = Aria2TlsReportWriter.Build(
+            1,
+            [new Aria2TlsCaseResult("trusted", true, "complete")],
+            CreateContext());
+
+        var reportJson = Aria2TlsReportWriter.Serialize(report);
+        var sanitized = Aria2TlsReportWriter.EnsureSanitized(reportJson);
+
+        Assert.Same(reportJson, sanitized);
+        Assert.Contains("\"SchemaVersion\": 2", sanitized, StringComparison.Ordinal);
+        Assert.Contains("\"Complete\": true", sanitized, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("test-session=fixture")]
+    [InlineData("Bearer fixture")]
+    [InlineData("Basic Zml4dHVyZQ==")]
+    [InlineData("X-Access-Token: fixture")]
+    [InlineData("X-API-Key: fixture")]
+    [InlineData("sessdata")]
+    [InlineData("bili_jct")]
+    [InlineData("dedeuserid")]
+    [InlineData("http://")]
+    [InlineData("https://")]
+    [InlineData("C:\\Users\\")]
+    [InlineData("/Users/")]
+    [InlineData("/home/")]
+    public void EnsureSanitizedRejectsSensitiveEvidence(string forbiddenTerm)
+    {
+        var reportJson = $"{{\"Outcome\":\"{forbiddenTerm}\"}}";
+
+        Assert.Throws<InvalidDataException>(
+            () => Aria2TlsReportWriter.EnsureSanitized(reportJson));
+    }
+
+    [Fact]
+    public async Task WriteCreatesParentDirectoryAndPersistsExactJson()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-aria2-report-writer-{Guid.NewGuid():N}");
+        var reportPath = Path.Combine(directory, "nested", "report.json");
+        const string reportJson = "{\"SchemaVersion\":2}";
+        try
+        {
+            await Aria2TlsReportWriter.WriteAsync(
+                reportPath,
+                reportJson,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+            Assert.Equal(
+                reportJson,
+                await File.ReadAllTextAsync(
+                    reportPath,
+                    TestContext.Current.CancellationToken).ConfigureAwait(true));
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public void SerializePreservesSerializerFailure()
+    {
+        var failure = new InvalidOperationException("serialization failure");
+        var report = Aria2TlsReportWriter.Build(
+            1,
+            [new Aria2TlsCaseResult("trusted", true, "complete")],
+            CreateContext());
+
+        var actual = Assert.Throws<InvalidOperationException>(() =>
+            Aria2TlsReportWriter.Serialize(report, _ => throw failure));
+
+        Assert.Same(failure, actual);
+    }
+
+    [Fact]
+    public async Task DirectoryCreationFailurePreventsWriteAndRemainsPrimary()
+    {
+        var failure = new UnauthorizedAccessException("directory creation failure");
+        var writeCalled = false;
+
+        var actual = await Record.ExceptionAsync(() => Aria2TlsReportWriter.WriteAsync(
+            Path.Combine("report-parent", "report.json"),
+            "{}",
+            _ => throw failure,
+            (_, _, _) =>
+            {
+                writeCalled = true;
+                return Task.CompletedTask;
+            },
+            TestContext.Current.CancellationToken)).ConfigureAwait(true);
+
+        Assert.Same(failure, actual);
+        Assert.False(writeCalled);
+    }
+
+    [Fact]
+    public async Task WriteFailureOccursAfterDirectoryCreationAndRemainsVisible()
+    {
+        var failure = new IOException("write failure");
+        var directoryCreated = false;
+
+        var actual = await Record.ExceptionAsync(() => Aria2TlsReportWriter.WriteAsync(
+            Path.Combine("report-parent", "report.json"),
+            "{}",
+            _ => directoryCreated = true,
+            (_, _, _) => Task.FromException(failure),
+            TestContext.Current.CancellationToken)).ConfigureAwait(true);
+
+        Assert.Same(failure, actual);
+        Assert.True(directoryCreated);
+    }
+
+    private static Aria2TlsReportContext CreateContext()
+    {
+        return new Aria2TlsReportContext(
+            Runtime: ".NET test",
+            OperatingSystem: "test-os",
+            Architecture: "X64",
+            RuntimeIdentifier: "test-runtime",
+            AssetRuntimeIdentifier: "test-asset",
+            CommitSha: "test-commit",
+            AriaVersion: "1.0-test",
+            BinarySha256: new string('A', 64),
+            RequiredFeature: Aria2TlsTestRuntime.SecureRedirectFeature,
+            TlsBackend: "test-backend",
+            CertificateAuthoritySource: "test-root-store");
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsRuntimeLifecycleTests.cs
+++ b/tests/DownKyi.Tests/Aria2TlsRuntimeLifecycleTests.cs
@@ -1,0 +1,696 @@
+using DownKyi.Core.Aria2cNet.Client;
+using DownKyi.TestInfrastructure;
+
+namespace DownKyi.Tests;
+
+public sealed class Aria2TlsRuntimeLifecycleTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(6)]
+    public async Task StartupFailureRollsBackEveryPreviouslyAcquiredStage(int failureIndex)
+    {
+        var acquired = new List<int>();
+        var rolledBack = new List<int>();
+        var primary = new TestStageException($"startup-{failureIndex}");
+        var steps = Enumerable.Range(0, 7)
+            .Select(index => new Aria2TlsStartupStep(
+                $"stage-{index}",
+                _ =>
+                {
+                    if (index == failureIndex)
+                    {
+                        return Task.FromException(primary);
+                    }
+
+                    acquired.Add(index);
+                    return Task.CompletedTask;
+                },
+                () =>
+                {
+                    rolledBack.Add(index);
+                    return Task.CompletedTask;
+                }))
+            .ToArray();
+
+        var exception = await Record.ExceptionAsync(() =>
+            Aria2TlsRuntimeStartup.RunAsync(
+                steps,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(primary, exception);
+        Assert.Equal(Enumerable.Range(0, failureIndex), acquired);
+        Assert.Equal(
+            Enumerable.Range(0, failureIndex).Reverse(),
+            rolledBack);
+    }
+
+    [Fact]
+    public async Task StartupPrimaryRemainsFirstWhenEveryRollbackFails()
+    {
+        var rollbackOrder = new List<string>();
+        var primary = new TestStageException("startup-primary");
+        var steps = new[]
+        {
+            CreateFailingRollbackStep("working-directory", rollbackOrder),
+            CreateFailingRollbackStep("trusted-root", rollbackOrder),
+            new Aria2TlsStartupStep(
+                "process",
+                _ => Task.FromException(primary))
+        };
+
+        var exception = await Assert.ThrowsAsync<Aria2TlsMultipleFailuresException>(() =>
+            Aria2TlsRuntimeStartup.RunAsync(
+                steps,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(primary, exception.PrimaryFailure.Exception);
+        Assert.Equal(
+            [
+                "runtime-startup/process",
+                "runtime-startup-rollback/trusted-root",
+                "runtime-startup-rollback/working-directory"
+            ],
+            exception.Failures.Select(failure => failure.Stage));
+        Assert.Equal(["trusted-root", "working-directory"], rollbackOrder);
+    }
+
+    [Fact]
+    public async Task PartialAcquisitionFailureRunsItsOwnRollbackAndPreservesPrimary()
+    {
+        var primary = new TestStageException("restrict-secret");
+        var rollbackFailure = new TestStageException("delete-secret");
+        var rollbackCalled = false;
+
+        var exception = await Assert.ThrowsAsync<Aria2TlsMultipleFailuresException>(() =>
+            Aria2TlsRuntimeStartup.AcquireWithPartialRollbackAsync(
+                "rpc-secret",
+                _ => Task.FromException(primary),
+                () =>
+                {
+                    rollbackCalled = true;
+                    return Task.FromException(rollbackFailure);
+                },
+                TestContext.Current.CancellationToken));
+
+        Assert.True(rollbackCalled);
+        Assert.Equal(
+            ["runtime-startup/rpc-secret", "runtime-startup-rollback/rpc-secret"],
+            exception.Failures.Select(failure => failure.Stage));
+        Assert.Same(primary, exception.PrimaryFailure.Exception);
+        Assert.Same(rollbackFailure, exception.Failures[1].Exception);
+    }
+
+    [Fact]
+    public async Task FailureBeforeProcessCreationRemovesTheWorkingDirectory()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-tls-startup-{Guid.NewGuid():N}");
+        var primary = new TestStageException("trust-file-write");
+        var steps = new[]
+        {
+            new Aria2TlsStartupStep(
+                "working-directory",
+                _ =>
+                {
+                    Directory.CreateDirectory(directory);
+                    return Task.CompletedTask;
+                },
+                () =>
+                {
+                    Directory.Delete(directory, recursive: true);
+                    return Task.CompletedTask;
+                }),
+            new Aria2TlsStartupStep(
+                "trusted-root-files",
+                _ => Task.FromException(primary))
+        };
+
+        var exception = await Record.ExceptionAsync(() =>
+            Aria2TlsRuntimeStartup.RunAsync(
+                steps,
+                TestContext.Current.CancellationToken));
+
+        Assert.Same(primary, exception);
+        Assert.False(Directory.Exists(directory));
+    }
+
+    [Fact]
+    public async Task GracefulRpcShutdownWaitsWithoutKillingTheProcess()
+    {
+        var process = new FakeProcessHandle();
+        process.WaitBehaviors.Enqueue(cancellationToken =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            process.Exited = true;
+            return Task.CompletedTask;
+        });
+        var lifetime = CreateProcessLifetime(process, () => Task.CompletedTask);
+        var failures = new Aria2TlsFailureCollector();
+
+        await lifetime.CleanupAsync(failures);
+
+        Assert.Empty(failures.Failures);
+        Assert.Equal(1, process.WaitCount);
+        Assert.False(process.KillCalled);
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task RpcShutdownFailureStillKillsAndBoundedlyReapsTheProcess()
+    {
+        var process = CreateTimeoutThenExitProcess();
+        var shutdownFailure = new TestStageException("rpc-shutdown");
+        var lifetime = CreateProcessLifetime(
+            process,
+            () => Task.FromException(shutdownFailure));
+        var failures = new Aria2TlsFailureCollector();
+
+        await lifetime.CleanupAsync(failures);
+
+        var failure = Assert.Single(failures.Failures);
+        Assert.Equal("runtime-disposal", failure.Stage);
+        Assert.Same(shutdownFailure, failure.Exception);
+        Assert.True(process.KillCalled);
+        Assert.Equal(2, process.WaitCount);
+        Assert.All(process.ObservedWaitTokens, token => Assert.True(token.CanBeCanceled));
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task RpcShutdownTimeoutStillKillsAndBoundedlyReapsTheProcess()
+    {
+        var process = CreateTimeoutThenExitProcess();
+        var shutdownCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var lifetime = CreateProcessLifetime(
+            process,
+            () => shutdownCompletion.Task);
+        var failures = new Aria2TlsFailureCollector();
+
+        await lifetime.CleanupAsync(failures);
+
+        var failure = Assert.Single(failures.Failures);
+        Assert.Equal("runtime-disposal", failure.Stage);
+        Assert.IsType<TimeoutException>(failure.Exception);
+        Assert.True(process.KillCalled);
+        Assert.Equal(2, process.WaitCount);
+        Assert.All(process.ObservedWaitTokens, token => Assert.True(token.CanBeCanceled));
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task TimedOutRpcShutdownLateFailureIsObservedAfterReap()
+    {
+        var process = CreateTimeoutThenExitProcess();
+        var lateFailure = new TestStageException("late RPC shutdown");
+        var shutdownCompletion = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        process.OnKill = () => shutdownCompletion.SetException(lateFailure);
+        var lifetime = CreateProcessLifetime(
+            process,
+            () => shutdownCompletion.Task);
+        var failures = new Aria2TlsFailureCollector();
+
+        await lifetime.CleanupAsync(failures);
+
+        Assert.Equal(
+            ["runtime-disposal", "runtime-disposal/late-completion"],
+            failures.Failures.Select(failure => failure.Stage));
+        Assert.IsType<TimeoutException>(failures.Failures[0].Exception);
+        Assert.Same(lateFailure, failures.Failures[1].Exception);
+        Assert.True(process.KillCalled);
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task KillAndReapFailuresDoNotPreventDrainOrProcessDisposal()
+    {
+        var process = new FakeProcessHandle
+        {
+            KillFailure = new TestStageException("kill")
+        };
+        process.WaitBehaviors.Enqueue(token => Task.Delay(Timeout.InfiniteTimeSpan, token));
+        process.WaitBehaviors.Enqueue(_ => Task.FromException(
+            new TestStageException("reap")));
+        var stdoutFailure = new TestStageException("stdout");
+        var stderrObserved = false;
+        var lifetime = CreateProcessLifetime(
+            process,
+            () => Task.CompletedTask,
+            Task.FromException<string>(stdoutFailure),
+            ObserveStderrAsync());
+        var failures = new Aria2TlsFailureCollector();
+
+        await lifetime.CleanupAsync(failures);
+
+        Assert.Equal(
+            ["process-kill", "process-reap", "stdout-drain"],
+            failures.Failures.Select(failure => failure.Stage));
+        Assert.True(stderrObserved);
+        Assert.True(process.Disposed);
+        Assert.All(process.ObservedWaitTokens, token => Assert.True(token.CanBeCanceled));
+
+        async Task<string> ObserveStderrAsync()
+        {
+            await Task.Yield();
+            stderrObserved = true;
+            return "observed";
+        }
+    }
+
+    [Fact]
+    public async Task StdoutAndStderrFailuresAreBothObservedInStableOrder()
+    {
+        var process = new FakeProcessHandle { Exited = true };
+        var stdoutFailure = new TestStageException("stdout");
+        var stderrFailure = new TestStageException("stderr");
+        var lifetime = CreateProcessLifetime(
+            process,
+            () => Task.CompletedTask,
+            Task.FromException<string>(stdoutFailure),
+            Task.FromException<string>(stderrFailure));
+        var failures = new Aria2TlsFailureCollector();
+
+        await lifetime.CleanupAsync(failures);
+
+        Assert.Equal(
+            ["stdout-drain", "stderr-drain"],
+            failures.Failures.Select(failure => failure.Stage));
+        Assert.Same(stdoutFailure, failures.Failures[0].Exception);
+        Assert.Same(stderrFailure, failures.Failures[1].Exception);
+        Assert.True(process.Disposed);
+    }
+
+    [Fact]
+    public async Task CallerCancellationDoesNotCancelCleanupOwnedOutputDrain()
+    {
+        using var callerCancellation = new CancellationTokenSource();
+        await callerCancellation.CancelAsync();
+        using var process = new FakeProcessHandle { Exited = true };
+        var stdoutObserved = false;
+        var stderrObserved = false;
+        var lifetime = CreateProcessLifetime(
+            process,
+            () => Task.CompletedTask,
+            ObserveAsync(() => stdoutObserved = true),
+            ObserveAsync(() => stderrObserved = true));
+        await using var lifetimeScope = lifetime.ConfigureAwait(true);
+        var failures = new Aria2TlsFailureCollector();
+
+        await lifetime.CleanupAsync(failures);
+
+        Assert.True(callerCancellation.IsCancellationRequested);
+        Assert.True(stdoutObserved);
+        Assert.True(stderrObserved);
+        Assert.Empty(failures.Failures);
+
+        static async Task<string> ObserveAsync(Action observed)
+        {
+            await Task.Yield();
+            observed();
+            return "observed";
+        }
+    }
+
+    [Fact]
+    public async Task RuntimeAttemptsDirectoryCleanupAfterTrustedRootFailure()
+    {
+        var process = new FakeProcessHandle { Exited = true };
+        var lifetime = CreateProcessLifetime(process, () => Task.CompletedTask);
+        await using var lifetimeScope = lifetime.ConfigureAwait(true);
+        var rootFailure = new TestStageException("root");
+        var filesystemFailure = new TestStageException("filesystem");
+        var root = new FakeTrustedRoot(rootFailure);
+        await using var rootScope = root.ConfigureAwait(true);
+        var directoryCalled = false;
+        var client = new AriaClient(
+            "http://localhost",
+            6800,
+            "test-token",
+            (_, _) => Task.FromResult<string?>(null));
+        var caught = await Record.ExceptionAsync(async () =>
+        {
+            var runtime = new Aria2TlsTestRuntime(
+                lifetime,
+                client,
+                root,
+                "test-directory",
+                "test-version",
+                "test-hash",
+                _ =>
+                {
+                    directoryCalled = true;
+                    throw filesystemFailure;
+                });
+            await using var runtimeScope = runtime.ConfigureAwait(true);
+        }).ConfigureAwait(true);
+        var exception = Assert.IsType<Aria2TlsMultipleFailuresException>(caught);
+
+        Assert.Equal(
+            ["trusted-root", "filesystem"],
+            exception.Failures.Select(failure => failure.Stage));
+        Assert.Same(rootFailure, exception.Failures[0].Exception);
+        Assert.Same(filesystemFailure, exception.Failures[1].Exception);
+        Assert.True(root.Disposed);
+        Assert.True(directoryCalled);
+    }
+
+    [Fact]
+    public async Task LinuxTrustedRootInstallRollbackPreservesEveryFailure()
+    {
+        using var authority = new TestCertificateAuthority("DownKyi TLS Root Test");
+        var commands = new List<string>();
+        var primary = new TestStageException("install-update");
+        var removeFailure = new TestStageException("rollback-remove");
+        var updateFailure = new TestStageException("rollback-update");
+        var updateCount = 0;
+
+        var exception = await Assert.ThrowsAsync<Aria2TlsMultipleFailuresException>(() =>
+            TrustedRootScope.InstallAsync(
+                authority.RootCertificate,
+                "root.pem",
+                "root.cer",
+                Aria2TlsHostPlatform.Linux,
+                RunCommandAsync,
+                _ => throw new InvalidOperationException("Windows registration was not expected."),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(4, commands.Count);
+        Assert.Equal(
+            [
+                "trusted-root-install",
+                "trusted-root-install-rollback/remove",
+                "trusted-root-install-rollback/update"
+            ],
+            exception.Failures.Select(failure => failure.Stage));
+        Assert.Same(primary, exception.Failures[0].Exception);
+        Assert.Same(removeFailure, exception.Failures[1].Exception);
+        Assert.Same(updateFailure, exception.Failures[2].Exception);
+
+        Task RunCommandAsync(
+            string _,
+            IReadOnlyList<string> arguments,
+            CancellationToken __)
+        {
+            commands.Add(string.Join(' ', arguments));
+            if (arguments.Contains("rm", StringComparer.Ordinal))
+            {
+                return Task.FromException(removeFailure);
+            }
+
+            if (arguments.Contains("update-ca-certificates", StringComparer.Ordinal))
+            {
+                updateCount++;
+                return Task.FromException(updateCount == 1 ? primary : updateFailure);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LinuxTrustedRootCopyFailureStillRunsCompleteRollback()
+    {
+        using var authority = new TestCertificateAuthority("DownKyi TLS Root Copy Test");
+        var primary = new IOException("partial certificate copy");
+        var commands = new List<string>();
+        var cleanupTokens = new List<CancellationToken>();
+
+        var actual = await Record.ExceptionAsync(() => TrustedRootScope.InstallAsync(
+            authority.RootCertificate,
+            "root.pem",
+            "root.cer",
+            Aria2TlsHostPlatform.Linux,
+            RunCommandAsync,
+            _ => throw new InvalidOperationException("Windows registration was not expected."),
+            TestContext.Current.CancellationToken));
+
+        Assert.Same(primary, actual);
+        Assert.Equal(3, commands.Count);
+        Assert.Contains(" install ", $" {commands[0]} ", StringComparison.Ordinal);
+        Assert.Contains(" rm ", $" {commands[1]} ", StringComparison.Ordinal);
+        Assert.Contains("update-ca-certificates", commands[2], StringComparison.Ordinal);
+        Assert.All(cleanupTokens, token => Assert.True(token.CanBeCanceled));
+
+        Task RunCommandAsync(
+            string _,
+            IReadOnlyList<string> arguments,
+            CancellationToken cancellationToken)
+        {
+            commands.Add(string.Join(' ', arguments));
+            if (arguments.Contains("install", StringComparer.Ordinal))
+            {
+                return Task.FromException(primary);
+            }
+
+            cleanupTokens.Add(cancellationToken);
+            return Task.CompletedTask;
+        }
+    }
+
+    [Fact]
+    public async Task LinuxTrustedRootRemovalAttemptsUpdateAfterRemoveFailure()
+    {
+        using var authority = new TestCertificateAuthority("DownKyi TLS Root Removal Test");
+        var removeFailure = new TestStageException("remove");
+        var updateFailure = new TestStageException("update");
+        var removalMode = false;
+        var calls = new List<string>();
+        var cleanupTokens = new List<CancellationToken>();
+        var scope = await TrustedRootScope.InstallAsync(
+            authority.RootCertificate,
+            "root.pem",
+            "root.cer",
+            Aria2TlsHostPlatform.Linux,
+            RunCommandAsync,
+            _ => throw new InvalidOperationException("Windows registration was not expected."),
+            TestContext.Current.CancellationToken);
+        removalMode = true;
+
+        var exception = await Assert.ThrowsAsync<Aria2TlsMultipleFailuresException>(
+            () => scope.DisposeAsync().AsTask());
+
+        Assert.Equal(
+            ["trusted-root-remove/linux-remove", "trusted-root-remove/linux-update"],
+            exception.Failures.Select(failure => failure.Stage));
+        Assert.Equal(2, calls.Count);
+        Assert.All(cleanupTokens, token => Assert.True(token.CanBeCanceled));
+
+        Task RunCommandAsync(
+            string _,
+            IReadOnlyList<string> arguments,
+            CancellationToken __)
+        {
+            if (!removalMode)
+            {
+                return Task.CompletedTask;
+            }
+
+            calls.Add(string.Join(' ', arguments));
+            cleanupTokens.Add(__);
+            return Task.FromException(
+                arguments.Contains("rm", StringComparer.Ordinal)
+                    ? removeFailure
+                    : updateFailure);
+        }
+    }
+
+    [Fact]
+    public async Task MacTrustedRootPartialInstallRollsBackAndPreservesPrimary()
+    {
+        using var authority = new TestCertificateAuthority("DownKyi TLS Mac Root Test");
+        var primary = new TestStageException("macos-add");
+        var rollback = new TestStageException("macos-delete");
+        var commands = new List<string>();
+
+        var exception = await Assert.ThrowsAsync<Aria2TlsMultipleFailuresException>(() =>
+            TrustedRootScope.InstallAsync(
+                authority.RootCertificate,
+                "root.pem",
+                "root.cer",
+                Aria2TlsHostPlatform.MacOS,
+                RunCommandAsync,
+                _ => throw new InvalidOperationException("Windows registration was not expected."),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(2, commands.Count);
+        Assert.Contains("add-trusted-cert", commands[0], StringComparison.Ordinal);
+        Assert.Contains("delete-certificate", commands[1], StringComparison.Ordinal);
+        Assert.Equal(
+            ["trusted-root-install/macos-add", "trusted-root-install-rollback/macos-delete"],
+            exception.Failures.Select(failure => failure.Stage));
+        Assert.Same(primary, exception.PrimaryFailure.Exception);
+        Assert.Same(rollback, exception.Failures[1].Exception);
+
+        Task RunCommandAsync(
+            string _,
+            IReadOnlyList<string> arguments,
+            CancellationToken __)
+        {
+            commands.Add(string.Join(' ', arguments));
+            return Task.FromException(commands.Count == 1 ? primary : rollback);
+        }
+    }
+
+    [Fact]
+    public void WindowsTrustedRootRemovalObservesDeleteAndCloseFailures()
+    {
+        var deleteCalled = false;
+        var closeCalled = false;
+        using var registration = WindowsTrustedRootRegistration.CreateForTest(
+            _ =>
+            {
+                deleteCalled = true;
+                return false;
+            },
+            _ =>
+            {
+                closeCalled = true;
+                return false;
+            });
+
+        var exception = Assert.Throws<Aria2TlsMultipleFailuresException>(registration.Dispose);
+
+        Assert.Equal(
+            [
+                "trusted-root-remove/windows-delete",
+                "trusted-root-remove/windows-close"
+            ],
+            exception.Failures.Select(failure => failure.Stage));
+        Assert.True(deleteCalled);
+        Assert.True(closeCalled);
+    }
+
+    private static Aria2TlsStartupStep CreateFailingRollbackStep(
+        string name,
+        List<string> rollbackOrder)
+    {
+        return new Aria2TlsStartupStep(
+            name,
+            _ => Task.CompletedTask,
+            () =>
+            {
+                rollbackOrder.Add(name);
+                return Task.FromException(new TestStageException($"rollback-{name}"));
+            });
+    }
+
+    private static FakeProcessHandle CreateTimeoutThenExitProcess()
+    {
+        var process = new FakeProcessHandle();
+        process.WaitBehaviors.Enqueue(token => Task.Delay(Timeout.InfiniteTimeSpan, token));
+        process.WaitBehaviors.Enqueue(_ =>
+        {
+            process.Exited = true;
+            return Task.CompletedTask;
+        });
+        return process;
+    }
+
+    private static Aria2TlsProcessLifetime CreateProcessLifetime(
+        FakeProcessHandle process,
+        Func<Task> forceShutdown,
+        Task<string>? standardOutput = null,
+        Task<string>? standardError = null)
+    {
+        return new Aria2TlsProcessLifetime(
+            process,
+            standardOutput ?? Task.FromResult(string.Empty),
+            standardError ?? Task.FromResult(string.Empty),
+            new CancellationTokenSource(),
+            forceShutdown,
+            TimeSpan.FromMilliseconds(20),
+            TimeSpan.FromMilliseconds(20));
+    }
+
+    private sealed class FakeProcessHandle : IAria2TlsProcessHandle
+    {
+        public Queue<Func<CancellationToken, Task>> WaitBehaviors { get; } = new();
+
+        public List<CancellationToken> ObservedWaitTokens { get; } = [];
+
+        public bool Disposed { get; private set; }
+
+        public bool Exited { get; set; }
+
+        public bool KillCalled { get; private set; }
+
+        public Exception? KillFailure { get; init; }
+
+        public Action? OnKill { get; set; }
+
+        public int WaitCount { get; private set; }
+
+        public bool HasExited => Exited;
+
+        public void KillEntireTree()
+        {
+            KillCalled = true;
+            OnKill?.Invoke();
+            if (KillFailure != null)
+            {
+                throw KillFailure;
+            }
+        }
+
+        public async Task WaitForExitAsync(CancellationToken cancellationToken)
+        {
+            WaitCount++;
+            ObservedWaitTokens.Add(cancellationToken);
+            if (WaitBehaviors.Count == 0)
+            {
+                Exited = true;
+                return;
+            }
+
+            await WaitBehaviors.Dequeue()(cancellationToken).ConfigureAwait(false);
+        }
+
+        public void Dispose()
+        {
+            Disposed = true;
+        }
+    }
+
+    private sealed class FakeTrustedRoot(Exception failure) : IAria2TlsTrustedRoot
+    {
+        public string Source => "fake-root";
+
+        public bool Disposed { get; private set; }
+
+        public ValueTask DisposeAsync()
+        {
+            if (Disposed)
+            {
+                return ValueTask.CompletedTask;
+            }
+
+            Disposed = true;
+            return ValueTask.FromException(failure);
+        }
+    }
+
+    private sealed class TestStageException : Exception
+    {
+        public TestStageException()
+        {
+        }
+
+        public TestStageException(string message)
+            : base(message)
+        {
+        }
+
+        public TestStageException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsRuntimeStartup.cs
+++ b/tests/DownKyi.Tests/Aria2TlsRuntimeStartup.cs
@@ -1,0 +1,69 @@
+namespace DownKyi.Tests;
+
+internal sealed record Aria2TlsStartupStep(
+    string Name,
+    Func<CancellationToken, Task> AcquireAsync,
+    Func<Task>? RollbackAsync = null);
+
+internal static class Aria2TlsRuntimeStartup
+{
+    public static async Task AcquireWithPartialRollbackAsync(
+        string stage,
+        Func<CancellationToken, Task> acquireAsync,
+        Func<Task> rollbackAsync,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(stage);
+        ArgumentNullException.ThrowIfNull(acquireAsync);
+        ArgumentNullException.ThrowIfNull(rollbackAsync);
+        var exception = await Record.ExceptionAsync(
+            () => acquireAsync(cancellationToken)).ConfigureAwait(false);
+        if (exception == null)
+        {
+            return;
+        }
+
+        var failures = new Aria2TlsFailureCollector();
+        failures.Capture($"runtime-startup/{stage}", exception);
+        await failures.RunAsync(
+            $"runtime-startup-rollback/{stage}",
+            rollbackAsync).ConfigureAwait(false);
+        failures.ThrowIfAny();
+    }
+
+    public static async Task RunAsync(
+        IReadOnlyList<Aria2TlsStartupStep> steps,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(steps);
+        var acquired = new List<Aria2TlsStartupStep>(steps.Count);
+        foreach (var step in steps)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(step.Name);
+            var exception = await Record.ExceptionAsync(
+                () => step.AcquireAsync(cancellationToken)).ConfigureAwait(false);
+            if (exception == null)
+            {
+                if (step.RollbackAsync != null)
+                {
+                    acquired.Add(step);
+                }
+
+                continue;
+            }
+
+            var failures = new Aria2TlsFailureCollector();
+            failures.Capture($"runtime-startup/{step.Name}", exception);
+            for (var index = acquired.Count - 1; index >= 0; index--)
+            {
+                var acquiredStep = acquired[index];
+                await failures.RunAsync(
+                    $"runtime-startup-rollback/{acquiredStep.Name}",
+                    acquiredStep.RollbackAsync!).ConfigureAwait(false);
+            }
+
+            failures.ThrowIfAny();
+            throw new InvalidOperationException("Unreachable startup failure path.");
+        }
+    }
+}

--- a/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
+++ b/tests/DownKyi.Tests/Aria2TlsTestRuntime.cs
@@ -16,31 +16,29 @@ namespace DownKyi.Tests;
 internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
 {
     public const string SecureRedirectFeature = "downkyi-secure-redirect-v2";
-    private readonly Process _process;
-    private readonly Task<string> _standardError;
-    private readonly Task<string> _standardOutput;
-    private readonly TrustedRootScope _trustedRoot;
+    private readonly Action<string> _deleteDirectory;
+    private readonly object _disposeSync = new();
+    private readonly Aria2TlsProcessLifetime _processLifetime;
+    private readonly IAria2TlsTrustedRoot _trustedRoot;
     private readonly string _workingDirectory;
-    private bool _disposed;
+    private Task? _disposeTask;
 
-    private Aria2TlsTestRuntime(
-        Process process,
-        Task<string> standardOutput,
-        Task<string> standardError,
+    internal Aria2TlsTestRuntime(
+        Aria2TlsProcessLifetime processLifetime,
         AriaClient client,
-        TrustedRootScope trustedRoot,
+        IAria2TlsTrustedRoot trustedRoot,
         string workingDirectory,
         string ariaVersion,
-        string binarySha256)
+        string binarySha256,
+        Action<string>? deleteDirectory = null)
     {
-        _process = process;
-        _standardOutput = standardOutput;
-        _standardError = standardError;
+        _processLifetime = processLifetime;
         Client = client;
         _trustedRoot = trustedRoot;
         _workingDirectory = workingDirectory;
         AriaVersion = ariaVersion;
         BinarySha256 = binarySha256;
+        _deleteDirectory = deleteDirectory ?? DeleteDirectory;
     }
 
     public AriaClient Client { get; }
@@ -75,76 +73,140 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
         var workingDirectory = Path.Combine(
             Path.GetTempPath(),
             $"downkyi-aria2-tls-{Guid.NewGuid():N}");
-        Directory.CreateDirectory(workingDirectory);
         var rootPath = Path.Combine(workingDirectory, "trusted-root.pem");
-        await File.WriteAllTextAsync(
-            rootPath,
-            trustedRoot.ExportCertificatePem(),
-            cancellationToken).ConfigureAwait(false);
         var rootCertificatePath = Path.Combine(workingDirectory, "trusted-root.cer");
-        await File.WriteAllBytesAsync(
-            rootCertificatePath,
-            trustedRoot.Export(X509ContentType.Cert),
-            cancellationToken).ConfigureAwait(false);
-        var trustedRootScope = await TrustedRootScope.InstallAsync(
-            trustedRoot,
-            rootPath,
-            rootCertificatePath,
-            cancellationToken).ConfigureAwait(false);
-        Process? process = null;
-        try
-        {
-            var port = GetAvailablePort();
-            var token = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
-            var secretFile = Path.Combine(workingDirectory, $".rpc-{Guid.NewGuid():N}.conf");
-            await File.WriteAllTextAsync(
-                secretFile,
-                $"rpc-secret={token}{Environment.NewLine}",
-                cancellationToken).ConfigureAwait(false);
-            RestrictSecretFile(secretFile);
+        var port = GetAvailablePort();
+        var rpcToken = Convert.ToHexString(RandomNumberGenerator.GetBytes(32));
+        var secretFile = Path.Combine(workingDirectory, $".rpc-{Guid.NewGuid():N}.conf");
+        var client = new AriaClient("http://127.0.0.1", port, rpcToken);
+        TrustedRootScope? trustedRootScope = null;
+        Aria2TlsProcessLifetime? processLifetime = null;
+        Process? startedProcess = null;
+        string? version = null;
+        await Aria2TlsRuntimeStartup.RunAsync(
+        [
+            new Aria2TlsStartupStep(
+                "working-directory",
+                _ =>
+                {
+                    Directory.CreateDirectory(workingDirectory);
+                    return Task.CompletedTask;
+                },
+                () =>
+                {
+                    DeleteDirectory(workingDirectory);
+                    return Task.CompletedTask;
+                }),
+            new Aria2TlsStartupStep(
+                "trusted-root-files",
+                async cancellation =>
+                {
+                    await File.WriteAllTextAsync(
+                        rootPath,
+                        trustedRoot.ExportCertificatePem(),
+                        cancellation).ConfigureAwait(false);
+                    await File.WriteAllBytesAsync(
+                        rootCertificatePath,
+                        trustedRoot.Export(X509ContentType.Cert),
+                        cancellation).ConfigureAwait(false);
+                }),
+            new Aria2TlsStartupStep(
+                "trusted-root-install",
+                async cancellation =>
+                {
+                    trustedRootScope = await TrustedRootScope.InstallAsync(
+                        trustedRoot,
+                        rootPath,
+                        rootCertificatePath,
+                        cancellation).ConfigureAwait(false);
+                },
+                () => trustedRootScope!.DisposeAsync().AsTask()),
+            new Aria2TlsStartupStep(
+                "rpc-secret",
+                cancellation => Aria2TlsRuntimeStartup.AcquireWithPartialRollbackAsync(
+                    "rpc-secret",
+                    async acquisitionCancellation =>
+                    {
+                        await File.WriteAllTextAsync(
+                            secretFile,
+                            $"rpc-secret={rpcToken}{Environment.NewLine}",
+                            acquisitionCancellation).ConfigureAwait(false);
+                        RestrictSecretFile(secretFile);
+                    },
+                    () =>
+                    {
+                        DeleteSecretFile(secretFile);
+                        return Task.CompletedTask;
+                    },
+                    cancellation),
+                () =>
+                {
+                    DeleteSecretFile(secretFile);
+                    return Task.CompletedTask;
+                }),
+            new Aria2TlsStartupStep(
+                "process",
+                async _ =>
+                {
+                    var startInfo = CreateStartInfo(
+                        binaryPath,
+                        workingDirectory,
+                        secretFile,
+                        port);
+                    var process = new Process { StartInfo = startInfo };
+                    var startFailure = Record.Exception(() =>
+                    {
+                        if (!process.Start())
+                        {
+                            throw new InvalidOperationException(
+                                "The aria2 TLS test process did not start.");
+                        }
+                    });
+                    if (startFailure != null)
+                    {
+                        var failures = new Aria2TlsFailureCollector();
+                        failures.Capture("runtime-startup/process", startFailure);
+                        failures.Run(
+                            "runtime-startup-rollback/process-dispose",
+                            process.Dispose);
+                        failures.ThrowIfAny();
+                        throw new InvalidOperationException(
+                            "Unreachable process startup failure path.");
+                    }
 
-            var startInfo = CreateStartInfo(
-                binaryPath,
-                workingDirectory,
-                secretFile,
-                port);
-            process = new Process { StartInfo = startInfo };
-            if (!process.Start())
-            {
-                throw new InvalidOperationException("The aria2 TLS test process did not start.");
-            }
+                    startedProcess = process;
+                    processLifetime = await Aria2TlsProcessLifetime.CreateAsync(
+                        process,
+                        () => client.ForceShutdownAsync(),
+                        TimeSpan.FromSeconds(5),
+                        TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+                },
+                () => processLifetime!.DisposeAsync().AsTask()),
+            new Aria2TlsStartupStep(
+                "rpc-ready",
+                async cancellation =>
+                {
+                    version = await WaitForReadyAsync(
+                        startedProcess!,
+                        client,
+                        cancellation).ConfigureAwait(false);
+                }),
+            new Aria2TlsStartupStep(
+                "rpc-secret-delete",
+                _ =>
+                {
+                    DeleteSecretFile(secretFile);
+                    return Task.CompletedTask;
+                })
+        ], cancellationToken).ConfigureAwait(false);
 
-            var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
-            var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
-            var client = new AriaClient("http://127.0.0.1", port, token);
-            var version = await WaitForReadyAsync(
-                process,
-                client,
-                cancellationToken).ConfigureAwait(false);
-            DeleteSecretFile(secretFile);
-            return new Aria2TlsTestRuntime(
-                process,
-                standardOutput,
-                standardError,
-                client,
-                trustedRootScope,
-                workingDirectory,
-                version,
-                binarySha256);
-        }
-        catch
-        {
-            if (process is { HasExited: false })
-            {
-                process.Kill(entireProcessTree: true);
-                await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
-            }
-
-            process?.Dispose();
-            await trustedRootScope.DisposeAsync().ConfigureAwait(false);
-            DeleteDirectory(workingDirectory);
-            throw;
-        }
+        return new Aria2TlsTestRuntime(
+            processLifetime!,
+            client,
+            trustedRootScope!,
+            workingDirectory,
+            version!,
+            binarySha256);
     }
 
     public async Task<string> AddDownloadAsync(
@@ -366,61 +428,68 @@ internal sealed class Aria2TlsTestRuntime : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
-        if (_disposed)
+        Task disposeTask;
+        lock (_disposeSync)
         {
-            return;
+            _disposeTask ??= DisposeCoreAsync();
+            disposeTask = _disposeTask;
         }
 
-        _disposed = true;
-        try
-        {
-            if (!_process.HasExited)
-            {
-                try
-                {
-                    await Client.ForceShutdownAsync().ConfigureAwait(false);
-                }
-                catch (HttpRequestException)
-                {
-                }
+        await disposeTask.ConfigureAwait(false);
+    }
 
-                using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-                try
-                {
-                    await _process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
-                }
-                catch (OperationCanceledException) when (timeout.IsCancellationRequested)
-                {
-                    _process.Kill(entireProcessTree: true);
-                    await _process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
-                }
-            }
-
-            await Task.WhenAll(_standardOutput, _standardError).ConfigureAwait(false);
-        }
-        finally
-        {
-            _process.Dispose();
-            await _trustedRoot.DisposeAsync().ConfigureAwait(false);
-            DeleteDirectory(_workingDirectory);
-        }
+    private async Task DisposeCoreAsync()
+    {
+        var failures = new Aria2TlsFailureCollector();
+        await _processLifetime.CleanupAsync(failures).ConfigureAwait(false);
+        await failures.RunAsync(
+            "trusted-root",
+            () => _trustedRoot.DisposeAsync().AsTask()).ConfigureAwait(false);
+        failures.Run("filesystem", () => _deleteDirectory(_workingDirectory));
+        failures.ThrowIfAny();
     }
 }
 
-internal sealed class TrustedRootScope : IAsyncDisposable
+internal interface IAria2TlsTrustedRoot : IAsyncDisposable
 {
+    string Source { get; }
+}
+
+internal enum Aria2TlsHostPlatform
+{
+    Linux,
+    Windows,
+    MacOS
+}
+
+internal delegate Task Aria2TlsTrustCommand(
+    string fileName,
+    IReadOnlyList<string> arguments,
+    CancellationToken cancellationToken);
+
+internal interface IWindowsTrustedRootRegistration : IDisposable
+{
+    string Source { get; }
+}
+
+internal sealed class TrustedRootScope : IAria2TlsTrustedRoot
+{
+    private static readonly TimeSpan CleanupCommandTimeout = TimeSpan.FromSeconds(15);
     private const string MacSystemKeychain = "/Library/Keychains/System.keychain";
     private readonly string? _linuxCertificatePath;
     private readonly string? _macCommonName;
-    private readonly WindowsTrustedRootRegistration? _windowsRoot;
+    private readonly Aria2TlsTrustCommand _runCommand;
+    private readonly IWindowsTrustedRootRegistration? _windowsRoot;
 
     private TrustedRootScope(
         string source,
-        WindowsTrustedRootRegistration? windowsRoot = null,
+        Aria2TlsTrustCommand runCommand,
+        IWindowsTrustedRootRegistration? windowsRoot = null,
         string? linuxCertificatePath = null,
         string? macCommonName = null)
     {
         Source = source;
+        _runCommand = runCommand;
         _windowsRoot = windowsRoot;
         _linuxCertificatePath = linuxCertificatePath;
         _macCommonName = macCommonName;
@@ -434,70 +503,201 @@ internal sealed class TrustedRootScope : IAsyncDisposable
         string rootCertificatePath,
         CancellationToken cancellationToken)
     {
+        return await InstallAsync(
+            root,
+            rootPemPath,
+            rootCertificatePath,
+            GetHostPlatform(),
+            RunBoundedProcessAsync,
+            InstallWindowsRoot,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    private static IWindowsTrustedRootRegistration InstallWindowsRoot(byte[] certificateBytes)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            throw new PlatformNotSupportedException(
+                "The Windows trusted-root store is only available on Windows.");
+        }
+
+        return WindowsTrustedRootRegistration.Install(certificateBytes);
+    }
+
+    internal static async Task<TrustedRootScope> InstallAsync(
+        X509Certificate2 root,
+        string rootPemPath,
+        string rootCertificatePath,
+        Aria2TlsHostPlatform platform,
+        Aria2TlsTrustCommand runCommand,
+        Func<byte[], IWindowsTrustedRootRegistration> installWindowsRoot,
+        CancellationToken cancellationToken)
+    {
         ArgumentNullException.ThrowIfNull(root);
         ArgumentException.ThrowIfNullOrWhiteSpace(rootPemPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(rootCertificatePath);
+        ArgumentNullException.ThrowIfNull(runCommand);
+        ArgumentNullException.ThrowIfNull(installWindowsRoot);
 
-        if (OperatingSystem.IsLinux())
+        if (platform == Aria2TlsHostPlatform.Linux)
         {
             var installedPath = Path.Combine(
                 "/usr/local/share/ca-certificates",
                 $"downkyi-aria2-{root.Thumbprint}.crt");
-            await RunBoundedProcessAsync(
-                "sudo",
-                ["-n", "install", "-m", "0644", "--", rootPemPath, installedPath],
-                cancellationToken).ConfigureAwait(false);
-            try
-            {
-                await RunBoundedProcessAsync(
+            var copyException = await Record.ExceptionAsync(
+                () => runCommand(
                     "sudo",
-                    ["-n", "update-ca-certificates"],
-                    cancellationToken).ConfigureAwait(false);
+                    ["-n", "install", "-m", "0644", "--", rootPemPath, installedPath],
+                    cancellationToken)).ConfigureAwait(false);
+            if (copyException != null)
+            {
+                await RollBackLinuxInstallAsync(
+                    "trusted-root-install/copy",
+                    copyException,
+                    installedPath,
+                    runCommand).ConfigureAwait(false);
+                throw new InvalidOperationException("Unreachable trusted-root copy rollback path.");
             }
-            catch
-            {
-                await RunBoundedProcessAsync(
-                    "sudo",
-                    ["-n", "rm", "-f", "--", installedPath],
-                    CancellationToken.None).ConfigureAwait(false);
-                await RunBoundedProcessAsync(
+
+            var exception = await Record.ExceptionAsync(
+                () => runCommand(
                     "sudo",
                     ["-n", "update-ca-certificates"],
-                    CancellationToken.None).ConfigureAwait(false);
-                throw;
+                    cancellationToken)).ConfigureAwait(false);
+            if (exception != null)
+            {
+                await RollBackLinuxInstallAsync(
+                    "trusted-root-install",
+                    exception,
+                    installedPath,
+                    runCommand).ConfigureAwait(false);
+                throw new InvalidOperationException("Unreachable trusted-root rollback path.");
             }
 
             return new TrustedRootScope(
                 "linux-system-ca-store",
+                runCommand,
                 linuxCertificatePath: installedPath);
         }
 
-        if (OperatingSystem.IsWindows())
+        if (platform == Aria2TlsHostPlatform.Windows)
         {
-            var registration = WindowsTrustedRootRegistration.Install(root.RawData);
+            var registration = installWindowsRoot(root.RawData);
             return new TrustedRootScope(
                 registration.Source,
+                runCommand,
                 windowsRoot: registration);
         }
 
         var commonName = root.GetNameInfo(X509NameType.SimpleName, forIssuer: false);
-        await RunBoundedProcessAsync(
-            "sudo",
-            [
-                "-n",
-                "security",
-                "add-trusted-cert",
-                "-d",
-                "-r",
-                "trustRoot",
-                "-k",
-                MacSystemKeychain,
-                rootCertificatePath
-            ],
-            cancellationToken).ConfigureAwait(false);
+        var addException = await Record.ExceptionAsync(
+            () => runCommand(
+                "sudo",
+                [
+                    "-n",
+                    "security",
+                    "add-trusted-cert",
+                    "-d",
+                    "-r",
+                    "trustRoot",
+                    "-k",
+                    MacSystemKeychain,
+                    rootCertificatePath
+                ],
+                cancellationToken)).ConfigureAwait(false);
+        if (addException != null)
+        {
+            var failures = new Aria2TlsFailureCollector();
+            failures.Capture("trusted-root-install/macos-add", addException);
+            await failures.RunAsync(
+                "trusted-root-install-rollback/macos-delete",
+                () => RunCleanupCommandAsync(
+                    runCommand,
+                    "sudo",
+                    CreateMacDeleteArguments(commonName))).ConfigureAwait(false);
+            failures.ThrowIfAny();
+            throw new InvalidOperationException("Unreachable macOS trusted-root rollback path.");
+        }
+
         return new TrustedRootScope(
             "macos-system-keychain",
+            runCommand,
             macCommonName: commonName);
+    }
+
+    private static Aria2TlsHostPlatform GetHostPlatform()
+    {
+        if (OperatingSystem.IsLinux())
+        {
+            return Aria2TlsHostPlatform.Linux;
+        }
+
+        return OperatingSystem.IsWindows()
+            ? Aria2TlsHostPlatform.Windows
+            : Aria2TlsHostPlatform.MacOS;
+    }
+
+    private static async Task RollBackLinuxInstallAsync(
+        string primaryStage,
+        Exception primaryException,
+        string installedPath,
+        Aria2TlsTrustCommand runCommand)
+    {
+        var failures = new Aria2TlsFailureCollector();
+        failures.Capture(primaryStage, primaryException);
+        await failures.RunAsync(
+            "trusted-root-install-rollback/remove",
+            () => RunCleanupCommandAsync(
+                runCommand,
+                "sudo",
+                ["-n", "rm", "-f", "--", installedPath])).ConfigureAwait(false);
+        await failures.RunAsync(
+            "trusted-root-install-rollback/update",
+            () => RunCleanupCommandAsync(
+                runCommand,
+                "sudo",
+                ["-n", "update-ca-certificates"])).ConfigureAwait(false);
+        failures.ThrowIfAny();
+    }
+
+    private static async Task RunCleanupCommandAsync(
+        Aria2TlsTrustCommand runCommand,
+        string fileName,
+        IReadOnlyList<string> arguments)
+    {
+        using var deadline = new CancellationTokenSource(CleanupCommandTimeout);
+        var command = runCommand(fileName, arguments, deadline.Token);
+        try
+        {
+            await command.WaitAsync(deadline.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (deadline.IsCancellationRequested)
+        {
+            ObserveLateCommandFault(command);
+            throw;
+        }
+    }
+
+    private static void ObserveLateCommandFault(Task command)
+    {
+        _ = command.ContinueWith(
+            completed => _ = completed.Exception,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously | TaskContinuationOptions.OnlyOnFaulted,
+            TaskScheduler.Default);
+    }
+
+    private static IReadOnlyList<string> CreateMacDeleteArguments(string commonName)
+    {
+        return
+        [
+            "-n",
+            "security",
+            "delete-certificate",
+            "-c",
+            commonName,
+            MacSystemKeychain
+        ];
     }
 
     private static async Task RunBoundedProcessAsync(
@@ -520,92 +720,248 @@ internal sealed class TrustedRootScope : IAsyncDisposable
 
         using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         timeout.CancelAfter(TimeSpan.FromSeconds(15));
-        using var process = Process.Start(startInfo)
+        Process? process = Process.Start(startInfo)
             ?? throw new InvalidOperationException("The certificate trust tool did not start.");
-        var standardError = process.StandardError.ReadToEndAsync(CancellationToken.None);
-        var standardOutput = process.StandardOutput.ReadToEndAsync(CancellationToken.None);
+        using var outputCancellation = new CancellationTokenSource();
+        Task<string>? standardError = null;
+        Task<string>? standardOutput = null;
+        var failures = new Aria2TlsFailureCollector();
         try
         {
-            await process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
+            var outputSetupFailure = Record.Exception(() =>
+            {
+                standardError = process.StandardError.ReadToEndAsync(outputCancellation.Token);
+                standardOutput = process.StandardOutput.ReadToEndAsync(outputCancellation.Token);
+            });
+            if (outputSetupFailure != null)
+            {
+                failures.Capture("trusted-root-command-output-start", outputSetupFailure);
+                await TerminateTrustCommandProcessAsync(process, failures).ConfigureAwait(false);
+                await ObserveTrustCommandOutputAsync(
+                    standardOutput ?? Task.FromResult(string.Empty),
+                    standardError ?? Task.FromResult(string.Empty),
+                    outputCancellation,
+                    failures).ConfigureAwait(false);
+            }
+            else
+            {
+                var waitFailure = await Record.ExceptionAsync(
+                    () => process.WaitForExitAsync(timeout.Token)).ConfigureAwait(false);
+                if (waitFailure != null)
+                {
+                    if (waitFailure is OperationCanceledException
+                        && timeout.IsCancellationRequested)
+                    {
+                        failures.Capture(
+                            "trusted-root-command",
+                            cancellationToken.IsCancellationRequested
+                                ? waitFailure
+                                : new TimeoutException(
+                                    "The certificate trust tool did not finish in time.",
+                                    waitFailure));
+                    }
+                    else
+                    {
+                        failures.Capture("trusted-root-command-wait", waitFailure);
+                    }
+
+                    await TerminateTrustCommandProcessAsync(process, failures)
+                        .ConfigureAwait(false);
+                }
+
+                await ObserveTrustCommandOutputAsync(
+                    standardOutput!,
+                    standardError!,
+                    outputCancellation,
+                    failures).ConfigureAwait(false);
+                if (waitFailure == null)
+                {
+                    failures.Run("trusted-root-command-exit", () =>
+                    {
+                        if (process.ExitCode != 0)
+                        {
+                            throw new InvalidOperationException(
+                                $"The certificate trust command failed with code {process.ExitCode}.");
+                        }
+                    });
+                }
+            }
         }
-        catch (OperationCanceledException) when (timeout.IsCancellationRequested)
+        finally
+        {
+            failures.Run("trusted-root-command-process-dispose", process.Dispose);
+            process = null;
+            failures.Run("trusted-root-command-output-dispose", outputCancellation.Dispose);
+        }
+
+        failures.ThrowIfAny();
+    }
+
+    private static async Task TerminateTrustCommandProcessAsync(
+        Process process,
+        Aria2TlsFailureCollector failures)
+    {
+        failures.Run("trusted-root-command-kill", () =>
         {
             if (!process.HasExited)
             {
                 process.Kill(entireProcessTree: true);
             }
+        });
+        await failures.RunAsync(
+            "trusted-root-command-reap",
+            async () =>
+            {
+                using var reapDeadline = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                try
+                {
+                    await process.WaitForExitAsync(reapDeadline.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException exception)
+                    when (reapDeadline.IsCancellationRequested)
+                {
+                    throw new TimeoutException(
+                        "The certificate trust tool did not exit after termination.",
+                        exception);
+                }
+            }).ConfigureAwait(false);
+    }
 
-            await process.WaitForExitAsync(CancellationToken.None).ConfigureAwait(false);
-            await Task.WhenAll(standardOutput, standardError).ConfigureAwait(false);
-            cancellationToken.ThrowIfCancellationRequested();
-            throw new TimeoutException("The certificate trust tool did not finish in time.");
-        }
-
-        await Task.WhenAll(standardOutput, standardError).ConfigureAwait(false);
-
-        if (process.ExitCode != 0)
+    private static async Task ObserveTrustCommandOutputAsync(
+        Task<string> standardOutput,
+        Task<string> standardError,
+        CancellationTokenSource outputCancellation,
+        Aria2TlsFailureCollector failures)
+    {
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var outputObservation = ObserveTrustCommandStreamAsync(
+            standardOutput,
+            "trusted-root-command-stdout",
+            deadline.Token);
+        var errorObservation = ObserveTrustCommandStreamAsync(
+            standardError,
+            "trusted-root-command-stderr",
+            deadline.Token);
+        var observations = await Task.WhenAll(outputObservation, errorObservation)
+            .ConfigureAwait(false);
+        foreach (var observation in observations)
         {
-            throw new InvalidOperationException(
-                $"The certificate trust command failed with code {process.ExitCode}.");
+            if (observation != null)
+            {
+                failures.Capture(observation.Value.Stage, observation.Value.Exception);
+            }
         }
+
+        if (observations.Any(observation => observation?.Exception is TimeoutException))
+        {
+            await failures.RunAsync(
+                "trusted-root-command-output-cancel",
+                () => outputCancellation.CancelAsync()).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<(string Stage, Exception Exception)?> ObserveTrustCommandStreamAsync(
+        Task<string> stream,
+        string stage,
+        CancellationToken cancellationToken)
+    {
+        var exception = await Record.ExceptionAsync(
+            () => stream.WaitAsync(cancellationToken)).ConfigureAwait(false);
+        if (exception == null)
+        {
+            return null;
+        }
+
+        if (exception is OperationCanceledException && cancellationToken.IsCancellationRequested)
+        {
+            return (stage, new TimeoutException(
+                $"{stage} did not complete before the cleanup deadline."));
+        }
+
+        return (stage, exception);
     }
 
     public async ValueTask DisposeAsync()
     {
+        var failures = new Aria2TlsFailureCollector();
         if (_linuxCertificatePath != null)
         {
-            await RunBoundedProcessAsync(
-                "sudo",
-                ["-n", "rm", "-f", "--", _linuxCertificatePath],
-                CancellationToken.None).ConfigureAwait(false);
-            await RunBoundedProcessAsync(
-                "sudo",
-                ["-n", "update-ca-certificates"],
-                CancellationToken.None).ConfigureAwait(false);
+            await failures.RunAsync(
+                "trusted-root-remove/linux-remove",
+                () => RunCleanupCommandAsync(
+                    _runCommand,
+                    "sudo",
+                    ["-n", "rm", "-f", "--", _linuxCertificatePath])).ConfigureAwait(false);
+            await failures.RunAsync(
+                "trusted-root-remove/linux-update",
+                () => RunCleanupCommandAsync(
+                    _runCommand,
+                    "sudo",
+                    ["-n", "update-ca-certificates"])).ConfigureAwait(false);
         }
 
         if (_windowsRoot != null)
         {
-            _windowsRoot.Dispose();
+            failures.Run("trusted-root-remove/windows", _windowsRoot.Dispose);
         }
 
         if (_macCommonName != null)
         {
-            await RunBoundedProcessAsync(
-                "sudo",
-                [
-                    "-n",
-                    "security",
-                    "delete-certificate",
-                    "-c",
-                    _macCommonName,
-                    MacSystemKeychain
-                ],
-                CancellationToken.None).ConfigureAwait(false);
+            await failures.RunAsync(
+                "trusted-root-remove/macos",
+                () => RunCleanupCommandAsync(
+                    _runCommand,
+                    "sudo",
+                    CreateMacDeleteArguments(_macCommonName))).ConfigureAwait(false);
         }
+
+        failures.ThrowIfAny();
     }
 }
 
-internal sealed class WindowsTrustedRootRegistration : IDisposable
+internal sealed class WindowsTrustedRootRegistration : IWindowsTrustedRootRegistration
 {
     private const uint CertificateEncoding = 0x00000001;
     private const uint CurrentUserStore = 0x00010000;
     private const uint LocalMachineStore = 0x00020000;
     private const uint StoreAddUseExisting = 2;
+    private readonly Func<IntPtr, bool> _closeStore;
+    private readonly Func<IntPtr, bool> _deleteCertificate;
+    private readonly Func<int> _getLastError;
     private IntPtr _certificateContext;
     private IntPtr _store;
 
     private WindowsTrustedRootRegistration(
         IntPtr store,
         IntPtr certificateContext,
-        string source)
+        string source,
+        Func<IntPtr, bool>? deleteCertificate = null,
+        Func<IntPtr, bool>? closeStore = null,
+        Func<int>? getLastError = null)
     {
         _store = store;
         _certificateContext = certificateContext;
         Source = source;
+        _deleteCertificate = deleteCertificate ?? CertDeleteCertificateFromStore;
+        _closeStore = closeStore ?? (handle => CertCloseStore(handle, flags: 0));
+        _getLastError = getLastError ?? Marshal.GetLastPInvokeError;
     }
 
     public string Source { get; }
+
+    internal static WindowsTrustedRootRegistration CreateForTest(
+        Func<IntPtr, bool> deleteCertificate,
+        Func<IntPtr, bool> closeStore,
+        Func<int>? getLastError = null)
+    {
+        return new WindowsTrustedRootRegistration(
+            new IntPtr(1),
+            new IntPtr(2),
+            "windows-test-root-store",
+            deleteCertificate,
+            closeStore,
+            getLastError ?? (() => 5));
+    }
 
     [SupportedOSPlatform("windows")]
     public static WindowsTrustedRootRegistration Install(byte[] certificate)
@@ -678,20 +1034,34 @@ internal sealed class WindowsTrustedRootRegistration : IDisposable
     {
         var context = Interlocked.Exchange(ref _certificateContext, IntPtr.Zero);
         var store = Interlocked.Exchange(ref _store, IntPtr.Zero);
-        try
+        var failures = new Aria2TlsFailureCollector();
+        if (context != IntPtr.Zero)
         {
-            if (context != IntPtr.Zero && !CertDeleteCertificateFromStore(context))
+            failures.Run("trusted-root-remove/windows-delete", () =>
             {
-                throw CreateNativeError("The Windows test root certificate could not be removed.");
-            }
+                if (!_deleteCertificate(context))
+                {
+                    throw CreateNativeError(
+                        "The Windows test root certificate could not be removed.",
+                        _getLastError());
+                }
+            });
         }
-        finally
+
+        if (store != IntPtr.Zero)
         {
-            if (store != IntPtr.Zero)
+            failures.Run("trusted-root-remove/windows-close", () =>
             {
-                CertCloseStore(store, flags: 0);
-            }
+                if (!_closeStore(store))
+                {
+                    throw CreateNativeError(
+                        "The Windows test root certificate store could not be closed.",
+                        _getLastError());
+                }
+            });
         }
+
+        failures.ThrowIfAny();
     }
 
     [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/tests/DownKyi.Tests/LoopbackTlsFileServerLifecycleTests.cs
+++ b/tests/DownKyi.Tests/LoopbackTlsFileServerLifecycleTests.cs
@@ -1,0 +1,154 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using DownKyi.TestInfrastructure;
+
+namespace DownKyi.Tests;
+
+public sealed class LoopbackTlsFileServerLifecycleTests
+{
+    private static readonly TimeSpan ObservationTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public async Task DisposeClosesActiveConnectionWithinTheShutdownBound()
+    {
+        using var certificate = TestCertificateAuthority.CreateSelfSignedServerCertificate();
+        var server = new LoopbackTlsFileServer(
+            _ => certificate,
+            "response"u8.ToArray(),
+            shutdownTimeout: TimeSpan.FromSeconds(1));
+        await using var serverLifetime = server.ConfigureAwait(false);
+        using var client = new TcpClient();
+        await client.ConnectAsync(
+            IPAddress.Loopback,
+            server.Url.Port,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+        await WaitUntilAsync(
+            () => server.ConnectionCount == 1,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        var elapsed = Stopwatch.StartNew();
+        await server.DisposeAsync().ConfigureAwait(true);
+        elapsed.Stop();
+
+        Assert.True(elapsed.Elapsed < ObservationTimeout, $"Cleanup took {elapsed.Elapsed}.");
+        Assert.True(server.Completion.IsCompleted);
+        Assert.Empty(server.CleanupFailures);
+    }
+
+    [Fact]
+    public async Task HandlerFailureIsObservableWithoutReplacingThePrimaryFailure()
+    {
+        var handlerFailure = new InvalidDataException("Synthetic TLS handler failure.");
+        var primaryFailure = new InvalidOperationException("Primary business failure.");
+        var server = new LoopbackTlsFileServer(
+            _ => throw handlerFailure,
+            "response"u8.ToArray(),
+            shutdownTimeout: TimeSpan.FromSeconds(1));
+        await using var serverOwnership = server.ConfigureAwait(false);
+
+        async Task ThrowPrimaryFailureAsync()
+        {
+            await using var serverLifetime = server.ConfigureAwait(false);
+            using var client = new TcpClient();
+            await client.ConnectAsync(
+                IPAddress.Loopback,
+                server.Url.Port,
+                TestContext.Current.CancellationToken).ConfigureAwait(false);
+            await WaitUntilAsync(
+                () => server.Failures.Any(
+                    failure => ReferenceEquals(failure, handlerFailure)),
+                TestContext.Current.CancellationToken).ConfigureAwait(false);
+            throw primaryFailure;
+        }
+
+        var actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            ThrowPrimaryFailureAsync).ConfigureAwait(true);
+
+        Assert.Same(primaryFailure, actual);
+        Assert.Contains(server.Failures, failure => ReferenceEquals(failure, handlerFailure));
+        Assert.Empty(server.CleanupFailures);
+    }
+
+    [Fact]
+    public async Task DisposeRecordsConnectionCompletionTimeoutAndReleasesResources()
+    {
+        using var certificate = TestCertificateAuthority.CreateSelfSignedServerCertificate();
+        using var handlerEntered = new ManualResetEventSlim();
+        using var releaseHandler = new ManualResetEventSlim();
+        var cleanupFailureSink = new ConcurrentQueue<LoopbackTlsCleanupFailure>();
+        var server = new LoopbackTlsFileServer(
+            _ =>
+            {
+                handlerEntered.Set();
+                releaseHandler.Wait();
+                return certificate;
+            },
+            "response"u8.ToArray(),
+            shutdownTimeout: TimeSpan.FromMilliseconds(100),
+            cleanupFailureSink: cleanupFailureSink);
+        using var client = new TcpClient();
+
+        try
+        {
+            await client.ConnectAsync(
+                IPAddress.Loopback,
+                server.Url.Port,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+            await WaitUntilAsync(
+                () => handlerEntered.IsSet,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+            var elapsed = Stopwatch.StartNew();
+            await server.DisposeAsync().ConfigureAwait(true);
+            elapsed.Stop();
+
+            Assert.True(elapsed.Elapsed < ObservationTimeout, $"Cleanup took {elapsed.Elapsed}.");
+            var timeout = Assert.Single(
+                server.CleanupFailures,
+                failure => failure.Operation
+                    == LoopbackTlsCleanupOperation.AwaitServerCompletion);
+            Assert.IsType<TimeoutException>(timeout.Exception);
+            var reportedTimeout = Assert.Single(
+                cleanupFailureSink,
+                failure => failure.Operation
+                    == LoopbackTlsCleanupOperation.AwaitServerCompletion);
+            Assert.Same(timeout.Exception, reportedTimeout.Exception);
+
+            using var reconnect = new TcpClient();
+            await Assert.ThrowsAnyAsync<SocketException>(async () =>
+                await reconnect.ConnectAsync(
+                    IPAddress.Loopback,
+                    server.Url.Port,
+                    TestContext.Current.CancellationToken).ConfigureAwait(false))
+                .ConfigureAwait(true);
+        }
+        finally
+        {
+            releaseHandler.Set();
+            await server.DisposeAsync().ConfigureAwait(true);
+            await server.Completion.WaitAsync(
+                ObservationTimeout,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+        }
+    }
+
+    private static async Task WaitUntilAsync(
+        Func<bool> predicate,
+        CancellationToken cancellationToken)
+    {
+        var deadline = DateTimeOffset.UtcNow + ObservationTimeout;
+        while (!predicate())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (DateTimeOffset.UtcNow >= deadline)
+            {
+                throw new TimeoutException("The expected loopback TLS state was not observed.");
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(10), cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/TestInfrastructure/LoopbackTlsFileServer.cs
+++ b/tests/TestInfrastructure/LoopbackTlsFileServer.cs
@@ -15,9 +15,29 @@ public sealed record LoopbackTlsRequest(
     long? RangeStart,
     long? RangeEnd);
 
+public enum LoopbackTlsCleanupOperation
+{
+    CancelShutdown,
+    StopListener,
+    DisposeConnection,
+    AwaitServerCompletion,
+    DisposeListener,
+    DisposeCancellationSource
+}
+
+public sealed record LoopbackTlsCleanupFailure(
+    LoopbackTlsCleanupOperation Operation,
+    int? ConnectionNumber,
+    Exception Exception);
+
 public sealed class LoopbackTlsFileServer : IAsyncDisposable
 {
-    private readonly CancellationTokenSource _shutdown = new();
+    private static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(5);
+    private readonly ConcurrentDictionary<int, TcpClient> _clients = new();
+    private readonly ConcurrentQueue<LoopbackTlsCleanupFailure> _cleanupFailures = new();
+    private readonly ConcurrentQueue<LoopbackTlsCleanupFailure>? _cleanupFailureSink;
+    private readonly object _disposeGate = new();
+    private readonly LoopbackTlsCancellation _shutdown;
     private readonly Func<int, X509Certificate2> _certificateFactory;
     private readonly Func<int, LoopbackTlsRequest, Uri?>? _redirectFactory;
     private readonly byte[] _payload;
@@ -25,9 +45,11 @@ public sealed class LoopbackTlsFileServer : IAsyncDisposable
     private readonly TimeSpan _chunkDelay;
     private readonly ConcurrentQueue<LoopbackTlsRequest> _requests = new();
     private readonly ConcurrentQueue<Exception> _failures = new();
-    private readonly TcpListener _listener;
+    private readonly LoopbackTlsListener _listener;
+    private readonly TimeSpan _shutdownTimeout;
     private readonly Task _serverTask;
     private int _connectionCount;
+    private Task? _disposeTask;
 
     public LoopbackTlsFileServer(
         Func<int, X509Certificate2> certificateFactory,
@@ -35,11 +57,21 @@ public sealed class LoopbackTlsFileServer : IAsyncDisposable
         Uri? redirectTarget = null,
         bool truncateFirstResponse = false,
         TimeSpan chunkDelay = default,
-        Func<int, LoopbackTlsRequest, Uri?>? redirectFactory = null)
+        Func<int, LoopbackTlsRequest, Uri?>? redirectFactory = null,
+        TimeSpan shutdownTimeout = default,
+        ConcurrentQueue<LoopbackTlsCleanupFailure>? cleanupFailureSink = null)
     {
         _certificateFactory = certificateFactory
             ?? throw new ArgumentNullException(nameof(certificateFactory));
         _payload = payload ?? throw new ArgumentNullException(nameof(payload));
+        _shutdownTimeout = shutdownTimeout == default
+            ? DefaultShutdownTimeout
+            : shutdownTimeout > TimeSpan.Zero
+                ? shutdownTimeout
+                : throw new ArgumentOutOfRangeException(
+                    nameof(shutdownTimeout),
+                    shutdownTimeout,
+                    "The TLS loopback shutdown timeout must be positive.");
         _redirectFactory = redirectFactory;
         if (_redirectFactory == null && redirectTarget != null)
         {
@@ -47,7 +79,9 @@ public sealed class LoopbackTlsFileServer : IAsyncDisposable
         }
         _truncateFirstResponse = truncateFirstResponse;
         _chunkDelay = chunkDelay;
-        _listener = new TcpListener(IPAddress.Loopback, 0);
+        _cleanupFailureSink = cleanupFailureSink;
+        _shutdown = new LoopbackTlsCancellation(_cleanupFailures, cleanupFailureSink);
+        _listener = new LoopbackTlsListener(_cleanupFailures, cleanupFailureSink);
         _listener.Start();
         var endpoint = (IPEndPoint)_listener.LocalEndpoint;
         Url = new Uri($"https://localhost:{endpoint.Port}/media.bin");
@@ -58,9 +92,14 @@ public sealed class LoopbackTlsFileServer : IAsyncDisposable
 
     public int ConnectionCount => Volatile.Read(ref _connectionCount);
 
+    public Task Completion => _serverTask;
+
     public IReadOnlyList<LoopbackTlsRequest> Requests => _requests.ToArray();
 
     public IReadOnlyList<Exception> Failures => _failures.ToArray();
+
+    public IReadOnlyList<LoopbackTlsCleanupFailure> CleanupFailures =>
+        _cleanupFailures.ToArray();
 
     private async Task RunAsync(CancellationToken cancellationToken)
     {
@@ -72,7 +111,8 @@ public sealed class LoopbackTlsFileServer : IAsyncDisposable
                 var client = await _listener.AcceptTcpClientAsync(cancellationToken)
                     .ConfigureAwait(false);
                 var connectionNumber = Interlocked.Increment(ref _connectionCount);
-                connections.Add(HandleClientAsync(
+                _clients[connectionNumber] = client;
+                connections.Add(ObserveClientAsync(
                     client,
                     connectionNumber,
                     cancellationToken));
@@ -88,6 +128,20 @@ public sealed class LoopbackTlsFileServer : IAsyncDisposable
         {
             await Task.WhenAll(connections).ConfigureAwait(false);
         }
+    }
+
+    private async Task ObserveClientAsync(
+        TcpClient client,
+        int connectionNumber,
+        CancellationToken cancellationToken)
+    {
+        var handler = HandleClientAsync(client, connectionNumber, cancellationToken);
+        await handler.ContinueWith(
+            completed => RecordHandlerCompletion(completed, _failures),
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default).ConfigureAwait(false);
+        _clients.TryRemove(connectionNumber, out _);
     }
 
     private async Task HandleClientAsync(
@@ -307,18 +361,246 @@ public sealed class LoopbackTlsFileServer : IAsyncDisposable
             : (start, null);
     }
 
-    public async ValueTask DisposeAsync()
+    public ValueTask DisposeAsync()
     {
-        await _shutdown.CancelAsync().ConfigureAwait(false);
-        _listener.Stop();
-        try
+        Task disposeTask;
+        lock (_disposeGate)
         {
-            await _serverTask.ConfigureAwait(false);
+            disposeTask = _disposeTask ??= DisposeCoreAsync();
         }
-        finally
+
+        return new ValueTask(disposeTask);
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        using var cleanupDeadline = new CancellationTokenSource(_shutdownTimeout);
+        await RunBoundedCleanupAsync(
+            LoopbackTlsCleanupOperation.CancelShutdown,
+            connectionNumber: null,
+            () => _shutdown.CancelAsync(),
+            cleanupDeadline.Token).ConfigureAwait(false);
+        await RunCleanupAsync(
+            LoopbackTlsCleanupOperation.StopListener,
+            connectionNumber: null,
+            _listener.Stop,
+            cleanupDeadline.Token).ConfigureAwait(false);
+
+        foreach (var connection in _clients.ToArray())
         {
-            _listener.Dispose();
-            _shutdown.Dispose();
+            await RunCleanupAsync(
+                LoopbackTlsCleanupOperation.DisposeConnection,
+                connection.Key,
+                connection.Value.Dispose,
+                cleanupDeadline.Token).ConfigureAwait(false);
+        }
+
+        await RunBoundedCleanupAsync(
+            LoopbackTlsCleanupOperation.AwaitServerCompletion,
+            connectionNumber: null,
+            () => _serverTask,
+            cleanupDeadline.Token).ConfigureAwait(false);
+        _listener.Dispose();
+        _shutdown.Dispose();
+    }
+
+    private async Task RunBoundedCleanupAsync(
+        LoopbackTlsCleanupOperation operation,
+        int? connectionNumber,
+        Func<Task> cleanup,
+        CancellationToken cleanupDeadline)
+    {
+        var cleanupTask = Task.Factory.StartNew(
+            cleanup,
+            CancellationToken.None,
+            TaskCreationOptions.DenyChildAttach,
+            TaskScheduler.Default).Unwrap();
+        var completed = await Task.WhenAny(
+            cleanupTask,
+            Task.Delay(Timeout.InfiniteTimeSpan, cleanupDeadline)).ConfigureAwait(false);
+        if (!ReferenceEquals(completed, cleanupTask))
+        {
+            RecordCleanupFailure(new LoopbackTlsCleanupFailure(
+                operation,
+                connectionNumber,
+                new TimeoutException(
+                    $"Loopback TLS cleanup stage '{operation}' exceeded its deadline.")));
+            _ = cleanupTask.ContinueWith(
+                lateCompletion => RecordCleanupCompletion(
+                    lateCompletion,
+                    operation,
+                    connectionNumber),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+            return;
+        }
+
+        RecordCleanupCompletion(cleanupTask, operation, connectionNumber);
+    }
+
+    private Task RunCleanupAsync(
+        LoopbackTlsCleanupOperation operation,
+        int? connectionNumber,
+        Action cleanup,
+        CancellationToken cleanupDeadline)
+    {
+        return RunBoundedCleanupAsync(
+            operation,
+            connectionNumber,
+            () =>
+            {
+                cleanup();
+                return Task.CompletedTask;
+            },
+            cleanupDeadline);
+    }
+
+    private static void RecordHandlerCompletion(
+        Task handler,
+        ConcurrentQueue<Exception> failures)
+    {
+        if (handler.IsFaulted)
+        {
+            foreach (var error in handler.Exception.Flatten().InnerExceptions)
+            {
+                failures.Enqueue(error);
+            }
+        }
+        else if (handler.IsCanceled)
+        {
+            failures.Enqueue(new TaskCanceledException(handler));
+        }
+    }
+
+    private void RecordCleanupCompletion(
+        Task cleanup,
+        LoopbackTlsCleanupOperation operation,
+        int? connectionNumber)
+    {
+        if (cleanup.IsFaulted)
+        {
+            foreach (var error in cleanup.Exception.Flatten().InnerExceptions)
+            {
+                RecordCleanupFailure(new LoopbackTlsCleanupFailure(
+                    operation,
+                    connectionNumber,
+                    error));
+            }
+        }
+        else if (cleanup.IsCanceled)
+        {
+            RecordCleanupFailure(new LoopbackTlsCleanupFailure(
+                operation,
+                connectionNumber,
+                new TaskCanceledException(cleanup)));
+        }
+    }
+
+    private void RecordCleanupFailure(LoopbackTlsCleanupFailure failure)
+    {
+        _cleanupFailures.Enqueue(failure);
+        if (_cleanupFailureSink != null
+            && !ReferenceEquals(_cleanupFailureSink, _cleanupFailures))
+        {
+            _cleanupFailureSink.Enqueue(failure);
+        }
+    }
+
+    private sealed class LoopbackTlsCancellation(
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
+        ConcurrentQueue<LoopbackTlsCleanupFailure>? cleanupFailureSink) : IDisposable
+    {
+        private readonly CancellationTokenSource _source = new();
+
+        public CancellationToken Token => _source.Token;
+
+        public Task CancelAsync()
+        {
+            return _source.CancelAsync();
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _source.Dispose();
+            }
+            catch (ObjectDisposedException error)
+            {
+                RecordCleanupFailure(
+                    cleanupFailures,
+                    cleanupFailureSink,
+                    new LoopbackTlsCleanupFailure(
+                    LoopbackTlsCleanupOperation.DisposeCancellationSource,
+                    ConnectionNumber: null,
+                    error));
+            }
+        }
+    }
+
+    private sealed class LoopbackTlsListener(
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
+        ConcurrentQueue<LoopbackTlsCleanupFailure>? cleanupFailureSink) : IDisposable
+    {
+        private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+
+        public EndPoint LocalEndpoint => _listener.LocalEndpoint;
+
+        public ValueTask<TcpClient> AcceptTcpClientAsync(CancellationToken cancellationToken)
+        {
+            return _listener.AcceptTcpClientAsync(cancellationToken);
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                _listener.Dispose();
+            }
+            catch (SocketException error)
+            {
+                RecordCleanupFailure(
+                    cleanupFailures,
+                    cleanupFailureSink,
+                    new LoopbackTlsCleanupFailure(
+                    LoopbackTlsCleanupOperation.DisposeListener,
+                    ConnectionNumber: null,
+                    error));
+            }
+            catch (ObjectDisposedException error)
+            {
+                RecordCleanupFailure(
+                    cleanupFailures,
+                    cleanupFailureSink,
+                    new LoopbackTlsCleanupFailure(
+                    LoopbackTlsCleanupOperation.DisposeListener,
+                    ConnectionNumber: null,
+                    error));
+            }
+        }
+
+        public void Start()
+        {
+            _listener.Start();
+        }
+
+        public void Stop()
+        {
+            _listener.Stop();
+        }
+    }
+
+    private static void RecordCleanupFailure(
+        ConcurrentQueue<LoopbackTlsCleanupFailure> cleanupFailures,
+        ConcurrentQueue<LoopbackTlsCleanupFailure>? cleanupFailureSink,
+        LoopbackTlsCleanupFailure failure)
+    {
+        cleanupFailures.Enqueue(failure);
+        if (cleanupFailureSink != null
+            && !ReferenceEquals(cleanupFailureSink, cleanupFailures))
+        {
+            cleanupFailureSink.Enqueue(failure);
         }
     }
 }


### PR DESCRIPTION
## Summary

- split the monolithic packaged aria2 TLS test into 26 independently discoverable behavior cases, with RPC lifecycle outside the certificate family
- add TLS-test-local primary-first failure preservation and focused lifecycle seams for startup rollback, process shutdown/kill/reap, output drain, trusted-root cleanup, working-directory cleanup, report writing, and loopback teardown
- stage CI as focused harness tests first, followed by packaged aria2 E2E with separate TRX and flight-recorder directories

## Failure preservation

- a single failure is rethrown with its original identity and stack
- multiple failures retain named stages, exception types, stacks, and execution order
- report/runtime/trusted-root/filesystem cleanup failures cannot replace the initial TLS/business failure
- timeout paths continue required cleanup and observe late RPC/loopback task failures

## Validation

- strict DownKyi.Tests build with all analyzers as errors: PASS (0 warnings, 0 errors)
- focused aria2 TLS lifecycle tests: PASS (49/49)
- packaged test discovery: 26 independent cases
- win-x64 packaged aria2 E2E: PASS (26/26)
- sanitized report fragments: 26 complete/passing single-case reports; 0 forbidden-value hits
- quality.yml parse and git diff --check: PASS

## Scope

- does not change CentralTestRunner cancellation
- does not change aria2 TLS product behavior
- hosted evidence for win-x86, Linux, and macOS matrix entries remains pending CI