### PR TITLE
fix(downloads): quarantine unsafe legacy output paths

### DIFF
--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -64,6 +64,19 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
         return _store.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
     }
 
+    public Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.IsLegacyUpgradeAdmissionBlockedAsync(cancellationToken);
+    }
+
+    public Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.ConfirmLegacyRemoteTasksStoppedAsync(cancellationToken);
+    }
+
     public Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -22,6 +22,11 @@ public interface IDownloadTaskApplicationService
         bool ignoreCase,
         CancellationToken cancellationToken);
 
+    Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken);
+
+    Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken);
+
     Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,

--- a/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
@@ -27,6 +27,13 @@ public interface IDownloadTaskStore
         bool ignoreCase,
         CancellationToken cancellationToken);
 
+    Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(false);
+
+    Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken) =>
+        Task.FromResult(OperationResult.Success());
+
     Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
@@ -1,3 +1,4 @@
+using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using Microsoft.Data.Sqlite;
 
@@ -5,13 +6,14 @@ namespace DownKyi.Infrastructure.Downloads;
 
 internal static class DownloadStoreSchema
 {
-    public const int CurrentVersion = 3;
+    public const int CurrentVersion = 4;
 
     public static async Task InitializeAsync(
         SqliteConnection connection,
         string databasePath,
         bool databaseExisted,
         IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
         CancellationToken cancellationToken)
     {
         var currentVersion = await DownloadStoreSchemaLifecycle
@@ -58,6 +60,18 @@ internal static class DownloadStoreSchema
             {
                 await DownloadStoreSchemaV3Migration
                     .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (currentVersion < 4)
+            {
+                await DownloadStoreSchemaV4Migration
+                    .ApplyAsync(
+                        connection,
+                        transaction,
+                        clock.UtcNow,
+                        physicalOutputPathResolver,
+                        cancellationToken)
                     .ConfigureAwait(false);
             }
 

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
@@ -40,11 +40,11 @@ internal static class DownloadStoreSchemaLifecycle
         int version,
         CancellationToken cancellationToken)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(version, 3);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(version, 4);
 
         using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = "PRAGMA user_version = 3";
+        command.CommandText = "PRAGMA user_version = 4";
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV4Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV4Migration.cs
@@ -1,0 +1,140 @@
+using DownKyi.Application.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV4Migration
+{
+    private const string QuarantineReason = "legacy-output-path-unverified";
+
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(physicalOutputPathResolver);
+
+        await CreateAdmissionGateAsync(connection, transaction, cancellationToken)
+            .ConfigureAwait(false);
+        var legacyTasks = await ReadLegacyUnfinishedTasksAsync(
+            connection,
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+        foreach (var task in legacyTasks)
+        {
+            if (IsSamePhysicalPath(task.BasePath, physicalOutputPathResolver))
+            {
+                continue;
+            }
+
+            await QuarantineAndBlockAdmissionAsync(
+                connection,
+                transaction,
+                task.Id,
+                appliedAtUtc,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 4, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task CreateAdmissionGateAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS download_upgrade_admission_gate (
+                singleton_id INTEGER PRIMARY KEY CHECK(singleton_id = 1),
+                remote_stopped_confirmed INTEGER NOT NULL DEFAULT 0
+                    CHECK(remote_stopped_confirmed IN (0, 1))
+            );
+            """;
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<LegacyUnfinishedTask>> ReadLegacyUnfinishedTasksAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            SELECT db.id, db.file_path
+            FROM download_base db
+            INNER JOIN downloading dl ON dl.id = db.id
+            WHERE NOT EXISTS (
+                      SELECT 1 FROM downloaded d
+                      WHERE d.id = db.id)
+            ORDER BY db.id
+            """;
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var tasks = new List<LegacyUnfinishedTask>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            tasks.Add(new LegacyUnfinishedTask(reader.GetString(0), reader.GetString(1)));
+        }
+
+        return tasks;
+    }
+
+    private static bool IsSamePhysicalPath(
+        string originalPath,
+        IPhysicalOutputPathResolver physicalOutputPathResolver)
+    {
+        try
+        {
+            var ignoreCase = DownloadOutputPathKey.UsesCaseInsensitiveComparison;
+            var originalKey = DownloadOutputPathKey.Create(originalPath, ignoreCase);
+            var physicalKey = DownloadOutputPathKey.Create(
+                physicalOutputPathResolver.ResolvePhysicalBasePath(originalPath),
+                ignoreCase);
+            return StringComparer.Ordinal.Equals(originalKey, physicalKey);
+        }
+        catch (Exception exception) when (exception is ArgumentException
+            or IOException
+            or NotSupportedException
+            or UnauthorizedAccessException
+            or System.Security.SecurityException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task QuarantineAndBlockAdmissionAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string taskId,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO download_quarantine
+                (source_table, record_id, field_name, reason, quarantined_at_utc)
+            VALUES ('downloading', @record_id, 'file_path', @reason, @quarantined_at_utc)
+            ON CONFLICT(source_table, record_id) DO NOTHING;
+
+            INSERT INTO download_upgrade_admission_gate
+                (singleton_id, remote_stopped_confirmed)
+            VALUES (1, 0)
+            ON CONFLICT(singleton_id) DO NOTHING;
+            """;
+        command.Parameters.AddWithValue("@record_id", taskId);
+        command.Parameters.AddWithValue("@reason", QuarantineReason);
+        command.Parameters.AddWithValue(
+            "@quarantined_at_utc",
+            quarantinedAtUtc.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed record LegacyUnfinishedTask(string Id, string BasePath);
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
@@ -1,3 +1,4 @@
+using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using DownKyi.Domain.Results;
 using Microsoft.Data.Sqlite;
@@ -13,6 +14,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
         "Removed {Count} orphaned downloading records.");
     private readonly SqliteDownloadTaskStoreOptions _options;
     private readonly IClock _clock;
+    private readonly IPhysicalOutputPathResolver _physicalOutputPathResolver;
     private readonly ILogger _logger;
     private readonly Type _disposedObjectType;
     private readonly string _connectionString;
@@ -23,11 +25,13 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
     public SqliteDownloadStoreDatabase(
         SqliteDownloadTaskStoreOptions options,
         IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
         ILogger logger,
         Type disposedObjectType)
     {
         _options = options;
         _clock = clock;
+        _physicalOutputPathResolver = physicalOutputPathResolver;
         _logger = logger;
         _disposedObjectType = disposedObjectType;
         _connectionString = new SqliteConnectionStringBuilder
@@ -126,6 +130,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
                 _options.DatabasePath,
                 databaseExisted,
                 _clock,
+                _physicalOutputPathResolver,
                 cancellationToken).ConfigureAwait(false);
             await RemoveOrphanedDownloadingRecordsAsync(connection, cancellationToken).ConfigureAwait(false);
             _initialized = true;

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
@@ -1,5 +1,6 @@
 using DownKyi.Application.Downloads;
 using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
 using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Infrastructure.Downloads;
@@ -32,6 +33,34 @@ internal sealed class SqliteDownloadStoreQuarantine(SqliteDownloadStoreDatabase 
         }
 
         return records;
+    }
+
+    public async Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT EXISTS (
+                SELECT 1 FROM download_upgrade_admission_gate
+                WHERE singleton_id = 1 AND remote_stopped_confirmed = 0)
+            """;
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture) != 0;
+    }
+
+    public async Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE download_upgrade_admission_gate
+            SET remote_stopped_confirmed = 1
+            WHERE singleton_id = 1
+            """;
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success();
     }
 
     public static async Task RecordAsync(

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -16,7 +16,19 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
     private readonly SqliteDownloadStoreQuarantine _quarantine;
 
     public SqliteDownloadTaskStore(SqliteDownloadTaskStoreOptions options, IClock clock)
-        : this(options, clock, NullLogger<SqliteDownloadTaskStore>.Instance)
+        : this(
+            options,
+            clock,
+            new FileSystemPhysicalOutputPathResolver(),
+            NullLogger<SqliteDownloadTaskStore>.Instance)
+    {
+    }
+
+    public SqliteDownloadTaskStore(
+        SqliteDownloadTaskStoreOptions options,
+        IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver)
+        : this(options, clock, physicalOutputPathResolver, NullLogger<SqliteDownloadTaskStore>.Instance)
     {
     }
 
@@ -24,9 +36,19 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         SqliteDownloadTaskStoreOptions options,
         IClock clock,
         ILogger<SqliteDownloadTaskStore> logger)
+        : this(options, clock, new FileSystemPhysicalOutputPathResolver(), logger)
+    {
+    }
+
+    public SqliteDownloadTaskStore(
+        SqliteDownloadTaskStoreOptions options,
+        IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
+        ILogger<SqliteDownloadTaskStore> logger)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(physicalOutputPathResolver);
         ArgumentNullException.ThrowIfNull(logger);
         if (options.BusyTimeout <= TimeSpan.Zero || options.BusyTimeout > TimeSpan.FromMinutes(1))
         {
@@ -36,6 +58,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         _database = new SqliteDownloadStoreDatabase(
             options,
             clock,
+            physicalOutputPathResolver,
             logger,
             typeof(SqliteDownloadTaskStore));
         _quarantine = new SqliteDownloadStoreQuarantine(_database);
@@ -94,6 +117,16 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
     public async Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
         CancellationToken cancellationToken) =>
         await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false);
+
+    public async Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(
+        CancellationToken cancellationToken) =>
+        await _quarantine.IsLegacyUpgradeAdmissionBlockedAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken) =>
+        await _quarantine.ConfirmLegacyRemoteTasksStoppedAsync(cancellationToken)
+            .ConfigureAwait(false);
 
     public void Dispose() => _database.Dispose();
 }

--- a/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
@@ -214,6 +214,22 @@ public sealed class DownloadTaskApplicationServiceTests
         Assert.Same(task, store.Current);
     }
 
+    [Fact]
+    public async Task LegacyUpgradeAdmissionStateAndConfirmationDelegateToStore()
+    {
+        var store = new RecordingStore { LegacyUpgradeAdmissionBlocked = true };
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+
+        Assert.True(await service.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.True((await service.ConfirmLegacyRemoteTasksStoppedAsync(
+            TestContext.Current.CancellationToken)).IsSuccess);
+
+        Assert.False(await service.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(1, store.LegacyRemoteStopConfirmationCount);
+    }
+
     private static DownloadTask CreateTask()
     {
         return DownloadTask.Create(
@@ -256,6 +272,10 @@ public sealed class DownloadTaskApplicationServiceTests
         public DownloadTask? Current { get; private set; }
 
         public List<long> ExpectedVersions { get; } = [];
+
+        public bool LegacyUpgradeAdmissionBlocked { get; set; }
+
+        public int LegacyRemoteStopConfirmationCount { get; private set; }
 
         public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
@@ -322,6 +342,18 @@ public sealed class DownloadTaskApplicationServiceTests
             string basePath,
             bool ignoreCase,
             CancellationToken cancellationToken) => Task.FromResult(false);
+
+        public Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(
+            CancellationToken cancellationToken) =>
+            Task.FromResult(LegacyUpgradeAdmissionBlocked);
+
+        public Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+            CancellationToken cancellationToken)
+        {
+            LegacyRemoteStopConfirmationCount++;
+            LegacyUpgradeAdmissionBlocked = false;
+            return Task.FromResult(OperationResult.Success());
+        }
 
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,

--- a/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
@@ -21,7 +21,7 @@ public sealed class DownloadStoreSchemaArchitectureTests
     {
         var source = ReadDownloadSource("DownloadStoreSchema.cs");
 
-        Assert.Contains("public const int CurrentVersion = 3", source, StringComparison.Ordinal);
+        Assert.Contains("public const int CurrentVersion = 4", source, StringComparison.Ordinal);
         Assert.Contains("BeginTransactionAsync", source, StringComparison.Ordinal);
         Assert.Contains("CommitAsync", source, StringComparison.Ordinal);
         Assert.Contains("RollbackAsync", source, StringComparison.Ordinal);
@@ -72,6 +72,29 @@ public sealed class DownloadStoreSchemaArchitectureTests
                 otherOwners,
                 otherOwner => Assert.DoesNotContain(otherOwner, source, StringComparison.Ordinal));
         }
+    }
+
+    [Fact]
+    public void VersionFourOwnsOnlyLegacyClassificationQuarantineAndAdmissionState()
+    {
+        var source = ReadDownloadSource("DownloadStoreSchemaV4Migration.cs");
+
+        Assert.Contains("IPhysicalOutputPathResolver", source, StringComparison.Ordinal);
+        Assert.Contains("DownloadOutputPathKey.Create", source, StringComparison.Ordinal);
+        Assert.Contains("download_quarantine", source, StringComparison.Ordinal);
+        Assert.Contains("download_upgrade_admission_gate", source, StringComparison.Ordinal);
+        Assert.Contains("NOT EXISTS (", source, StringComparison.Ordinal);
+        Assert.Contains("FROM downloaded", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("UPDATE download_base", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("UPDATE downloading", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DELETE FROM", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("File.Delete", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Directory.Delete", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("File.Move", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Directory.Move", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Aria2", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(".Stop", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ResetAsync", source, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ReadDownloadSource(string fileName)

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -65,6 +65,12 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
             "await _commands.ClearHistoryAsync(cancellationToken).ConfigureAwait(false)",
         ["GetQuarantinedRecordsAsync"] =
             "await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false)",
+        ["IsLegacyUpgradeAdmissionBlockedAsync"] =
+            "await _quarantine.IsLegacyUpgradeAdmissionBlockedAsync(cancellationToken)" +
+            ".ConfigureAwait(false)",
+        ["ConfirmLegacyRemoteTasksStoppedAsync"] =
+            "await _quarantine.ConfirmLegacyRemoteTasksStoppedAsync(cancellationToken)" +
+            ".ConfigureAwait(false)",
         ["Dispose"] = "_database.Dispose()"
     };
     private static readonly string[] Collaborators =

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -24,7 +24,11 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(true);
         using var version = connection.CreateCommand();
         version.CommandText = "PRAGMA user_version";
-        Assert.Equal(3L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(4L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.True(await TableExistsAsync("download_upgrade_admission_gate"));
+        Assert.Equal(1, await CountSchemaMigrationAsync(4));
+        Assert.False(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -46,6 +50,224 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         Assert.Single(Directory.GetFiles(
             Path.Combine(_directory, "Backup"),
             "download.db.schema-v0-*.bak"));
+    }
+
+    [Fact]
+    public async Task VersionThreeEquivalentPhysicalPathRemainsAvailableWithoutBlockingAdmission()
+    {
+        var originalPath = Path.Combine(_directory, "equivalent", "video");
+        var equivalentPath = Path.Combine(originalPath, ".") + Path.DirectorySeparatorChar;
+        if (Path.DirectorySeparatorChar != Path.AltDirectorySeparatorChar)
+        {
+            equivalentPath = equivalentPath.Replace(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+        }
+
+        if (DownloadOutputPathKey.UsesCaseInsensitiveComparison)
+        {
+            equivalentPath = equivalentPath.ToUpperInvariant();
+        }
+
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("equivalent", originalPath));
+        var resolutionCalls = 0;
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(_ =>
+        {
+            resolutionCalls++;
+            return equivalentPath;
+        }));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, resolutionCalls);
+        Assert.Equal(
+            "equivalent",
+            Assert.Single(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken)).Id.Value);
+        Assert.Empty(await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+        Assert.False(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(originalPath, (await ReadStoredStateAsync("equivalent")).Path);
+    }
+
+    [Fact]
+    public async Task VersionThreePhysicalPathChangeQuarantinesWithoutMutatingTaskOrFiles()
+    {
+        var originalPath = Path.Combine(_directory, "logical", "video");
+        var physicalPath = Path.Combine(_directory, "physical", "video");
+        var partialPath = Path.Combine(_directory, "logical", "video.download");
+        var ariaPath = Path.Combine(_directory, "logical", "video.aria2");
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllTextAsync(partialPath, "partial", TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(ariaPath, "aria", TestContext.Current.CancellationToken);
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("changed", originalPath));
+        var before = await ReadStoredStateAsync("changed");
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(_ => physicalPath));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        var quarantine = Assert.Single(
+            await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("changed", quarantine.RecordId);
+        Assert.Equal("downloading", quarantine.SourceTable);
+        Assert.Equal("file_path", quarantine.FieldName);
+        Assert.Equal("legacy-output-path-unverified", quarantine.Reason);
+        Assert.True(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(before, await ReadStoredStateAsync("changed"));
+        Assert.True(File.Exists(partialPath));
+        Assert.True(File.Exists(ariaPath));
+    }
+
+    [Fact]
+    public async Task VersionThreePhysicalResolverFailureQuarantinesAndBlocksAdmission()
+    {
+        var originalPath = Path.Combine(_directory, "unresolved", "video");
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("unresolved", originalPath));
+        var before = await ReadStoredStateAsync("unresolved");
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(
+            _ => throw new IOException("Synthetic resolver failure.")));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(
+            "unresolved",
+            Assert.Single(
+                await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken)).RecordId);
+        Assert.True(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(before, await ReadStoredStateAsync("unresolved"));
+    }
+
+    [Fact]
+    public async Task VersionThreeCompletedTaskIsSkippedAndExistingQuarantineStillBlocksPathRisk()
+    {
+        var completed = CreateCompletedTask(
+            "completed",
+            123,
+            Path.Combine(_directory, "completed", "video"));
+        var quarantined = CreatePausedTask(
+            "already-quarantined",
+            Path.Combine(_directory, "quarantined", "video"));
+        await CreateVersionThreeDatabaseAsync(completed, quarantined);
+        await InsertPreexistingQuarantineAsync("already-quarantined");
+        var completedBefore = await ReadStoredStateAsync("completed");
+        var quarantinedBefore = await ReadStoredStateAsync("already-quarantined");
+        var resolvedPaths = new List<string>();
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(path =>
+        {
+            resolvedPaths.Add(path);
+            return path + "-physical";
+        }));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal([quarantined.Output.BasePath], resolvedPaths);
+        Assert.Equal(
+            "completed",
+            Assert.Single((await store.GetHistoryPageAsync(
+                null,
+                10,
+                TestContext.Current.CancellationToken)).Items).Id.Value);
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        var quarantine = Assert.Single(
+            await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("already-quarantined", quarantine.RecordId);
+        Assert.Equal("preexisting-corrupt-record", quarantine.Reason);
+        Assert.True(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(completedBefore, await ReadStoredStateAsync("completed"));
+        Assert.Equal(quarantinedBefore, await ReadStoredStateAsync("already-quarantined"));
+    }
+
+    [Fact]
+    public async Task VersionFourMigrationAndRestartAreIdempotentAcrossMultipleLegacyTasks()
+    {
+        var safePath = Path.Combine(_directory, "safe", "video");
+        await CreateVersionThreeDatabaseAsync(
+            CreatePausedTask("unsafe-a", Path.Combine(_directory, "logical-a", "video")),
+            CreatePausedTask("safe", safePath),
+            CreatePausedTask("unsafe-b", Path.Combine(_directory, "logical-b", "video")));
+        using (var first = CreateStore(new StubPhysicalOutputPathResolver(path =>
+               path == safePath ? path : path + "-physical")))
+        {
+            await first.InitializeAsync(TestContext.Current.CancellationToken);
+            await first.InitializeAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(
+                ["unsafe-a", "unsafe-b"],
+                (await first.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken))
+                    .Select(record => record.RecordId));
+            Assert.True(await first.IsLegacyUpgradeAdmissionBlockedAsync(
+                TestContext.Current.CancellationToken));
+        }
+
+        using var reopened = CreateStore(new StubPhysicalOutputPathResolver(
+            _ => throw new InvalidOperationException("Version four must not rescan.")));
+        await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ["unsafe-a", "unsafe-b"],
+            (await reopened.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken))
+                .Select(record => record.RecordId));
+        Assert.Equal(
+            "safe",
+            Assert.Single(await reopened.GetUnfinishedAsync(TestContext.Current.CancellationToken)).Id.Value);
+        Assert.True(await reopened.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(1, await CountSchemaMigrationAsync(4));
+    }
+
+    [Fact]
+    public async Task ConfirmationOnlyReleasesAdmissionGateAndPersistsAcrossRestart()
+    {
+        var originalPath = Path.Combine(_directory, "confirm-logical", "video");
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("confirm", originalPath));
+        var before = await ReadStoredStateAsync("confirm");
+        using (var store = CreateStore(new StubPhysicalOutputPathResolver(path => path + "-physical")))
+        {
+            await store.InitializeAsync(TestContext.Current.CancellationToken);
+            Assert.True((await store.ConfirmLegacyRemoteTasksStoppedAsync(
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.False(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+                TestContext.Current.CancellationToken));
+            Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+            Assert.Single(await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(before, await ReadStoredStateAsync("confirm"));
+        }
+
+        using var reopened = CreateStore(new StubPhysicalOutputPathResolver(
+            _ => throw new InvalidOperationException("Version four must not rescan.")));
+        Assert.False(await reopened.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Empty(await reopened.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(
+            "confirm",
+            Assert.Single(
+                await reopened.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken)).RecordId);
+        Assert.Equal(before, await ReadStoredStateAsync("confirm"));
+    }
+
+    [Fact]
+    public async Task VersionFourFailureRollsBackQuarantineGateLedgerAndUserVersion()
+    {
+        var originalPath = Path.Combine(_directory, "rollback-logical", "video");
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("rollback", originalPath));
+        await CreateQuarantineFailureTriggerAsync();
+        var before = await ReadStoredStateAsync("rollback");
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(path => path + "-physical"));
+
+        await Assert.ThrowsAsync<SqliteException>(() =>
+            store.InitializeAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.False(await TableExistsAsync("download_upgrade_admission_gate"));
+        Assert.Equal(0, await CountSchemaMigrationAsync(4));
+        Assert.Equal(0, await CountQuarantineRecordsAsync());
+        Assert.Equal(before, await ReadStoredStateAsync("rollback"));
+        Assert.Single(Directory.GetFiles(
+            Path.Combine(_directory, "Backup"),
+            "download.db.schema-v3-*.bak"));
     }
 
     [Fact]
@@ -129,7 +351,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             await reopened.InitializeAsync(TestContext.Current.CancellationToken);
         }
 
-        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.Equal(4, await ReadSchemaVersionAsync());
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
     }
 
@@ -142,7 +364,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
 
         await store.InitializeAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.Equal(4, await ReadSchemaVersionAsync());
         Assert.Equal(1, await CountDownloadBaseRecordAsync("legacy-resume"));
         Assert.Equal(1, await CountDownloadingRecordAsync("legacy-resume"));
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
@@ -429,21 +651,22 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         }
     }
 
-    private SqliteDownloadTaskStore CreateStore()
+    private SqliteDownloadTaskStore CreateStore(IPhysicalOutputPathResolver? resolver = null)
     {
         Directory.CreateDirectory(_directory);
         return new SqliteDownloadTaskStore(
             new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
-            _clock);
+            _clock,
+            resolver ?? new StubPhysicalOutputPathResolver(static path => path));
     }
 
-    private DownloadTask CreatePausedTask(string id)
+    private DownloadTask CreatePausedTask(string id, string? outputPath = null)
     {
         var task = DownloadTask.Create(
             new DownloadTaskId(id),
             CreateMetadata(id),
             CreatePlan(),
-            new DownloadOutput(Path.Combine(_directory, id), "1 GB"),
+            new DownloadOutput(outputPath ?? Path.Combine(_directory, id), "1 GB"),
             _clock.UtcNow);
         task = task.Start(_clock.UtcNow.AddSeconds(1)).RequireValue();
         task = task.UpdateTransferState(
@@ -466,13 +689,16 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             _clock.UtcNow);
     }
 
-    private DownloadTask CreateCompletedTask(string id, long finishedTimestamp)
+    private DownloadTask CreateCompletedTask(
+        string id,
+        long finishedTimestamp,
+        string? outputPath = null)
     {
         var task = DownloadTask.Create(
             new DownloadTaskId(id),
             CreateMetadata(id),
             CreatePlan(),
-            new DownloadOutput(Path.Combine(_directory, id), "1 GB"),
+            new DownloadOutput(outputPath ?? Path.Combine(_directory, id), "1 GB"),
             _clock.UtcNow);
         task = task.Start(_clock.UtcNow.AddSeconds(1)).RequireValue();
         return task.Complete(
@@ -548,6 +774,123 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var command = connection.CreateCommand();
         command.CommandText = "PRAGMA user_version";
         return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken).ConfigureAwait(false))!;
+    }
+
+    private async Task CreateVersionThreeDatabaseAsync(params DownloadTask[] tasks)
+    {
+        using (var store = CreateStore())
+        {
+            await store.InitializeAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+            foreach (var task in tasks)
+            {
+                Assert.True((await store.AddAsync(
+                    task,
+                    TestContext.Current.CancellationToken).ConfigureAwait(false)).IsSuccess);
+            }
+        }
+
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            DROP TABLE download_upgrade_admission_gate;
+            DELETE FROM download_schema_migrations WHERE version = 4;
+            PRAGMA user_version = 3;
+            """;
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InsertPreexistingQuarantineAsync(string id)
+    {
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO download_quarantine
+                (source_table, record_id, field_name, reason, quarantined_at_utc)
+            VALUES ('downloading', @id, 'need_download_content',
+                    'preexisting-corrupt-record', @now)
+            """;
+        command.Parameters.AddWithValue("@id", id);
+        command.Parameters.AddWithValue("@now", _clock.UtcNow.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task CreateQuarantineFailureTriggerAsync()
+    {
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TRIGGER reject_version_four_quarantine
+            BEFORE INSERT ON download_quarantine
+            BEGIN
+                SELECT RAISE(ABORT, 'synthetic version four failure');
+            END;
+            """;
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<StoredDownloadState> ReadStoredStateAsync(string id)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT db.file_path, dl.gid, dl.download_files, dl.downloaded_files,
+                   d.finished_timestamp
+            FROM download_base db
+            LEFT JOIN downloading dl ON dl.id = db.id
+            LEFT JOIN downloaded d ON d.id = db.id
+            WHERE db.id = @id
+            """;
+        command.Parameters.AddWithValue("@id", id);
+        using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        Assert.True(await reader.ReadAsync(TestContext.Current.CancellationToken).ConfigureAwait(false));
+        var gidIsNull = await reader.IsDBNullAsync(1, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        var downloadFilesIsNull = await reader.IsDBNullAsync(2, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        var downloadedFilesIsNull = await reader.IsDBNullAsync(3, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        var finishedTimestampIsNull = await reader.IsDBNullAsync(4, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        return new StoredDownloadState(
+            reader.GetString(0),
+            gidIsNull ? null : reader.GetString(1),
+            downloadFilesIsNull ? null : reader.GetString(2),
+            downloadedFilesIsNull ? null : reader.GetString(3),
+            finishedTimestampIsNull ? null : reader.GetInt64(4));
+    }
+
+    private async Task<bool> TableExistsAsync(string tableName)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT EXISTS (
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'table' AND name = @name)
+            """;
+        command.Parameters.AddWithValue("@name", tableName);
+        return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false))! != 0;
+    }
+
+    private async Task<long> CountSchemaMigrationAsync(int version)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM download_schema_migrations WHERE version = @version";
+        command.Parameters.AddWithValue("@version", version);
+        return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false))!;
+    }
+
+    private async Task<long> CountQuarantineRecordsAsync()
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM download_quarantine";
+        return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false))!;
     }
 
     private async Task CorruptRequestedAssetsAsync(string id, string sensitiveValue)
