### PR TITLE
fix(downloads): freeze physical output path on admission

### DIFF
--- a/src/DownKyi.Desktop/Composition/DesktopComposition.cs
+++ b/src/DownKyi.Desktop/Composition/DesktopComposition.cs
@@ -91,6 +91,7 @@ internal static class DesktopComposition
         });
         services.AddSingleton<IWbiKeyProvider, WbiKeyProvider>();
         services.AddSingleton<FfmpegProcessor>();
+        services.AddSingleton<IPhysicalOutputPathResolver, FileSystemPhysicalOutputPathResolver>();
         services.AddSingleton<IDownloadTaskStore, SqliteDownloadTaskStore>();
         services.AddSingleton<IDownloadTaskApplicationService, DownloadTaskApplicationService>();
         services.AddSingleton<DownloadTaskProjectionStore>();

--- a/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
+++ b/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
@@ -258,13 +258,26 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
                         .ConfigureAwait(true);
                 }
 
-                await _admission
-                    .AdmitAsync(
-                        downloadingItem,
-                        settings.Basic.RepeatFileAutoAddNumberSuffix,
-                        cancellationToken)
-                    .ConfigureAwait(true);
-                addedCount++;
+                try
+                {
+                    await _admission
+                        .AdmitAsync(
+                            downloadingItem,
+                            settings.Basic.RepeatFileAutoAddNumberSuffix,
+                            cancellationToken)
+                        .ConfigureAwait(true);
+                    addedCount++;
+                }
+                catch (IOException exception)
+                {
+                    _logger.LogWarningMessage("Download task admission failed.", exception);
+                    var alert = new AlertService(_dialogService);
+                    await alert
+                        .ShowError(
+                            DictionaryResource.GetString("DirectoryError"),
+                            cancellationToken)
+                        .ConfigureAwait(true);
+                }
             }
         }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
@@ -20,16 +20,18 @@ internal static class DownloadOutputPathResolver
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
         ArgumentNullException.ThrowIfNull(isReservedAsync);
         comparer ??= PlatformComparer;
-        var occupiedPaths = GetExistingBasePaths(basePath).ToHashSet(comparer);
+        var occupiedPaths = GetExistingBasePaths(basePath)
+            .Select(CreateComparisonKey)
+            .ToHashSet(comparer);
         for (var suffix = 0; ; suffix++)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var candidate = suffix == 0 ? basePath : $"{basePath}({suffix})";
-            var normalizedCandidate = Normalize(candidate);
-            if (!occupiedPaths.Contains(normalizedCandidate) &&
-                !await isReservedAsync(normalizedCandidate, cancellationToken).ConfigureAwait(false))
+            var comparisonKey = CreateComparisonKey(candidate);
+            if (!occupiedPaths.Contains(comparisonKey) &&
+                !await isReservedAsync(candidate, cancellationToken).ConfigureAwait(false))
             {
-                return normalizedCandidate;
+                return candidate;
             }
 
             if (!autoAddNumberSuffix)
