### PR TITLE
refactor: S1 split DownloadStoreSchema migrations

### DIFF
--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
@@ -1,7 +1,4 @@
-using System.Globalization;
-using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
-using DownKyi.Domain.Downloads;
 using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Infrastructure.Downloads;
@@ -10,22 +7,6 @@ internal static class DownloadStoreSchema
 {
     public const int CurrentVersion = 3;
 
-    private enum VersionTwoColumn
-    {
-        BaseVersion,
-        BaseCreatedAtUtc,
-        BaseUpdatedAtUtc,
-        DownloadingPhase,
-        DownloadingFailureCode,
-        DownloadingFailureMessage,
-        DownloadingFailureTransient,
-        DownloadingDownloadedBytes,
-        DownloadingTotalBytes,
-        DownloadingBytesPerSecond
-    }
-
-    private const string OutputReservationColumn = "output_reservation_key";
-
     public static async Task InitializeAsync(
         SqliteConnection connection,
         string databasePath,
@@ -33,7 +14,9 @@ internal static class DownloadStoreSchema
         IClock clock,
         CancellationToken cancellationToken)
     {
-        var currentVersion = await ReadUserVersionAsync(connection, cancellationToken).ConfigureAwait(false);
+        var currentVersion = await DownloadStoreSchemaLifecycle
+            .ReadUserVersionAsync(connection, cancellationToken)
+            .ConfigureAwait(false);
         if (currentVersion > CurrentVersion)
         {
             throw new InvalidOperationException(
@@ -42,7 +25,9 @@ internal static class DownloadStoreSchema
 
         if (databaseExisted && currentVersion < CurrentVersion)
         {
-            await BackupAsync(connection, databasePath, currentVersion, clock, cancellationToken).ConfigureAwait(false);
+            await DownloadStoreSchemaLifecycle
+                .BackupAsync(connection, databasePath, currentVersion, clock, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         if (currentVersion == CurrentVersion)
@@ -57,23 +42,28 @@ internal static class DownloadStoreSchema
         {
             if (currentVersion < 1)
             {
-                await ApplyVersionOneAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                await DownloadStoreSchemaV1Migration
+                    .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
             if (currentVersion < 2)
             {
-                await ApplyVersionTwoAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                await DownloadStoreSchemaV2Migration
+                    .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
             if (currentVersion < 3)
             {
-                await ApplyVersionThreeAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                await DownloadStoreSchemaV3Migration
+                    .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
-            await SetUserVersionAsync(connection, transaction, CurrentVersion, cancellationToken).ConfigureAwait(false);
+            await DownloadStoreSchemaLifecycle
+                .SetUserVersionAsync(connection, transaction, CurrentVersion, cancellationToken)
+                .ConfigureAwait(false);
             await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
@@ -81,407 +71,5 @@ internal static class DownloadStoreSchema
             await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
             throw;
         }
-    }
-
-    private static async Task ApplyVersionOneAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        const string sql = """
-            CREATE TABLE IF NOT EXISTS download_base (
-                id                    TEXT PRIMARY KEY,
-                need_download_content TEXT NOT NULL DEFAULT '{}',
-                bvid                  TEXT NOT NULL DEFAULT '',
-                avid                  INTEGER NOT NULL DEFAULT 0,
-                cid                   INTEGER NOT NULL DEFAULT 0,
-                episode_id            INTEGER NOT NULL DEFAULT 0,
-                cover_url             TEXT NOT NULL DEFAULT '',
-                page_cover_url        TEXT NOT NULL DEFAULT '',
-                zone_id               INTEGER NOT NULL DEFAULT 0,
-                [order]               INTEGER NOT NULL DEFAULT 0,
-                main_title            TEXT NOT NULL DEFAULT '',
-                name                  TEXT NOT NULL DEFAULT '',
-                duration              TEXT NOT NULL DEFAULT '',
-                video_codec_name      TEXT NOT NULL DEFAULT '',
-                resolution            TEXT NOT NULL DEFAULT '{}',
-                audio_codec           TEXT,
-                file_path             TEXT NOT NULL DEFAULT '',
-                file_size             TEXT,
-                page                  INTEGER NOT NULL DEFAULT 1
-            );
-
-            CREATE TABLE IF NOT EXISTS downloading (
-                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
-                gid                   TEXT,
-                download_files        TEXT NOT NULL DEFAULT '{}',
-                downloaded_files      TEXT NOT NULL DEFAULT '[]',
-                play_stream_type      INTEGER NOT NULL DEFAULT 0,
-                download_status       INTEGER NOT NULL DEFAULT 0,
-                download_content      TEXT,
-                download_status_title TEXT,
-                progress              REAL NOT NULL DEFAULT 0,
-                downloading_file_size TEXT,
-                max_speed             INTEGER NOT NULL DEFAULT 0,
-                speed_display         TEXT
-            );
-
-            CREATE TABLE IF NOT EXISTS downloaded (
-                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
-                max_speed_display     TEXT,
-                finished_timestamp    INTEGER NOT NULL DEFAULT 0,
-                finished_time         TEXT NOT NULL DEFAULT ''
-            );
-
-            CREATE TABLE IF NOT EXISTS download_schema_migrations (
-                version               INTEGER PRIMARY KEY,
-                applied_at_utc        INTEGER NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS download_quarantine (
-                quarantine_id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                source_table          TEXT NOT NULL,
-                record_id             TEXT NOT NULL,
-                field_name            TEXT NOT NULL,
-                reason                TEXT NOT NULL,
-                quarantined_at_utc    INTEGER NOT NULL,
-                UNIQUE(source_table, record_id)
-            );
-
-            CREATE INDEX IF NOT EXISTS ix_downloading_status ON downloading(download_status);
-            CREATE INDEX IF NOT EXISTS ix_downloaded_finished_timestamp ON downloaded(finished_timestamp DESC, id DESC);
-            CREATE INDEX IF NOT EXISTS ix_download_base_main_title_order ON download_base(main_title, [order]);
-            """;
-
-        using (var command = connection.CreateCommand())
-        {
-            command.Transaction = transaction;
-            command.CommandText = sql;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await RecordMigrationAsync(connection, transaction, 1, appliedAtUtc, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task ApplyVersionTwoAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        foreach (var column in Enum.GetValues<VersionTwoColumn>())
-        {
-            await AddColumnIfMissingAsync(connection, transaction, column, cancellationToken).ConfigureAwait(false);
-        }
-
-        const string phaseSql = """
-            UPDATE downloading
-            SET phase = CASE download_status
-                WHEN 2 THEN @pausing
-                WHEN 3 THEN @paused
-                WHEN 4 THEN @downloading
-                WHEN 5 THEN @queued
-                WHEN 6 THEN @failed
-                ELSE @queued
-            END
-            WHERE phase IS NULL;
-            """;
-        using (var command = connection.CreateCommand())
-        {
-            command.Transaction = transaction;
-            command.CommandText = phaseSql;
-            command.Parameters.AddWithValue("@pausing", (int)DownloadPhase.Pausing);
-            command.Parameters.AddWithValue("@paused", (int)DownloadPhase.Paused);
-            command.Parameters.AddWithValue("@downloading", (int)DownloadPhase.Downloading);
-            command.Parameters.AddWithValue("@failed", (int)DownloadPhase.Failed);
-            command.Parameters.AddWithValue("@queued", (int)DownloadPhase.Queued);
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await RecordMigrationAsync(connection, transaction, 2, appliedAtUtc, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task ApplyVersionThreeAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        if (!await HasDownloadBaseColumnAsync(
-                connection,
-                transaction,
-                OutputReservationColumn,
-                cancellationToken).ConfigureAwait(false))
-        {
-            using var alter = connection.CreateCommand();
-            alter.Transaction = transaction;
-            alter.CommandText =
-                $"ALTER TABLE download_base ADD COLUMN {OutputReservationColumn} TEXT";
-            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await BackfillOutputReservationsAsync(connection, transaction, cancellationToken)
-            .ConfigureAwait(false);
-
-        using (var command = connection.CreateCommand())
-        {
-            command.Transaction = transaction;
-            command.CommandText = """
-                CREATE INDEX IF NOT EXISTS ix_download_base_file_path
-                    ON download_base(file_path);
-                CREATE INDEX IF NOT EXISTS ix_download_base_file_path_nocase
-                    ON download_base(file_path COLLATE NOCASE);
-                CREATE UNIQUE INDEX IF NOT EXISTS ux_download_base_output_reservation
-                    ON download_base(output_reservation_key)
-                    WHERE output_reservation_key IS NOT NULL;
-                """;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await RecordMigrationAsync(connection, transaction, 3, appliedAtUtc, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    private static async Task BackfillOutputReservationsAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        CancellationToken cancellationToken)
-    {
-        var rows = new List<(string Id, string BasePath)>();
-        using (var select = connection.CreateCommand())
-        {
-            select.Transaction = transaction;
-            select.CommandText = """
-                SELECT db.id, db.file_path
-                FROM download_base db
-                INNER JOIN downloading dl ON dl.id = db.id
-                ORDER BY db.id
-                """;
-            using var reader = await select.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                rows.Add((reader.GetString(0), reader.GetString(1)));
-            }
-        }
-
-        var keys = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {
-            string key;
-            try
-            {
-                key = DownloadOutputPathKey.Create(
-                    row.BasePath,
-                    DownloadOutputPathKey.UsesCaseInsensitiveComparison);
-            }
-            catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
-            {
-                continue;
-            }
-
-            if (!keys.Add(key))
-            {
-                continue;
-            }
-
-            using var update = connection.CreateCommand();
-            update.Transaction = transaction;
-            update.CommandText = """
-                UPDATE download_base
-                SET output_reservation_key = @key
-                WHERE id = @id
-                """;
-            update.Parameters.AddWithValue("@key", key);
-            update.Parameters.AddWithValue("@id", row.Id);
-            await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private static async Task<bool> HasDownloadBaseColumnAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        string column,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = "PRAGMA table_info(download_base)";
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            if (reader.GetString(1).Equals(column, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static async Task AddColumnIfMissingAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        VersionTwoColumn column,
-        CancellationToken cancellationToken)
-    {
-        using var inspect = connection.CreateCommand();
-        inspect.Transaction = transaction;
-        if (IsBaseColumn(column))
-        {
-            inspect.CommandText = "PRAGMA table_info(download_base)";
-        }
-        else
-        {
-            inspect.CommandText = "PRAGMA table_info(downloading)";
-        }
-
-        var columnName = GetColumnName(column);
-        using (var reader = await inspect.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
-        {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                if (reader.GetString(1).Equals(columnName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
-            }
-        }
-
-        using var alter = connection.CreateCommand();
-        alter.Transaction = transaction;
-        SetAlterColumnSql(alter, column);
-        await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static bool IsBaseColumn(VersionTwoColumn column) => column is
-        VersionTwoColumn.BaseVersion or
-        VersionTwoColumn.BaseCreatedAtUtc or
-        VersionTwoColumn.BaseUpdatedAtUtc;
-
-    private static string GetColumnName(VersionTwoColumn column) => column switch
-    {
-        VersionTwoColumn.BaseVersion => "version",
-        VersionTwoColumn.BaseCreatedAtUtc => "created_at_utc",
-        VersionTwoColumn.BaseUpdatedAtUtc => "updated_at_utc",
-        VersionTwoColumn.DownloadingPhase => "phase",
-        VersionTwoColumn.DownloadingFailureCode => "failure_code",
-        VersionTwoColumn.DownloadingFailureMessage => "failure_message",
-        VersionTwoColumn.DownloadingFailureTransient => "failure_transient",
-        VersionTwoColumn.DownloadingDownloadedBytes => "downloaded_bytes",
-        VersionTwoColumn.DownloadingTotalBytes => "total_bytes",
-        VersionTwoColumn.DownloadingBytesPerSecond => "bytes_per_second",
-        _ => throw new ArgumentOutOfRangeException(nameof(column))
-    };
-
-    private static void SetAlterColumnSql(SqliteCommand command, VersionTwoColumn column)
-    {
-        switch (column)
-        {
-            case VersionTwoColumn.BaseVersion:
-                command.CommandText =
-                    "ALTER TABLE download_base ADD COLUMN version INTEGER NOT NULL DEFAULT 0";
-                break;
-            case VersionTwoColumn.BaseCreatedAtUtc:
-                command.CommandText =
-                    "ALTER TABLE download_base ADD COLUMN created_at_utc INTEGER NOT NULL DEFAULT 0";
-                break;
-            case VersionTwoColumn.BaseUpdatedAtUtc:
-                command.CommandText =
-                    "ALTER TABLE download_base ADD COLUMN updated_at_utc INTEGER NOT NULL DEFAULT 0";
-                break;
-            case VersionTwoColumn.DownloadingPhase:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN phase INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingFailureCode:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_code TEXT";
-                break;
-            case VersionTwoColumn.DownloadingFailureMessage:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_message TEXT";
-                break;
-            case VersionTwoColumn.DownloadingFailureTransient:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_transient INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingDownloadedBytes:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN downloaded_bytes INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingTotalBytes:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN total_bytes INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingBytesPerSecond:
-                command.CommandText =
-                    "ALTER TABLE downloading ADD COLUMN bytes_per_second INTEGER NOT NULL DEFAULT 0";
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(column));
-        }
-    }
-
-    private static async Task RecordMigrationAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        int version,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = """
-            INSERT OR REPLACE INTO download_schema_migrations(version, applied_at_utc)
-            VALUES (@version, @applied_at_utc)
-            """;
-        command.Parameters.AddWithValue("@version", version);
-        command.Parameters.AddWithValue("@applied_at_utc", appliedAtUtc.ToUnixTimeMilliseconds());
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task<int> ReadUserVersionAsync(
-        SqliteConnection connection,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = "PRAGMA user_version";
-        var value = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-        return Convert.ToInt32(value, CultureInfo.InvariantCulture);
-    }
-
-    private static async Task SetUserVersionAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        int version,
-        CancellationToken cancellationToken)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(version, CurrentVersion);
-
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = "PRAGMA user_version = 3";
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task BackupAsync(
-        SqliteConnection source,
-        string databasePath,
-        int sourceVersion,
-        IClock clock,
-        CancellationToken cancellationToken)
-    {
-        var directory = Path.GetDirectoryName(databasePath) ?? ".";
-        var backupDirectory = Path.Combine(directory, "Backup");
-        Directory.CreateDirectory(backupDirectory);
-        var timestamp = clock.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'", CultureInfo.InvariantCulture);
-        var backupPath = Path.Combine(
-            backupDirectory,
-            $"{Path.GetFileName(databasePath)}.schema-v{sourceVersion}-{timestamp}.bak");
-        var connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = backupPath,
-            Mode = SqliteOpenMode.ReadWriteCreate,
-            Pooling = false
-        }.ToString();
-
-        using var backup = new SqliteConnection(connectionString);
-        await backup.OpenAsync(cancellationToken).ConfigureAwait(false);
-        source.BackupDatabase(backup);
     }
 }

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using DownKyi.Application.Time;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaLifecycle
+{
+    public static async Task RecordMigrationAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        int version,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT OR REPLACE INTO download_schema_migrations(version, applied_at_utc)
+            VALUES (@version, @applied_at_utc)
+            """;
+        command.Parameters.AddWithValue("@version", version);
+        command.Parameters.AddWithValue("@applied_at_utc", appliedAtUtc.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<int> ReadUserVersionAsync(
+        SqliteConnection connection,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA user_version";
+        var value = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+    }
+
+    public static async Task SetUserVersionAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        int version,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(version, 3);
+
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "PRAGMA user_version = 3";
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task BackupAsync(
+        SqliteConnection source,
+        string databasePath,
+        int sourceVersion,
+        IClock clock,
+        CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(databasePath) ?? ".";
+        var backupDirectory = Path.Combine(directory, "Backup");
+        Directory.CreateDirectory(backupDirectory);
+        var timestamp = clock.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'", CultureInfo.InvariantCulture);
+        var backupPath = Path.Combine(
+            backupDirectory,
+            $"{Path.GetFileName(databasePath)}.schema-v{sourceVersion}-{timestamp}.bak");
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = backupPath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = false
+        }.ToString();
+
+        using var backup = new SqliteConnection(connectionString);
+        await backup.OpenAsync(cancellationToken).ConfigureAwait(false);
+        source.BackupDatabase(backup);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV1Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV1Migration.cs
@@ -1,0 +1,89 @@
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV1Migration
+{
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            CREATE TABLE IF NOT EXISTS download_base (
+                id                    TEXT PRIMARY KEY,
+                need_download_content TEXT NOT NULL DEFAULT '{}',
+                bvid                  TEXT NOT NULL DEFAULT '',
+                avid                  INTEGER NOT NULL DEFAULT 0,
+                cid                   INTEGER NOT NULL DEFAULT 0,
+                episode_id            INTEGER NOT NULL DEFAULT 0,
+                cover_url             TEXT NOT NULL DEFAULT '',
+                page_cover_url        TEXT NOT NULL DEFAULT '',
+                zone_id               INTEGER NOT NULL DEFAULT 0,
+                [order]               INTEGER NOT NULL DEFAULT 0,
+                main_title            TEXT NOT NULL DEFAULT '',
+                name                  TEXT NOT NULL DEFAULT '',
+                duration              TEXT NOT NULL DEFAULT '',
+                video_codec_name      TEXT NOT NULL DEFAULT '',
+                resolution            TEXT NOT NULL DEFAULT '{}',
+                audio_codec           TEXT,
+                file_path             TEXT NOT NULL DEFAULT '',
+                file_size             TEXT,
+                page                  INTEGER NOT NULL DEFAULT 1
+            );
+
+            CREATE TABLE IF NOT EXISTS downloading (
+                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
+                gid                   TEXT,
+                download_files        TEXT NOT NULL DEFAULT '{}',
+                downloaded_files      TEXT NOT NULL DEFAULT '[]',
+                play_stream_type      INTEGER NOT NULL DEFAULT 0,
+                download_status       INTEGER NOT NULL DEFAULT 0,
+                download_content      TEXT,
+                download_status_title TEXT,
+                progress              REAL NOT NULL DEFAULT 0,
+                downloading_file_size TEXT,
+                max_speed             INTEGER NOT NULL DEFAULT 0,
+                speed_display         TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS downloaded (
+                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
+                max_speed_display     TEXT,
+                finished_timestamp    INTEGER NOT NULL DEFAULT 0,
+                finished_time         TEXT NOT NULL DEFAULT ''
+            );
+
+            CREATE TABLE IF NOT EXISTS download_schema_migrations (
+                version               INTEGER PRIMARY KEY,
+                applied_at_utc        INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS download_quarantine (
+                quarantine_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_table          TEXT NOT NULL,
+                record_id             TEXT NOT NULL,
+                field_name            TEXT NOT NULL,
+                reason                TEXT NOT NULL,
+                quarantined_at_utc    INTEGER NOT NULL,
+                UNIQUE(source_table, record_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_downloading_status ON downloading(download_status);
+            CREATE INDEX IF NOT EXISTS ix_downloaded_finished_timestamp ON downloaded(finished_timestamp DESC, id DESC);
+            CREATE INDEX IF NOT EXISTS ix_download_base_main_title_order ON download_base(main_title, [order]);
+            """;
+
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 1, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV2Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV2Migration.cs
@@ -1,0 +1,159 @@
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV2Migration
+{
+    private enum VersionTwoColumn
+    {
+        BaseVersion,
+        BaseCreatedAtUtc,
+        BaseUpdatedAtUtc,
+        DownloadingPhase,
+        DownloadingFailureCode,
+        DownloadingFailureMessage,
+        DownloadingFailureTransient,
+        DownloadingDownloadedBytes,
+        DownloadingTotalBytes,
+        DownloadingBytesPerSecond
+    }
+
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        foreach (var column in Enum.GetValues<VersionTwoColumn>())
+        {
+            await AddColumnIfMissingAsync(connection, transaction, column, cancellationToken).ConfigureAwait(false);
+        }
+
+        const string phaseSql = """
+            UPDATE downloading
+            SET phase = CASE download_status
+                WHEN 2 THEN @pausing
+                WHEN 3 THEN @paused
+                WHEN 4 THEN @downloading
+                WHEN 5 THEN @queued
+                WHEN 6 THEN @failed
+                ELSE @queued
+            END
+            WHERE phase IS NULL;
+            """;
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = phaseSql;
+            command.Parameters.AddWithValue("@pausing", (int)DownloadPhase.Pausing);
+            command.Parameters.AddWithValue("@paused", (int)DownloadPhase.Paused);
+            command.Parameters.AddWithValue("@downloading", (int)DownloadPhase.Downloading);
+            command.Parameters.AddWithValue("@failed", (int)DownloadPhase.Failed);
+            command.Parameters.AddWithValue("@queued", (int)DownloadPhase.Queued);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 2, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task AddColumnIfMissingAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        VersionTwoColumn column,
+        CancellationToken cancellationToken)
+    {
+        using var inspect = connection.CreateCommand();
+        inspect.Transaction = transaction;
+        if (IsBaseColumn(column))
+        {
+            inspect.CommandText = "PRAGMA table_info(download_base)";
+        }
+        else
+        {
+            inspect.CommandText = "PRAGMA table_info(downloading)";
+        }
+
+        var columnName = GetColumnName(column);
+        using (var reader = await inspect.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (reader.GetString(1).Equals(columnName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+        }
+
+        using var alter = connection.CreateCommand();
+        alter.Transaction = transaction;
+        SetAlterColumnSql(alter, column);
+        await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsBaseColumn(VersionTwoColumn column) => column is
+        VersionTwoColumn.BaseVersion or
+        VersionTwoColumn.BaseCreatedAtUtc or
+        VersionTwoColumn.BaseUpdatedAtUtc;
+
+    private static string GetColumnName(VersionTwoColumn column) => column switch
+    {
+        VersionTwoColumn.BaseVersion => "version",
+        VersionTwoColumn.BaseCreatedAtUtc => "created_at_utc",
+        VersionTwoColumn.BaseUpdatedAtUtc => "updated_at_utc",
+        VersionTwoColumn.DownloadingPhase => "phase",
+        VersionTwoColumn.DownloadingFailureCode => "failure_code",
+        VersionTwoColumn.DownloadingFailureMessage => "failure_message",
+        VersionTwoColumn.DownloadingFailureTransient => "failure_transient",
+        VersionTwoColumn.DownloadingDownloadedBytes => "downloaded_bytes",
+        VersionTwoColumn.DownloadingTotalBytes => "total_bytes",
+        VersionTwoColumn.DownloadingBytesPerSecond => "bytes_per_second",
+        _ => throw new ArgumentOutOfRangeException(nameof(column))
+    };
+
+    private static void SetAlterColumnSql(SqliteCommand command, VersionTwoColumn column)
+    {
+        switch (column)
+        {
+            case VersionTwoColumn.BaseVersion:
+                command.CommandText =
+                    "ALTER TABLE download_base ADD COLUMN version INTEGER NOT NULL DEFAULT 0";
+                break;
+            case VersionTwoColumn.BaseCreatedAtUtc:
+                command.CommandText =
+                    "ALTER TABLE download_base ADD COLUMN created_at_utc INTEGER NOT NULL DEFAULT 0";
+                break;
+            case VersionTwoColumn.BaseUpdatedAtUtc:
+                command.CommandText =
+                    "ALTER TABLE download_base ADD COLUMN updated_at_utc INTEGER NOT NULL DEFAULT 0";
+                break;
+            case VersionTwoColumn.DownloadingPhase:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN phase INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingFailureCode:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_code TEXT";
+                break;
+            case VersionTwoColumn.DownloadingFailureMessage:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_message TEXT";
+                break;
+            case VersionTwoColumn.DownloadingFailureTransient:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_transient INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingDownloadedBytes:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN downloaded_bytes INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingTotalBytes:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN total_bytes INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingBytesPerSecond:
+                command.CommandText =
+                    "ALTER TABLE downloading ADD COLUMN bytes_per_second INTEGER NOT NULL DEFAULT 0";
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(column));
+        }
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV3Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV3Migration.cs
@@ -1,0 +1,127 @@
+using DownKyi.Application.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV3Migration
+{
+    private const string OutputReservationColumn = "output_reservation_key";
+
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (!await HasDownloadBaseColumnAsync(
+                connection,
+                transaction,
+                OutputReservationColumn,
+                cancellationToken).ConfigureAwait(false))
+        {
+            using var alter = connection.CreateCommand();
+            alter.Transaction = transaction;
+            alter.CommandText =
+                $"ALTER TABLE download_base ADD COLUMN {OutputReservationColumn} TEXT";
+            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await BackfillOutputReservationsAsync(connection, transaction, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = """
+                CREATE INDEX IF NOT EXISTS ix_download_base_file_path
+                    ON download_base(file_path);
+                CREATE INDEX IF NOT EXISTS ix_download_base_file_path_nocase
+                    ON download_base(file_path COLLATE NOCASE);
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_download_base_output_reservation
+                    ON download_base(output_reservation_key)
+                    WHERE output_reservation_key IS NOT NULL;
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 3, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task BackfillOutputReservationsAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        var rows = new List<(string Id, string BasePath)>();
+        using (var select = connection.CreateCommand())
+        {
+            select.Transaction = transaction;
+            select.CommandText = """
+                SELECT db.id, db.file_path
+                FROM download_base db
+                INNER JOIN downloading dl ON dl.id = db.id
+                ORDER BY db.id
+                """;
+            using var reader = await select.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                rows.Add((reader.GetString(0), reader.GetString(1)));
+            }
+        }
+
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            string key;
+            try
+            {
+                key = DownloadOutputPathKey.Create(
+                    row.BasePath,
+                    DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+            }
+            catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
+            {
+                continue;
+            }
+
+            if (!keys.Add(key))
+            {
+                continue;
+            }
+
+            using var update = connection.CreateCommand();
+            update.Transaction = transaction;
+            update.CommandText = """
+                UPDATE download_base
+                SET output_reservation_key = @key
+                WHERE id = @id
+                """;
+            update.Parameters.AddWithValue("@key", key);
+            update.Parameters.AddWithValue("@id", row.Id);
+            await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<bool> HasDownloadBaseColumnAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string column,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "PRAGMA table_info(download_base)";
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (reader.GetString(1).Equals(column, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
+++ b/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\DownKyi.Infrastructure\DownKyi.Infrastructure.csproj" />
     <ProjectReference Include="..\..\tools\DownKyi.CentralTestRunner\DownKyi.CentralTestRunner.csproj" />
   </ItemGroup>
 

--- a/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
@@ -1,14 +1,20 @@
+using DownKyi.Infrastructure.Downloads;
+
 namespace DownKyi.Architecture.Tests;
 
 public sealed class DownloadStoreSchemaArchitectureTests
 {
+    private const string MigrationOwnerNamespace = "DownKyi.Infrastructure.Downloads";
+    private const string MigrationOwnerPrefix = "DownloadStoreSchemaV";
+    private const string MigrationOwnerSuffix = "Migration";
     private static readonly string RepositoryRoot = FindRepositoryRoot();
-    private static readonly string[] MigrationOwners =
-    [
-        "DownloadStoreSchemaV1Migration",
-        "DownloadStoreSchemaV2Migration",
-        "DownloadStoreSchemaV3Migration"
-    ];
+    private static readonly string[] MigrationOwners = typeof(SqliteDownloadTaskStoreOptions)
+        .Assembly
+        .GetTypes()
+        .Where(IsMigrationOwner)
+        .Select(type => type.Name)
+        .Order(StringComparer.Ordinal)
+        .ToArray();
 
     [Fact]
     public void CoordinatorOwnsUpgradeOrderWithoutOwningMigrationSql()
@@ -44,6 +50,17 @@ public sealed class DownloadStoreSchemaArchitectureTests
     }
 
     [Fact]
+    public void VersionOwnerDiscoveryIncludesFutureVersionsAndRejectsLookalikes()
+    {
+        Assert.NotEmpty(MigrationOwners);
+        Assert.True(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV4Migration"));
+        Assert.False(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV0Migration"));
+        Assert.False(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV04Migration"));
+        Assert.False(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV4MigrationHelper"));
+        Assert.False(IsMigrationOwner("DownKyi.Infrastructure.Other", "DownloadStoreSchemaV4Migration"));
+    }
+
+    [Fact]
     public void VersionOwnersDoNotDependOnOneAnother()
     {
         foreach (var owner in MigrationOwners)
@@ -65,6 +82,39 @@ public sealed class DownloadStoreSchemaArchitectureTests
             "DownKyi.Infrastructure",
             "Downloads",
             fileName));
+    }
+
+    private static bool IsMigrationOwner(Type type)
+    {
+        return type.DeclaringType is null && IsMigrationOwner(type.Namespace, type.Name);
+    }
+
+    private static bool IsMigrationOwner(string? typeNamespace, string typeName)
+    {
+        if (!string.Equals(typeNamespace, MigrationOwnerNamespace, StringComparison.Ordinal)
+            || !typeName.StartsWith(MigrationOwnerPrefix, StringComparison.Ordinal)
+            || !typeName.EndsWith(MigrationOwnerSuffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var version = typeName.AsSpan(
+            MigrationOwnerPrefix.Length,
+            typeName.Length - MigrationOwnerPrefix.Length - MigrationOwnerSuffix.Length);
+        if (version.IsEmpty || version[0] == '0')
+        {
+            return false;
+        }
+
+        foreach (var character in version)
+        {
+            if (character is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static string FindRepositoryRoot()

--- a/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
@@ -1,0 +1,85 @@
+namespace DownKyi.Architecture.Tests;
+
+public sealed class DownloadStoreSchemaArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string[] MigrationOwners =
+    [
+        "DownloadStoreSchemaV1Migration",
+        "DownloadStoreSchemaV2Migration",
+        "DownloadStoreSchemaV3Migration"
+    ];
+
+    [Fact]
+    public void CoordinatorOwnsUpgradeOrderWithoutOwningMigrationSql()
+    {
+        var source = ReadDownloadSource("DownloadStoreSchema.cs");
+
+        Assert.Contains("public const int CurrentVersion = 3", source, StringComparison.Ordinal);
+        Assert.Contains("BeginTransactionAsync", source, StringComparison.Ordinal);
+        Assert.Contains("CommitAsync", source, StringComparison.Ordinal);
+        Assert.Contains("RollbackAsync", source, StringComparison.Ordinal);
+        Assert.Contains("BackupAsync", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CommandText", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CREATE TABLE", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ALTER TABLE", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("CREATE INDEX", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("UPDATE downloading", source, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VersionOwnersAreNamedNonPartialAndReceiveTheCompleteMigrationContext()
+    {
+        foreach (var owner in MigrationOwners)
+        {
+            var source = ReadDownloadSource($"{owner}.cs");
+
+            Assert.Contains($"internal static class {owner}", source, StringComparison.Ordinal);
+            Assert.DoesNotContain($"partial class {owner}", source, StringComparison.Ordinal);
+            Assert.Contains("SqliteConnection connection", source, StringComparison.Ordinal);
+            Assert.Contains("SqliteTransaction transaction", source, StringComparison.Ordinal);
+            Assert.Contains("DateTimeOffset appliedAtUtc", source, StringComparison.Ordinal);
+            Assert.Contains("CancellationToken cancellationToken", source, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void VersionOwnersDoNotDependOnOneAnother()
+    {
+        foreach (var owner in MigrationOwners)
+        {
+            var source = ReadDownloadSource($"{owner}.cs");
+            var otherOwners = MigrationOwners.Where(candidate => candidate != owner);
+
+            Assert.All(
+                otherOwners,
+                otherOwner => Assert.DoesNotContain(otherOwner, source, StringComparison.Ordinal));
+        }
+    }
+
+    private static string ReadDownloadSource(string fileName)
+    {
+        return File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "src",
+            "DownKyi.Infrastructure",
+            "Downloads",
+            fileName));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}


### PR DESCRIPTION
## Summary

- Split the existing DownloadStoreSchema implementation into named version migration owners and a shared lifecycle owner.
- This is a structural-only S1 refactor with no product-semantic or schema-contract change.
- `DownloadStoreSchema.CurrentVersion` remains `3`.

## Ownership

- `DownloadStoreSchema` remains the coordinator: it reads the current version, decides whether a pre-migration backup is required, orders V1 -> V2 -> V3, owns the single transaction, sets the final user version, and commits or rolls back.
- `DownloadStoreSchemaLifecycle` owns shared schema lifecycle mechanics: reading and setting `PRAGMA user_version`, recording applied migrations, and creating pre-migration backups.
- `DownloadStoreSchemaV1Migration` owns the original tables and indexes plus the V1 migration record.
- `DownloadStoreSchemaV2Migration` owns the V2 column additions and download-phase backfill plus the V2 migration record.
- `DownloadStoreSchemaV3Migration` owns the output-reservation column, backfill, and indexes plus the V3 migration record.
- Architecture coverage keeps SQL out of the coordinator and keeps each version owner named, non-partial, fully contextual, and independent of sibling migration owners.

## Local verification already completed

- Focused tests: 19/19 passed.
- Architecture tests: 283/283 passed.
- Strict Release build: 0 warnings, 0 errors.
- Format verification: 0/970 files required changes.
- `git diff --check`: passed.

These gates were completed before publication and were not rerun merely to manufacture a green result.

## Merge gates

This Draft PR is not merge-ready until naturally triggered required CI and CodeQL pass for the exact head, and the same head receives a clean review. Do not substitute historical/local evidence or reruns for those gates.