### PR TITLE
fix: preserve output across root identity failure

### DIFF
--- a/tests/DownKyi.Architecture.Tests/FlightRecorderOutputTests.cs
+++ b/tests/DownKyi.Architecture.Tests/FlightRecorderOutputTests.cs
@@ -6,6 +6,8 @@ namespace DownKyi.Architecture.Tests;
 
 public sealed class FlightRecorderOutputTests
 {
+    private const string DiscardedLineMarker = "[output line exceeded 8192 characters and was discarded]";
+
     [Fact]
     public async Task UnterminatedOversizedOutputIsDiscardedWithoutUnboundedEvidence()
     {
@@ -34,7 +36,7 @@ public sealed class FlightRecorderOutputTests
             Assert.True(new FileInfo(result.EvidencePath).Length < 16_384);
             using var document = JsonDocument.Parse(artifact);
             Assert.Contains(
-                "[output line exceeded 8192 characters and was discarded]",
+                DiscardedLineMarker,
                 document.RootElement.GetProperty("StdoutTail").GetString(),
                 StringComparison.Ordinal);
         }
@@ -44,7 +46,55 @@ public sealed class FlightRecorderOutputTests
         }
     }
 
-    private static ProcessStartInfo CreateFixtureStartInfo(string secret)
+    [Fact]
+    public async Task RootIdentityFailureStillDrainsOutputProducedByTheOwnedProcess()
+    {
+        const string secret = "fixture-root-identity-secret";
+        var evidenceDirectory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-flight-recorder-identity-{Guid.NewGuid():N}");
+        var readyPath = Path.Combine(evidenceDirectory, "fixture-ready");
+        Directory.CreateDirectory(evidenceDirectory);
+        try
+        {
+            var result = await FlightRecorderExecution.RunAsync(
+                new ProcessExecutionRequest(
+                    "fixture.identity-failure.slice",
+                    "fixture.identity-failure.test",
+                    CreateFixtureStartInfo(secret, readyPath),
+                    TimeSpan.FromSeconds(10),
+                    TimeSpan.FromSeconds(3),
+                    evidenceDirectory,
+                    RootStartTimeReader: _ =>
+                    {
+                        if (!SpinWait.SpinUntil(() => File.Exists(readyPath), TimeSpan.FromSeconds(3)))
+                        {
+                            throw new InvalidOperationException("The fixture did not produce output before identity capture.");
+                        }
+
+                        throw new System.ComponentModel.Win32Exception("fixture identity unavailable");
+                    }),
+                CancellationToken.None);
+
+            Assert.Equal(2, result.ExitCode);
+            var artifact = await File.ReadAllTextAsync(
+                result.EvidencePath,
+                TestContext.Current.CancellationToken);
+            Assert.DoesNotContain(secret, artifact, StringComparison.Ordinal);
+            using var document = JsonDocument.Parse(artifact);
+            Assert.Equal("root_identity_failed", document.RootElement.GetProperty("Outcome").GetString());
+            Assert.Contains(
+                DiscardedLineMarker,
+                document.RootElement.GetProperty("StdoutTail").GetString(),
+                StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(evidenceDirectory, recursive: true);
+        }
+    }
+
+    private static ProcessStartInfo CreateFixtureStartInfo(string secret, string? readyPath = null)
     {
         var runnerAssembly = typeof(FlightRecorderExecution).Assembly.Location;
         var runtimeConfig = Path.Combine(
@@ -63,6 +113,10 @@ public sealed class FlightRecorderOutputTests
         startInfo.ArgumentList.Add(runnerAssembly);
         startInfo.ArgumentList.Add("fixture-long-line");
         startInfo.ArgumentList.Add(secret);
+        if (readyPath is not null)
+        {
+            startInfo.ArgumentList.Add(readyPath);
+        }
         return startInfo;
     }
 }

--- a/tools/DownKyi.CentralTestRunner/FlightRecorderExecution.cs
+++ b/tools/DownKyi.CentralTestRunner/FlightRecorderExecution.cs
@@ -9,7 +9,8 @@ internal sealed record ProcessExecutionRequest(
     TimeSpan Timeout,
     TimeSpan CleanupTimeout,
     string EvidenceDirectory,
-    Func<int, TimeSpan, Task<FinalProcessSnapshot>>? SnapshotCapture = null);
+    Func<int, TimeSpan, Task<FinalProcessSnapshot>>? SnapshotCapture = null,
+    Func<Process, DateTimeOffset>? RootStartTimeReader = null);
 
 internal sealed record ProcessExecutionResult(
     int ExitCode,
@@ -45,31 +46,6 @@ internal static class FlightRecorderExecution
             return new ProcessExecutionResult(2, 0, default, recorder.EvidencePath, recorder);
         }
 