@@ -46,8 +48,7 @@ internal static class DownloadOutputPathResolver
 
     private static string[] GetExistingBasePaths(string basePath)
     {
-        var normalizedBasePath = Normalize(basePath);
-        var directory = Path.GetDirectoryName(normalizedBasePath);
+        var directory = Path.GetDirectoryName(basePath);
         if (directory == null || !Directory.Exists(directory))
         {
             return [];
@@ -56,11 +57,10 @@ internal static class DownloadOutputPathResolver
         return Directory
             .EnumerateFiles(directory)
             .Select(file => Path.Combine(directory, Path.GetFileNameWithoutExtension(file)))
-            .Select(Normalize)
             .ToArray();
     }
 
-    private static string Normalize(string path)
+    private static string CreateComparisonKey(string path)
     {
         return DownloadOutputPathKey.Create(path, ignoreCase: false);
     }

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
@@ -13,6 +13,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
     private readonly IDownloadTaskApplicationService _tasks;
     private readonly DownloadTaskProjectionStore _projections;
     private readonly IDownloadTaskQueue _taskQueue;
+    private readonly IPhysicalOutputPathResolver _physicalOutputPathResolver;
     private readonly SemaphoreSlim _admissionGate = new(1, 1);
     private bool _disposed;
 
@@ -20,12 +21,15 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         DownloadListState downloadLists,
         IDownloadTaskApplicationService tasks,
         DownloadTaskProjectionStore projections,
-        IDownloadTaskQueue taskQueue)
+        IDownloadTaskQueue taskQueue,
+        IPhysicalOutputPathResolver physicalOutputPathResolver)
     {
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
         _projections = projections ?? throw new ArgumentNullException(nameof(projections));
         _taskQueue = taskQueue ?? throw new ArgumentNullException(nameof(taskQueue));
+        _physicalOutputPathResolver = physicalOutputPathResolver
+            ?? throw new ArgumentNullException(nameof(physicalOutputPathResolver));
     }
 
     public async Task AdmitAsync(
@@ -38,14 +42,17 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         await _admissionGate.WaitAsync(cancellationToken).ConfigureAwait(true);
         try
         {
-            item.DownloadBase.FilePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
-                item.DownloadBase.FilePath,
+            var physicalBasePath = _physicalOutputPathResolver.ResolvePhysicalBasePath(
+                item.DownloadBase.FilePath);
+            var admittedBasePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+                physicalBasePath,
                 autoAddNumberSuffix,
                 (candidate, token) => _tasks.IsOutputPathReservedAsync(
                     candidate,
                     DownloadOutputPathKey.UsesCaseInsensitiveComparison,
                     token),
                 cancellationToken).ConfigureAwait(true);
+            item.DownloadBase.FilePath = admittedBasePath;
 
             await _projections.AddDownloadingAsync(item, cancellationToken).ConfigureAwait(true);
 

--- a/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using DownKyi.Application.Desktop;
 using DownKyi.Application.Diagnostics;
 using DownKyi.Domain.Results;
-using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.Services.Download;
@@ -43,7 +42,7 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
         string path;
         try
         {
-            path = GetDownloadDirectoryPath(downloading);
+            path = GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
             Directory.CreateDirectory(path);
         }
         catch (Exception exception) when (exception is IOException
@@ -91,9 +90,4 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
                    nameof(filePath));
     }
 
-    internal static string GetDownloadDirectoryPath(DownloadingItem downloading)
-    {
-        ArgumentNullException.ThrowIfNull(downloading);
-        return GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
-    }
 }

