### PR TITLE
refactor: S2 split SQLite download task store

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -581,6 +581,11 @@ type: core
 paths:
   - src/DownKyi.Infrastructure/Time/SystemClock.cs
   - src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQueries.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreCommands.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadTaskRecordMapper.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlWriter.cs
@@ -596,7 +601,7 @@ contracts:
   - Infrastructure never references Desktop or Prism.
   - SystemClock returns UTC time; deterministic tests replace IClock at the composition boundary.
   - SQLite uses one short pooled connection per operation, WAL, parameterized queries, optimistic versions, and transactional state moves.
-  - `SqliteDownloadTaskStore` owns initialization, transactions, and public query coordination; record restoration, quarantine reads, and SQL write commands stay in their dedicated owners.
+  - `SqliteDownloadTaskStore` is a non-partial compatibility facade with no SQL. `SqliteDownloadStoreDatabase` owns connections, initialization, orphan cleanup, and store-operation transaction boundaries; queries, commands, output reservations, and quarantine stay in explicit inward collaborators.
   - Existing databases are backed up before schema migration; failed migrations roll back and never advance `user_version`.
   - One malformed row is quarantined with record ID, field, and sanitized reason; raw JSON and personal paths are not copied into diagnostics.
   - The progress writer has a one-slot bounded wake channel, a bounded task set, contiguous coalescing, and a final shutdown flush.
@@ -1994,7 +1999,7 @@ contracts:
   - New, resumed, and persisted startup tasks enqueue `DownloadTaskId` directly; no runtime owner scans an observable UI collection for work.
   - `DownloadTaskAdmissionService` is the singleton admission coordinator. Under one asynchronous gate it probes indexed candidates, resolves on-disk collisions, persists the selected base path, then publishes the UI projection and queue ID; it never reloads all unfinished tasks for each admission.
   - SQLite schema v3 stores the normalized active reservation key in `download_base`. Task insertion claims that key in the same transaction, and a partial unique index rejects check-then-insert races. The Domain/SQLite store remains the ownership truth; no mutable path registry, cache, or UI collection owns reservations.
-  - `SqliteDownloadTaskStore` owns only its initialization gate and operation-scoped connections. Its disposal cannot clear the provider-global connection pool shared by sibling stores or connections; process/test-host teardown is the only layer allowed to perform global pool cleanup.
+  - `SqliteDownloadStoreDatabase` owns the initialization gate and operation-scoped connections behind the `SqliteDownloadTaskStore` facade. Its disposal cannot clear the provider-global connection pool shared by sibling stores or connections; process/test-host teardown is the only layer allowed to perform global pool cleanup.
   - Queued, Downloading, Pausing, Paused, Failed, and Canceled tasks retain normalized output reservations. Canceled tasks release the claim only after generated-file cleanup succeeds and the task commits Deleted; Completed tasks release it during the completion transaction. Existing output files still prevent reuse.
   - Output-path comparison is ordinal and case-insensitive on Windows and macOS, and ordinal on Linux. The macOS rule is deliberately fail-closed for the default case-insensitive filesystems. When automatic numeric suffixing is disabled, any active or on-disk collision rejects admission instead of silently renaming the output.
   - `DownloadTransferCoordinator` is the only media-transfer retry budget owner. It supplies exactly one URL to a backend call, rotates backup addresses, and permits one playback-address refresh.

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreOperationResults.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreOperationResults.cs
@@ -1,0 +1,31 @@
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreOperationResults
+{
+    public static OperationResult Conflict(DownloadTaskId taskId, string reason)
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.store.conflict",
+            $"Download task '{taskId.Value}' {reason}.",
+            OperationErrorKind.Conflict));
+    }
+
+    public static OperationResult NotFound(DownloadTaskId taskId)
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.store.not_found",
+            $"Download task '{taskId.Value}' was not found.",
+            OperationErrorKind.NotFound));
+    }
+
+    public static OperationResult OutputPathConflict()
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.store.output_path_reserved",
+            "The selected output path is already reserved by another active download.",
+            OperationErrorKind.Conflict));
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
@@ -1,6 +1,3 @@
-using DownKyi.Domain.Downloads;
-using Microsoft.Data.Sqlite;
-
 namespace DownKyi.Infrastructure.Downloads;
 
 internal static class DownloadTaskSqlReader
