### PR TITLE
fix(downloads): reserve physical output identity

### DIFF
--- a/src/DownKyi.Application/Downloads/DownloadOutputPathKey.cs
+++ b/src/DownKyi.Application/Downloads/DownloadOutputPathKey.cs
@@ -1,18 +1,29 @@
-using System.Text;
-
 namespace DownKyi.Application.Downloads;
 
 public static class DownloadOutputPathKey
 {
+    private static readonly FileSystemOutputIdentityProvider IdentityProvider =
+        FileSystemOutputIdentityProvider.Instance;
+
     public static bool UsesCaseInsensitiveComparison =>
         OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
 
-    public static string Create(string basePath, bool ignoreCase)
+    public static string NormalizeLogicalPath(
+        string basePath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
-        var normalized = Path
-            .TrimEndingDirectorySeparator(Path.GetFullPath(basePath))
-            .Normalize(NormalizationForm.FormC);
-        return ignoreCase ? normalized.ToUpperInvariant() : normalized;
+
+        return Path.TrimEndingDirectorySeparator(
+            Path.GetFullPath(
+                basePath));
+    }
+
+    public static string Create(
+        string basePath,
+        bool ignoreCase)
+    {
+        return IdentityProvider.CreateReservationKey(
+            basePath,
+            ignoreCase);
     }
 }

--- a/src/DownKyi.Application/Downloads/DownloadOutputPathKey.cs
+++ b/src/DownKyi.Application/Downloads/DownloadOutputPathKey.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace DownKyi.Application.Downloads;
 
 public static class DownloadOutputPathKey
@@ -13,9 +15,12 @@ public static class DownloadOutputPathKey
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
 
-        return Path.TrimEndingDirectorySeparator(
-            Path.GetFullPath(
-                basePath));
+        return Path
+            .TrimEndingDirectorySeparator(
+                Path.GetFullPath(
+                    basePath))
+            .Normalize(
+                NormalizationForm.FormC);
     }
 
     public static string Create(

--- a/src/DownKyi.Application/Downloads/FileSystemOutputIdentityProvider.cs
+++ b/src/DownKyi.Application/Downloads/FileSystemOutputIdentityProvider.cs
@@ -1,0 +1,128 @@
+namespace DownKyi.Application.Downloads;
+
+public sealed class FileSystemOutputIdentityProvider : IOutputIdentityProvider
+{
+    public static FileSystemOutputIdentityProvider Instance { get; } = new();
+
+    private FileSystemOutputIdentityProvider()
+    {
+    }
+
+    public string CreateReservationKey(
+        string basePath,
+        bool ignoreCase)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
+
+        var logicalPath =
+            DownloadOutputPathKey.NormalizeLogicalPath(
+                basePath);
+
+        var physicalPath =
+            ResolveExistingAliases(
+                logicalPath);
+
+        return ignoreCase
+            ? physicalPath.ToUpperInvariant()
+            : physicalPath;
+    }
+
+    private static string ResolveExistingAliases(
+        string fullPath)
+    {
+        var root =
+            Path.GetPathRoot(
+                fullPath);
+
+        if (string.IsNullOrEmpty(root))
+        {
+            return fullPath;
+        }
+
+        var relative =
+            Path.GetRelativePath(
+                root,
+                fullPath);
+
+        if (relative == ".")
+        {
+            return fullPath;
+        }
+
+        var segments =
+            relative.Split(
+                Path.DirectorySeparatorChar,
+                StringSplitOptions.RemoveEmptyEntries);
+
+        var current =
+            root;
+
+        for (var index = 0;
+             index < segments.Length;
+             index++)
+        {
+            var candidate =
+                Path.Combine(
+                    current,
+                    segments[index]);
+
+            if (Directory.Exists(candidate))
+            {
+                var directory =
+                    new DirectoryInfo(
+                        candidate);
+
+                var target =
+                    directory.ResolveLinkTarget(
+                        returnFinalTarget: true);
+
+                current =
+                    target?.FullName
+                    ?? directory.FullName;
+
+                continue;
+            }
+
+            if (File.Exists(candidate))
+            {
+                if (index != segments.Length - 1)
+                {
+                    throw new IOException(
+                        $"A file blocks output path traversal: '{candidate}'.");
+                }
+
+                var file =
+                    new FileInfo(
+                        candidate);
+
+                var target =
+                    file.ResolveLinkTarget(
+                        returnFinalTarget: true);
+
+                current =
+                    target?.FullName
+                    ?? file.FullName;
+
+                continue;
+            }
+
+            // The remaining path does not exist yet. Its identity is rooted
+            // underneath the already resolved physical ancestor.
+            for (var remaining = index;
+                 remaining < segments.Length;
+                 remaining++)
+            {
+                current =
+                    Path.Combine(
+                        current,
+                        segments[remaining]);
+            }
+
+            break;
+        }
+
+        return Path.TrimEndingDirectorySeparator(
+            Path.GetFullPath(
+                current));
+    }
+}