--- a/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
@@ -38,11 +38,13 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
     {
         ArgumentNullException.ThrowIfNull(context);
         var downloading = context.Downloading;
+        var playbackBasePath = downloading.DownloadBase.FilePath
+            .Replace("\\", "/", StringComparison.Ordinal);
 
         string path;
         try
         {
-            path = GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
+            path = GetDownloadDirectoryPath(playbackBasePath);
             Directory.CreateDirectory(path);
         }
         catch (Exception exception) when (exception is IOException

--- a/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DownKyi.Application.Desktop;
 using DownKyi.Application.Diagnostics;
 using DownKyi.Domain.Results;
+using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.Services.Download;
@@ -38,13 +39,11 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
     {
         ArgumentNullException.ThrowIfNull(context);
         var downloading = context.Downloading;
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath
-            .Replace("\\", "/", StringComparison.Ordinal);
 
         string path;
         try
         {
-            path = GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
+            path = GetDownloadDirectoryPath(downloading);
             Directory.CreateDirectory(path);
         }
         catch (Exception exception) when (exception is IOException
@@ -92,4 +91,9 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
                    nameof(filePath));
     }
 
+    internal static string GetDownloadDirectoryPath(DownloadingItem downloading)
+    {
+        ArgumentNullException.ThrowIfNull(downloading);
+        return GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
+    }
 }

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -28,7 +28,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
         var listState = new DownloadListState();
         var queue = new RecordingDownloadTaskQueue();
-        using var admission = new DownloadTaskAdmissionService(listState, tasks, projections, queue);
+        using var admission = CreateAdmission(listState, tasks, projections, queue);
         var basePath = Path.Combine(_directory, "same-output");
         var first = CreateItem("first", basePath);
         var second = CreateItem("second", basePath);
@@ -56,7 +56,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -89,7 +89,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -123,7 +123,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -148,7 +148,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -167,6 +167,149 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
         Assert.Equal(basePath, item.DownloadBase.FilePath);
         Assert.Empty(await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CollisionResolutionPreservesRawCandidateSpelling()
+    {
+        var basePath = Path.Combine(_directory, "cafe\u0301-output");
+
+        var resolved = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+            basePath,
+            autoAddNumberSuffix: true,
+            static (_, _) => Task.FromResult(false),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(Path.GetFullPath(basePath), resolved, ignoreCase: false);
+    }
+
+    [Fact]
+    public async Task AdmissionFreezesPhysicalPathBeforeReservationPersistenceProjectionAndQueue()
+    {
+        Directory.CreateDirectory(_directory);
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore);
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var queue = new AdmissionObservingQueue(listState, projections);
+        var logicalBasePath = Path.Combine(_directory, "logical-alias", "cafe\u0301-output");
+        var frozenBasePath = Path.Combine(_directory, "physical-target", "cafe\u0301-output");
+        var resolver = new RecordingPhysicalOutputPathResolver(_ => frozenBasePath);
+        using var admission = CreateAdmission(listState, tasks, projections, queue, resolver);
+        var item = CreateItem("frozen", logicalBasePath);
+
+        await admission.AdmitAsync(item, true, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        var persisted = Assert.Single(await tasks.GetUnfinishedAsync(
+            TestContext.Current.CancellationToken));
+        var taskId = new DownloadTaskId(item.DownloadBase.Id);
+        Assert.Equal([logicalBasePath], resolver.Inputs);
+        Assert.Equal([frozenBasePath], store.ReservationPaths);
+        Assert.Equal(frozenBasePath, item.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal(frozenBasePath, persisted.Output.BasePath, ignoreCase: false);
+        Assert.Equal(
+            frozenBasePath,
+            projections.GetRequiredSnapshot(taskId).Output.BasePath,
+            ignoreCase: false);
+        Assert.Same(item, Assert.Single(listState.Downloading));
+        Assert.Equal(taskId, Assert.Single(queue.Enqueued));
+        Assert.Equal([frozenBasePath], queue.ObservedPaths);
+        Assert.DoesNotContain(
+            logicalBasePath,
+            new[] { item.DownloadBase.FilePath, persisted.Output.BasePath },
+            StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolverFailureHasNoPersistenceListOrQueueSideEffects()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        var logicalBasePath = Path.Combine(_directory, "broken-alias", "output");
+        var resolver = new RecordingPhysicalOutputPathResolver(
+            _ => throw new IOException("Alias resolution failed."));
+        using var admission = CreateAdmission(listState, tasks, projections, queue, resolver);
+        var item = CreateItem("unresolved", logicalBasePath);
+
+        await Assert.ThrowsAsync<IOException>(() => admission.AdmitAsync(
+            item,
+            true,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal([logicalBasePath], resolver.Inputs);
+        Assert.Equal(logicalBasePath, item.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Empty(await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(listState.Downloading);
+        Assert.Empty(queue.Enqueued);
+    }
+
+    [Fact]
+    public async Task PersistenceFailureDoesNotPublishToListOrQueue()
+    {
+        Directory.CreateDirectory(_directory);
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore) { RejectAdds = true };
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        using var admission = CreateAdmission(listState, tasks, projections, queue);
+        var item = CreateItem("rejected", Path.Combine(_directory, "rejected-output"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => admission.AdmitAsync(
+            item,
+            true,
+            TestContext.Current.CancellationToken));
+
+        Assert.Empty(await innerStore.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(listState.Downloading);
+        Assert.Empty(queue.Enqueued);
+    }
+
+    [Fact]
+    public async Task AliasesSharePhysicalCollisionSequenceAndRemainFrozenAfterRetarget()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var frozenBasePath = Path.Combine(_directory, "physical-target", "output");
+        var currentTarget = frozenBasePath;
+        var resolver = new RecordingPhysicalOutputPathResolver(_ => currentTarget);
+        using var admission = CreateAdmission(
+            new DownloadListState(),
+            tasks,
+            projections,
+            new RecordingDownloadTaskQueue(),
+            resolver);
+        var first = CreateItem("first-alias", Path.Combine(_directory, "alias-a", "output"));
+        var second = CreateItem("second-alias", Path.Combine(_directory, "alias-b", "output"));
+
+        await admission.AdmitAsync(first, true, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+        currentTarget = Path.Combine(_directory, "retargeted", "output");
+        Assert.Equal(frozenBasePath, first.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal(
+            frozenBasePath,
+            projections.GetRequiredSnapshot(new DownloadTaskId(first.DownloadBase.Id)).Output.BasePath,
+            ignoreCase: false);
+        currentTarget = frozenBasePath;
+        await admission.AdmitAsync(second, true, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(frozenBasePath, first.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal($"{frozenBasePath}(1)", second.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal(2, resolver.Inputs.Count);
     }
 
     [Fact]
@@ -202,7 +345,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -224,6 +367,21 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         return new SqliteDownloadTaskStore(
             new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
             new SystemClock());
+    }
+
+    private static DownloadTaskAdmissionService CreateAdmission(
+        DownloadListState listState,
+        IDownloadTaskApplicationService tasks,
+        DownloadTaskProjectionStore projections,
+        IDownloadTaskQueue queue,
+        IPhysicalOutputPathResolver? resolver = null)
+    {
+        return new DownloadTaskAdmissionService(
+            listState,
+            tasks,
+            projections,
+            queue,
+            resolver ?? new FileSystemPhysicalOutputPathResolver());
     }
 
     private static DownloadingItem CreateItem(string id, string basePath)
@@ -249,16 +407,24 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
     private sealed class CountingDownloadTaskStore(IDownloadTaskStore inner) : IDownloadTaskStore
     {
+        public bool RejectAdds { get; init; }
+
         public int GetUnfinishedCallCount { get; private set; }
 
         public int ReservationProbeCount { get; private set; }
+
+        public List<string> ReservationPaths { get; } = [];
 
         public Task InitializeAsync(CancellationToken cancellationToken) =>
             inner.InitializeAsync(cancellationToken);
 
         public Task<OperationResult> AddAsync(
             DownloadTask task,
-            CancellationToken cancellationToken) => inner.AddAsync(task, cancellationToken);
+            CancellationToken cancellationToken) => RejectAdds
+                ? Task.FromResult(OperationResult.Failure(new OperationError(
+                    "test.persistence_rejected",
+                    "Persistence rejected the task.")))
+                : inner.AddAsync(task, cancellationToken);
 
         public Task<OperationResult> UpdateAsync(
             DownloadTask task,
@@ -288,6 +454,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             CancellationToken cancellationToken)
         {
             ReservationProbeCount++;
+            ReservationPaths.Add(basePath);
             return inner.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
         }
 
@@ -306,6 +473,46 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
         public Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
             CancellationToken cancellationToken) => inner.GetQuarantinedRecordsAsync(cancellationToken);
+    }
+
+    private sealed class RecordingPhysicalOutputPathResolver(Func<string, string> resolve)
+        : IPhysicalOutputPathResolver
+    {
+        public List<string> Inputs { get; } = [];
+
+        public string ResolvePhysicalBasePath(string logicalBasePath)
+        {
+            Inputs.Add(logicalBasePath);
+            return resolve(logicalBasePath);
+        }
+    }
+
+    private sealed class AdmissionObservingQueue(
+        DownloadListState listState,
+        DownloadTaskProjectionStore projections) : IDownloadTaskQueue
+    {
+        public List<DownloadTaskId> Enqueued { get; } = [];
+
+        public List<string> ObservedPaths { get; } = [];
+
+        public Task EnqueueAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var listItem = Assert.Single(
+                listState.Downloading,
+                item => item.DownloadBase.Id == taskId.Value);
+            Assert.Equal(
+                listItem.DownloadBase.FilePath,
+                projections.GetRequiredSnapshot(taskId).Output.BasePath,
+                ignoreCase: false);
+            Enqueued.Add(taskId);
+            ObservedPaths.Add(listItem.DownloadBase.FilePath);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> CancelAsync(DownloadTaskId taskId) => Task.FromResult(true);
     }
 
     public void Dispose()

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -381,7 +381,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             tasks,
             projections,
             queue,
-            resolver ?? new FileSystemPhysicalOutputPathResolver());
+            resolver ?? new RecordingPhysicalOutputPathResolver(static path => path));
     }
 
     private static DownloadingItem CreateItem(string id, string basePath)

--- a/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
+++ b/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
@@ -6,6 +6,7 @@ using DownKyi.Infrastructure.Time;
 using DownKyi.Models;
 using DownKyi.Services.Download;
 using DownKyi.ViewModels.DownloadManager;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Tests;
@@ -72,21 +73,18 @@ public sealed class DurlDownloadIdentityTests
     }
 
     [Fact]
-    public async Task PlaybackStageDoesNotRewriteFrozenBasePathWhenDirectoryPreparationFails()
+    public async Task PlaybackStageUsesLegacySeparatorsWithoutRewritingFrozenBasePath()
     {
         var directory = Path.Combine(
             Path.GetTempPath(),
             "downkyi-playback-path-tests",
             Guid.NewGuid().ToString("N"));
+        var databasePath = Path.Combine(directory, "download.db");
         Directory.CreateDirectory(directory);
         try
         {
-            var blockedDirectory = Path.Combine(directory, "blocked");
-            await File.WriteAllTextAsync(
-                blockedDirectory,
-                "not a directory",
-                TestContext.Current.CancellationToken);
-            var frozenBasePath = Path.Combine(blockedDirectory, "frozen\\alias");
+            var frozenBasePath = Path.Combine(directory, "legacy\\nested\\video");
+            var expectedDirectory = Path.Combine(directory, "legacy", "nested");
             var downloadBase = new DownloadBase
             {
                 Id = "frozen-playback-path",
@@ -98,25 +96,36 @@ public sealed class DurlDownloadIdentityTests
                 Downloading = new Downloading
                 {
                     Id = downloadBase.Id,
-                    DownloadBase = downloadBase
+                    DownloadBase = downloadBase,
+                    DownloadStatus = DownloadStatus.WaitForDownload
                 },
                 PlayUrl = new PlayUrl()
             };
             using var store = new SqliteDownloadTaskStore(
-                new SqliteDownloadTaskStoreOptions(Path.Combine(directory, "download.db")),
+                new SqliteDownloadTaskStoreOptions(databasePath),
                 new SystemClock());
             using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
             using var settings = new TestSettingsStore();
+            var taskId = new DownloadTaskId(downloadBase.Id);
+            var stateWriter = new DownloadTaskStateWriter(tasks);
+            var task = DownloadTaskProjectionMapper.CreateNewTask(
+                downloading,
+                DateTimeOffset.UnixEpoch);
+            Assert.True((await tasks.AddAsync(
+                task,
+                TestContext.Current.CancellationToken).ConfigureAwait(true)).IsSuccess);
+            await stateWriter.StartAsync(taskId, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
             var stage = new ResolvePlaybackStage(
                 new TestDesktopInteractionContext().Notifications,
-                new DownloadActivityPresenter(new DownloadTaskStateWriter(tasks)),
+                new DownloadActivityPresenter(stateWriter),
                 new DownloadPlaybackResolver(
                     new TestWbiKeyProvider(),
                     TimeProvider.System,
                     new TestBilibiliApiClient()),
                 NullLogger<ResolvePlaybackStage>.Instance);
             var context = new DownloadExecutionContext(
-                new DownloadTaskId(downloadBase.Id),
+                taskId,
                 downloading,
                 settings.Store.Current,
                 static (_, token) => token.ThrowIfCancellationRequested());
@@ -125,11 +134,20 @@ public sealed class DurlDownloadIdentityTests
                 context,
                 TestContext.Current.CancellationToken);
 
-            Assert.False(result.IsSuccess);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(expectedDirectory, context.DownloadDirectory);
             Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
         }
         finally
         {
+            using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+            {
+                DataSource = databasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = true,
+                DefaultTimeout = 5
+            }.ToString());
+            SqliteConnection.ClearPool(connection);
             Directory.Delete(directory, recursive: true);
         }
     }

--- a/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
+++ b/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
@@ -1,5 +1,7 @@
 using DownKyi.Core.BiliApi.VideoStream.Models;
+using DownKyi.Models;
 using DownKyi.Services.Download;
+using DownKyi.ViewModels.DownloadManager;
 
 namespace DownKyi.Tests;
 
@@ -62,5 +64,20 @@ public sealed class DurlDownloadIdentityTests
         Assert.Equal(
             Path.Combine("downloads", "nested"),
             ResolvePlaybackStage.GetDownloadDirectoryPath(filePath));
+    }
+
+    [Fact]
+    public void PlaybackPathResolutionDoesNotRewriteFrozenBasePath()
+    {
+        var frozenBasePath = Path.Combine("downloads", "cafe\u0301", "video");
+        var downloading = new DownloadingItem
+        {
+            DownloadBase = new DownloadBase { FilePath = frozenBasePath }
+        };
+
+        var directory = ResolvePlaybackStage.GetDownloadDirectoryPath(downloading);
+
+        Assert.Equal(Path.GetDirectoryName(frozenBasePath), directory);
+        Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
     }
 }

--- a/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
+++ b/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
@@ -1,7 +1,12 @@
+using DownKyi.Application.Downloads;
 using DownKyi.Core.BiliApi.VideoStream.Models;
+using DownKyi.Domain.Downloads;
+using DownKyi.Infrastructure.Downloads;
+using DownKyi.Infrastructure.Time;
 using DownKyi.Models;
 using DownKyi.Services.Download;
 using DownKyi.ViewModels.DownloadManager;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Tests;
 
@@ -67,17 +72,65 @@ public sealed class DurlDownloadIdentityTests
     }
 
     [Fact]
-    public void PlaybackPathResolutionDoesNotRewriteFrozenBasePath()
+    public async Task PlaybackStageDoesNotRewriteFrozenBasePathWhenDirectoryPreparationFails()
     {
-        var frozenBasePath = Path.Combine("downloads", "cafe\u0301", "video");
-        var downloading = new DownloadingItem
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "downkyi-playback-path-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
         {
-            DownloadBase = new DownloadBase { FilePath = frozenBasePath }
-        };
+            var blockedDirectory = Path.Combine(directory, "blocked");
+            await File.WriteAllTextAsync(
+                blockedDirectory,
+                "not a directory",
+                TestContext.Current.CancellationToken);
+            var frozenBasePath = Path.Combine(blockedDirectory, "frozen\\alias");
+            var downloadBase = new DownloadBase
+            {
+                Id = "frozen-playback-path",
+                FilePath = frozenBasePath
+            };
+            var downloading = new DownloadingItem
+            {
+                DownloadBase = downloadBase,
+                Downloading = new Downloading
+                {
+                    Id = downloadBase.Id,
+                    DownloadBase = downloadBase
+                },
+                PlayUrl = new PlayUrl()
+            };
+            using var store = new SqliteDownloadTaskStore(
+                new SqliteDownloadTaskStoreOptions(Path.Combine(directory, "download.db")),
+                new SystemClock());
+            using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+            using var settings = new TestSettingsStore();
+            var stage = new ResolvePlaybackStage(
+                new TestDesktopInteractionContext().Notifications,
+                new DownloadActivityPresenter(new DownloadTaskStateWriter(tasks)),
+                new DownloadPlaybackResolver(
+                    new TestWbiKeyProvider(),
+                    TimeProvider.System,
+                    new TestBilibiliApiClient()),
+                NullLogger<ResolvePlaybackStage>.Instance);
+            var context = new DownloadExecutionContext(
+                new DownloadTaskId(downloadBase.Id),
+                downloading,
+                settings.Store.Current,
+                static (_, token) => token.ThrowIfCancellationRequested());
 
-        var directory = ResolvePlaybackStage.GetDownloadDirectoryPath(downloading);
+            var result = await stage.ExecuteAsync(
+                context,
+                TestContext.Current.CancellationToken);
 
-        Assert.Equal(Path.GetDirectoryName(frozenBasePath), directory);
-        Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
+            Assert.False(result.IsSuccess);
+            Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 }

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -10,6 +10,7 @@ using DownKyi.Presentation;
 using DownKyi.Services;
 using DownKyi.Services.Download;
 using DownKyi.Services.Video;
+using DownKyi.Utils;
 using Microsoft.Extensions.Logging;
 using CoreVideoPage = DownKyi.Core.BiliApi.Video.Models.VideoPage;
 using VideoPage = DownKyi.Presentation.VideoPage;
@@ -206,12 +207,62 @@ public sealed class VideoTagLoadingTests : IDisposable
         Assert.Null(Assert.Single(context.ListState.Downloading).Metadata);
     }
 
-    private DownloadTestContext CreateContext(bool generateMetadata)
+    [Fact]
+    public async Task ResolverFailureIsReportedAndDoesNotBlockNextAdmission()
+    {
+        var resolver = new FailFirstPhysicalOutputPathResolver();
+        using var context = CreateContext(generateMetadata: false, resolver);
+        var first = CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([]));
+        first.Cid = 1;
+        first.Name = "first";
+        var second = CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([]));
+        second.Cid = 2;
+        second.Name = "second";
+        context.Prepare(first, second);
+
+        var added = await context.Service
+            .AddToDownload(_directory, cancellationToken: TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(1, added);
+        Assert.Equal(2, resolver.CallCount);
+        Assert.Equal(1, context.Store.AddCount);
+        Assert.Equal("second", Assert.Single(context.ListState.Downloading).DownloadBase.Name);
+        Assert.Single(context.Queue.Enqueued);
+        var request = Assert.Single(context.Dialogs.Requests);
+        Assert.Equal(AppDialog.Alert, request.Dialog);
+        var message = Assert.IsType<string>(request.Parameters!["message"]);
+        Assert.Equal(DictionaryResource.GetString("DirectoryError"), message);
+        Assert.DoesNotContain(_directory, message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UnknownResolverFailureKeepsExistingFailureBehavior()
+    {
+        using var context = CreateContext(
+            generateMetadata: false,
+            new UnknownFailurePhysicalOutputPathResolver());
+        context.Prepare(CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([])));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => context.Service.AddToDownload(
+            _directory,
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, context.Store.AddCount);
+        Assert.Empty(context.ListState.Downloading);
+        Assert.Empty(context.Queue.Enqueued);
+        Assert.Empty(context.Dialogs.Requests);
+    }
+
+    private DownloadTestContext CreateContext(
+        bool generateMetadata,
+        IPhysicalOutputPathResolver? resolver = null)
     {
         Directory.CreateDirectory(_directory);
         return new DownloadTestContext(
             Path.Combine(_directory, $"settings-{Guid.NewGuid():N}.json"),
-            generateMetadata);
+            generateMetadata,
+            resolver);
     }
 
     private static VideoPage CreatePage(
@@ -254,7 +305,10 @@ public sealed class VideoTagLoadingTests : IDisposable
         private readonly DownloadTaskProjectionStore _projectionStore;
         private readonly DownloadTaskAdmissionService _admission;
 
-        public DownloadTestContext(string settingsPath, bool generateMetadata)
+        public DownloadTestContext(
+            string settingsPath,
+            bool generateMetadata,
+            IPhysicalOutputPathResolver? resolver)
         {
             _settings = new DownKyi.Core.Settings.SettingsStore(settingsPath);
             _settings.Update(settings => settings with
@@ -274,6 +328,7 @@ public sealed class VideoTagLoadingTests : IDisposable
             ListState = new DownloadListState();
             Queue = new RecordingDownloadTaskQueue();
             Logger = new RecordingLogger<DownloadMovieMetadataBuilder>();
+            Dialogs = new RecordingDialogService();
             var desktop = new TestDesktopInteractionContext();
             var client = new TestBilibiliApiClient();
             _admission = new DownloadTaskAdmissionService(
@@ -281,12 +336,12 @@ public sealed class VideoTagLoadingTests : IDisposable
                 _taskService,
                 _projectionStore,
                 Queue,
-                new FileSystemPhysicalOutputPathResolver());
+                resolver ?? new FileSystemPhysicalOutputPathResolver());
             var duplicatePolicy = new DownloadDuplicatePolicy(
                 ListState,
                 _projectionStore,
                 desktop.Notifications,
-                desktop.Dialogs);
+                Dialogs);
             Service = new AddToDownloadService(
                 DownKyi.Core.BiliApi.VideoStream.PlayStreamType.Video,
                 _admission,
@@ -296,7 +351,7 @@ public sealed class VideoTagLoadingTests : IDisposable
                 new VideoTagProvider(client),
                 new TestWbiKeyProvider(),
                 client,
-                desktop.Dialogs,
+                Dialogs,
                 new RecordingLogger<AddToDownloadService>());
         }
 