@@ -683,4 +1026,17 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             return Task.Delay(delay, cancellationToken);
         }
     }
+
+    private sealed class StubPhysicalOutputPathResolver(Func<string, string> resolve)
+        : IPhysicalOutputPathResolver
+    {
+        public string ResolvePhysicalBasePath(string logicalBasePath) => resolve(logicalBasePath);
+    }
+
+    private sealed record StoredDownloadState(
+        string Path,
+        string? Gid,
+        string? DownloadFiles,
+        string? DownloadedFiles,
+        long? FinishedTimestamp);
 }


### PR DESCRIPTION
## Summary

- Add the v4 download-store migration that classifies only legacy unfinished tasks.
- Keep normal physical/equivalent paths unchanged.
- Quarantine legacy tasks whose resolved physical path changes or cannot be resolved safely, and persist a singleton remote-equivalent admission gate.
- Confirmation releases only the gate; quarantined tasks remain quarantined and must be deleted/recreated.

## Safety boundaries

- Never migrate or rewrite legacy path, aria2 GID, or transfer-file JSON.
- Never stop/reset aria2 or delete partial, .aria2, .download, media, or other user files.
- Completed tasks are excluded.
- Existing quarantine reasons are preserved while path risk still blocks admission.
- Migration, ledger, quarantine, gate, and user_version=4 share one transaction and roll back together.
- No Desktop UI, queue, or aria orchestration is included; those belong to Q2.
- Business tests use deterministic resolvers and do not probe host-specific filesystem aliases.

## Local evidence

- Pre-change store baseline: 20/20
- Final store/schema focused: 27/27
- Application contract: 7/7
- Architecture: 298/298
- Strict Release build: 0 warnings, 0 errors
- Format verify and git diff --check: passed

Architecture and strict build passed before the final narrowly scoped existing-quarantine gate correction; the affected final store tests and format verification were rerun successfully. Exact-head remote CI remains required.

This is a stacked Draft PR based on S2 and must not be merged independently before its base.