-        var rootPid = process.Id;
-        DateTimeOffset rootStartTime;
-        try
-        {
-            rootStartTime = process.StartTime.ToUniversalTime();
-        }
-        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
-        {
-            await recorder.RecordAsync(
-                "root_identity_failed",
-                pid: rootPid,
-                detail: exception.Message).ConfigureAwait(false);
-            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
-            await StopAsync(process, request.CleanupTimeout, recorder).ConfigureAwait(false);
-            await recorder.FinalizeFailureAsync("root_identity_failed", standardOutput, standardError)
-                .ConfigureAwait(false);
-            return new ProcessExecutionResult(2, rootPid, default, recorder.EvidencePath, recorder);
-        }
-
-        recorder.SetRootIdentity(rootPid, rootStartTime);
-        await recorder.RecordAsync(
-            "process_start",
-            pid: rootPid,
-            startTimeUtc: rootStartTime).ConfigureAwait(false);
-
         using var outputCapture = new CancellationTokenSource();
         var outputTask = BoundedOutputCapture.CaptureAsync(
             process.StandardOutput,
@@ -83,6 +59,38 @@ internal static class FlightRecorderExecution
             Console.Error,
             recorder.Redactor,
             outputCapture.Token);
+        var rootPid = process.Id;
+        DateTimeOffset rootStartTime;
+        try
+        {
+            rootStartTime = (request.RootStartTimeReader ?? ReadRootStartTimeUtc)(process);
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            await recorder.RecordAsync(
+                "root_identity_failed",
+                pid: rootPid,
+                detail: exception.Message).ConfigureAwait(false);
+            await recorder.CaptureFinalSnapshotOnceAsync().ConfigureAwait(false);
+            await StopAsync(process, request.CleanupTimeout, recorder).ConfigureAwait(false);
+            await DrainOutputAsync(
+                outputTask,
+                errorTask,
+                outputCapture,
+                request.CleanupTimeout,
+                recorder,
+                rootPid).ConfigureAwait(false);
+            await recorder.FinalizeFailureAsync("root_identity_failed", standardOutput, standardError)
+                .ConfigureAwait(false);
+            return new ProcessExecutionResult(2, rootPid, default, recorder.EvidencePath, recorder);
+        }
+
+        recorder.SetRootIdentity(rootPid, rootStartTime);
+        await recorder.RecordAsync(
+            "process_start",
+            pid: rootPid,
+            startTimeUtc: rootStartTime).ConfigureAwait(false);
+
         using var timeout = new CancellationTokenSource(request.Timeout);
         using var waitCancellation = CancellationTokenSource.CreateLinkedTokenSource(
             cancellationToken,
@@ -162,6 +170,11 @@ internal static class FlightRecorderExecution
             rootStartTime,
             recorder.EvidencePath,
             recorder);
+    }
+
+    private static DateTimeOffset ReadRootStartTimeUtc(Process process)
+    {
+        return process.StartTime.ToUniversalTime();
     }
 
     public static async Task PreservePostExitFailureAsync(

--- a/tools/DownKyi.CentralTestRunner/Program.cs
+++ b/tools/DownKyi.CentralTestRunner/Program.cs
@@ -88,6 +88,11 @@ internal static class Program
         {
             await Console.Out.WriteAsync($"token={args[1]}{new string('x', 32768)}").ConfigureAwait(false);
             await Console.Out.FlushAsync().ConfigureAwait(false);
+            if (args.Length > 2)
+            {
+                await File.WriteAllTextAsync(args[2], "ready").ConfigureAwait(false);
+                await Task.Delay(Timeout.InfiniteTimeSpan).ConfigureAwait(false);
+            }
             return 1;
         }
 


### PR DESCRIPTION
## Summary

- start bounded stdout/stderr capture immediately after the owned process starts
- drain both streams before finalizing a root-identity failure
- add a causal regression that blocks identity capture until oversized output is confirmed produced

## Failure evidence

Main run 34020300088 failed on macOS at FlightRecorderOutputTests.UnterminatedOversizedOutputIsDiscardedWithoutUnboundedEvidence: expected the bounded discard marker, but StdoutTail was empty. The failure path could read process identity before stream capture existed.

## Verification

- focused FlightRecorderOutputTests: 2 passed
- DownKyi.Architecture.Tests: 280 passed
- Release solution build with warnings as errors: 0 warnings, 0 errors
- dotnet format --verify-no-changes: passed