--- a/src/DownKyi.Application/Downloads/FileSystemOutputIdentityProvider.cs
+++ b/src/DownKyi.Application/Downloads/FileSystemOutputIdentityProvider.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace DownKyi.Application.Downloads;
 
 public sealed class FileSystemOutputIdentityProvider : IOutputIdentityProvider
@@ -22,9 +24,13 @@ public sealed class FileSystemOutputIdentityProvider : IOutputIdentityProvider
             ResolveExistingAliases(
                 logicalPath);
 
+        var normalizedPhysicalPath =
+            physicalPath.Normalize(
+                NormalizationForm.FormC);
+
         return ignoreCase
-            ? physicalPath.ToUpperInvariant()
-            : physicalPath;
+            ? normalizedPhysicalPath.ToUpperInvariant()
+            : normalizedPhysicalPath;
     }
 
     private static string ResolveExistingAliases(

--- a/src/DownKyi.Application/Downloads/IOutputIdentityProvider.cs
+++ b/src/DownKyi.Application/Downloads/IOutputIdentityProvider.cs
@@ -1,0 +1,15 @@
+namespace DownKyi.Application.Downloads;
+
+/// <summary>
+/// Converts an output base path into the identity used for durable
+/// reservation arbitration.
+///
+/// This identity is intentionally separate from the logical path that is
+/// stored on the download task.
+/// </summary>
+public interface IOutputIdentityProvider
+{
+    string CreateReservationKey(
+        string basePath,
+        bool ignoreCase);
+}

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
@@ -62,6 +62,6 @@ internal static class DownloadOutputPathResolver
 
     private static string Normalize(string path)
     {
-        return DownloadOutputPathKey.Create(path, ignoreCase: false);
+        return DownloadOutputPathKey.NormalizeLogicalPath(path);
     }
 }

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.OutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.OutputReservations.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using System.IO;
+using DownKyi.Application.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static partial class DownloadStoreSchema
+{
+    private static async Task ApplyVersionThreeAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (!await HasDownloadBaseColumnAsync(
+                connection,
+                transaction,
+                OutputReservationColumn,
+                cancellationToken).ConfigureAwait(false))
+        {
+            using var alter = connection.CreateCommand();
+            alter.Transaction = transaction;
+            alter.CommandText =
+                $"ALTER TABLE download_base ADD COLUMN {OutputReservationColumn} TEXT";
+            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await BackfillOutputReservationsAsync(connection, transaction, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = """
+                CREATE INDEX IF NOT EXISTS ix_download_base_file_path
+                    ON download_base(file_path);
+                CREATE INDEX IF NOT EXISTS ix_download_base_file_path_nocase
+                    ON download_base(file_path COLLATE NOCASE);
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_download_base_output_reservation
+                    ON download_base(output_reservation_key)
+                    WHERE output_reservation_key IS NOT NULL;
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await RecordMigrationAsync(connection, transaction, 3, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task ApplyVersionFourAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        // Version 3 persisted lexical/Form-C reservation keys. Rebuild the
+        // active set using filesystem-resolved identity.
+        //
+        // Clear all keys first. An existing database may already contain
+        // two active rows that were admitted through different aliases to
+        // the same physical destination. Keeping either legacy key while
+        // rewriting another row could cause a transient UNIQUE collision.
+        using (var clear = connection.CreateCommand())
+        {
+            clear.Transaction = transaction;
+            clear.CommandText = """
+                DROP INDEX IF EXISTS ux_download_base_output_reservation;
+
+                UPDATE download_base
+                SET output_reservation_key = NULL;
+                """;
+
+            await clear
+                .ExecuteNonQueryAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await BackfillOutputReservationsAsync(
+                connection,
+                transaction,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        using (var createIndex = connection.CreateCommand())
+        {
+            createIndex.Transaction = transaction;
+            createIndex.CommandText = """
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_download_base_output_reservation
+                    ON download_base(output_reservation_key)
+                    WHERE output_reservation_key IS NOT NULL;
+                """;
+
+            await createIndex
+                .ExecuteNonQueryAsync(cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        await RecordMigrationAsync(
+                connection,
+                transaction,
+                4,
+                appliedAtUtc,
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+    private static async Task BackfillOutputReservationsAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        var rows = new List<(string Id, string BasePath)>();
+        using (var select = connection.CreateCommand())
+        {
+            select.Transaction = transaction;
+            select.CommandText = """
+                SELECT db.id, db.file_path
+                FROM download_base db
+                INNER JOIN downloading dl ON dl.id = db.id
+                ORDER BY db.id
+                """;
+            using var reader = await select.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                rows.Add((reader.GetString(0), reader.GetString(1)));
+            }
+        }
+
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            string key;
+            try
+            {
+                key = DownloadOutputPathKey.Create(
+                    row.BasePath,
+                    DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+            }
+            catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
+            {
+                continue;
+            }
+
+            if (!keys.Add(key))
+            {
+                continue;
+            }
+
+            using var update = connection.CreateCommand();
+            update.Transaction = transaction;
+            update.CommandText = """
+                UPDATE download_base
+                SET output_reservation_key = @key
+                WHERE id = @id
+                """;
+            update.Parameters.AddWithValue("@key", key);
+            update.Parameters.AddWithValue("@id", row.Id);
+            await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
@@ -6,9 +6,9 @@ using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Infrastructure.Downloads;
 
-internal static class DownloadStoreSchema
+internal static partial class DownloadStoreSchema
 {
-    public const int CurrentVersion = 3;
+    public const int CurrentVersion = 4;
 
     private enum VersionTwoColumn
     {
@@ -70,6 +70,12 @@ internal static class DownloadStoreSchema
             if (currentVersion < 3)
             {
                 await ApplyVersionThreeAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (currentVersion < 4)
+            {
+                await ApplyVersionFourAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
@@ -200,102 +206,6 @@ internal static class DownloadStoreSchema
         }
 
         await RecordMigrationAsync(connection, transaction, 2, appliedAtUtc, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task ApplyVersionThreeAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        if (!await HasDownloadBaseColumnAsync(
-                connection,
-                transaction,
-                OutputReservationColumn,
-                cancellationToken).ConfigureAwait(false))
-        {
-            using var alter = connection.CreateCommand();
-            alter.Transaction = transaction;
-            alter.CommandText =
-                $"ALTER TABLE download_base ADD COLUMN {OutputReservationColumn} TEXT";
-            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await BackfillOutputReservationsAsync(connection, transaction, cancellationToken)
-            .ConfigureAwait(false);
-
-        using (var command = connection.CreateCommand())
-        {
-            command.Transaction = transaction;
-            command.CommandText = """
-                CREATE INDEX IF NOT EXISTS ix_download_base_file_path
-                    ON download_base(file_path);
-                CREATE INDEX IF NOT EXISTS ix_download_base_file_path_nocase
-                    ON download_base(file_path COLLATE NOCASE);
-                CREATE UNIQUE INDEX IF NOT EXISTS ux_download_base_output_reservation
-                    ON download_base(output_reservation_key)
-                    WHERE output_reservation_key IS NOT NULL;
-                """;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await RecordMigrationAsync(connection, transaction, 3, appliedAtUtc, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    private static async Task BackfillOutputReservationsAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        CancellationToken cancellationToken)
-    {
-        var rows = new List<(string Id, string BasePath)>();
-        using (var select = connection.CreateCommand())
-        {
-            select.Transaction = transaction;
-            select.CommandText = """
-                SELECT db.id, db.file_path
-                FROM download_base db
-                INNER JOIN downloading dl ON dl.id = db.id
-                ORDER BY db.id
-                """;
-            using var reader = await select.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                rows.Add((reader.GetString(0), reader.GetString(1)));
-            }
-        }
-
-        var keys = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {
-            string key;
-            try
-            {
-                key = DownloadOutputPathKey.Create(
-                    row.BasePath,
-                    DownloadOutputPathKey.UsesCaseInsensitiveComparison);
-            }
-            catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
-            {
-                continue;
-            }
-
-            if (!keys.Add(key))
-            {
-                continue;
-            }
-
-            using var update = connection.CreateCommand();
-            update.Transaction = transaction;
-            update.CommandText = """
-                UPDATE download_base
-                SET output_reservation_key = @key
-                WHERE id = @id
-                """;
-            update.Parameters.AddWithValue("@key", key);
-            update.Parameters.AddWithValue("@id", row.Id);
-            await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
     }
 
     private static async Task<bool> HasDownloadBaseColumnAsync(
@@ -451,14 +361,22 @@ internal static class DownloadStoreSchema
         int version,
         CancellationToken cancellationToken)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(version, CurrentVersion);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(
+            version,
+            CurrentVersion);
 
         using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = "PRAGMA user_version = 3";
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
 
+        // SQLite PRAGMA assignments do not support normal SQL parameters.
+        // Keep this as a compile-time literal so CA2100 can prove that no
+        // user-controlled SQL reaches CommandText.
+        command.CommandText = "PRAGMA user_version = 4";
+
+        await command
+            .ExecuteNonQueryAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
     private static async Task BackupAsync(
         SqliteConnection source,
         string databasePath,

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.OutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.OutputReservations.cs
@@ -116,9 +116,74 @@ public sealed partial class SqliteDownloadTaskStore
         command.Parameters.AddWithValue("@key", key);
         command.Parameters.AddWithValue("@file_path", basePath);
         var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-        return Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture) != 0;
+        if (Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture) != 0)
+        {
+            return true;
+        }
+
+        return await HasLegacyPhysicalReservationAsync(
+                connection,
+                transaction,
+                key,
+                ignoreCase,
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
+    private static async Task<bool> HasLegacyPhysicalReservationAsync(
+        SqliteConnection connection,
+        SqliteTransaction? transaction,
+        string reservationKey,
+        bool ignoreCase,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            SELECT db.file_path
+            FROM download_base db
+            INNER JOIN downloading dl ON dl.id = db.id
+            WHERE db.output_reservation_key IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM download_quarantine q
+                  WHERE q.source_table = 'downloading'
+                    AND q.record_id = db.id)
+            ORDER BY db.id
+            """;
+
+        using var reader =
+            await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            string candidateKey;
+            try
+            {
+                candidateKey =
+                    DownloadOutputPathKey.Create(
+                        reader.GetString(0),
+                        ignoreCase);
+            }
+            catch (Exception exception)
+                when (exception is ArgumentException
+                      or IOException
+                      or NotSupportedException)
+            {
+                continue;
+            }
+
+            if (string.Equals(
+                    candidateKey,
+                    reservationKey,
+                    StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
     private static OperationResult OutputPathConflict()
     {
         return OperationResult.Failure(new OperationError(

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -24,7 +24,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(true);
         using var version = connection.CreateCommand();
         version.CommandText = "PRAGMA user_version";
-        Assert.Equal(3L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(4L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             await reopened.InitializeAsync(TestContext.Current.CancellationToken);
         }
 
-        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.Equal(4, await ReadSchemaVersionAsync());
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
     }
 
@@ -142,7 +142,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
 
         await store.InitializeAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.Equal(4, await ReadSchemaVersionAsync());
         Assert.Equal(1, await CountDownloadBaseRecordAsync("legacy-resume"));
         Assert.Equal(1, await CountDownloadingRecordAsync("legacy-resume"));
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
@@ -168,6 +168,286 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
     }
 
+    [Fact]
+    public async Task JunctionAliasCannotClaimSamePhysicalOutputPath()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var cancellationToken =
+            TestContext.Current.CancellationToken;
+
+        var realDirectory =
+            Path.Combine(
+                _directory,
+                "claim-real");
+
+        var aliasDirectory =
+            Path.Combine(
+                _directory,
+                "claim-alias");
+
+        Directory.CreateDirectory(realDirectory);
+
+        await CreateDirectoryJunctionAsync(
+                aliasDirectory,
+                realDirectory,
+                cancellationToken)
+            .ConfigureAwait(true);
+
+        var realOutput =
+            Path.Combine(
+                realDirectory,
+                "shared-output");
+
+        var aliasOutput =
+            Path.Combine(
+                aliasDirectory,
+                "shared-output");
+
+        using var store = CreateStore();
+
+        var first =
+            await store.AddAsync(
+                    CreateQueuedTask(
+                        "junction-real-owner",
+                        realOutput),
+                    cancellationToken)
+                .ConfigureAwait(true);
+
+        var second =
+            await store.AddAsync(
+                    CreateQueuedTask(
+                        "junction-alias-owner",
+                        aliasOutput),
+                    cancellationToken)
+                .ConfigureAwait(true);
+
+        Assert.True(first.IsSuccess);
+
+        Assert.False(second.IsSuccess);
+        Assert.Equal(
+            "download.store.output_path_reserved",
+            second.Error?.Code);
+
+        Assert.True(
+            await store.IsOutputPathReservedAsync(
+                    realOutput,
+                    DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                    cancellationToken)
+                .ConfigureAwait(true));
+
+        Assert.True(
+            await store.IsOutputPathReservedAsync(
+                    aliasOutput,
+                    DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                    cancellationToken)
+                .ConfigureAwait(true));
+    }
+
+    [Fact]
+    public async Task VersionThreeReservationKeysAreRebuiltUsingFilesystemIdentity()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        var cancellationToken =
+            TestContext.Current.CancellationToken;
+
+        var realDirectory =
+            Path.Combine(
+                _directory,
+                "migration-real");
+
+        var aliasDirectory =
+            Path.Combine(
+                _directory,
+                "migration-alias");
+
+        Directory.CreateDirectory(realDirectory);
+        Directory.CreateDirectory(aliasDirectory);
+
+        var realOutput =
+            Path.Combine(
+                realDirectory,
+                "shared-output");
+
+        var aliasOutput =
+            Path.Combine(
+                aliasDirectory,
+                "shared-output");
+
+        using (var store = CreateStore())
+        {
+            Assert.True(
+                (await store.AddAsync(
+                        CreateQueuedTask(
+                            "migration-real-task",
+                            realOutput),
+                        cancellationToken)
+                    .ConfigureAwait(true))
+                .IsSuccess);
+
+            Assert.True(
+                (await store.AddAsync(
+                        CreateQueuedTask(
+                            "migration-alias-task",
+                            aliasOutput),
+                        cancellationToken)
+                    .ConfigureAwait(true))
+                .IsSuccess);
+        }
+
+        Directory.Delete(aliasDirectory);
+
+        await CreateDirectoryJunctionAsync(
+                aliasDirectory,
+                realDirectory,
+                cancellationToken)
+            .ConfigureAwait(true);
+
+        var legacyRealKey =
+            CreateLegacyVersionThreeReservationKey(realOutput);
+
+        var legacyAliasKey =
+            CreateLegacyVersionThreeReservationKey(aliasOutput);
+
+        Assert.NotEqual(
+            legacyRealKey,
+            legacyAliasKey);
+
+        using (var connection =
+               await OpenConnectionAsync(readOnly: false)
+                   .ConfigureAwait(true))
+        {
+            using var command =
+                connection.CreateCommand();
+
+            command.CommandText = """
+                PRAGMA user_version = 3;
+
+                UPDATE download_base
+                SET output_reservation_key = @real_key
+                WHERE id = 'migration-real-task';
+
+                UPDATE download_base
+                SET output_reservation_key = @alias_key
+                WHERE id = 'migration-alias-task';
+                """;
+
+            command.Parameters.AddWithValue(
+                "@real_key",
+                legacyRealKey);
+
+            command.Parameters.AddWithValue(
+                "@alias_key",
+                legacyAliasKey);
+
+            await command.ExecuteNonQueryAsync(
+                    cancellationToken)
+                .ConfigureAwait(true);
+        }
+
+        using (var reopened = CreateStore())
+        {
+            await reopened.InitializeAsync(
+                    cancellationToken)
+                .ConfigureAwait(true);
+
+            Assert.True(
+                await reopened.IsOutputPathReservedAsync(
+                        realOutput,
+                        DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                        cancellationToken)
+                    .ConfigureAwait(true));
+
+            Assert.True(
+                await reopened.IsOutputPathReservedAsync(
+                        aliasOutput,
+                        DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                        cancellationToken)
+                    .ConfigureAwait(true));
+        }
+
+        Assert.Equal(
+            4,
+            await ReadSchemaVersionAsync()
+                .ConfigureAwait(true));
+
+        var reservationKeys =
+            await ReadActiveReservationKeysAsync()
+                .ConfigureAwait(true);
+
+        var expectedPhysicalKey =
+            DownloadOutputPathKey.Create(
+                realOutput,
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+
+        Assert.Equal(
+            expectedPhysicalKey,
+            Assert.Single(reservationKeys));
+
+        using (var reopenedAfterMigration = CreateStore())
+        {
+            var migratedPhysicalOwner =
+                await reopenedAfterMigration.FindAsync(
+                        new DownloadTaskId("migration-alias-task"),
+                        cancellationToken)
+                    .ConfigureAwait(true);
+
+            Assert.NotNull(migratedPhysicalOwner);
+
+            var canceledOwner =
+                migratedPhysicalOwner
+                    .Cancel(_clock.UtcNow.AddSeconds(1))
+                    .RequireValue();
+
+            Assert.True(
+                (await reopenedAfterMigration.UpdateAsync(
+                        canceledOwner,
+                        migratedPhysicalOwner.Version,
+                        cancellationToken)
+                    .ConfigureAwait(true))
+                .IsSuccess);
+
+            var deletedOwner =
+                canceledOwner
+                    .Delete(_clock.UtcNow.AddSeconds(2))
+                    .RequireValue();
+
+            Assert.True(
+                (await reopenedAfterMigration.UpdateAsync(
+                        deletedOwner,
+                        canceledOwner.Version,
+                        cancellationToken)
+                    .ConfigureAwait(true))
+                .IsSuccess);
+
+            Assert.Equal(
+                1L,
+                await CountDownloadingRecordAsync(
+                        "migration-real-task")
+                    .ConfigureAwait(true));
+
+            var survivingPhysicalReservation =
+                await reopenedAfterMigration.IsOutputPathReservedAsync(
+                        aliasOutput,
+                        DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                        cancellationToken)
+                    .ConfigureAwait(true);
+
+            Assert.True(survivingPhysicalReservation);
+        }
+
+        Assert.Single(
+            Directory.GetFiles(
+                Path.Combine(_directory, "Backup"),
+                "download.db.schema-v3-*.bak"));
+    }
     [Fact]
     public async Task PausedTaskPreservesResumeStateAcrossReopen()
     {
@@ -409,6 +689,31 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             DefaultTimeout = 5
         }.ToString());
         SqliteConnection.ClearPool(connection);
+
+        foreach (var aliasName in new[]
+        {
+            "claim-alias",
+            "migration-alias"
+        })
+        {
+            var alias =
+                Path.Combine(
+                    _directory,
+                    aliasName);
+
+            if (!Directory.Exists(alias))
+            {
+                continue;
+            }
+
+            var attributes =
+                File.GetAttributes(alias);
+
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                Directory.Delete(alias);
+            }
+        }
         if (Directory.Exists(_directory))
         {
             Directory.Delete(_directory, recursive: true);
@@ -489,6 +794,100 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             1);
     }
 
+    private static string CreateLegacyVersionThreeReservationKey(
+        string path)
+    {
+        var normalized =
+            Path.TrimEndingDirectorySeparator(
+                    Path.GetFullPath(path))
+                .Normalize(
+                    System.Text.NormalizationForm.FormC);
+
+        return DownloadOutputPathKey
+            .UsesCaseInsensitiveComparison
+                ? normalized.ToUpperInvariant()
+                : normalized;
+    }
+
+    private async Task<List<string>> ReadActiveReservationKeysAsync()
+    {
+        using var connection =
+            await OpenReadOnlyConnectionAsync()
+                .ConfigureAwait(false);
+
+        using var command =
+            connection.CreateCommand();
+
+        command.CommandText = """
+            SELECT db.output_reservation_key
+            FROM download_base db
+            INNER JOIN downloading dl
+                ON dl.id = db.id
+            WHERE db.output_reservation_key IS NOT NULL
+            ORDER BY db.id
+            """;
+
+        var results =
+            new List<string>();
+
+        using var reader =
+            await command
+                .ExecuteReaderAsync(
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(false);
+
+        while (await reader
+                   .ReadAsync(
+                       TestContext.Current.CancellationToken)
+                   .ConfigureAwait(false))
+        {
+            results.Add(
+                reader.GetString(0));
+        }
+
+        return results;
+    }
+
+    private static async Task CreateDirectoryJunctionAsync(
+        string junctionPath,
+        string targetPath,
+        CancellationToken cancellationToken)
+    {
+        var startInfo =
+            new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments =
+                    $"/d /c mklink /J \"{junctionPath}\" \"{targetPath}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+        using var process =
+            System.Diagnostics.Process.Start(
+                startInfo)
+            ?? throw new InvalidOperationException(
+                "Failed to start cmd.exe for junction creation.");
+
+        await process
+            .WaitForExitAsync(
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            var error =
+                await process.StandardError
+                    .ReadToEndAsync(
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+            throw new IOException(
+                $"Failed to create junction: {error}");
+        }
+    }
     private async Task<SqliteConnection> OpenReadOnlyConnectionAsync()
     {
         var connection = new SqliteConnection(new SqliteConnectionStringBuilder

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -8,6 +8,8 @@ namespace DownKyi.Infrastructure.Tests;
 
 public sealed class SqliteDownloadTaskStoreTests : IDisposable
 {
+    public static bool IsWindows => OperatingSystem.IsWindows();
+
     private readonly string _directory = Path.Combine(
         Path.GetTempPath(),
         "downkyi-download-store-tests",
@@ -168,14 +170,9 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
     }
 
-    [Fact]
+    [Fact(Skip = "Requires Windows directory-junction semantics.", SkipUnless = nameof(IsWindows))]
     public async Task JunctionAliasCannotClaimSamePhysicalOutputPath()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            return;
-        }
-
         var cancellationToken =
             TestContext.Current.CancellationToken;
 
@@ -247,14 +244,9 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
                 .ConfigureAwait(true));
     }
 
-    [Fact]
+    [Fact(Skip = "Requires Windows directory-junction semantics.", SkipUnless = nameof(IsWindows))]
     public async Task VersionThreeReservationKeysAreRebuiltUsingFilesystemIdentity()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            return;
-        }
-
         var cancellationToken =
             TestContext.Current.CancellationToken;
 

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -170,6 +170,164 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task JunctionAliasUsesDistinctLogicalSuffix()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(_directory);
+
+        var realDirectory =
+            Path.Combine(_directory, "junction-real");
+
+        var aliasDirectory =
+            Path.Combine(_directory, "junction-alias");
+
+        Directory.CreateDirectory(realDirectory);
+
+        await CreateDirectoryJunctionAsync(
+                aliasDirectory,
+                realDirectory,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        try
+        {
+            using var store = CreateStore();
+            var clock = new SystemClock();
+            using var tasks =
+                new DownloadTaskApplicationService(store, clock);
+            using var projections =
+                new DownloadTaskProjectionStore(tasks, clock);
+            using var admission =
+                new DownloadTaskAdmissionService(
+                    new DownloadListState(),
+                    tasks,
+                    projections,
+                    new RecordingDownloadTaskQueue());
+
+            var realOutput =
+                Path.Combine(realDirectory, "same-output");
+
+            var aliasOutput =
+                Path.Combine(aliasDirectory, "same-output");
+
+            var first =
+                CreateItem("junction-real-owner", realOutput);
+
+            var second =
+                CreateItem("junction-alias-owner", aliasOutput);
+
+            await admission.AdmitAsync(
+                    first,
+                    true,
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+
+            await admission.AdmitAsync(
+                    second,
+                    true,
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+
+            Assert.Equal(
+                Path.GetFullPath(aliasOutput + "(1)"),
+                second.DownloadBase.FilePath);
+        }
+        finally
+        {
+            if (Directory.Exists(aliasDirectory))
+            {
+                Directory.Delete(aliasDirectory);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task JunctionAliasFailsClosedWhenAutoSuffixDisabled()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        Directory.CreateDirectory(_directory);
+
+        var realDirectory =
+            Path.Combine(_directory, "no-suffix-real");
+
+        var aliasDirectory =
+            Path.Combine(_directory, "no-suffix-alias");
+
+        Directory.CreateDirectory(realDirectory);
+
+        await CreateDirectoryJunctionAsync(
+                aliasDirectory,
+                realDirectory,
+                TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        try
+        {
+            using var store = CreateStore();
+            var clock = new SystemClock();
+            using var tasks =
+                new DownloadTaskApplicationService(store, clock);
+            using var projections =
+                new DownloadTaskProjectionStore(tasks, clock);
+            using var admission =
+                new DownloadTaskAdmissionService(
+                    new DownloadListState(),
+                    tasks,
+                    projections,
+                    new RecordingDownloadTaskQueue());
+
+            var realOutput =
+                Path.Combine(realDirectory, "same-output");
+
+            var aliasOutput =
+                Path.Combine(aliasDirectory, "same-output");
+
+            var first =
+                CreateItem("no-suffix-real-owner", realOutput);
+
+            var second =
+                CreateItem("no-suffix-alias-owner", aliasOutput);
+
+            await admission.AdmitAsync(
+                    first,
+                    true,
+                    TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+
+            await Assert.ThrowsAsync<IOException>(
+                () => admission.AdmitAsync(
+                    second,
+                    false,
+                    TestContext.Current.CancellationToken));
+
+            Assert.Equal(
+                aliasOutput,
+                second.DownloadBase.FilePath);
+
+            var persisted =
+                await tasks.GetUnfinishedAsync(
+                        TestContext.Current.CancellationToken)
+                    .ConfigureAwait(true);
+
+            Assert.Single(persisted);
+        }
+        finally
+        {
+            if (Directory.Exists(aliasDirectory))
+            {
+                Directory.Delete(aliasDirectory);
+            }
+        }
+    }
+    [Fact]
     public void CaseInsensitivePathKeyTreatsMacStyleCaseVariantsAsOneOutput()
     {
         var first = Path.Combine(_directory, "Video");
@@ -219,6 +377,43 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         Assert.Equal(20, store.ReservationProbeCount);
     }
 
+    private static async Task CreateDirectoryJunctionAsync(
+        string junctionPath,
+        string targetPath,
+        CancellationToken cancellationToken)
+    {
+        var startInfo =
+            new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments =
+                    $"/d /c mklink /J \"{junctionPath}\" \"{targetPath}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+
+        using var process =
+            System.Diagnostics.Process.Start(startInfo)
+            ?? throw new InvalidOperationException(
+                "Failed to start cmd.exe for junction creation.");
+
+        await process.WaitForExitAsync(
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (process.ExitCode != 0)
+        {
+            var error =
+                await process.StandardError.ReadToEndAsync(
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+            throw new IOException(
+                $"Failed to create junction: {error}");
+        }
+    }
     private SqliteDownloadTaskStore CreateStore()
     {
         return new SqliteDownloadTaskStore(

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -374,7 +374,27 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             true,
             TestContext.Current.CancellationToken).ConfigureAwait(true);
 
-        Assert.Equal(Path.GetFullPath($"{decomposed}(1)"), second.DownloadBase.FilePath);
+        Assert.Equal(Path.GetFullPath($"{composed}(1)"), second.DownloadBase.FilePath);
+    }
+
+    [Fact]
+    public async Task ExistingCanonicalUnicodeAliasUsesFirstFreeSuffix()
+    {
+        Directory.CreateDirectory(_directory);
+        var composed = Path.Combine(_directory, "caf\u00E9");
+        var decomposed = Path.Combine(_directory, "cafe\u0301");
+        await File.WriteAllTextAsync(
+            $"{composed}.mp4",
+            "occupied",
+            TestContext.Current.CancellationToken);
+
+        var resolved = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+            decomposed,
+            autoAddNumberSuffix: true,
+            static (_, _) => Task.FromResult(false),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(Path.GetFullPath($"{composed}(1)"), resolved);
     }
 
     [Fact]

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -13,6 +13,8 @@ namespace DownKyi.Tests;
 
 public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 {
+    public static bool IsWindows => OperatingSystem.IsWindows();
+
     private readonly string _directory = Path.Combine(
         Path.GetTempPath(),
         "downkyi-admission-tests",
@@ -169,14 +171,9 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         Assert.Empty(await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken));
     }
 
-    [Fact]
+    [Fact(Skip = "Requires Windows directory-junction semantics.", SkipUnless = nameof(IsWindows))]
     public async Task JunctionAliasUsesDistinctLogicalSuffix()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            return;
-        }
-
         Directory.CreateDirectory(_directory);
 
         var realDirectory =
@@ -245,14 +242,9 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         }
     }
 
-    [Fact]
+    [Fact(Skip = "Requires Windows directory-junction semantics.", SkipUnless = nameof(IsWindows))]
     public async Task JunctionAliasFailsClosedWhenAutoSuffixDisabled()
     {
-        if (!OperatingSystem.IsWindows())
-        {
-            return;
-        }
-
         Directory.CreateDirectory(_directory);
 
         var realDirectory =
@@ -339,6 +331,50 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         Assert.NotEqual(
             DownloadOutputPathKey.Create(first, ignoreCase: false),
             DownloadOutputPathKey.Create(second, ignoreCase: false));
+    }
+
+    [Fact]
+    public void PathKeyTreatsCanonicalUnicodeVariantsAsOneOutput()
+    {
+        var composed = Path.Combine(_directory, "caf\u00E9");
+        var decomposed = Path.Combine(_directory, "cafe\u0301");
+
+        Assert.Equal(
+            DownloadOutputPathKey.Create(composed, ignoreCase: false),
+            DownloadOutputPathKey.Create(decomposed, ignoreCase: false));
+        Assert.Equal(
+            DownloadOutputPathKey.Create(composed, ignoreCase: true),
+            DownloadOutputPathKey.Create(decomposed, ignoreCase: true));
+    }
+
+    [Fact]
+    public async Task CanonicalUnicodeAliasUsesFirstFreeSuffix()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        using var admission = new DownloadTaskAdmissionService(
+            new DownloadListState(),
+            tasks,
+            projections,
+            new RecordingDownloadTaskQueue());
+        var composed = Path.Combine(_directory, "caf\u00E9");
+        var decomposed = Path.Combine(_directory, "cafe\u0301");
+        var first = CreateItem("unicode-composed", composed);
+        var second = CreateItem("unicode-decomposed", decomposed);
+
+        await admission.AdmitAsync(
+            first,
+            true,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+        await admission.AdmitAsync(
+            second,
+            true,
+            TestContext.Current.CancellationToken).ConfigureAwait(true);
+
+        Assert.Equal(Path.GetFullPath($"{decomposed}(1)"), second.DownloadBase.FilePath);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- introduce a durable physical output reservation identity while preserving the logical download path
- collapse Windows junction/reparse aliases and anchor nonexistent suffixes beneath the nearest resolved physical ancestor
- normalize reservation keys to Unicode Form C before applying the platform case policy
- migrate SQLite reservation keys to schema version 4 and preserve legacy null-key lookup after migration

This is PR #228 Module 1, split into an independently verifiable change.

Refs #176

## Scope boundary
Included only: `DownloadOutputPathKey`, `IOutputIdentityProvider` / `FileSystemOutputIdentityProvider`, SQLite output-reservation schema and lookup, the logical-path resolver handoff, and direct regressions.

Excluded: quarantine lifecycle, atomic batch admission, publication, artifact provenance, safe deletion, and retry idempotency. Those remain separate modules. Existing connection-specific `SqliteConnection.ClearPool(connection)` and junction cleanup are preserved.

## Validation
Windows x64, exact tree committed at `3fc5f251582a446c7b5377d8e3e3b9209384df55`:
- `dotnet restore ./DownKyi.sln`
- strict Release solution build with analyzers and warnings-as-errors: 0 warnings, 0 errors
- focused `SqliteDownloadTaskStoreTests`: 21/21
- focused `DownloadTaskAdmissionServiceTests`: 13/13
- Application tests: 21/21
- Infrastructure tests: 76/76
- Desktop tests: 23/23
- executable compatibility/service tests: 362 passed, 1 explicit unrelated aria2 TLS skip
- Architecture tests: 280/280
- `dotnet format ./DownKyi.sln --verify-no-changes --no-restore`
- failure-before-fix regression: an existing composed `café.mp4` did not block the decomposed equivalent and returned the unsuffixed path; the repaired exact-head class run passed 13/13
- `git diff --check`

## Remaining verification boundary
Local junction regressions ran on Windows. Linux and macOS behavior, including normalization-insensitive macOS filesystem behavior, remains for exact-head hosted CI. No full solution test run, package audit, secret scan, or release/package validation was performed for this scoped module.