### PR TITLE
fix: enforce cleanup snapshot and ETW deadlines

### DIFF
--- a/tests/DownKyi.Architecture.Tests/CentralTestRunnerCancellationComponentTests.cs
+++ b/tests/DownKyi.Architecture.Tests/CentralTestRunnerCancellationComponentTests.cs
@@ -177,6 +177,37 @@ public sealed class CentralTestRunnerCancellationComponentTests
     }
 
     [Fact]
+    public async Task SynchronousRelationshipSnapshotIsBoundedByTheRequestedTimeout()
+    {
+        using var releaseSnapshot = new ManualResetEventSlim();
+        var snapshotStarted = new TaskCompletionSource(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            var snapshot = ProcessTreeSnapshot.ReadParentIdsAsync(
+                () =>
+                {
+                    snapshotStarted.TrySetResult();
+                    releaseSnapshot.Wait();
+                    return [];
+                },
+                TimeSpan.FromMilliseconds(100));
+
+            await snapshotStarted.Task.WaitAsync(
+                TestTimeout,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+            var exception = await Assert.ThrowsAsync<TimeoutException>(() => snapshot)
+                .ConfigureAwait(true);
+
+            Assert.Contains("bounded cleanup window", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            releaseSnapshot.Set();
+        }
+    }
+
+    [Fact]
     public async Task RelationshipSnapshotCommandFailureIsTyped()
     {
         var startInfo = CreateDotNetStartInfo();

--- a/tests/DownKyi.Windows.Tests/WindowsEtwResourceFlightRecorderTests.cs
+++ b/tests/DownKyi.Windows.Tests/WindowsEtwResourceFlightRecorderTests.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics;
+using DownKyi.TestInfrastructure;
+
+namespace DownKyi.Windows.Tests;
+
+public sealed class WindowsEtwResourceFlightRecorderTests
+{
+    private static readonly TimeSpan TestTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public void DiagnosticToolDrainsStandardOutputAndErrorConcurrently()
+    {
+        var result = WindowsEtwResourceFlightRecorder.RunTool(
+            "pwsh.exe",
+            TestTimeout,
+            TestTimeout,
+            "-NoLogo",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$payload = 'x' * (128 * 1024); " +
+            "[Console]::Out.Write($payload); [Console]::Error.Write($payload)");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal(256 * 1024, result.Output.Length);
+    }
+
+    [Fact]
+    public void DiagnosticToolTimeoutPrecedesPipeCompletion()
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var exception = Assert.Throws<TimeoutException>(
+            () => WindowsEtwResourceFlightRecorder.RunTool(
+                "pwsh.exe",
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromSeconds(2),
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "[Console]::Out.Write('started'); Start-Sleep -Seconds 30"));
+
+        Assert.Contains("diagnostic timeout", exception.Message, StringComparison.Ordinal);
+        Assert.InRange(stopwatch.Elapsed, TimeSpan.Zero, TestTimeout);
+    }
+}

--- a/tests/TestInfrastructure/DownKyi.TestInfrastructure.csproj
+++ b/tests/TestInfrastructure/DownKyi.TestInfrastructure.csproj
@@ -11,4 +11,8 @@
     <Compile Remove="TestDataIsolationRegistration.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="DownKyi.Windows.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/tests/TestInfrastructure/WindowsEtwResourceFlightRecorder.cs
+++ b/tests/TestInfrastructure/WindowsEtwResourceFlightRecorder.cs
@@ -511,7 +511,18 @@ internal sealed class WindowsEtwResourceFlightRecorder : IDisposable
         return int.TryParse(trimmed, NumberStyles.Integer, CultureInfo.InvariantCulture, out processId);
     }
 
-    private static ToolResult RunTool(string executable, params string[] arguments)
+    private static ToolResult RunTool(string executable, params string[] arguments) =>
+        RunTool(
+            executable,
+            TimeSpan.FromSeconds(15),
+            TimeSpan.FromSeconds(5),
+            arguments);
+
+    internal static ToolResult RunTool(
+        string executable,
+        TimeSpan exitTimeout,
+        TimeSpan cleanupTimeout,
+        params string[] arguments)
     {
         var startInfo = new ProcessStartInfo(executable)
         {
@@ -525,18 +536,111 @@ internal sealed class WindowsEtwResourceFlightRecorder : IDisposable
             startInfo.ArgumentList.Add(argument);
         }
 
-        using var process = Process.Start(startInfo) ??
-            throw new InvalidOperationException($"Unable to start {executable}.");
-        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
-        if (!process.WaitForExit(TimeSpan.FromSeconds(15)))
+        using var process = new Process { StartInfo = startInfo };
+        if (!process.Start())
         {
-            process.Kill(entireProcessTree: true);
+            throw new InvalidOperationException($"Unable to start {executable}.");
+        }
+
+        string standardOutput = string.Empty;
+        string standardError = string.Empty;
+        Exception? outputFailure = null;
+        Exception? errorFailure = null;
+        var outputReader = CreateReaderThread(
+            $"{executable} stdout drain",
+            () => process.StandardOutput.ReadToEnd(),
+            value => standardOutput = value,
+            exception => outputFailure = exception);
+        var errorReader = CreateReaderThread(
+            $"{executable} stderr drain",
+            () => process.StandardError.ReadToEnd(),
+            value => standardError = value,
+            exception => errorFailure = exception);
+        outputReader.Start();
+        errorReader.Start();
+
+        var timedOut = !process.WaitForExit(exitTimeout);
+        if (timedOut)
+        {
+            TerminateTool(process, executable, cleanupTimeout);
+        }
+
+        if (!JoinReaders(outputReader, errorReader, cleanupTimeout))
+        {
+            if (!timedOut)
+            {
+                TerminateTool(process, executable, cleanupTimeout);
+            }
+
+            throw new TimeoutException($"{executable} output did not drain within the diagnostic cleanup timeout.");
+        }
+
+        if (timedOut)
+        {
             throw new TimeoutException($"{executable} did not finish within the diagnostic timeout.");
         }
 
+        if (outputFailure is not null || errorFailure is not null)
+        {
+            throw new InvalidOperationException(
+                $"Unable to drain {executable} diagnostic output.",
+                outputFailure ?? errorFailure);
+        }
+
+        var output = standardOutput + standardError;
         return new ToolResult(
             process.ExitCode,
             Sanitize(output.ReplaceLineEndings(" ").Trim()));
+    }
+
+    private static Thread CreateReaderThread(
+        string name,
+        Func<string> read,
+        Action<string> complete,
+        Action<Exception> fail) =>
+        new(() =>
+        {
+            try
+            {
+                complete(read());
+            }
+            catch (Exception exception) when (exception is IOException or InvalidOperationException or ObjectDisposedException)
+            {
+                fail(exception);
+            }
+        })
+        {
+            IsBackground = true,
+            Name = name,
+        };
+
+    private static bool JoinReaders(Thread outputReader, Thread errorReader, TimeSpan timeout)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        if (!outputReader.Join(timeout))
+        {
+            return false;
+        }
+
+        var remaining = timeout - stopwatch.Elapsed;
+        return errorReader.Join(remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero);
+    }
+
+    private static void TerminateTool(Process process, string executable, TimeSpan timeout)
+    {
+        try
+        {
+            process.Kill(entireProcessTree: true);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            // The diagnostic tool may have exited while the timeout was observed.
+        }
+
+        if (!process.WaitForExit(timeout))
+        {
+            throw new TimeoutException($"{executable} did not exit within the diagnostic cleanup timeout.");
+        }
     }
 
     private static string ReadRunIdentity()
