### PR TITLE
test: stabilize controlled Windows directory lock fixture

### DIFF
--- a/tests/DownKyi.Windows.Tests/TargetedResourceForensicsWindowsTests.cs
+++ b/tests/DownKyi.Windows.Tests/TargetedResourceForensicsWindowsTests.cs
@@ -357,7 +357,7 @@ public sealed class TargetedResourceForensicsWindowsTests
             Assert.Contains("readyForOperationUtc=", artifact, StringComparison.Ordinal);
             Assert.Contains(">Process</EventName>", artifact, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("ParentId", artifact, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("fixture-hold", artifact, StringComparison.Ordinal);
+            Assert.Contains("fixture-directory-lock", artifact, StringComparison.Ordinal);
             Assert.Contains(">Create</Opcode>", artifact, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Cleanup", artifact, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("Close", artifact, StringComparison.OrdinalIgnoreCase);

--- a/tests/DownKyi.Windows.Tests/TargetedResourceForensicsWindowsTests.cs
+++ b/tests/DownKyi.Windows.Tests/TargetedResourceForensicsWindowsTests.cs
@@ -44,13 +44,8 @@ public sealed class TargetedResourceForensicsWindowsTests
         Process? owner = null;
         try
         {
-            owner = StartDirectoryOwner(targetDirectory);
-            var ready = await owner.StandardOutput.ReadLineAsync(
-                    TestContext.Current.CancellationToken).AsTask()
-                .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken)
-                .ConfigureAwait(true);
-            Assert.StartsWith("fixture-ready pid=", ready, StringComparison.Ordinal);
-            DuplicateDirectoryHandleIntoProcess(targetDirectory, owner);
+            owner = StartDirectoryLockOwner(targetDirectory);
+            await WaitForDirectoryLockReadyAsync(owner).ConfigureAwait(true);
 
             Assert.Equal(
                 DeleteAccessState.SharingViolation,
@@ -307,18 +302,13 @@ public sealed class TargetedResourceForensicsWindowsTests
         TargetedResourceForensics? forensics = null;
         try
         {
+            owner = StartDirectoryLockOwner(targetDirectory);
+            await WaitForDirectoryLockReadyAsync(owner).ConfigureAwait(true);
             forensics = TargetedResourceForensics.Start(
                 targetDirectory,
                 nameof(ControlledDirectoryOwnerProducesCorrelatedLifecycleArtifact),
                 Environment.ProcessId);
-            owner = StartDirectoryOwner(targetDirectory);
-            var ready = await owner.StandardOutput.ReadLineAsync(
-                    TestContext.Current.CancellationToken).AsTask()
-                .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken)
-                .ConfigureAwait(true);
-            Assert.StartsWith("fixture-ready pid=", ready, StringComparison.Ordinal);
             forensics.AddKnownProcessId(owner.Id, "root-owner");
-            DuplicateDirectoryHandleIntoProcess(targetDirectory, owner);
 
             Assert.Equal(
                 DeleteAccessState.SharingViolation,
@@ -419,6 +409,32 @@ public sealed class TargetedResourceForensicsWindowsTests
             throw new InvalidOperationException("Unable to start the controlled directory owner.");
     }
 
+    private static Process StartDirectoryLockOwner(string workingDirectory)
+    {
+        var runtimeConfig = Path.Combine(
+            AppContext.BaseDirectory,
+            "DownKyi.Windows.Tests.runtimeconfig.json");
+        var fixtureAssembly = Path.Combine(
+            AppContext.BaseDirectory,
+            "DownKyi.CentralTestRunner.dll");
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = AppContext.BaseDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        startInfo.ArgumentList.Add("exec");
+        startInfo.ArgumentList.Add("--runtimeconfig");
+        startInfo.ArgumentList.Add(runtimeConfig);
+        startInfo.ArgumentList.Add(fixtureAssembly);
+        startInfo.ArgumentList.Add("fixture-directory-lock");
+        startInfo.ArgumentList.Add(workingDirectory);
+        return Process.Start(startInfo) ??
+            throw new InvalidOperationException("Unable to start the controlled directory lock owner.");
+    }
+
     private static async Task WaitForOwnerReadyAsync(Process owner)
     {
         var ready = await owner.StandardOutput.ReadLineAsync(
@@ -426,6 +442,22 @@ public sealed class TargetedResourceForensicsWindowsTests
             .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken)
             .ConfigureAwait(true);
         Assert.StartsWith("fixture-ready pid=", ready, StringComparison.Ordinal);
+    }
+
+    private static async Task WaitForDirectoryLockReadyAsync(Process owner)
+    {
+        var ready = await owner.StandardOutput.ReadLineAsync(
+                TestContext.Current.CancellationToken).AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+        if (ready is null)
+        {
+            var error = await owner.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+            Assert.Fail($"Directory lock owner exited before its barrier: {error}");
+        }
+
+        Assert.Equal("fixture-lock-ready", ready);
     }
 
     private static async Task StopOwnerAsync(Process? owner)

--- a/tools/DownKyi.CentralTestRunner/Program.cs
+++ b/tools/DownKyi.CentralTestRunner/Program.cs
@@ -1,3 +1,7 @@
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
 namespace DownKyi.CentralTestRunner;
 
 internal static class Program
@@ -12,6 +16,40 @@ internal static class Program
                 $"fixture-ready pid={Environment.ProcessId} start={startTimeUtc:O}");
             await Console.Out.FlushAsync().ConfigureAwait(false);
             await Task.Delay(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+            return 0;
+        }
+
+        if (args.Length > 1 && string.Equals(args[0], "fixture-directory-lock", StringComparison.Ordinal))
+        {
+            using var directoryLock = NativeMethods.CreateFile(
+                args[1],
+                NativeMethods.ListDirectory,
+                NativeMethods.ShareRead | NativeMethods.ShareWrite,
+                IntPtr.Zero,
+                NativeMethods.OpenExisting,
+                NativeMethods.BackupSemantics,
+                IntPtr.Zero);
+            if (directoryLock.IsInvalid)
+            {
+                throw new Win32Exception(Marshal.GetLastPInvokeError());
+            }
+
+            var lockReferenceAdded = false;
+            directoryLock.DangerousAddRef(ref lockReferenceAdded);
+            try
+            {
+                await Console.Out.WriteLineAsync("fixture-lock-ready").ConfigureAwait(false);
+                await Console.Out.FlushAsync().ConfigureAwait(false);
+                await Task.Delay(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+            }
+            finally
+            {
+                if (lockReferenceAdded)
+                {
+                    directoryLock.DangerousRelease();
+                }
+            }
+
             return 0;
         }
 
@@ -89,5 +127,30 @@ internal static class Program
         {
             return 130;
         }
+    }
+
+    private static class NativeMethods
+    {
+        internal const uint ShareRead = 0x00000001;
+        internal const uint ShareWrite = 0x00000002;
+        internal const uint ListDirectory = 0x00000001;
+        internal const uint OpenExisting = 3;
+        internal const uint BackupSemantics = 0x02000000;
+
+        [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+        [DllImport(
+            "kernel32.dll",
+            EntryPoint = "CreateFileW",
+            ExactSpelling = true,
+            CharSet = CharSet.Unicode,
+            SetLastError = true)]
+        internal static extern SafeFileHandle CreateFile(
+            string fileName,
+            uint desiredAccess,
+            uint shareMode,
+            IntPtr securityAttributes,
+            uint creationDisposition,
+            uint flagsAndAttributes,
+            IntPtr templateFile);
     }
 }


### PR DESCRIPTION
## Why

Unblock the release-critical Strict PR CI path by making the targeted Windows resource-forensics fixture establish its DELETE-sharing barrier in the owner process before sampling.

## Scope

- add the dedicated ixture-directory-lock command to DownKyi.CentralTestRunner
- start that fixture before the forensics sampler and wait for its explicit ready barrier
- keep the fixture working directory outside the directory being locked

This intentionally excludes PR #219's Code Metrics, aria2, macOS diagnostics, and other unrelated changes.

## Validation

- strict Release solution build: passed, 0 warnings / 0 errors
- local focused run proved the lock transition (SharingViolation while owner alive, Allowed after exit); final artifact assertion could not run because the local ETW session returned 