@@ -22,69 +19,4 @@ internal static class DownloadTaskSqlReader
         LEFT JOIN downloaded d ON d.id = db.id
         """;
 
-    public static async Task<IReadOnlyList<DownloadTask>> ReadManyAsync(
-        SqliteConnection connection,
-        SqliteCommand command,
-        string sourceTable,
-        DateTimeOffset quarantinedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        var tasks = new List<DownloadTask>();
-        var corrupt = new List<(string RecordId, DownloadRecordCorruptException Error)>();
-        using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
-        {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                var recordId = reader.GetString(reader.GetOrdinal("id"));
-                try
-                {
-                    tasks.Add(DownloadTaskRecordMapper.Read(reader));
-                }
-                catch (DownloadRecordCorruptException exception)
-                {
-                    corrupt.Add((recordId, exception));
-                }
-            }
-        }
-
-        foreach (var item in corrupt)
-        {
-            await QuarantineAsync(
-                    connection,
-                    sourceTable,
-                    item.RecordId,
-                    item.Error,
-                    quarantinedAtUtc,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return tasks;
-    }
-
-    public static async Task QuarantineAsync(
-        SqliteConnection connection,
-        string sourceTable,
-        string recordId,
-        DownloadRecordCorruptException error,
-        DateTimeOffset quarantinedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO download_quarantine
-                (source_table, record_id, field_name, reason, quarantined_at_utc)
-            VALUES (@source_table, @record_id, @field_name, @reason, @quarantined_at_utc)
-            ON CONFLICT(source_table, record_id) DO UPDATE SET
-                field_name = excluded.field_name,
-                reason = excluded.reason,
-                quarantined_at_utc = excluded.quarantined_at_utc
-            """;
-        command.Parameters.AddWithValue("@source_table", sourceTable);
-        command.Parameters.AddWithValue("@record_id", recordId);
-        command.Parameters.AddWithValue("@field_name", error.FieldName);
-        command.Parameters.AddWithValue("@reason", error.Message);
-        command.Parameters.AddWithValue("@quarantined_at_utc", quarantinedAtUtc.ToUnixTimeMilliseconds());
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
 }

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreCommands.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreCommands.cs
@@ -1,0 +1,140 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreCommands(SqliteDownloadStoreDatabase database)
+{
+    private readonly SqliteDownloadStoreDatabase _database = database;
+
+    public Task<OperationResult> UpdateAsync(
+        DownloadTask task,
+        long expectedVersion,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ArgumentOutOfRangeException.ThrowIfNegative(expectedVersion);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(expectedVersion, task.Version);
+
+        return _database.ExecuteTransactionAsync(
+            async (connection, transaction, token) =>
+            {
+                var updated = await DownloadTaskSqlWriter.UpdateBaseAsync(
+                    connection,
+                    transaction,
+                    task,
+                    expectedVersion,
+                    token).ConfigureAwait(false);
+                if (updated == 0)
+                {
+                    return DownloadStoreOperationResults.Conflict(
+                        task.Id,
+                        "has changed since it was loaded");
+                }
+
+                if (task.Phase == DownloadPhase.Deleted)
+                {
+                    await DownloadTaskSqlWriter
+                        .DeleteBaseAsync(connection, transaction, task.Id, token)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await DownloadTaskSqlWriter
+                        .WriteStateRowAsync(connection, transaction, task, token)
+                        .ConfigureAwait(false);
+                }
+
+                return OperationResult.Success();
+            },
+            cancellationToken);
+    }
+
+    public Task<OperationResult> UpdateProgressAsync(
+        DownloadProgressWrite progressWrite,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(progressWrite);
+        return _database.ExecuteTransactionAsync(
+            async (connection, transaction, token) =>
+            {
+                using var versionCommand = connection.CreateCommand();
+                versionCommand.Transaction = transaction;
+                versionCommand.CommandText = """
+                    UPDATE download_base
+                    SET version = @target_version, updated_at_utc = @updated_at_utc
+                    WHERE id = @id AND version = @expected_version
+                    """;
+                versionCommand.Parameters.AddWithValue("@target_version", progressWrite.TargetVersion);
+                versionCommand.Parameters.AddWithValue(
+                    "@updated_at_utc",
+                    progressWrite.UpdatedAtUtc.ToUnixTimeMilliseconds());
+                versionCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
+                versionCommand.Parameters.AddWithValue("@expected_version", progressWrite.ExpectedVersion);
+                var changed = await versionCommand.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                if (changed == 0)
+                {
+                    return DownloadStoreOperationResults.Conflict(
+                        progressWrite.TaskId,
+                        "has changed since progress was sampled");
+                }
+
+                using var progressCommand = connection.CreateCommand();
+                progressCommand.Transaction = transaction;
+                progressCommand.CommandText = """
+                    UPDATE downloading
+                    SET progress = @progress,
+                        downloaded_bytes = @downloaded_bytes,
+                        total_bytes = @total_bytes,
+                        bytes_per_second = @bytes_per_second,
+                        downloading_file_size = @downloaded_size_text,
+                        speed_display = @speed_text,
+                        max_speed = MAX(max_speed, @bytes_per_second)
+                    WHERE id = @id
+                    """;
+                DownloadTaskSqlWriter.BindProgress(progressCommand, progressWrite.Progress);
+                progressCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
+                changed = await progressCommand.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                return changed == 0
+                    ? DownloadStoreOperationResults.NotFound(progressWrite.TaskId)
+                    : OperationResult.Success();
+            },
+            cancellationToken);
+    }
+
+    public async Task<OperationResult> DeleteAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM download_base WHERE id = @id";
+        command.Parameters.AddWithValue("@id", taskId.Value);
+        var changed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return changed == 0
+            ? DownloadStoreOperationResults.NotFound(taskId)
+            : OperationResult.Success();
+    }
+
+    public Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken)
+    {
+        return _database.ExecuteTransactionAsync(
+            async (connection, transaction, token) =>
+            {
+                const string sql = """
+                    DELETE FROM download_base
+                    WHERE id IN (SELECT id FROM downloaded)
+                      AND id NOT IN (SELECT id FROM downloading);
+                    DELETE FROM downloaded;
+                    """;
+                using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = sql;
+                await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                return OperationResult.Success();
+            },
+            cancellationToken);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
@@ -14,6 +14,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
     private readonly SqliteDownloadTaskStoreOptions _options;
     private readonly IClock _clock;
     private readonly ILogger _logger;
+    private readonly Type _disposedObjectType;
     private readonly string _connectionString;
     private readonly SemaphoreSlim _initializationGate = new(1, 1);
     private volatile bool _initialized;
@@ -22,11 +23,13 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
     public SqliteDownloadStoreDatabase(
         SqliteDownloadTaskStoreOptions options,
         IClock clock,
-        ILogger logger)
+        ILogger logger,
+        Type disposedObjectType)
     {
         _options = options;
         _clock = clock;
         _logger = logger;
+        _disposedObjectType = disposedObjectType;
         _connectionString = new SqliteConnectionStringBuilder
         {
             DataSource = options.DatabasePath,
@@ -100,7 +103,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(_disposed, _disposedObjectType);
         if (_initialized)
         {
             return;

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
@@ -1,0 +1,193 @@
+using DownKyi.Application.Time;
+using DownKyi.Domain.Results;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreDatabase : IDisposable
+{
+    private static readonly Action<ILogger, int, Exception?> LogOrphanCleanup = LoggerMessage.Define<int>(
+        LogLevel.Information,
+        new EventId(1001, "DownloadStoreOrphanCleanup"),
+        "Removed {Count} orphaned downloading records.");
+    private readonly SqliteDownloadTaskStoreOptions _options;
+    private readonly IClock _clock;
+    private readonly ILogger _logger;
+    private readonly string _connectionString;
+    private readonly SemaphoreSlim _initializationGate = new(1, 1);
+    private volatile bool _initialized;
+    private bool _disposed;
+
+    public SqliteDownloadStoreDatabase(
+        SqliteDownloadTaskStoreOptions options,
+        IClock clock,
+        ILogger logger)
+    {
+        _options = options;
+        _clock = clock;
+        _logger = logger;
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = options.DatabasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = checked((int)Math.Ceiling(options.BusyTimeout.TotalSeconds))
+        }.ToString();
+    }
+
+    public Task InitializeAsync(CancellationToken cancellationToken) =>
+        EnsureInitializedAsync(cancellationToken);
+
+    public async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await OpenConnectionCoreAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<OperationResult> ExecuteTransactionAsync(
+        Func<SqliteConnection, SqliteTransaction, CancellationToken, Task<OperationResult>> operation,
+        CancellationToken cancellationToken) =>
+        ExecuteTransactionCoreAsync(operation, immediate: false, cancellationToken);
+
+    public Task<OperationResult> ExecuteImmediateTransactionAsync(
+        Func<SqliteConnection, SqliteTransaction, CancellationToken, Task<OperationResult>> operation,
+        CancellationToken cancellationToken) =>
+        ExecuteTransactionCoreAsync(operation, immediate: true, cancellationToken);
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _initializationGate.Dispose();
+    }
+
+    private async Task<OperationResult> ExecuteTransactionCoreAsync(
+        Func<SqliteConnection, SqliteTransaction, CancellationToken, Task<OperationResult>> operation,
+        bool immediate,
+        CancellationToken cancellationToken)
+    {
+        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var transaction = immediate
+            ? BeginImmediateTransaction(connection)
+            : (SqliteTransaction)await connection
+                .BeginTransactionAsync(cancellationToken)
+                .ConfigureAwait(false);
+        try
+        {
+            var result = await operation(connection, transaction, cancellationToken).ConfigureAwait(false);
+            if (result.IsSuccess)
+            {
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_initialized)
+        {
+            return;
+        }
+
+        await _initializationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            var databaseExisted = File.Exists(_options.DatabasePath)
+                && new FileInfo(_options.DatabasePath).Length > 0;
+            Directory.CreateDirectory(Path.GetDirectoryName(_options.DatabasePath) ?? ".");
+            using var connection = await OpenConnectionCoreAsync(cancellationToken).ConfigureAwait(false);
+            await DownloadStoreSchema.InitializeAsync(
+                connection,
+                _options.DatabasePath,
+                databaseExisted,
+                _clock,
+                cancellationToken).ConfigureAwait(false);
+            await RemoveOrphanedDownloadingRecordsAsync(connection, cancellationToken).ConfigureAwait(false);
+            _initialized = true;
+        }
+        finally
+        {
+            _initializationGate.Release();
+        }
+    }
+
+    private async Task RemoveOrphanedDownloadingRecordsAsync(
+        SqliteConnection connection,
+        CancellationToken cancellationToken)
+    {
+        using var transaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = """
+                DELETE FROM downloading
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM download_base
+                    WHERE download_base.id = downloading.id)
+                """;
+            var removed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            if (removed > 0)
+            {
+                LogOrphanCleanup(_logger, removed, null);
+            }
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task<SqliteConnection> OpenConnectionCoreAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        try
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                PRAGMA foreign_keys = ON;
+                PRAGMA journal_mode = WAL;
+                PRAGMA synchronous = NORMAL;
+                PRAGMA temp_store = MEMORY;
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            return connection;
+        }
+        catch
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static SqliteTransaction BeginImmediateTransaction(SqliteConnection connection) =>
+        connection.BeginTransaction(deferred: false);
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
@@ -5,9 +5,11 @@ using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Infrastructure.Downloads;
 
-public sealed partial class SqliteDownloadTaskStore
+internal sealed class SqliteDownloadStoreOutputReservations(SqliteDownloadStoreDatabase database)
 {
-    public async Task<OperationResult> AddAsync(
+    private readonly SqliteDownloadStoreDatabase _database = database;
+
+    public Task<OperationResult> AddAsync(
         DownloadTask task,
         CancellationToken cancellationToken)
     {
@@ -17,46 +19,40 @@ public sealed partial class SqliteDownloadTaskStore
             throw new ArgumentException("A deleted task cannot be inserted.", nameof(task));
         }
 
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = BeginImmediateTransaction(connection);
-        try
-        {
-            if (task.Phase != DownloadPhase.Completed &&
-                await IsOutputPathReservedCoreAsync(
-                    connection,
-                    transaction,
-                    task.Output.BasePath,
-                    DownloadOutputPathKey.UsesCaseInsensitiveComparison,
-                    cancellationToken).ConfigureAwait(false))
+        return _database.ExecuteImmediateTransactionAsync(
+            async (connection, transaction, token) =>
             {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return OutputPathConflict();
-            }
+                try
+                {
+                    if (task.Phase != DownloadPhase.Completed &&
+                        await IsOutputPathReservedCoreAsync(
+                            connection,
+                            transaction,
+                            task.Output.BasePath,
+                            DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                            token).ConfigureAwait(false))
+                    {
+                        return DownloadStoreOperationResults.OutputPathConflict();
+                    }
 
-            await DownloadTaskSqlWriter
-                .InsertBaseAsync(connection, transaction, task, cancellationToken)
-                .ConfigureAwait(false);
-            await DownloadTaskSqlWriter
-                .WriteStateRowAsync(connection, transaction, task, cancellationToken)
-                .ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch (SqliteException exception) when (exception.SqliteErrorCode == 19)
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            return exception.Message.Contains(
-                "output_reservation_key",
-                StringComparison.OrdinalIgnoreCase)
-                ? OutputPathConflict()
-                : Conflict(task.Id, "already exists");
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
+                    await DownloadTaskSqlWriter
+                        .InsertBaseAsync(connection, transaction, task, token)
+                        .ConfigureAwait(false);
+                    await DownloadTaskSqlWriter
+                        .WriteStateRowAsync(connection, transaction, task, token)
+                        .ConfigureAwait(false);
+                    return OperationResult.Success();
+                }
+                catch (SqliteException exception) when (exception.SqliteErrorCode == 19)
+                {
+                    return exception.Message.Contains(
+                        "output_reservation_key",
+                        StringComparison.OrdinalIgnoreCase)
+                        ? DownloadStoreOperationResults.OutputPathConflict()
+                        : DownloadStoreOperationResults.Conflict(task.Id, "already exists");
+                }
+            },
+            cancellationToken);
     }
 
     public async Task<bool> IsOutputPathReservedAsync(
@@ -65,8 +61,7 @@ public sealed partial class SqliteDownloadTaskStore
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         return await IsOutputPathReservedCoreAsync(
             connection,
             transaction: null,
@@ -118,16 +113,4 @@ public sealed partial class SqliteDownloadTaskStore
         var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
         return Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture) != 0;
     }
-
-    private static OperationResult OutputPathConflict()
-    {
-        return OperationResult.Failure(new OperationError(
-            "download.store.output_path_reserved",
-            "The selected output path is already reserved by another active download.",
-            OperationErrorKind.Conflict));
-    }
-
-    private static SqliteTransaction BeginImmediateTransaction(SqliteConnection connection) =>
-        connection.BeginTransaction(deferred: false);
-
 }

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
@@ -1,0 +1,62 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreQuarantine(SqliteDownloadStoreDatabase database)
+{
+    private readonly SqliteDownloadStoreDatabase _database = database;
+
+    public async Task<IReadOnlyList<QuarantinedDownloadRecord>> GetRecordsAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT quarantine_id, source_table, record_id, field_name, reason, quarantined_at_utc
+            FROM download_quarantine
+            ORDER BY quarantine_id ASC
+            """;
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var records = new List<QuarantinedDownloadRecord>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            records.Add(new QuarantinedDownloadRecord(
+                reader.GetInt64(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(5))));
+        }
+
+        return records;
+    }
+
+    public static async Task RecordAsync(
+        SqliteConnection connection,
+        string sourceTable,
+        string recordId,
+        DownloadRecordCorruptException error,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO download_quarantine
+                (source_table, record_id, field_name, reason, quarantined_at_utc)
+            VALUES (@source_table, @record_id, @field_name, @reason, @quarantined_at_utc)
+            ON CONFLICT(source_table, record_id) DO UPDATE SET
+                field_name = excluded.field_name,
+                reason = excluded.reason,
+                quarantined_at_utc = excluded.quarantined_at_utc
+            """;
+        command.Parameters.AddWithValue("@source_table", sourceTable);
+        command.Parameters.AddWithValue("@record_id", recordId);
+        command.Parameters.AddWithValue("@field_name", error.FieldName);
+        command.Parameters.AddWithValue("@reason", error.Message);
+        command.Parameters.AddWithValue("@quarantined_at_utc", quarantinedAtUtc.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQueries.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQueries.cs
@@ -1,0 +1,161 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Application.Time;
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreQueries(
+    SqliteDownloadStoreDatabase database,
+    IClock clock)
+{
+    private const int MaximumHistoryPageSize = 500;
+    private readonly SqliteDownloadStoreDatabase _database = database;
+    private readonly IClock _clock = clock;
+
+    public async Task<DownloadTask?> FindAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
+            WHERE db.id = @id
+              AND NOT EXISTS (
+                  SELECT 1 FROM download_quarantine q
+                  WHERE q.record_id = db.id
+                    AND q.source_table = CASE WHEN d.id IS NULL THEN 'downloading' ELSE 'downloaded' END)
+            """;
+        command.Parameters.AddWithValue("@id", taskId.Value);
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        try
+        {
+            return DownloadTaskRecordMapper.Read(reader);
+        }
+        catch (DownloadRecordCorruptException exception)
+        {
+            var isHistory = !await reader
+                .IsDBNullAsync(reader.GetOrdinal("finished_timestamp"), cancellationToken)
+                .ConfigureAwait(false);
+            var source = isHistory ? "downloaded" : "downloading";
+            await reader.DisposeAsync().ConfigureAwait(false);
+            await SqliteDownloadStoreQuarantine
+                .RecordAsync(connection, source, taskId.Value, exception, _clock.UtcNow, cancellationToken)
+                .ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
+            WHERE dl.id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM download_quarantine q
+                  WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+            ORDER BY db.main_title COLLATE NOCASE, db.[order] ASC, db.id ASC
+            """;
+        return await ReadManyAsync(
+            connection,
+            command,
+            "downloading",
+            _clock.UtcNow,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<DownloadHistoryPage> GetHistoryPageAsync(
+        DownloadHistoryCursor? cursor,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(pageSize, MaximumHistoryPageSize);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
+            WHERE d.id IS NOT NULL
+              AND (@cursor_timestamp IS NULL
+                   OR d.finished_timestamp < @cursor_timestamp
+                   OR (d.finished_timestamp = @cursor_timestamp AND d.id < @cursor_id))
+              AND NOT EXISTS (
+                  SELECT 1 FROM download_quarantine q
+                  WHERE q.source_table = 'downloaded' AND q.record_id = db.id)
+            ORDER BY d.finished_timestamp DESC, d.id DESC
+            LIMIT @limit
+            """;
+        command.Parameters.AddWithValue("@cursor_timestamp", cursor?.FinishedTimestamp ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@cursor_id", cursor?.TaskId.Value ?? string.Empty);
+        command.Parameters.AddWithValue("@limit", checked(pageSize + 1));
+        var items = (await ReadManyAsync(
+                connection,
+                command,
+                "downloaded",
+                _clock.UtcNow,
+                cancellationToken).ConfigureAwait(false))
+            .ToList();
+        var hasMore = items.Count > pageSize;
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        DownloadHistoryCursor? nextCursor = null;
+        if (hasMore && items.Count > 0)
+        {
+            var last = items[^1];
+            nextCursor = new DownloadHistoryCursor(last.Completion!.FinishedTimestamp, last.Id);
+        }
+
+        return new DownloadHistoryPage(items, nextCursor);
+    }
+
+    private static async Task<IReadOnlyList<DownloadTask>> ReadManyAsync(
+        SqliteConnection connection,
+        SqliteCommand command,
+        string sourceTable,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var tasks = new List<DownloadTask>();
+        var corrupt = new List<(string RecordId, DownloadRecordCorruptException Error)>();
+        using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var recordId = reader.GetString(reader.GetOrdinal("id"));
+                try
+                {
+                    tasks.Add(DownloadTaskRecordMapper.Read(reader));
+                }
+                catch (DownloadRecordCorruptException exception)
+                {
+                    corrupt.Add((recordId, exception));
+                }
+            }
+        }
+
+        foreach (var item in corrupt)
+        {
+            await SqliteDownloadStoreQuarantine
+                .RecordAsync(
+                    connection,
+                    sourceTable,
+                    item.RecordId,
+                    item.Error,
+                    quarantinedAtUtc,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return tasks;
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -33,7 +33,11 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
             throw new ArgumentOutOfRangeException(nameof(options));
         }
 
-        _database = new SqliteDownloadStoreDatabase(options, clock, logger);
+        _database = new SqliteDownloadStoreDatabase(
+            options,
+            clock,
+            logger,
+            typeof(SqliteDownloadTaskStore));
         _quarantine = new SqliteDownloadStoreQuarantine(_database);
         _queries = new SqliteDownloadStoreQueries(_database, clock);
         _commands = new SqliteDownloadStoreCommands(_database);

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -2,26 +2,18 @@ using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using DownKyi.Domain.Downloads;
 using DownKyi.Domain.Results;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Infrastructure.Downloads;
 
-public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
+public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
 {
-    private const int MaximumHistoryPageSize = 500;
-    private static readonly Action<ILogger, int, Exception?> LogOrphanCleanup = LoggerMessage.Define<int>(
-        LogLevel.Information,
-        new EventId(1001, "DownloadStoreOrphanCleanup"),
-        "Removed {Count} orphaned downloading records.");
-    private readonly SqliteDownloadTaskStoreOptions _options;
-    private readonly IClock _clock;
-    private readonly ILogger<SqliteDownloadTaskStore> _logger;
-    private readonly string _connectionString;
-    private readonly SemaphoreSlim _initializationGate = new(1, 1);
-    private volatile bool _initialized;
-    private bool _disposed;
+    private readonly SqliteDownloadStoreDatabase _database;
+    private readonly SqliteDownloadStoreQueries _queries;
+    private readonly SqliteDownloadStoreCommands _commands;
+    private readonly SqliteDownloadStoreOutputReservations _outputReservations;
+    private readonly SqliteDownloadStoreQuarantine _quarantine;
 
     public SqliteDownloadTaskStore(SqliteDownloadTaskStoreOptions options, IClock clock)
         : this(options, clock, NullLogger<SqliteDownloadTaskStore>.Instance)
@@ -41,421 +33,63 @@ public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDispo
             throw new ArgumentOutOfRangeException(nameof(options));
         }
 
-        _options = options;
-        _clock = clock;
-        _logger = logger;
-        _connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = options.DatabasePath,
-            Mode = SqliteOpenMode.ReadWriteCreate,
-            Pooling = true,
-            DefaultTimeout = checked((int)Math.Ceiling(options.BusyTimeout.TotalSeconds))
-        }.ToString();
+        _database = new SqliteDownloadStoreDatabase(options, clock, logger);
+        _quarantine = new SqliteDownloadStoreQuarantine(_database);
+        _queries = new SqliteDownloadStoreQueries(_database, clock);
+        _commands = new SqliteDownloadStoreCommands(_database);
+        _outputReservations = new SqliteDownloadStoreOutputReservations(_database);
     }
 
-    public Task InitializeAsync(CancellationToken cancellationToken)
-    {
-        return EnsureInitializedAsync(cancellationToken);
-    }
+    public Task InitializeAsync(CancellationToken cancellationToken) =>
+        _database.InitializeAsync(cancellationToken);
+
+    public async Task<OperationResult> AddAsync(DownloadTask task, CancellationToken cancellationToken) =>
+        await _outputReservations.AddAsync(task, cancellationToken).ConfigureAwait(false);
 
     public async Task<OperationResult> UpdateAsync(
         DownloadTask task,
         long expectedVersion,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(task);
-        ArgumentOutOfRangeException.ThrowIfNegative(expectedVersion);
-        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(expectedVersion, task.Version);
-
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        try
-        {
-            var updated = await DownloadTaskSqlWriter.UpdateBaseAsync(
-                connection,
-                transaction,
-                task,
-                expectedVersion,
-                cancellationToken).ConfigureAwait(false);
-            if (updated == 0)
-            {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return Conflict(task.Id, "has changed since it was loaded");
-            }
-
-            if (task.Phase == DownloadPhase.Deleted)
-            {
-                await DownloadTaskSqlWriter
-                    .DeleteBaseAsync(connection, transaction, task.Id, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                await DownloadTaskSqlWriter
-                    .WriteStateRowAsync(connection, transaction, task, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
+        CancellationToken cancellationToken) =>
+        await _commands.UpdateAsync(task, expectedVersion, cancellationToken).ConfigureAwait(false);
 
     public async Task<OperationResult> UpdateProgressAsync(
         DownloadProgressWrite progressWrite,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(progressWrite);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
+        CancellationToken cancellationToken) =>
+        await _commands.UpdateProgressAsync(progressWrite, cancellationToken).ConfigureAwait(false);
+
+    public async Task<DownloadTask?> FindAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        await _queries.FindAsync(taskId, cancellationToken).ConfigureAwait(false);
+
+    public async Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken) =>
+        await _queries.GetUnfinishedAsync(cancellationToken).ConfigureAwait(false);
+
+    public async Task<bool> IsOutputPathReservedAsync(
+        string basePath,
+        bool ignoreCase,
+        CancellationToken cancellationToken) =>
+        await _outputReservations
+            .IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken)
             .ConfigureAwait(false);
-        try
-        {
-            using var versionCommand = connection.CreateCommand();
-            versionCommand.Transaction = transaction;
-            versionCommand.CommandText = """
-                UPDATE download_base
-                SET version = @target_version, updated_at_utc = @updated_at_utc
-                WHERE id = @id AND version = @expected_version
-                """;
-            versionCommand.Parameters.AddWithValue("@target_version", progressWrite.TargetVersion);
-            versionCommand.Parameters.AddWithValue("@updated_at_utc", progressWrite.UpdatedAtUtc.ToUnixTimeMilliseconds());
-            versionCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
-            versionCommand.Parameters.AddWithValue("@expected_version", progressWrite.ExpectedVersion);
-            var changed = await versionCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            if (changed == 0)
-            {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return Conflict(progressWrite.TaskId, "has changed since progress was sampled");
-            }
-
-            using var progressCommand = connection.CreateCommand();
-            progressCommand.Transaction = transaction;
-            progressCommand.CommandText = """
-                UPDATE downloading
-                SET progress = @progress,
-                    downloaded_bytes = @downloaded_bytes,
-                    total_bytes = @total_bytes,
-                    bytes_per_second = @bytes_per_second,
-                    downloading_file_size = @downloaded_size_text,
-                    speed_display = @speed_text,
-                    max_speed = MAX(max_speed, @bytes_per_second)
-                WHERE id = @id
-                """;
-            DownloadTaskSqlWriter.BindProgress(progressCommand, progressWrite.Progress);
-            progressCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
-            changed = await progressCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            if (changed == 0)
-            {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return NotFound(progressWrite.TaskId);
-            }
-
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
-
-    public async Task<DownloadTask?> FindAsync(DownloadTaskId taskId, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(taskId);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
-            WHERE db.id = @id
-              AND NOT EXISTS (
-                  SELECT 1 FROM download_quarantine q
-                  WHERE q.record_id = db.id
-                    AND q.source_table = CASE WHEN d.id IS NULL THEN 'downloading' ELSE 'downloaded' END)
-            """;
-        command.Parameters.AddWithValue("@id", taskId.Value);
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            return null;
-        }
-
-        try
-        {
-            return DownloadTaskRecordMapper.Read(reader);
-        }
-        catch (DownloadRecordCorruptException exception)
-        {
-            var isHistory = !await reader
-                .IsDBNullAsync(reader.GetOrdinal("finished_timestamp"), cancellationToken)
-                .ConfigureAwait(false);
-            var source = isHistory ? "downloaded" : "downloading";
-            await reader.DisposeAsync().ConfigureAwait(false);
-            await DownloadTaskSqlReader
-                .QuarantineAsync(connection, source, taskId.Value, exception, _clock.UtcNow, cancellationToken)
-                .ConfigureAwait(false);
-            return null;
-        }
-    }
-
-    public async Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
-            WHERE dl.id IS NOT NULL
-              AND NOT EXISTS (
-                  SELECT 1 FROM download_quarantine q
-                  WHERE q.source_table = 'downloading' AND q.record_id = db.id)
-            ORDER BY db.main_title COLLATE NOCASE, db.[order] ASC, db.id ASC
-            """;
-        return await DownloadTaskSqlReader
-            .ReadManyAsync(connection, command, "downloading", _clock.UtcNow, cancellationToken)
-            .ConfigureAwait(false);
-    }
 
     public async Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,
-        CancellationToken cancellationToken)
-    {
-        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(pageSize, MaximumHistoryPageSize);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
-            WHERE d.id IS NOT NULL
-              AND (@cursor_timestamp IS NULL
-                   OR d.finished_timestamp < @cursor_timestamp
-                   OR (d.finished_timestamp = @cursor_timestamp AND d.id < @cursor_id))
-              AND NOT EXISTS (
-                  SELECT 1 FROM download_quarantine q
-                  WHERE q.source_table = 'downloaded' AND q.record_id = db.id)
-            ORDER BY d.finished_timestamp DESC, d.id DESC
-            LIMIT @limit
-            """;
-        command.Parameters.AddWithValue("@cursor_timestamp", cursor?.FinishedTimestamp ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@cursor_id", cursor?.TaskId.Value ?? string.Empty);
-        command.Parameters.AddWithValue("@limit", checked(pageSize + 1));
-        var items = (await DownloadTaskSqlReader.ReadManyAsync(
-                connection,
-                command,
-                "downloaded",
-                _clock.UtcNow,
-                cancellationToken).ConfigureAwait(false))
-            .ToList();
-        var hasMore = items.Count > pageSize;
-        if (hasMore)
-        {
-            items.RemoveAt(items.Count - 1);
-        }
+        CancellationToken cancellationToken) =>
+        await _queries.GetHistoryPageAsync(cursor, pageSize, cancellationToken).ConfigureAwait(false);
 
-        DownloadHistoryCursor? nextCursor = null;
-        if (hasMore && items.Count > 0)
-        {
-            var last = items[^1];
-            nextCursor = new DownloadHistoryCursor(last.Completion!.FinishedTimestamp, last.Id);
-        }
+    public async Task<OperationResult> DeleteAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        await _commands.DeleteAsync(taskId, cancellationToken).ConfigureAwait(false);
 
-        return new DownloadHistoryPage(items, nextCursor);
-    }
-
-    public async Task<OperationResult> DeleteAsync(DownloadTaskId taskId, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(taskId);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = "DELETE FROM download_base WHERE id = @id";
-        command.Parameters.AddWithValue("@id", taskId.Value);
-        var changed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        return changed == 0 ? NotFound(taskId) : OperationResult.Success();
-    }
-
-    public async Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        try
-        {
-            const string sql = """
-                DELETE FROM download_base
-                WHERE id IN (SELECT id FROM downloaded)
-                  AND id NOT IN (SELECT id FROM downloading);
-                DELETE FROM downloaded;
-                """;
-            using var command = connection.CreateCommand();
-            command.Transaction = transaction;
-            command.CommandText = sql;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
+    public async Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken) =>
+        await _commands.ClearHistoryAsync(cancellationToken).ConfigureAwait(false);
 
     public async Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
-        CancellationToken cancellationToken)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT quarantine_id, source_table, record_id, field_name, reason, quarantined_at_utc
-            FROM download_quarantine
-            ORDER BY quarantine_id ASC
-            """;
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        var records = new List<QuarantinedDownloadRecord>();
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            records.Add(new QuarantinedDownloadRecord(
-                reader.GetInt64(0),
-                reader.GetString(1),
-                reader.GetString(2),
-                reader.GetString(3),
-                reader.GetString(4),
-                DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(5))));
-        }
+        CancellationToken cancellationToken) =>
+        await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false);
 
-        return records;
-    }
-
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _disposed = true;
-        _initializationGate.Dispose();
-    }
-
-    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
-    {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        if (_initialized)
-        {
-            return;
-        }
-
-        await _initializationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            if (_initialized)
-            {
-                return;
-            }
-
-            var databaseExisted = File.Exists(_options.DatabasePath)
-                && new FileInfo(_options.DatabasePath).Length > 0;
-            Directory.CreateDirectory(Path.GetDirectoryName(_options.DatabasePath) ?? ".");
-            using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-            await DownloadStoreSchema.InitializeAsync(
-                connection,
-                _options.DatabasePath,
-                databaseExisted,
-                _clock,
-                cancellationToken).ConfigureAwait(false);
-            await RemoveOrphanedDownloadingRecordsAsync(connection, cancellationToken).ConfigureAwait(false);
-            _initialized = true;
-        }
-        finally
-        {
-            _initializationGate.Release();
-        }
-    }
-
-    private async Task RemoveOrphanedDownloadingRecordsAsync(
-        SqliteConnection connection,
-        CancellationToken cancellationToken)
-    {
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        try
-        {
-            using var command = connection.CreateCommand();
-            command.Transaction = transaction;
-            command.CommandText = """
-                DELETE FROM downloading
-                WHERE NOT EXISTS (
-                    SELECT 1
-                    FROM download_base
-                    WHERE download_base.id = downloading.id)
-                """;
-            var removed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            if (removed > 0)
-            {
-                LogOrphanCleanup(_logger, removed, null);
-            }
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
-
-    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
-    {
-        var connection = new SqliteConnection(_connectionString);
-        try
-        {
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-            using var command = connection.CreateCommand();
-            command.CommandText = """
-                PRAGMA foreign_keys = ON;
-                PRAGMA journal_mode = WAL;
-                PRAGMA synchronous = NORMAL;
-                PRAGMA temp_store = MEMORY;
-                """;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            return connection;
-        }
-        catch
-        {
-            await connection.DisposeAsync().ConfigureAwait(false);
-            throw;
-        }
-    }
-
-    private static OperationResult Conflict(DownloadTaskId taskId, string reason)
-    {
-        return OperationResult.Failure(new OperationError(
-            "download.store.conflict",
-            $"Download task '{taskId.Value}' {reason}.",
-            OperationErrorKind.Conflict));
-    }
-
-    private static OperationResult NotFound(DownloadTaskId taskId)
-    {
-        return OperationResult.Failure(new OperationError(
-            "download.store.not_found",
-            $"Download task '{taskId.Value}' was not found.",
-            OperationErrorKind.NotFound));
-    }
-
+    public void Dispose() => _database.Dispose();
 }

--- a/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
@@ -264,22 +264,35 @@ public sealed class ModuleBoundaryBaselineTests
     }
 
     [Fact]
-    public void SqliteDownloadStoreCoordinatesDedicatedRecordAndCommandOwners()
+    public void SqliteDownloadStoreCoordinatesDedicatedPersistenceOwners()
     {
         var downloadRoot = Path.Combine(RepositoryRoot, "src", "DownKyi.Infrastructure", "Downloads");
         var storeSource = File.ReadAllText(Path.Combine(downloadRoot, "SqliteDownloadTaskStore.cs"));
+        var querySource = File.ReadAllText(Path.Combine(downloadRoot, "SqliteDownloadStoreQueries.cs"));
+        var commandSource = File.ReadAllText(Path.Combine(downloadRoot, "SqliteDownloadStoreCommands.cs"));
+        var reservationSource = File.ReadAllText(Path.Combine(
+            downloadRoot,
+            "SqliteDownloadStoreOutputReservations.cs"));
+        var quarantineSource = File.ReadAllText(Path.Combine(
+            downloadRoot,
+            "SqliteDownloadStoreQuarantine.cs"));
         var mapperSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskRecordMapper.cs"));
         var readerSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskSqlReader.cs"));
         var writerSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskSqlWriter.cs"));
 
-        Assert.Contains("DownloadTaskRecordMapper.Read", storeSource, StringComparison.Ordinal);
-        Assert.Contains("DownloadTaskSqlReader.ReadManyAsync", storeSource, StringComparison.Ordinal);
-        Assert.Contains("DownloadTaskSqlWriter", storeSource, StringComparison.Ordinal);
-        Assert.Contains("WriteStateRowAsync", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreQueries", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreCommands", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreOutputReservations", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreQuarantine", storeSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskRecordMapper.Read", querySource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlReader.SelectColumns", querySource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlWriter", commandSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlWriter", reservationSource, StringComparison.Ordinal);
         Assert.DoesNotContain("DownloadTask.Restore", storeSource, StringComparison.Ordinal);
         Assert.DoesNotContain("INSERT INTO downloading", storeSource, StringComparison.Ordinal);
         Assert.Contains("DownloadTask.Restore", mapperSource, StringComparison.Ordinal);
-        Assert.Contains("INSERT INTO download_quarantine", readerSource, StringComparison.Ordinal);
+        Assert.Contains("SELECT", readerSource, StringComparison.Ordinal);
+        Assert.Contains("INSERT INTO download_quarantine", quarantineSource, StringComparison.Ordinal);
         Assert.Contains("INSERT INTO downloading", writerSource, StringComparison.Ordinal);
     }
 

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -3,9 +3,54 @@ namespace DownKyi.Architecture.Tests;
 public sealed class SqliteDownloadTaskStoreArchitectureTests
 {
     private const string FacadeFile = "SqliteDownloadTaskStore.cs";
+    private const string Facade = "SqliteDownloadTaskStore";
     private const string Database = "SqliteDownloadStoreDatabase";
     private static readonly string RepositoryRoot = FindRepositoryRoot();
     private static readonly string[] SqlMarkers = ["SELECT ", "INSERT ", "UPDATE ", "DELETE ", "PRAGMA "];
+    private static readonly string[] ForbiddenOwnerTokens =
+    [
+        Facade,
+        "IServiceProvider",
+        "IServiceScope",
+        "IServiceScopeFactory",
+        "ServiceProvider",
+        "GetService",
+        "GetRequiredService",
+        "CreateScope",
+        "ActivatorUtilities",
+        "Reflection",
+        "BindingFlags",
+        "MethodInfo",
+        "PropertyInfo",
+        "FieldInfo",
+        "ConstructorInfo",
+        "Assembly",
+        "Activator",
+        "dynamic"
+    ];
+    private static readonly Dictionary<string, string> ExpectedFacadeDelegations = new(StringComparer.Ordinal)
+    {
+        ["InitializeAsync"] = "_database.InitializeAsync(cancellationToken)",
+        ["AddAsync"] = "await _outputReservations.AddAsync(task, cancellationToken).ConfigureAwait(false)",
+        ["UpdateAsync"] =
+            "await _commands.UpdateAsync(task, expectedVersion, cancellationToken).ConfigureAwait(false)",
+        ["UpdateProgressAsync"] =
+            "await _commands.UpdateProgressAsync(progressWrite, cancellationToken).ConfigureAwait(false)",
+        ["FindAsync"] = "await _queries.FindAsync(taskId, cancellationToken).ConfigureAwait(false)",
+        ["GetUnfinishedAsync"] =
+            "await _queries.GetUnfinishedAsync(cancellationToken).ConfigureAwait(false)",
+        ["IsOutputPathReservedAsync"] =
+            "await _outputReservations.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken)" +
+            ".ConfigureAwait(false)",
+        ["GetHistoryPageAsync"] =
+            "await _queries.GetHistoryPageAsync(cursor, pageSize, cancellationToken).ConfigureAwait(false)",
+        ["DeleteAsync"] = "await _commands.DeleteAsync(taskId, cancellationToken).ConfigureAwait(false)",
+        ["ClearHistoryAsync"] =
+            "await _commands.ClearHistoryAsync(cancellationToken).ConfigureAwait(false)",
+        ["GetQuarantinedRecordsAsync"] =
+            "await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false)",
+        ["Dispose"] = "_database.Dispose()"
+    };
     private static readonly string[] Collaborators =
     [
         "SqliteDownloadStoreQueries",
@@ -38,6 +83,7 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         Assert.All(
             Collaborators,
             collaborator => Assert.Contains($"new {collaborator}", source, StringComparison.Ordinal));
+        Assert.Empty(FindFacadeDelegationViolations(source, ExpectedFacadeDelegations));
     }
 
     [Fact]
@@ -63,6 +109,52 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         Assert.All(
             Collaborators,
             collaborator => Assert.DoesNotContain(collaborator, database, StringComparison.Ordinal));
+
+        foreach (var owner in Collaborators.Append(Database))
+        {
+            Assert.Empty(FindForbiddenOwnerDependencyViolations(
+                owner,
+                ReadDownloadSource($"{owner}.cs")));
+        }
+    }
+
+    [Fact]
+    public void FacadeDelegationRuleRejectsPolicyControlFlow()
+    {
+        const string source = """
+            public sealed class SqliteDownloadTaskStore
+            {
+                public async Task AddAsync(object task, CancellationToken cancellationToken) =>
+                    task is null
+                        ? throw new ArgumentNullException(nameof(task))
+                        : await _outputReservations.AddAsync(task, cancellationToken).ConfigureAwait(false);
+            }
+            """;
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["AddAsync"] = ExpectedFacadeDelegations["AddAsync"]
+        };
+
+        var violations = FindFacadeDelegationViolations(source, expected);
+
+        Assert.Contains(violations, violation => violation.Contains("AddAsync", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("SqliteDownloadTaskStore", "public facade")]
+    [InlineData("IServiceProvider", "service resolution")]
+    [InlineData("GetRequiredService", "service resolution")]
+    [InlineData("BindingFlags", "reflection")]
+    [InlineData("DownloadStoreContext", "general context")]
+    public void OwnerDependencyRuleRejectsForbiddenTypeTokens(string token, string expectedReason)
+    {
+        var source = $"internal sealed class Owner {{ private {token} _dependency; }}";
+
+        var violations = FindForbiddenOwnerDependencyViolations("Owner", source);
+
+        Assert.Contains(violations, violation =>
+            violation.Contains(token, StringComparison.Ordinal) &&
+            violation.Contains(expectedReason, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -97,6 +189,221 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
 
     private static string ReadDownloadSource(string fileName) =>
         File.ReadAllText(Path.Combine(DownloadSourceRoot, fileName));
+
+    private static List<string> FindFacadeDelegationViolations(
+        string source,
+        IReadOnlyDictionary<string, string> expectedDelegations)
+    {
+        var tokens = Tokenize(source);
+        var violations = new List<string>();
+        var found = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            if (tokens[index] != "public")
+            {
+                continue;
+            }
+
+            var delimiter = FindHeaderDelimiter(tokens, index + 1);
+            if (delimiter < 0 || tokens[delimiter] != "(")
+            {
+                continue;
+            }
+
+            var methodName = tokens[delimiter - 1];
+            if (methodName == Facade)
+            {
+                continue;
+            }
+
+            if (!expectedDelegations.TryGetValue(methodName, out var expectedExpression))
+            {
+                violations.Add($"Facade has unexpected public method '{methodName}'.");
+                continue;
+            }
+
+            found.Add(methodName);
+            var closeParenthesis = FindMatchingParenthesis(tokens, delimiter);
+            if (closeParenthesis < 0 || closeParenthesis + 1 >= tokens.Count ||
+                tokens[closeParenthesis + 1] != "=>")
+            {
+                violations.Add($"Facade method '{methodName}' must be expression-bodied delegation.");
+                continue;
+            }
+
+            var semicolon = tokens.IndexOf(";", closeParenthesis + 2);
+            if (semicolon < 0)
+            {
+                violations.Add($"Facade method '{methodName}' has no terminating semicolon.");
+                continue;
+            }
+
+            var actual = tokens.GetRange(closeParenthesis + 2, semicolon - closeParenthesis - 2);
+            var expected = Tokenize(expectedExpression);
+            if (!actual.SequenceEqual(expected, StringComparer.Ordinal))
+            {
+                violations.Add(
+                    $"Facade method '{methodName}' must only delegate to its assigned owner. " +
+                    $"Expected '{string.Join(' ', expected)}'; actual '{string.Join(' ', actual)}'.");
+            }
+        }
+
+        foreach (var missing in expectedDelegations.Keys.Except(found, StringComparer.Ordinal))
+        {
+            violations.Add($"Facade method '{missing}' is missing.");
+        }
+
+        return violations;
+    }
+
+    private static List<string> FindForbiddenOwnerDependencyViolations(
+        string owner,
+        string source)
+    {
+        var identifiers = Tokenize(source)
+            .Where(token => token.Length > 0 && (char.IsLetter(token[0]) || token[0] == '_'))
+            .ToHashSet(StringComparer.Ordinal);
+        var violations = new List<string>();
+        foreach (var token in ForbiddenOwnerTokens.Where(identifiers.Contains))
+        {
+            var reason = token switch
+            {
+                Facade => "public facade",
+                "IServiceProvider" or "IServiceScope" or "IServiceScopeFactory" or "ServiceProvider" or
+                    "GetService" or "GetRequiredService" or "CreateScope" or "ActivatorUtilities" =>
+                    "service resolution",
+                _ => "reflection"
+            };
+            violations.Add($"{owner} references forbidden {reason} token '{token}'.");
+        }
+
+        foreach (var context in identifiers.Where(identifier => identifier.EndsWith("Context", StringComparison.Ordinal)))
+        {
+            violations.Add($"{owner} references forbidden general context token '{context}'.");
+        }
+
+        return violations;
+    }
+
+    private static int FindHeaderDelimiter(List<string> tokens, int start)
+    {
+        for (var index = start; index < tokens.Count; index++)
+        {
+            if (tokens[index] is "(" or "{" or ";" or "=>")
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindMatchingParenthesis(List<string> tokens, int openParenthesis)
+    {
+        var depth = 0;
+        for (var index = openParenthesis; index < tokens.Count; index++)
+        {
+            if (tokens[index] == "(")
+            {
+                depth++;
+            }
+            else if (tokens[index] == ")" && --depth == 0)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static List<string> Tokenize(string source)
+    {
+        var tokens = new List<string>();
+        for (var index = 0; index < source.Length;)
+        {
+            if (char.IsWhiteSpace(source[index]))
+            {
+                index++;
+                continue;
+            }
+
+            if (source[index] == '/' && index + 1 < source.Length && source[index + 1] == '/')
+            {
+                index = source.IndexOf('\n', index + 2);
+                if (index < 0)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (source[index] == '/' && index + 1 < source.Length && source[index + 1] == '*')
+            {
+                var endComment = source.IndexOf("*/", index + 2, StringComparison.Ordinal);
+                index = endComment < 0 ? source.Length : endComment + 2;
+                continue;
+            }
+
+            if (source[index] is '"' or '\'')
+            {
+                index = SkipLiteral(source, index, source[index]);
+                continue;
+            }
+
+            if (char.IsLetter(source[index]) || source[index] == '_')
+            {
+                var start = index++;
+                while (index < source.Length &&
+                       (char.IsLetterOrDigit(source[index]) || source[index] == '_'))
+                {
+                    index++;
+                }
+
+                tokens.Add(source[start..index]);
+                continue;
+            }
+
+            if (source[index] == '=' && index + 1 < source.Length && source[index + 1] == '>')
+            {
+                tokens.Add("=>");
+                index += 2;
+                continue;
+            }
+
+            tokens.Add(source[index].ToString());
+            index++;
+        }
+
+        return tokens;
+    }
+
+    private static int SkipLiteral(string source, int start, char delimiter)
+    {
+        var quoteCount = delimiter == '"'
+            ? source.AsSpan(start).IndexOfAnyExcept('"')
+            : 1;
+        if (quoteCount >= 3)
+        {
+            var rawDelimiter = new string('"', quoteCount);
+            var rawEnd = source.IndexOf(rawDelimiter, start + quoteCount, StringComparison.Ordinal);
+            return rawEnd < 0 ? source.Length : rawEnd + quoteCount;
+        }
+
+        for (var index = start + 1; index < source.Length; index++)
+        {
+            if (source[index] == '\\')
+            {
+                index++;
+            }
+            else if (source[index] == delimiter)
+            {
+                return index + 1;
+            }
+        }
+
+        return source.Length;
+    }
 
     private static string FindRepositoryRoot()
     {

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -1,0 +1,116 @@
+namespace DownKyi.Architecture.Tests;
+
+public sealed class SqliteDownloadTaskStoreArchitectureTests
+{
+    private const string FacadeFile = "SqliteDownloadTaskStore.cs";
+    private const string Database = "SqliteDownloadStoreDatabase";
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string[] SqlMarkers = ["SELECT ", "INSERT ", "UPDATE ", "DELETE ", "PRAGMA "];
+    private static readonly string[] Collaborators =
+    [
+        "SqliteDownloadStoreQueries",
+        "SqliteDownloadStoreCommands",
+        "SqliteDownloadStoreOutputReservations",
+        "SqliteDownloadStoreQuarantine"
+    ];
+
+    [Fact]
+    public void FacadeIsNonPartialAndContainsNoSql()
+    {
+        var source = ReadDownloadSource(FacadeFile);
+
+        Assert.Contains("public sealed class SqliteDownloadTaskStore", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("partial class SqliteDownloadTaskStore", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CommandText", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Microsoft.Data.Sqlite", source, StringComparison.Ordinal);
+        Assert.All(
+            SqlMarkers,
+            sql => Assert.DoesNotContain(sql, source, StringComparison.OrdinalIgnoreCase));
+        Assert.False(File.Exists(Path.Combine(DownloadSourceRoot, "SqliteDownloadTaskStore.OutputReservations.cs")));
+    }
+
+    [Fact]
+    public void FacadeDelegatesToExplicitCollaborators()
+    {
+        var source = ReadDownloadSource(FacadeFile);
+
+        Assert.Contains($"new {Database}", source, StringComparison.Ordinal);
+        Assert.All(
+            Collaborators,
+            collaborator => Assert.Contains($"new {collaborator}", source, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CollaboratorsDependOnDatabaseWithoutPeerCoupling()
+    {
+        foreach (var collaborator in Collaborators)
+        {
+            var source = ReadDownloadSource($"{collaborator}.cs");
+            Assert.Contains($"internal sealed class {collaborator}", source, StringComparison.Ordinal);
+            Assert.Contains(Database, source, StringComparison.Ordinal);
+            Assert.DoesNotContain($"partial class {collaborator}", source, StringComparison.Ordinal);
+
+            var forbiddenPeers = Collaborators.Where(peer =>
+                peer != collaborator &&
+                !(collaborator == "SqliteDownloadStoreQueries" &&
+                  peer == "SqliteDownloadStoreQuarantine"));
+            Assert.All(
+                forbiddenPeers,
+                peer => Assert.DoesNotContain(peer, source, StringComparison.Ordinal));
+        }
+
+        var database = ReadDownloadSource($"{Database}.cs");
+        Assert.All(
+            Collaborators,
+            collaborator => Assert.DoesNotContain(collaborator, database, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DatabaseOwnsConnectionsInitializationAndStoreTransactionBoundaries()
+    {
+        var database = ReadDownloadSource($"{Database}.cs");
+        Assert.Contains("new SqliteConnection", database, StringComparison.Ordinal);
+        Assert.Contains("SemaphoreSlim", database, StringComparison.Ordinal);
+        Assert.Contains("DownloadStoreSchema.InitializeAsync", database, StringComparison.Ordinal);
+        Assert.Contains("RemoveOrphanedDownloadingRecordsAsync", database, StringComparison.Ordinal);
+        Assert.Contains("BeginTransaction", database, StringComparison.Ordinal);
+        Assert.Contains("CommitAsync", database, StringComparison.Ordinal);
+        Assert.Contains("RollbackAsync", database, StringComparison.Ordinal);
+
+        foreach (var file in new[] { FacadeFile }.Concat(Collaborators.Select(name => $"{name}.cs")))
+        {
+            var source = ReadDownloadSource(file);
+            Assert.DoesNotContain("new SqliteConnection", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("BeginTransaction", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("CommitAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RollbackAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("SemaphoreSlim", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("DownloadStoreSchema.InitializeAsync", source, StringComparison.Ordinal);
+        }
+    }
+
+    private static string DownloadSourceRoot => Path.Combine(
+        RepositoryRoot,
+        "src",
+        "DownKyi.Infrastructure",
+        "Downloads");
+
+    private static string ReadDownloadSource(string fileName) =>
+        File.ReadAllText(Path.Combine(DownloadSourceRoot, fileName));
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -191,6 +191,23 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
     }
 
     [Fact]
+    public void OwnerDependencyRuleRejectsNullConditionalReflectionInvocationSequence()
+    {
+        const string source = """
+            internal sealed class Owner
+            {
+                public object? Build(object target) =>
+                    target.GetType().GetMethod("Build")?.Invoke(target, parameters: null);
+            }
+            """;
+
+        var violations = FindForbiddenOwnerDependencyViolations("Owner", source);
+
+        Assert.Contains(violations, violation =>
+            violation.Contains("GetType().GetMethod(...).Invoke", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void OwnerDependencyRuleIgnoresReflectionWordsInCommentsAndLiterals()
     {
         const string source = """"
@@ -358,6 +375,11 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
 
             var cursor = lookupClose + 1;
             while (cursor < tokens.Count && tokens[cursor] == "!")
+            {
+                cursor++;
+            }
+
+            if (cursor + 1 < tokens.Count && tokens[cursor] == "?" && tokens[cursor + 1] == ".")
             {
                 cursor++;
             }

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -28,6 +28,22 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         "Activator",
         "dynamic"
     ];
+    private static readonly HashSet<string> ReflectionLookups =
+    [
+        "GetMethod",
+        "GetProperty",
+        "GetField",
+        "GetConstructor",
+        "GetEvent",
+        "GetMember"
+    ];
+    private static readonly HashSet<string> ReflectionInvocations =
+    [
+        "Invoke",
+        "GetValue",
+        "SetValue",
+        "CreateDelegate"
+    ];
     private static readonly Dictionary<string, string> ExpectedFacadeDelegations = new(StringComparer.Ordinal)
     {
         ["InitializeAsync"] = "_database.InitializeAsync(cancellationToken)",
@@ -158,6 +174,38 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
     }
 
     [Fact]
+    public void OwnerDependencyRuleRejectsReflectionLookupInvocationSequence()
+    {
+        const string source = """
+            internal sealed class Owner
+            {
+                public object? Build(object target) =>
+                    target.GetType().GetMethod("Build")!.Invoke(target, parameters: null);
+            }
+            """;
+
+        var violations = FindForbiddenOwnerDependencyViolations("Owner", source);
+
+        Assert.Contains(violations, violation =>
+            violation.Contains("GetType().GetMethod(...).Invoke", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void OwnerDependencyRuleIgnoresReflectionWordsInCommentsAndLiterals()
+    {
+        const string source = """"
+            internal sealed class Owner
+            {
+                // target.GetType().GetMethod("Build")!.Invoke(...)
+                private const string Text = "GetType GetMethod Invoke";
+                private const string RawText = """target.GetType().GetMethod("Build")!.Invoke(...)""";
+            }
+            """";
+
+        Assert.Empty(FindForbiddenOwnerDependencyViolations("Owner", source));
+    }
+
+    [Fact]
     public void DatabaseOwnsConnectionsInitializationAndStoreTransactionBoundaries()
     {
         var database = ReadDownloadSource($"{Database}.cs");
@@ -260,7 +308,8 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         string owner,
         string source)
     {
-        var identifiers = Tokenize(source)
+        var tokens = Tokenize(source);
+        var identifiers = tokens
             .Where(token => token.Length > 0 && (char.IsLetter(token[0]) || token[0] == '_'))
             .ToHashSet(StringComparer.Ordinal);
         var violations = new List<string>();
@@ -282,7 +331,45 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
             violations.Add($"{owner} references forbidden general context token '{context}'.");
         }
 
+        AddReflectionSequenceViolations(owner, tokens, violations);
+
         return violations;
+    }
+
+    private static void AddReflectionSequenceViolations(
+        string owner,
+        List<string> tokens,
+        List<string> violations)
+    {
+        for (var index = 0; index + 5 < tokens.Count; index++)
+        {
+            if (tokens[index] != "GetType" || tokens[index + 1] != "(" || tokens[index + 2] != ")" ||
+                tokens[index + 3] != "." || !ReflectionLookups.Contains(tokens[index + 4]) ||
+                tokens[index + 5] != "(")
+            {
+                continue;
+            }
+
+            var lookupClose = FindMatchingParenthesis(tokens, index + 5);
+            if (lookupClose < 0)
+            {
+                continue;
+            }
+
+            var cursor = lookupClose + 1;
+            while (cursor < tokens.Count && tokens[cursor] == "!")
+            {
+                cursor++;
+            }
+
+            if (cursor + 2 < tokens.Count && tokens[cursor] == "." &&
+                ReflectionInvocations.Contains(tokens[cursor + 1]) && tokens[cursor + 2] == "(")
+            {
+                violations.Add(
+                    $"{owner} uses forbidden reflection call sequence " +
+                    $"'GetType().{tokens[index + 4]}(...).{tokens[cursor + 1]}(...)'.");
+            }
+        }
     }
 
     private static int FindHeaderDelimiter(List<string> tokens, int start)

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -399,6 +399,20 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             (long)(await findProbe.ExecuteScalarAsync(TestContext.Current.CancellationToken))!);
     }
 
+    [Fact]
+    public async Task DisposedStoreReportsThePublicStoreAsObjectName()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+        store.Dispose();
+
+        var operation = store.GetUnfinishedAsync(TestContext.Current.CancellationToken);
+        var exception = await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await operation.ConfigureAwait(true));
+
+        Assert.Equal(typeof(SqliteDownloadTaskStore).FullName, exception.ObjectName);
+    }
+
     public void Dispose()
     {
         using var connection = new SqliteConnection(new SqliteConnectionStringBuilder


### PR DESCRIPTION
## Summary

- Split SqliteDownloadTaskStore into a thin public facade and explicit database, query, command, output-reservation, and quarantine owners.
- Preserve public constructors/API, SQL and parameter sets, transaction and initialization behavior, async exception timing, and quarantine timestamp semantics.
- Keep DownloadStoreSchema v1-v3, Q1 quarantine behavior, Desktop/UI, queue, aria, and path product semantics out of scope.

## Ownership

- SqliteDownloadTaskStore: non-partial facade with delegation only; no SQL.
- SqliteDownloadStoreDatabase: connection, initialization gate, orphan cleanup, and operation transaction ownership.
- SqliteDownloadStoreQueries: query, paging, and record mapping.
- SqliteDownloadStoreCommands: update, progress, delete, and history commands.
- SqliteDownloadStoreOutputReservations: atomic output-path reservation and add.
- SqliteDownloadStoreQuarantine: corrupt-record quarantine reads and writes.

Architecture tests enforce the facade and one-way collaborator boundaries.

## Local evidence

- SqliteDownloadTaskStore characterization: 19/19
- Architecture suite: 288/288
- Strict Release build: 0 warnings, 0 errors
- dotnet format --verify-no-changes: passed
- git diff --check: passed
- SQL literal and parameter-name multisets versus base: no differences

This is a stacked Draft PR based on the S1 schema-split branch. Do not merge independently before its base.