### PR TITLE
fix(logging): preserve active log directory during retention

### DIFF
--- a/src/DownKyi.Infrastructure/Logging/ApplicationLogRetentionManager.cs
+++ b/src/DownKyi.Infrastructure/Logging/ApplicationLogRetentionManager.cs
@@ -94,7 +94,7 @@ internal sealed class ApplicationLogRetentionManager
                 Interlocked.Increment(ref _capacityDeletionCount);
             }
 
-            RemoveEmptyDayDirectories();
+            RemoveEmptyDayDirectories(activePath);
             Interlocked.Exchange(ref _retainedBytes, Math.Max(0, retainedBytes));
             Interlocked.Exchange(ref _lastMaintenanceUtcTicks, nowUtc.UtcTicks);
         }
@@ -231,18 +231,26 @@ internal sealed class ApplicationLogRetentionManager
         }
     }
 
-    private void RemoveEmptyDayDirectories()
+    private void RemoveEmptyDayDirectories(string? activePath)
     {
         if (!Directory.Exists(_options.LogDirectory))
         {
             return;
         }
 
+        var activeDirectory = activePath == null
+            ? null
+            : Path.GetDirectoryName(Path.GetFullPath(activePath));
         foreach (var directory in Directory.GetDirectories(
                      _options.LogDirectory,
                      "????-??-??",
                      SearchOption.TopDirectoryOnly))
         {
+            if (activeDirectory != null && PathsEqual(directory, activeDirectory))
+            {
+                continue;
+            }
+
             try
             {
                 if (!Directory.EnumerateFileSystemEntries(directory).Any())

--- a/tests/DownKyi.Infrastructure.Tests/ApplicationLogProviderTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/ApplicationLogProviderTests.cs
@@ -308,6 +308,20 @@ public sealed class ApplicationLogProviderTests : IDisposable
     }
 
     [Fact]
+    public void RetentionPreservesActiveDayDirectoryBeforeFirstEntryIsCreated()
+    {
+        var now = new DateTimeOffset(2026, 7, 18, 0, 0, 0, TimeSpan.Zero);
+        var activeDirectory = Path.Combine(_directory, "2026-07-18");
+        var activePath = Path.Combine(activeDirectory, "events.jsonl");
+        Directory.CreateDirectory(activeDirectory);
+        var retention = new ApplicationLogRetentionManager(new ApplicationLogOptions(_directory));
+
+        retention.Apply(activePath, now);
+
+        Assert.True(Directory.Exists(activeDirectory));
+    }
+
+    [Fact]
     public async Task StartupRetentionDeletesExpiredLogsAndReportsMetrics()
     {
         var cancellationToken = TestContext.Current.CancellationToken;


### PR DESCRIPTION
## Root cause

Startup retention could remove the active date directory during the window after the logging provider created the directory but before NLog's asynchronous file target created the first file. A final entry was accepted by `TryWrite`, but the queued write then lost its parent directory before `FlushAsync` / `DisposeAsync` completed, so the entry was not persisted. This is a production lifecycle race, not a test timing issue or an NLog queue-drain defect.

## Change

- Preserve the directory that owns `activePath` while retention removes other empty date directories.
- Add a deterministic regression covering the pre-first-entry window.
- No cancellation, CA1506, Windows #220, retry, or sleep changes.

## Local verification (`adadf777`)

- Strict Release solution build: 0 warnings, 0 errors.
- Formal CentralTestRunner: all 8 Windows-applicable projects passed; `DownKyi.Infrastructure.Tests` 74/74.
- `dotnet format`, module-boundary audit, actionlint, vulnerable/deprecated package checks, Gitleaks 8.30.1, and `git diff --check` passed.

This PR is intentionally isolated for hosted macOS validation of `ApplicationLogProviderTests.AsyncDisposalDrainsAcceptedEntries`.