@@ -310,7 +365,9 @@ public sealed class VideoTagLoadingTests : IDisposable
 
         public RecordingLogger<DownloadMovieMetadataBuilder> Logger { get; }
 
-        public void Prepare(VideoPage page)
+        public RecordingDialogService Dialogs { get; }
+
+        public void Prepare(params VideoPage[] pages)
         {
             Service.GetVideo(
                 new VideoInfoView
@@ -325,7 +382,7 @@ public sealed class VideoTagLoadingTests : IDisposable
                         Id = 1,
                         IsSelected = true,
                         Title = "section",
-                        VideoPages = [page]
+                        VideoPages = pages
                     }
                 ]);
         }
@@ -336,6 +393,46 @@ public sealed class VideoTagLoadingTests : IDisposable
             _projectionStore.Dispose();
             _taskService.Dispose();
             _settings.Dispose();
+        }
+    }
+
+    private sealed class RecordingDialogService : IAppDialogService
+    {
+        public List<AppDialogRequest> Requests { get; } = [];
+
+        public Task<AppDialogResult> ShowAsync(
+            AppDialogRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(new AppDialogResult(
+                AppDialogOutcome.Canceled,
+                new Dictionary<string, object?>()));
+        }
+    }
+
+    private sealed class FailFirstPhysicalOutputPathResolver : IPhysicalOutputPathResolver
+    {
+        public int CallCount { get; private set; }
+
+        public string ResolvePhysicalBasePath(string logicalBasePath)
+        {
+            CallCount++;
+            if (CallCount == 1)
+            {
+                throw new IOException("Unable to resolve physical output path.");
+            }
+
+            return logicalBasePath;
+        }
+    }
+
+    private sealed class UnknownFailurePhysicalOutputPathResolver : IPhysicalOutputPathResolver
+    {
+        public string ResolvePhysicalBasePath(string logicalBasePath)
+        {
+            throw new InvalidOperationException("Unexpected resolver failure.");
         }
     }
 

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -4,6 +4,7 @@ using DownKyi.Application.Desktop;
 using DownKyi.Application.Downloads;
 using DownKyi.Domain.Downloads;
 using DownKyi.Domain.Results;