@@ -585,7 +689,7 @@ internal sealed class WindowsEtwResourceFlightRecorder : IDisposable
         }
     }
 
-    private sealed record ToolResult(int ExitCode, string Output);
+    internal sealed record ToolResult(int ExitCode, string Output);
 
     private sealed record FilteredTrace(string Summary, string Content);
 }

--- a/tools/DownKyi.CentralTestRunner/ProcessTreeSnapshot.cs
+++ b/tools/DownKyi.CentralTestRunner/ProcessTreeSnapshot.cs
@@ -63,10 +63,27 @@ internal static class ProcessTreeSnapshot
     {
         if (OperatingSystem.IsWindows())
         {
-            return Task.FromResult(WindowsProcessRelationshipSnapshot.ReadParentIds());
+            return ReadParentIdsAsync(
+                WindowsProcessRelationshipSnapshot.ReadParentIds,
+                timeout);
         }
 
         return ReadParentIdsAsync(CreateUnixSnapshotStartInfo(), timeout);
+    }
+
+    internal static async Task<Dictionary<int, int>> ReadParentIdsAsync(
+        Func<Dictionary<int, int>> readParentIds,
+        TimeSpan timeout)
+    {
+        try
+        {
+            return await Task.Run(readParentIds).WaitAsync(timeout).ConfigureAwait(false);
+        }
+        catch (TimeoutException)
+        {
+            throw new TimeoutException(
+                "Process relationship snapshot exceeded the bounded cleanup window.");
+        }
     }
 
     internal static async Task<Dictionary<int, int>> ReadParentIdsAsync(


### PR DESCRIPTION
## Summary

Follow-up to #220 for two waits that were still unbounded in practice.

- run the synchronous Windows Toolhelp process snapshot on a worker and apply the caller's timeout before cancellation cleanup proceeds
- drain ETW diagnostic tool stdout/stderr concurrently, enforce the 15-second process deadline, kill the process tree on timeout, and bound post-exit drains
- add regressions for a stalled synchronous snapshot, pipe-buffer pressure, and a tool that never closes its output pipe before the deadline

## Verification

- `dotnet restore ./DownKyi.sln`
- `pwsh ./script/validate-release-version.ps1`
- strict Release solution build with all analyzers and warnings as errors
- `pwsh ./script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild` (8/8 Windows-selected projects passed)
- `dotnet format ./DownKyi.sln --verify-no-changes --no-restore`
- module boundary audit
- actionlint 1.7.12
- vulnerable and deprecated transitive package audits
- Gitleaks 8.30.1 (1115 candidate files, 0 findings)
- `git diff --check`