+using DownKyi.Infrastructure.Downloads;
 using DownKyi.Infrastructure.Time;
 using DownKyi.Presentation;
 using DownKyi.Services;
@@ -279,7 +280,8 @@ public sealed class VideoTagLoadingTests : IDisposable
                 ListState,
                 _taskService,
                 _projectionStore,
-                Queue);
+                Queue,
+                new FileSystemPhysicalOutputPathResolver());
             var duplicatePolicy = new DownloadDuplicatePolicy(
                 ListState,
                 _projectionStore,


### PR DESCRIPTION
## Summary

- resolve a draft output path to its physical base exactly once at new-task admission
- freeze and persist the raw physical spelling before collision reservation, projection, list publication, and queueing
- keep normalized path keys comparison-only and stop playback setup from rewriting the frozen path

## Scope

This is Module 1B and protects newly admitted tasks only. It builds on the physical path resolver merged in #230.

Legacy v3 tasks and their upgrade/quarantine behavior remain intentionally unchanged for later Module 1C/1D work. This PR does not change the store schema, `user_version`, aria2 identity, quarantine triggers, completed history, or publication retry behavior.

## Verification

- baseline regression first failed because collision resolution changed decomposed raw spelling to composed spelling
- focused `DownloadTaskAdmissionServiceTests` through `DownKyi.CentralTestRunner`
- focused `DurlDownloadIdentityTests` through `DownKyi.CentralTestRunner`
- strict full-solution Release build with warnings, analyzers, and code style as errors
- `dotnet format DownKyi.sln --verify-no-changes --no-restore --verbosity diagnostic`
- `git diff --check`
