### PR TITLE
Integrate frozen output admission and legacy quarantine

### DIFF
--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -581,6 +581,11 @@ type: core
 paths:
   - src/DownKyi.Infrastructure/Time/SystemClock.cs
   - src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQueries.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreCommands.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
+  - src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadTaskRecordMapper.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
   - src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlWriter.cs
@@ -596,7 +601,7 @@ contracts:
   - Infrastructure never references Desktop or Prism.
   - SystemClock returns UTC time; deterministic tests replace IClock at the composition boundary.
   - SQLite uses one short pooled connection per operation, WAL, parameterized queries, optimistic versions, and transactional state moves.
-  - `SqliteDownloadTaskStore` owns initialization, transactions, and public query coordination; record restoration, quarantine reads, and SQL write commands stay in their dedicated owners.
+  - `SqliteDownloadTaskStore` is a non-partial compatibility facade with no SQL. `SqliteDownloadStoreDatabase` owns connections, initialization, orphan cleanup, and store-operation transaction boundaries; queries, commands, output reservations, and quarantine stay in explicit inward collaborators.
   - Existing databases are backed up before schema migration; failed migrations roll back and never advance `user_version`.
   - One malformed row is quarantined with record ID, field, and sanitized reason; raw JSON and personal paths are not copied into diagnostics.
   - The progress writer has a one-slot bounded wake channel, a bounded task set, contiguous coalescing, and a final shutdown flush.
@@ -1994,7 +1999,7 @@ contracts:
   - New, resumed, and persisted startup tasks enqueue `DownloadTaskId` directly; no runtime owner scans an observable UI collection for work.
   - `DownloadTaskAdmissionService` is the singleton admission coordinator. Under one asynchronous gate it probes indexed candidates, resolves on-disk collisions, persists the selected base path, then publishes the UI projection and queue ID; it never reloads all unfinished tasks for each admission.
   - SQLite schema v3 stores the normalized active reservation key in `download_base`. Task insertion claims that key in the same transaction, and a partial unique index rejects check-then-insert races. The Domain/SQLite store remains the ownership truth; no mutable path registry, cache, or UI collection owns reservations.
-  - `SqliteDownloadTaskStore` owns only its initialization gate and operation-scoped connections. Its disposal cannot clear the provider-global connection pool shared by sibling stores or connections; process/test-host teardown is the only layer allowed to perform global pool cleanup.
+  - `SqliteDownloadStoreDatabase` owns the initialization gate and operation-scoped connections behind the `SqliteDownloadTaskStore` facade. Its disposal cannot clear the provider-global connection pool shared by sibling stores or connections; process/test-host teardown is the only layer allowed to perform global pool cleanup.
   - Queued, Downloading, Pausing, Paused, Failed, and Canceled tasks retain normalized output reservations. Canceled tasks release the claim only after generated-file cleanup succeeds and the task commits Deleted; Completed tasks release it during the completion transaction. Existing output files still prevent reuse.
   - Output-path comparison is ordinal and case-insensitive on Windows and macOS, and ordinal on Linux. The macOS rule is deliberately fail-closed for the default case-insensitive filesystems. When automatic numeric suffixing is disabled, any active or on-disk collision rejects admission instead of silently renaming the output.
   - `DownloadTransferCoordinator` is the only media-transfer retry budget owner. It supplies exactly one URL to a backend call, rotates backup addresses, and permits one playback-address refresh.

--- a/src/DownKyi.Application/Downloads/DownloadAddCoordinator.cs
+++ b/src/DownKyi.Application/Downloads/DownloadAddCoordinator.cs
@@ -3,12 +3,20 @@ namespace DownKyi.Application.Downloads;
 public static class DownloadAddCoordinator
 {
     public static async Task<int?> AddToDownloadIfDirectorySelectedAsync(
+        Func<Task<bool>> ensureAdmissionAsync,
         Func<Task<string?>> selectDirectoryAsync,
         Func<string, Task<int>> addToDownloadAsync,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(ensureAdmissionAsync);
         ArgumentNullException.ThrowIfNull(selectDirectoryAsync);
         ArgumentNullException.ThrowIfNull(addToDownloadAsync);
+        if (!await ensureAdmissionAsync().ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
         var directory = await selectDirectoryAsync().ConfigureAwait(false);
         if (directory == null)
         {

--- a/src/DownKyi.Application/Downloads/DownloadAdmissionErrors.cs
+++ b/src/DownKyi.Application/Downloads/DownloadAdmissionErrors.cs
@@ -1,0 +1,21 @@
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Application.Downloads;
+
+public static class DownloadAdmissionErrors
+{
+    public const string LegacyUpgradeBlockedCode = "download.admission.legacy_upgrade_blocked";
+
+    public static OperationError LegacyUpgradeBlocked()
+    {
+        return new OperationError(
+            LegacyUpgradeBlockedCode,
+            "New downloads are blocked until the legacy remote-task risk is confirmed resolved.",
+            OperationErrorKind.Conflict);
+    }
+
+    public static bool IsLegacyUpgradeBlocked(OperationError? error)
+    {
+        return string.Equals(error?.Code, LegacyUpgradeBlockedCode, StringComparison.Ordinal);
+    }
+}

--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -64,6 +64,19 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
         return _store.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
     }
 
+    public Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.IsLegacyUpgradeAdmissionBlockedAsync(cancellationToken);
+    }
+
+    public Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.ConfirmLegacyRemoteTasksStoppedAsync(cancellationToken);
+    }
+
     public Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,

--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -29,6 +29,16 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
     {
         ArgumentNullException.ThrowIfNull(task);
         ObjectDisposedException.ThrowIf(_disposed, this);
+        if (task.Phase == DownloadPhase.Queued)
+        {
+            var admission = await CheckNewDownloadAdmissionAsync(cancellationToken)
+                .ConfigureAwait(false);
+            if (!admission.IsSuccess)
+            {
+                return OperationResult.Failure<DownloadTask>(RequireError(admission));
+            }
+        }
+
         var result = await _store.AddAsync(task, cancellationToken).ConfigureAwait(false);
         if (!result.IsSuccess)
         {
@@ -37,6 +47,16 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
 
         Publish(task, DownloadTaskChangeKind.Added);
         return OperationResult.Success(task);
+    }
+
+    public async Task<OperationResult> CheckNewDownloadAdmissionAsync(
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return await _store.IsLegacyUpgradeAdmissionBlockedAsync(cancellationToken)
+            .ConfigureAwait(false)
+            ? OperationResult.Failure(DownloadAdmissionErrors.LegacyUpgradeBlocked())
+            : OperationResult.Success();
     }
 
     public Task<DownloadTask?> FindAsync(

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -11,6 +11,9 @@ public interface IDownloadTaskApplicationService
         DownloadTask task,
         CancellationToken cancellationToken);
 
+    Task<OperationResult> CheckNewDownloadAdmissionAsync(
+        CancellationToken cancellationToken);
+
     Task<DownloadTask?> FindAsync(
         DownloadTaskId taskId,
         CancellationToken cancellationToken);

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -22,6 +22,11 @@ public interface IDownloadTaskApplicationService
         bool ignoreCase,
         CancellationToken cancellationToken);
 
+    Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken);
+
+    Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken);
+
     Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,

--- a/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
@@ -27,6 +27,13 @@ public interface IDownloadTaskStore
         bool ignoreCase,
         CancellationToken cancellationToken);
 
+    Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken) =>
+        Task.FromResult(false);
+
+    Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken) =>
+        Task.FromResult(OperationResult.Success());
+
     Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,

--- a/src/DownKyi.Desktop/Composition/DesktopComposition.cs
+++ b/src/DownKyi.Desktop/Composition/DesktopComposition.cs
@@ -100,6 +100,7 @@ internal static class DesktopComposition
         services.AddSingleton<IDownloadTaskQueue>(provider =>
             provider.GetRequiredService<DownloadTaskQueueGateway>());
         services.AddSingleton<DownloadTaskAdmissionService>();
+        services.AddSingleton<LegacyDownloadAdmissionPresenter>();
         services.AddSingleton<DownloadListState>();
         services.AddSingleton<DownloadTaskFileService>();
         services.AddSingleton<AriaRuntimeClientRegistry>();

--- a/src/DownKyi.Desktop/Composition/DesktopComposition.cs
+++ b/src/DownKyi.Desktop/Composition/DesktopComposition.cs
@@ -91,6 +91,7 @@ internal static class DesktopComposition
         });
         services.AddSingleton<IWbiKeyProvider, WbiKeyProvider>();
         services.AddSingleton<FfmpegProcessor>();
+        services.AddSingleton<IPhysicalOutputPathResolver, FileSystemPhysicalOutputPathResolver>();
         services.AddSingleton<IDownloadTaskStore, SqliteDownloadTaskStore>();
         services.AddSingleton<IDownloadTaskApplicationService, DownloadTaskApplicationService>();
         services.AddSingleton<DownloadTaskProjectionStore>();

--- a/src/DownKyi.Desktop/Languages/Default.axaml
+++ b/src/DownKyi.Desktop/Languages/Default.axaml
@@ -137,6 +137,8 @@
     <system:String x:Key="TipAddDownloadingZero">没有选中项符合下载要求！</system:String>
     <system:String x:Key="TipAddDownloadingFinished1">成功添加了</system:String>
     <system:String x:Key="TipAddDownloadingFinished2">项~</system:String>
+    <system:String x:Key="LegacyDownloadAdmissionBlocked">升级时发现部分旧的未完成任务保存位置不安全或已经变化。程序无法确认这些任务是否由原来的自定义远端 aria2 负责；旧的远端 aria2 可能仍在写入文件。为避免两个 aria2 同时写入，现已暂时阻止新增下载。&#10;&#10;请先到原来的远端 aria2 停止这些旧任务。确认已经停止后，点击“确定”恢复新增下载；取消或关闭不会解除阻止。</system:String>
+    <system:String x:Key="LegacyDownloadAdmissionConfirmationFailed">无法保存确认，新增下载仍被阻止。</system:String>
     
     <!--  DownloadManager  -->
     <system:String x:Key="Downloading">正在下载</system:String>

--- a/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
+++ b/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
@@ -22,6 +22,7 @@ namespace DownKyi.Services.Download;
 internal sealed class AddToDownloadService : IAddToDownloadSession
 {
     private readonly DownloadTaskAdmissionService _admission;
+    private readonly LegacyDownloadAdmissionPresenter _admissionPresenter;
     private readonly DownloadDuplicatePolicy _duplicatePolicy;
     private readonly DownloadMovieMetadataBuilder _metadataBuilder;
     private readonly ISettingsStore _settingsStore;
@@ -35,6 +36,7 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
     public AddToDownloadService(
         PlayStreamType streamType,
         DownloadTaskAdmissionService admission,
+        LegacyDownloadAdmissionPresenter admissionPresenter,
         DownloadDuplicatePolicy duplicatePolicy,
         DownloadMovieMetadataBuilder metadataBuilder,
         ISettingsStore settingsStore,
@@ -45,6 +47,8 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
         ILogger<AddToDownloadService> logger)
     {
         _admission = admission ?? throw new ArgumentNullException(nameof(admission));
+        _admissionPresenter = admissionPresenter
+            ?? throw new ArgumentNullException(nameof(admissionPresenter));
         _duplicatePolicy = duplicatePolicy ?? throw new ArgumentNullException(nameof(duplicatePolicy));
         _metadataBuilder = metadataBuilder ?? throw new ArgumentNullException(nameof(metadataBuilder));
         _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
@@ -70,6 +74,11 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
                 _videoInfoService = new CheeseInfoService(settingsStore, client);
                 break;
         }
+    }
+
+    public Task<bool> EnsureAdmissionAsync(CancellationToken cancellationToken = default)
+    {
+        return _admissionPresenter.EnsureAdmissionAsync(cancellationToken);
     }
 
     public void SetVideoInfoService(IInfoService videoInfoService)

--- a/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
+++ b/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
@@ -258,13 +258,26 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
                         .ConfigureAwait(true);
                 }
 
-                await _admission
-                    .AdmitAsync(
-                        downloadingItem,
-                        settings.Basic.RepeatFileAutoAddNumberSuffix,
-                        cancellationToken)
-                    .ConfigureAwait(true);
-                addedCount++;
+                try
+                {
+                    await _admission
+                        .AdmitAsync(
+                            downloadingItem,
+                            settings.Basic.RepeatFileAutoAddNumberSuffix,
+                            cancellationToken)
+                        .ConfigureAwait(true);
+                    addedCount++;
+                }
+                catch (IOException exception)
+                {
+                    _logger.LogWarningMessage("Download task admission failed.", exception);
+                    var alert = new AlertService(_dialogService);
+                    await alert
+                        .ShowError(
+                            DictionaryResource.GetString("DirectoryError"),
+                            cancellationToken)
+                        .ConfigureAwait(true);
+                }
             }
         }
 

--- a/src/DownKyi.Desktop/Services/Download/AddToDownloadServiceFactory.cs
+++ b/src/DownKyi.Desktop/Services/Download/AddToDownloadServiceFactory.cs
@@ -18,6 +18,7 @@ internal interface IAddToDownloadServiceFactory
 internal sealed class AddToDownloadServiceFactory : IAddToDownloadServiceFactory
 {
     private readonly DownloadTaskAdmissionService _admission;
+    private readonly LegacyDownloadAdmissionPresenter _admissionPresenter;
     private readonly DownloadDuplicatePolicy _duplicatePolicy;
     private readonly DownloadMovieMetadataBuilder _metadataBuilder;
     private readonly ISettingsStore _settingsStore;
@@ -29,6 +30,7 @@ internal sealed class AddToDownloadServiceFactory : IAddToDownloadServiceFactory
 
     public AddToDownloadServiceFactory(
         DownloadTaskAdmissionService admission,
+        LegacyDownloadAdmissionPresenter admissionPresenter,
         DownloadDuplicatePolicy duplicatePolicy,
         DownloadMovieMetadataBuilder metadataBuilder,
         ISettingsStore settingsStore,
@@ -39,6 +41,8 @@ internal sealed class AddToDownloadServiceFactory : IAddToDownloadServiceFactory
         ILogger<AddToDownloadService> logger)
     {
         _admission = admission ?? throw new ArgumentNullException(nameof(admission));
+        _admissionPresenter = admissionPresenter
+            ?? throw new ArgumentNullException(nameof(admissionPresenter));
         _duplicatePolicy = duplicatePolicy ?? throw new ArgumentNullException(nameof(duplicatePolicy));
         _metadataBuilder = metadataBuilder ?? throw new ArgumentNullException(nameof(metadataBuilder));
         _settingsStore = settingsStore ?? throw new ArgumentNullException(nameof(settingsStore));
@@ -54,6 +58,7 @@ internal sealed class AddToDownloadServiceFactory : IAddToDownloadServiceFactory
         return new AddToDownloadService(
             streamType,
             _admission,
+            _admissionPresenter,
             _duplicatePolicy,
             _metadataBuilder,
             _settingsStore,

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
@@ -20,16 +20,18 @@ internal static class DownloadOutputPathResolver
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
         ArgumentNullException.ThrowIfNull(isReservedAsync);
         comparer ??= PlatformComparer;
-        var occupiedPaths = GetExistingBasePaths(basePath).ToHashSet(comparer);
+        var occupiedPaths = GetExistingBasePaths(basePath)
+            .Select(CreateComparisonKey)
+            .ToHashSet(comparer);
         for (var suffix = 0; ; suffix++)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var candidate = suffix == 0 ? basePath : $"{basePath}({suffix})";
-            var normalizedCandidate = Normalize(candidate);
-            if (!occupiedPaths.Contains(normalizedCandidate) &&
-                !await isReservedAsync(normalizedCandidate, cancellationToken).ConfigureAwait(false))
+            var comparisonKey = CreateComparisonKey(candidate);
+            if (!occupiedPaths.Contains(comparisonKey) &&
+                !await isReservedAsync(candidate, cancellationToken).ConfigureAwait(false))
             {
-                return normalizedCandidate;
+                return candidate;
             }
 
             if (!autoAddNumberSuffix)
@@ -46,8 +48,7 @@ internal static class DownloadOutputPathResolver
 
     private static string[] GetExistingBasePaths(string basePath)
     {
-        var normalizedBasePath = Normalize(basePath);
-        var directory = Path.GetDirectoryName(normalizedBasePath);
+        var directory = Path.GetDirectoryName(basePath);
         if (directory == null || !Directory.Exists(directory))
         {
             return [];
@@ -56,11 +57,10 @@ internal static class DownloadOutputPathResolver
         return Directory
             .EnumerateFiles(directory)
             .Select(file => Path.Combine(directory, Path.GetFileNameWithoutExtension(file)))
-            .Select(Normalize)
             .ToArray();
     }
 
-    private static string Normalize(string path)
+    private static string CreateComparisonKey(string path)
     {
         return DownloadOutputPathKey.Create(path, ignoreCase: false);
     }

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
@@ -13,6 +13,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
     private readonly IDownloadTaskApplicationService _tasks;
     private readonly DownloadTaskProjectionStore _projections;
     private readonly IDownloadTaskQueue _taskQueue;
+    private readonly IPhysicalOutputPathResolver _physicalOutputPathResolver;
     private readonly SemaphoreSlim _admissionGate = new(1, 1);
     private bool _disposed;
 
@@ -20,12 +21,15 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         DownloadListState downloadLists,
         IDownloadTaskApplicationService tasks,
         DownloadTaskProjectionStore projections,
-        IDownloadTaskQueue taskQueue)
+        IDownloadTaskQueue taskQueue,
+        IPhysicalOutputPathResolver physicalOutputPathResolver)
     {
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
         _projections = projections ?? throw new ArgumentNullException(nameof(projections));
         _taskQueue = taskQueue ?? throw new ArgumentNullException(nameof(taskQueue));
+        _physicalOutputPathResolver = physicalOutputPathResolver
+            ?? throw new ArgumentNullException(nameof(physicalOutputPathResolver));
     }
 
     public async Task AdmitAsync(
@@ -38,14 +42,17 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         await _admissionGate.WaitAsync(cancellationToken).ConfigureAwait(true);
         try
         {
-            item.DownloadBase.FilePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
-                item.DownloadBase.FilePath,
+            var physicalBasePath = _physicalOutputPathResolver.ResolvePhysicalBasePath(
+                item.DownloadBase.FilePath);
+            var admittedBasePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+                physicalBasePath,
                 autoAddNumberSuffix,
                 (candidate, token) => _tasks.IsOutputPathReservedAsync(
                     candidate,
                     DownloadOutputPathKey.UsesCaseInsensitiveComparison,
                     token),
                 cancellationToken).ConfigureAwait(true);
+            item.DownloadBase.FilePath = admittedBasePath;
 
             await _projections.AddDownloadingAsync(item, cancellationToken).ConfigureAwait(true);
 

--- a/src/DownKyi.Desktop/Services/Download/IAddToDownloadSession.cs
+++ b/src/DownKyi.Desktop/Services/Download/IAddToDownloadSession.cs
@@ -7,6 +7,8 @@ namespace DownKyi.Services.Download;
 
 internal interface IAddToDownloadSession
 {
+    Task<bool> EnsureAdmissionAsync(CancellationToken cancellationToken = default);
+
     Task<string?> SetDirectory(CancellationToken cancellationToken = default);
 
     void SetVideoInfoService(IInfoService videoInfoService);

--- a/src/DownKyi.Desktop/Services/Download/LegacyDownloadAdmissionPresenter.cs
+++ b/src/DownKyi.Desktop/Services/Download/LegacyDownloadAdmissionPresenter.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using DownKyi.Application.Desktop;
+using DownKyi.Application.Downloads;
+using DownKyi.Utils;
+
+namespace DownKyi.Services.Download;
+
+internal sealed class LegacyDownloadAdmissionPresenter
+{
+    private readonly IDownloadTaskApplicationService _tasks;
+    private readonly IAppDialogService _dialogs;
+
+    public LegacyDownloadAdmissionPresenter(
+        IDownloadTaskApplicationService tasks,
+        IAppDialogService dialogs)
+    {
+        _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
+        _dialogs = dialogs ?? throw new ArgumentNullException(nameof(dialogs));
+    }
+
+    public async Task<bool> EnsureAdmissionAsync(CancellationToken cancellationToken)
+    {
+        var admission = await _tasks.CheckNewDownloadAdmissionAsync(cancellationToken)
+            .ConfigureAwait(true);
+        if (admission.IsSuccess)
+        {
+            return true;
+        }
+
+        if (!DownloadAdmissionErrors.IsLegacyUpgradeBlocked(admission.Error))
+        {
+            throw new InvalidOperationException(
+                admission.Error?.Message ?? "Download admission failed without an error.");
+        }
+
+        var alert = new AlertService(_dialogs);
+        var outcome = await alert.ShowWarning(
+            DictionaryResource.GetString("LegacyDownloadAdmissionBlocked"),
+            buttonNumber: 2,
+            cancellationToken).ConfigureAwait(true);
+        if (outcome != AppDialogOutcome.Accepted)
+        {
+            return false;
+        }
+
+        var confirmation = await _tasks
+            .ConfirmLegacyRemoteTasksStoppedAsync(cancellationToken)
+            .ConfigureAwait(true);
+        if (confirmation.IsSuccess)
+        {
+            return true;
+        }
+
+        await alert.ShowError(
+            confirmation.Error?.Message
+                ?? DictionaryResource.GetString("LegacyDownloadAdmissionConfirmationFailed"),
+            cancellationToken).ConfigureAwait(true);
+        return false;
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using DownKyi.Application.Desktop;
 using DownKyi.Application.Diagnostics;
 using DownKyi.Domain.Results;
-using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.Services.Download;
@@ -43,7 +42,7 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
         string path;
         try
         {
-            path = GetDownloadDirectoryPath(downloading);
+            path = GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
             Directory.CreateDirectory(path);
         }
         catch (Exception exception) when (exception is IOException
@@ -91,9 +90,4 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
                    nameof(filePath));
     }
 
-    internal static string GetDownloadDirectoryPath(DownloadingItem downloading)
-    {
-        ArgumentNullException.ThrowIfNull(downloading);
-        return GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
-    }
 }

--- a/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
@@ -38,11 +38,13 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
     {
         ArgumentNullException.ThrowIfNull(context);
         var downloading = context.Downloading;
+        var playbackBasePath = downloading.DownloadBase.FilePath
+            .Replace("\\", "/", StringComparison.Ordinal);
 
         string path;
         try
         {
-            path = GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
+            path = GetDownloadDirectoryPath(playbackBasePath);
             Directory.CreateDirectory(path);
         }
         catch (Exception exception) when (exception is IOException

--- a/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/ResolvePlaybackStage.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using DownKyi.Application.Desktop;
 using DownKyi.Application.Diagnostics;
 using DownKyi.Domain.Results;
+using DownKyi.ViewModels.DownloadManager;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.Services.Download;
@@ -38,13 +39,11 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
     {
         ArgumentNullException.ThrowIfNull(context);
         var downloading = context.Downloading;
-        downloading.DownloadBase.FilePath = downloading.DownloadBase.FilePath
-            .Replace("\\", "/", StringComparison.Ordinal);
 
         string path;
         try
         {
-            path = GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
+            path = GetDownloadDirectoryPath(downloading);
             Directory.CreateDirectory(path);
         }
         catch (Exception exception) when (exception is IOException
@@ -92,4 +91,9 @@ internal sealed class ResolvePlaybackStage : IDownloadPipelineStage
                    nameof(filePath));
     }
 
+    internal static string GetDownloadDirectoryPath(DownloadingItem downloading)
+    {
+        ArgumentNullException.ThrowIfNull(downloading);
+        return GetDownloadDirectoryPath(downloading.DownloadBase.FilePath);
+    }
 }

--- a/src/DownKyi.Desktop/Services/Media/ContentDownloadCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Media/ContentDownloadCoordinator.cs
@@ -113,6 +113,7 @@ internal sealed class ContentDownloadCoordinator : IContentDownloadCoordinator
 
         var addToDownloadSession = _serviceFactory.Create(ToPlayStreamType(selectedItems[0].Kind));
         return await DownloadAddCoordinator.AddToDownloadIfDirectorySelectedAsync(
+            () => addToDownloadSession.EnsureAdmissionAsync(cancellationToken),
             () => addToDownloadSession.SetDirectory(cancellationToken),
             directory => AddItemsAsync(
                 addToDownloadSession,

--- a/src/DownKyi.Desktop/Services/Video/VideoDetailDownloadCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Video/VideoDetailDownloadCoordinator.cs
@@ -46,6 +46,7 @@ internal sealed class VideoDetailDownloadCoordinator : IVideoDetailDownloadCoord
 
         var addService = _serviceFactory.Create(streamType.Value);
         return DownloadAddCoordinator.AddToDownloadIfDirectorySelectedAsync(
+            () => addService.EnsureAdmissionAsync(cancellationToken),
             () => addService.SetDirectory(cancellationToken),
             async directory =>
             {

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreOperationResults.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreOperationResults.cs
@@ -1,0 +1,31 @@
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreOperationResults
+{
+    public static OperationResult Conflict(DownloadTaskId taskId, string reason)
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.store.conflict",
+            $"Download task '{taskId.Value}' {reason}.",
+            OperationErrorKind.Conflict));
+    }
+
+    public static OperationResult NotFound(DownloadTaskId taskId)
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.store.not_found",
+            $"Download task '{taskId.Value}' was not found.",
+            OperationErrorKind.NotFound));
+    }
+
+    public static OperationResult OutputPathConflict()
+    {
+        return OperationResult.Failure(new OperationError(
+            "download.store.output_path_reserved",
+            "The selected output path is already reserved by another active download.",
+            OperationErrorKind.Conflict));
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
@@ -1,7 +1,4 @@
-using System.Globalization;
-using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
-using DownKyi.Domain.Downloads;
 using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Infrastructure.Downloads;
@@ -10,22 +7,6 @@ internal static class DownloadStoreSchema
 {
     public const int CurrentVersion = 3;
 
-    private enum VersionTwoColumn
-    {
-        BaseVersion,
-        BaseCreatedAtUtc,
-        BaseUpdatedAtUtc,
-        DownloadingPhase,
-        DownloadingFailureCode,
-        DownloadingFailureMessage,
-        DownloadingFailureTransient,
-        DownloadingDownloadedBytes,
-        DownloadingTotalBytes,
-        DownloadingBytesPerSecond
-    }
-
-    private const string OutputReservationColumn = "output_reservation_key";
-
     public static async Task InitializeAsync(
         SqliteConnection connection,
         string databasePath,
@@ -33,7 +14,9 @@ internal static class DownloadStoreSchema
         IClock clock,
         CancellationToken cancellationToken)
     {
-        var currentVersion = await ReadUserVersionAsync(connection, cancellationToken).ConfigureAwait(false);
+        var currentVersion = await DownloadStoreSchemaLifecycle
+            .ReadUserVersionAsync(connection, cancellationToken)
+            .ConfigureAwait(false);
         if (currentVersion > CurrentVersion)
         {
             throw new InvalidOperationException(
@@ -42,7 +25,9 @@ internal static class DownloadStoreSchema
 
         if (databaseExisted && currentVersion < CurrentVersion)
         {
-            await BackupAsync(connection, databasePath, currentVersion, clock, cancellationToken).ConfigureAwait(false);
+            await DownloadStoreSchemaLifecycle
+                .BackupAsync(connection, databasePath, currentVersion, clock, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         if (currentVersion == CurrentVersion)
@@ -57,23 +42,28 @@ internal static class DownloadStoreSchema
         {
             if (currentVersion < 1)
             {
-                await ApplyVersionOneAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                await DownloadStoreSchemaV1Migration
+                    .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
             if (currentVersion < 2)
             {
-                await ApplyVersionTwoAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                await DownloadStoreSchemaV2Migration
+                    .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
             if (currentVersion < 3)
             {
-                await ApplyVersionThreeAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                await DownloadStoreSchemaV3Migration
+                    .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
                     .ConfigureAwait(false);
             }
 
-            await SetUserVersionAsync(connection, transaction, CurrentVersion, cancellationToken).ConfigureAwait(false);
+            await DownloadStoreSchemaLifecycle
+                .SetUserVersionAsync(connection, transaction, CurrentVersion, cancellationToken)
+                .ConfigureAwait(false);
             await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
         }
         catch
@@ -81,407 +71,5 @@ internal static class DownloadStoreSchema
             await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
             throw;
         }
-    }
-
-    private static async Task ApplyVersionOneAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        const string sql = """
-            CREATE TABLE IF NOT EXISTS download_base (
-                id                    TEXT PRIMARY KEY,
-                need_download_content TEXT NOT NULL DEFAULT '{}',
-                bvid                  TEXT NOT NULL DEFAULT '',
-                avid                  INTEGER NOT NULL DEFAULT 0,
-                cid                   INTEGER NOT NULL DEFAULT 0,
-                episode_id            INTEGER NOT NULL DEFAULT 0,
-                cover_url             TEXT NOT NULL DEFAULT '',
-                page_cover_url        TEXT NOT NULL DEFAULT '',
-                zone_id               INTEGER NOT NULL DEFAULT 0,
-                [order]               INTEGER NOT NULL DEFAULT 0,
-                main_title            TEXT NOT NULL DEFAULT '',
-                name                  TEXT NOT NULL DEFAULT '',
-                duration              TEXT NOT NULL DEFAULT '',
-                video_codec_name      TEXT NOT NULL DEFAULT '',
-                resolution            TEXT NOT NULL DEFAULT '{}',
-                audio_codec           TEXT,
-                file_path             TEXT NOT NULL DEFAULT '',
-                file_size             TEXT,
-                page                  INTEGER NOT NULL DEFAULT 1
-            );
-
-            CREATE TABLE IF NOT EXISTS downloading (
-                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
-                gid                   TEXT,
-                download_files        TEXT NOT NULL DEFAULT '{}',
-                downloaded_files      TEXT NOT NULL DEFAULT '[]',
-                play_stream_type      INTEGER NOT NULL DEFAULT 0,
-                download_status       INTEGER NOT NULL DEFAULT 0,
-                download_content      TEXT,
-                download_status_title TEXT,
-                progress              REAL NOT NULL DEFAULT 0,
-                downloading_file_size TEXT,
-                max_speed             INTEGER NOT NULL DEFAULT 0,
-                speed_display         TEXT
-            );
-
-            CREATE TABLE IF NOT EXISTS downloaded (
-                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
-                max_speed_display     TEXT,
-                finished_timestamp    INTEGER NOT NULL DEFAULT 0,
-                finished_time         TEXT NOT NULL DEFAULT ''
-            );
-
-            CREATE TABLE IF NOT EXISTS download_schema_migrations (
-                version               INTEGER PRIMARY KEY,
-                applied_at_utc        INTEGER NOT NULL
-            );
-
-            CREATE TABLE IF NOT EXISTS download_quarantine (
-                quarantine_id         INTEGER PRIMARY KEY AUTOINCREMENT,
-                source_table          TEXT NOT NULL,
-                record_id             TEXT NOT NULL,
-                field_name            TEXT NOT NULL,
-                reason                TEXT NOT NULL,
-                quarantined_at_utc    INTEGER NOT NULL,
-                UNIQUE(source_table, record_id)
-            );
-
-            CREATE INDEX IF NOT EXISTS ix_downloading_status ON downloading(download_status);
-            CREATE INDEX IF NOT EXISTS ix_downloaded_finished_timestamp ON downloaded(finished_timestamp DESC, id DESC);
-            CREATE INDEX IF NOT EXISTS ix_download_base_main_title_order ON download_base(main_title, [order]);
-            """;
-
-        using (var command = connection.CreateCommand())
-        {
-            command.Transaction = transaction;
-            command.CommandText = sql;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await RecordMigrationAsync(connection, transaction, 1, appliedAtUtc, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task ApplyVersionTwoAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        foreach (var column in Enum.GetValues<VersionTwoColumn>())
-        {
-            await AddColumnIfMissingAsync(connection, transaction, column, cancellationToken).ConfigureAwait(false);
-        }
-
-        const string phaseSql = """
-            UPDATE downloading
-            SET phase = CASE download_status
-                WHEN 2 THEN @pausing
-                WHEN 3 THEN @paused
-                WHEN 4 THEN @downloading
-                WHEN 5 THEN @queued
-                WHEN 6 THEN @failed
-                ELSE @queued
-            END
-            WHERE phase IS NULL;
-            """;
-        using (var command = connection.CreateCommand())
-        {
-            command.Transaction = transaction;
-            command.CommandText = phaseSql;
-            command.Parameters.AddWithValue("@pausing", (int)DownloadPhase.Pausing);
-            command.Parameters.AddWithValue("@paused", (int)DownloadPhase.Paused);
-            command.Parameters.AddWithValue("@downloading", (int)DownloadPhase.Downloading);
-            command.Parameters.AddWithValue("@failed", (int)DownloadPhase.Failed);
-            command.Parameters.AddWithValue("@queued", (int)DownloadPhase.Queued);
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await RecordMigrationAsync(connection, transaction, 2, appliedAtUtc, cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task ApplyVersionThreeAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        if (!await HasDownloadBaseColumnAsync(
-                connection,
-                transaction,
-                OutputReservationColumn,
-                cancellationToken).ConfigureAwait(false))
-        {
-            using var alter = connection.CreateCommand();
-            alter.Transaction = transaction;
-            alter.CommandText =
-                $"ALTER TABLE download_base ADD COLUMN {OutputReservationColumn} TEXT";
-            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await BackfillOutputReservationsAsync(connection, transaction, cancellationToken)
-            .ConfigureAwait(false);
-
-        using (var command = connection.CreateCommand())
-        {
-            command.Transaction = transaction;
-            command.CommandText = """
-                CREATE INDEX IF NOT EXISTS ix_download_base_file_path
-                    ON download_base(file_path);
-                CREATE INDEX IF NOT EXISTS ix_download_base_file_path_nocase
-                    ON download_base(file_path COLLATE NOCASE);
-                CREATE UNIQUE INDEX IF NOT EXISTS ux_download_base_output_reservation
-                    ON download_base(output_reservation_key)
-                    WHERE output_reservation_key IS NOT NULL;
-                """;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        await RecordMigrationAsync(connection, transaction, 3, appliedAtUtc, cancellationToken)
-            .ConfigureAwait(false);
-    }
-
-    private static async Task BackfillOutputReservationsAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        CancellationToken cancellationToken)
-    {
-        var rows = new List<(string Id, string BasePath)>();
-        using (var select = connection.CreateCommand())
-        {
-            select.Transaction = transaction;
-            select.CommandText = """
-                SELECT db.id, db.file_path
-                FROM download_base db
-                INNER JOIN downloading dl ON dl.id = db.id
-                ORDER BY db.id
-                """;
-            using var reader = await select.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                rows.Add((reader.GetString(0), reader.GetString(1)));
-            }
-        }
-
-        var keys = new HashSet<string>(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {
-            string key;
-            try
-            {
-                key = DownloadOutputPathKey.Create(
-                    row.BasePath,
-                    DownloadOutputPathKey.UsesCaseInsensitiveComparison);
-            }
-            catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
-            {
-                continue;
-            }
-
-            if (!keys.Add(key))
-            {
-                continue;
-            }
-
-            using var update = connection.CreateCommand();
-            update.Transaction = transaction;
-            update.CommandText = """
-                UPDATE download_base
-                SET output_reservation_key = @key
-                WHERE id = @id
-                """;
-            update.Parameters.AddWithValue("@key", key);
-            update.Parameters.AddWithValue("@id", row.Id);
-            await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private static async Task<bool> HasDownloadBaseColumnAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        string column,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = "PRAGMA table_info(download_base)";
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            if (reader.GetString(1).Equals(column, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static async Task AddColumnIfMissingAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        VersionTwoColumn column,
-        CancellationToken cancellationToken)
-    {
-        using var inspect = connection.CreateCommand();
-        inspect.Transaction = transaction;
-        if (IsBaseColumn(column))
-        {
-            inspect.CommandText = "PRAGMA table_info(download_base)";
-        }
-        else
-        {
-            inspect.CommandText = "PRAGMA table_info(downloading)";
-        }
-
-        var columnName = GetColumnName(column);
-        using (var reader = await inspect.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
-        {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                if (reader.GetString(1).Equals(columnName, StringComparison.OrdinalIgnoreCase))
-                {
-                    return;
-                }
-            }
-        }
-
-        using var alter = connection.CreateCommand();
-        alter.Transaction = transaction;
-        SetAlterColumnSql(alter, column);
-        await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static bool IsBaseColumn(VersionTwoColumn column) => column is
-        VersionTwoColumn.BaseVersion or
-        VersionTwoColumn.BaseCreatedAtUtc or
-        VersionTwoColumn.BaseUpdatedAtUtc;
-
-    private static string GetColumnName(VersionTwoColumn column) => column switch
-    {
-        VersionTwoColumn.BaseVersion => "version",
-        VersionTwoColumn.BaseCreatedAtUtc => "created_at_utc",
-        VersionTwoColumn.BaseUpdatedAtUtc => "updated_at_utc",
-        VersionTwoColumn.DownloadingPhase => "phase",
-        VersionTwoColumn.DownloadingFailureCode => "failure_code",
-        VersionTwoColumn.DownloadingFailureMessage => "failure_message",
-        VersionTwoColumn.DownloadingFailureTransient => "failure_transient",
-        VersionTwoColumn.DownloadingDownloadedBytes => "downloaded_bytes",
-        VersionTwoColumn.DownloadingTotalBytes => "total_bytes",
-        VersionTwoColumn.DownloadingBytesPerSecond => "bytes_per_second",
-        _ => throw new ArgumentOutOfRangeException(nameof(column))
-    };
-
-    private static void SetAlterColumnSql(SqliteCommand command, VersionTwoColumn column)
-    {
-        switch (column)
-        {
-            case VersionTwoColumn.BaseVersion:
-                command.CommandText =
-                    "ALTER TABLE download_base ADD COLUMN version INTEGER NOT NULL DEFAULT 0";
-                break;
-            case VersionTwoColumn.BaseCreatedAtUtc:
-                command.CommandText =
-                    "ALTER TABLE download_base ADD COLUMN created_at_utc INTEGER NOT NULL DEFAULT 0";
-                break;
-            case VersionTwoColumn.BaseUpdatedAtUtc:
-                command.CommandText =
-                    "ALTER TABLE download_base ADD COLUMN updated_at_utc INTEGER NOT NULL DEFAULT 0";
-                break;
-            case VersionTwoColumn.DownloadingPhase:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN phase INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingFailureCode:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_code TEXT";
-                break;
-            case VersionTwoColumn.DownloadingFailureMessage:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_message TEXT";
-                break;
-            case VersionTwoColumn.DownloadingFailureTransient:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_transient INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingDownloadedBytes:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN downloaded_bytes INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingTotalBytes:
-                command.CommandText = "ALTER TABLE downloading ADD COLUMN total_bytes INTEGER";
-                break;
-            case VersionTwoColumn.DownloadingBytesPerSecond:
-                command.CommandText =
-                    "ALTER TABLE downloading ADD COLUMN bytes_per_second INTEGER NOT NULL DEFAULT 0";
-                break;
-            default:
-                throw new ArgumentOutOfRangeException(nameof(column));
-        }
-    }
-
-    private static async Task RecordMigrationAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        int version,
-        DateTimeOffset appliedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = """
-            INSERT OR REPLACE INTO download_schema_migrations(version, applied_at_utc)
-            VALUES (@version, @applied_at_utc)
-            """;
-        command.Parameters.AddWithValue("@version", version);
-        command.Parameters.AddWithValue("@applied_at_utc", appliedAtUtc.ToUnixTimeMilliseconds());
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task<int> ReadUserVersionAsync(
-        SqliteConnection connection,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = "PRAGMA user_version";
-        var value = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
-        return Convert.ToInt32(value, CultureInfo.InvariantCulture);
-    }
-
-    private static async Task SetUserVersionAsync(
-        SqliteConnection connection,
-        SqliteTransaction transaction,
-        int version,
-        CancellationToken cancellationToken)
-    {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(version, CurrentVersion);
-
-        using var command = connection.CreateCommand();
-        command.Transaction = transaction;
-        command.CommandText = "PRAGMA user_version = 3";
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
-
-    private static async Task BackupAsync(
-        SqliteConnection source,
-        string databasePath,
-        int sourceVersion,
-        IClock clock,
-        CancellationToken cancellationToken)
-    {
-        var directory = Path.GetDirectoryName(databasePath) ?? ".";
-        var backupDirectory = Path.Combine(directory, "Backup");
-        Directory.CreateDirectory(backupDirectory);
-        var timestamp = clock.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'", CultureInfo.InvariantCulture);
-        var backupPath = Path.Combine(
-            backupDirectory,
-            $"{Path.GetFileName(databasePath)}.schema-v{sourceVersion}-{timestamp}.bak");
-        var connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = backupPath,
-            Mode = SqliteOpenMode.ReadWriteCreate,
-            Pooling = false
-        }.ToString();
-
-        using var backup = new SqliteConnection(connectionString);
-        await backup.OpenAsync(cancellationToken).ConfigureAwait(false);
-        source.BackupDatabase(backup);
     }
 }

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchema.cs
@@ -1,3 +1,4 @@
+using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using Microsoft.Data.Sqlite;
 
@@ -5,13 +6,14 @@ namespace DownKyi.Infrastructure.Downloads;
 
 internal static class DownloadStoreSchema
 {
-    public const int CurrentVersion = 3;
+    public const int CurrentVersion = 4;
 
     public static async Task InitializeAsync(
         SqliteConnection connection,
         string databasePath,
         bool databaseExisted,
         IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
         CancellationToken cancellationToken)
     {
         var currentVersion = await DownloadStoreSchemaLifecycle
@@ -58,6 +60,18 @@ internal static class DownloadStoreSchema
             {
                 await DownloadStoreSchemaV3Migration
                     .ApplyAsync(connection, transaction, clock.UtcNow, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (currentVersion < 4)
+            {
+                await DownloadStoreSchemaV4Migration
+                    .ApplyAsync(
+                        connection,
+                        transaction,
+                        clock.UtcNow,
+                        physicalOutputPathResolver,
+                        cancellationToken)
                     .ConfigureAwait(false);
             }
 

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
@@ -40,11 +40,11 @@ internal static class DownloadStoreSchemaLifecycle
         int version,
         CancellationToken cancellationToken)
     {
-        ArgumentOutOfRangeException.ThrowIfNotEqual(version, 3);
+        ArgumentOutOfRangeException.ThrowIfNotEqual(version, 4);
 
         using var command = connection.CreateCommand();
         command.Transaction = transaction;
-        command.CommandText = "PRAGMA user_version = 3";
+        command.CommandText = "PRAGMA user_version = 4";
         await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
@@ -1,0 +1,76 @@
+using System.Globalization;
+using DownKyi.Application.Time;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaLifecycle
+{
+    public static async Task RecordMigrationAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        int version,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT OR REPLACE INTO download_schema_migrations(version, applied_at_utc)
+            VALUES (@version, @applied_at_utc)
+            """;
+        command.Parameters.AddWithValue("@version", version);
+        command.Parameters.AddWithValue("@applied_at_utc", appliedAtUtc.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task<int> ReadUserVersionAsync(
+        SqliteConnection connection,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = "PRAGMA user_version";
+        var value = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return Convert.ToInt32(value, CultureInfo.InvariantCulture);
+    }
+
+    public static async Task SetUserVersionAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        int version,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfNotEqual(version, 3);
+
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "PRAGMA user_version = 3";
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public static async Task BackupAsync(
+        SqliteConnection source,
+        string databasePath,
+        int sourceVersion,
+        IClock clock,
+        CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(databasePath) ?? ".";
+        var backupDirectory = Path.Combine(directory, "Backup");
+        Directory.CreateDirectory(backupDirectory);
+        var timestamp = clock.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'", CultureInfo.InvariantCulture);
+        var backupPath = Path.Combine(
+            backupDirectory,
+            $"{Path.GetFileName(databasePath)}.schema-v{sourceVersion}-{timestamp}.bak");
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = backupPath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = false
+        }.ToString();
+
+        using var backup = new SqliteConnection(connectionString);
+        await backup.OpenAsync(cancellationToken).ConfigureAwait(false);
+        source.BackupDatabase(backup);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV1Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV1Migration.cs
@@ -1,0 +1,89 @@
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV1Migration
+{
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        const string sql = """
+            CREATE TABLE IF NOT EXISTS download_base (
+                id                    TEXT PRIMARY KEY,
+                need_download_content TEXT NOT NULL DEFAULT '{}',
+                bvid                  TEXT NOT NULL DEFAULT '',
+                avid                  INTEGER NOT NULL DEFAULT 0,
+                cid                   INTEGER NOT NULL DEFAULT 0,
+                episode_id            INTEGER NOT NULL DEFAULT 0,
+                cover_url             TEXT NOT NULL DEFAULT '',
+                page_cover_url        TEXT NOT NULL DEFAULT '',
+                zone_id               INTEGER NOT NULL DEFAULT 0,
+                [order]               INTEGER NOT NULL DEFAULT 0,
+                main_title            TEXT NOT NULL DEFAULT '',
+                name                  TEXT NOT NULL DEFAULT '',
+                duration              TEXT NOT NULL DEFAULT '',
+                video_codec_name      TEXT NOT NULL DEFAULT '',
+                resolution            TEXT NOT NULL DEFAULT '{}',
+                audio_codec           TEXT,
+                file_path             TEXT NOT NULL DEFAULT '',
+                file_size             TEXT,
+                page                  INTEGER NOT NULL DEFAULT 1
+            );
+
+            CREATE TABLE IF NOT EXISTS downloading (
+                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
+                gid                   TEXT,
+                download_files        TEXT NOT NULL DEFAULT '{}',
+                downloaded_files      TEXT NOT NULL DEFAULT '[]',
+                play_stream_type      INTEGER NOT NULL DEFAULT 0,
+                download_status       INTEGER NOT NULL DEFAULT 0,
+                download_content      TEXT,
+                download_status_title TEXT,
+                progress              REAL NOT NULL DEFAULT 0,
+                downloading_file_size TEXT,
+                max_speed             INTEGER NOT NULL DEFAULT 0,
+                speed_display         TEXT
+            );
+
+            CREATE TABLE IF NOT EXISTS downloaded (
+                id                    TEXT PRIMARY KEY REFERENCES download_base(id) ON DELETE CASCADE,
+                max_speed_display     TEXT,
+                finished_timestamp    INTEGER NOT NULL DEFAULT 0,
+                finished_time         TEXT NOT NULL DEFAULT ''
+            );
+
+            CREATE TABLE IF NOT EXISTS download_schema_migrations (
+                version               INTEGER PRIMARY KEY,
+                applied_at_utc        INTEGER NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS download_quarantine (
+                quarantine_id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                source_table          TEXT NOT NULL,
+                record_id             TEXT NOT NULL,
+                field_name            TEXT NOT NULL,
+                reason                TEXT NOT NULL,
+                quarantined_at_utc    INTEGER NOT NULL,
+                UNIQUE(source_table, record_id)
+            );
+
+            CREATE INDEX IF NOT EXISTS ix_downloading_status ON downloading(download_status);
+            CREATE INDEX IF NOT EXISTS ix_downloaded_finished_timestamp ON downloaded(finished_timestamp DESC, id DESC);
+            CREATE INDEX IF NOT EXISTS ix_download_base_main_title_order ON download_base(main_title, [order]);
+            """;
+
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = sql;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 1, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV2Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV2Migration.cs
@@ -1,0 +1,159 @@
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV2Migration
+{
+    private enum VersionTwoColumn
+    {
+        BaseVersion,
+        BaseCreatedAtUtc,
+        BaseUpdatedAtUtc,
+        DownloadingPhase,
+        DownloadingFailureCode,
+        DownloadingFailureMessage,
+        DownloadingFailureTransient,
+        DownloadingDownloadedBytes,
+        DownloadingTotalBytes,
+        DownloadingBytesPerSecond
+    }
+
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        foreach (var column in Enum.GetValues<VersionTwoColumn>())
+        {
+            await AddColumnIfMissingAsync(connection, transaction, column, cancellationToken).ConfigureAwait(false);
+        }
+
+        const string phaseSql = """
+            UPDATE downloading
+            SET phase = CASE download_status
+                WHEN 2 THEN @pausing
+                WHEN 3 THEN @paused
+                WHEN 4 THEN @downloading
+                WHEN 5 THEN @queued
+                WHEN 6 THEN @failed
+                ELSE @queued
+            END
+            WHERE phase IS NULL;
+            """;
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = phaseSql;
+            command.Parameters.AddWithValue("@pausing", (int)DownloadPhase.Pausing);
+            command.Parameters.AddWithValue("@paused", (int)DownloadPhase.Paused);
+            command.Parameters.AddWithValue("@downloading", (int)DownloadPhase.Downloading);
+            command.Parameters.AddWithValue("@failed", (int)DownloadPhase.Failed);
+            command.Parameters.AddWithValue("@queued", (int)DownloadPhase.Queued);
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 2, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task AddColumnIfMissingAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        VersionTwoColumn column,
+        CancellationToken cancellationToken)
+    {
+        using var inspect = connection.CreateCommand();
+        inspect.Transaction = transaction;
+        if (IsBaseColumn(column))
+        {
+            inspect.CommandText = "PRAGMA table_info(download_base)";
+        }
+        else
+        {
+            inspect.CommandText = "PRAGMA table_info(downloading)";
+        }
+
+        var columnName = GetColumnName(column);
+        using (var reader = await inspect.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                if (reader.GetString(1).Equals(columnName, StringComparison.OrdinalIgnoreCase))
+                {
+                    return;
+                }
+            }
+        }
+
+        using var alter = connection.CreateCommand();
+        alter.Transaction = transaction;
+        SetAlterColumnSql(alter, column);
+        await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static bool IsBaseColumn(VersionTwoColumn column) => column is
+        VersionTwoColumn.BaseVersion or
+        VersionTwoColumn.BaseCreatedAtUtc or
+        VersionTwoColumn.BaseUpdatedAtUtc;
+
+    private static string GetColumnName(VersionTwoColumn column) => column switch
+    {
+        VersionTwoColumn.BaseVersion => "version",
+        VersionTwoColumn.BaseCreatedAtUtc => "created_at_utc",
+        VersionTwoColumn.BaseUpdatedAtUtc => "updated_at_utc",
+        VersionTwoColumn.DownloadingPhase => "phase",
+        VersionTwoColumn.DownloadingFailureCode => "failure_code",
+        VersionTwoColumn.DownloadingFailureMessage => "failure_message",
+        VersionTwoColumn.DownloadingFailureTransient => "failure_transient",
+        VersionTwoColumn.DownloadingDownloadedBytes => "downloaded_bytes",
+        VersionTwoColumn.DownloadingTotalBytes => "total_bytes",
+        VersionTwoColumn.DownloadingBytesPerSecond => "bytes_per_second",
+        _ => throw new ArgumentOutOfRangeException(nameof(column))
+    };
+
+    private static void SetAlterColumnSql(SqliteCommand command, VersionTwoColumn column)
+    {
+        switch (column)
+        {
+            case VersionTwoColumn.BaseVersion:
+                command.CommandText =
+                    "ALTER TABLE download_base ADD COLUMN version INTEGER NOT NULL DEFAULT 0";
+                break;
+            case VersionTwoColumn.BaseCreatedAtUtc:
+                command.CommandText =
+                    "ALTER TABLE download_base ADD COLUMN created_at_utc INTEGER NOT NULL DEFAULT 0";
+                break;
+            case VersionTwoColumn.BaseUpdatedAtUtc:
+                command.CommandText =
+                    "ALTER TABLE download_base ADD COLUMN updated_at_utc INTEGER NOT NULL DEFAULT 0";
+                break;
+            case VersionTwoColumn.DownloadingPhase:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN phase INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingFailureCode:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_code TEXT";
+                break;
+            case VersionTwoColumn.DownloadingFailureMessage:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_message TEXT";
+                break;
+            case VersionTwoColumn.DownloadingFailureTransient:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN failure_transient INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingDownloadedBytes:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN downloaded_bytes INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingTotalBytes:
+                command.CommandText = "ALTER TABLE downloading ADD COLUMN total_bytes INTEGER";
+                break;
+            case VersionTwoColumn.DownloadingBytesPerSecond:
+                command.CommandText =
+                    "ALTER TABLE downloading ADD COLUMN bytes_per_second INTEGER NOT NULL DEFAULT 0";
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(column));
+        }
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV3Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV3Migration.cs
@@ -1,0 +1,127 @@
+using DownKyi.Application.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV3Migration
+{
+    private const string OutputReservationColumn = "output_reservation_key";
+
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        if (!await HasDownloadBaseColumnAsync(
+                connection,
+                transaction,
+                OutputReservationColumn,
+                cancellationToken).ConfigureAwait(false))
+        {
+            using var alter = connection.CreateCommand();
+            alter.Transaction = transaction;
+            alter.CommandText =
+                $"ALTER TABLE download_base ADD COLUMN {OutputReservationColumn} TEXT";
+            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await BackfillOutputReservationsAsync(connection, transaction, cancellationToken)
+            .ConfigureAwait(false);
+
+        using (var command = connection.CreateCommand())
+        {
+            command.Transaction = transaction;
+            command.CommandText = """
+                CREATE INDEX IF NOT EXISTS ix_download_base_file_path
+                    ON download_base(file_path);
+                CREATE INDEX IF NOT EXISTS ix_download_base_file_path_nocase
+                    ON download_base(file_path COLLATE NOCASE);
+                CREATE UNIQUE INDEX IF NOT EXISTS ux_download_base_output_reservation
+                    ON download_base(output_reservation_key)
+                    WHERE output_reservation_key IS NOT NULL;
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 3, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task BackfillOutputReservationsAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        var rows = new List<(string Id, string BasePath)>();
+        using (var select = connection.CreateCommand())
+        {
+            select.Transaction = transaction;
+            select.CommandText = """
+                SELECT db.id, db.file_path
+                FROM download_base db
+                INNER JOIN downloading dl ON dl.id = db.id
+                ORDER BY db.id
+                """;
+            using var reader = await select.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                rows.Add((reader.GetString(0), reader.GetString(1)));
+            }
+        }
+
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            string key;
+            try
+            {
+                key = DownloadOutputPathKey.Create(
+                    row.BasePath,
+                    DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+            }
+            catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
+            {
+                continue;
+            }
+
+            if (!keys.Add(key))
+            {
+                continue;
+            }
+
+            using var update = connection.CreateCommand();
+            update.Transaction = transaction;
+            update.CommandText = """
+                UPDATE download_base
+                SET output_reservation_key = @key
+                WHERE id = @id
+                """;
+            update.Parameters.AddWithValue("@key", key);
+            update.Parameters.AddWithValue("@id", row.Id);
+            await update.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    private static async Task<bool> HasDownloadBaseColumnAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string column,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = "PRAGMA table_info(download_base)";
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (reader.GetString(1).Equals(column, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV4Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV4Migration.cs
@@ -22,9 +22,17 @@ internal static class DownloadStoreSchemaV4Migration
             connection,
             transaction,
             cancellationToken).ConfigureAwait(false);
-        foreach (var task in legacyTasks)
+        var pathResolutions = legacyTasks
+            .Select(task => ResolveLegacyPath(task, physicalOutputPathResolver))
+            .ToArray();
+        var aliasedPhysicalKeys = pathResolutions
+            .Where(resolution => resolution.OriginalKeyDiffersFromPhysical)
+            .Select(resolution => resolution.PhysicalKey!)
+            .ToHashSet(StringComparer.Ordinal);
+        foreach (var resolution in pathResolutions)
         {
-            if (IsSamePhysicalPath(task.BasePath, physicalOutputPathResolver))
+            if (resolution.PhysicalKey is not null
+                && !aliasedPhysicalKeys.Contains(resolution.PhysicalKey))
             {
                 continue;
             }
@@ -32,7 +40,7 @@ internal static class DownloadStoreSchemaV4Migration
             await QuarantineAndBlockAdmissionAsync(
                 connection,
                 transaction,
-                task.Id,
+                resolution.Task.Id,
                 appliedAtUtc,
                 cancellationToken).ConfigureAwait(false);
         }
@@ -85,18 +93,21 @@ internal static class DownloadStoreSchemaV4Migration
         return tasks;
     }
 
-    private static bool IsSamePhysicalPath(
-        string originalPath,
+    private static LegacyPathResolution ResolveLegacyPath(
+        LegacyUnfinishedTask task,
         IPhysicalOutputPathResolver physicalOutputPathResolver)
     {
         try
         {
             var ignoreCase = DownloadOutputPathKey.UsesCaseInsensitiveComparison;
-            var originalKey = DownloadOutputPathKey.Create(originalPath, ignoreCase);
+            var originalKey = DownloadOutputPathKey.Create(task.BasePath, ignoreCase);
             var physicalKey = DownloadOutputPathKey.Create(
-                physicalOutputPathResolver.ResolvePhysicalBasePath(originalPath),
+                physicalOutputPathResolver.ResolvePhysicalBasePath(task.BasePath),
                 ignoreCase);
-            return StringComparer.Ordinal.Equals(originalKey, physicalKey);
+            return new LegacyPathResolution(
+                task,
+                physicalKey,
+                !StringComparer.Ordinal.Equals(originalKey, physicalKey));
         }
         catch (Exception exception) when (exception is ArgumentException
             or IOException
@@ -104,7 +115,7 @@ internal static class DownloadStoreSchemaV4Migration
             or UnauthorizedAccessException
             or System.Security.SecurityException)
         {
-            return false;
+            return new LegacyPathResolution(task, null, false);
         }
     }
 
@@ -137,4 +148,9 @@ internal static class DownloadStoreSchemaV4Migration
     }
 
     private sealed record LegacyUnfinishedTask(string Id, string BasePath);
+
+    private sealed record LegacyPathResolution(
+        LegacyUnfinishedTask Task,
+        string? PhysicalKey,
+        bool OriginalKeyDiffersFromPhysical);
 }

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV4Migration.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaV4Migration.cs
@@ -1,0 +1,140 @@
+using DownKyi.Application.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal static class DownloadStoreSchemaV4Migration
+{
+    private const string QuarantineReason = "legacy-output-path-unverified";
+
+    public static async Task ApplyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        DateTimeOffset appliedAtUtc,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(physicalOutputPathResolver);
+
+        await CreateAdmissionGateAsync(connection, transaction, cancellationToken)
+            .ConfigureAwait(false);
+        var legacyTasks = await ReadLegacyUnfinishedTasksAsync(
+            connection,
+            transaction,
+            cancellationToken).ConfigureAwait(false);
+        foreach (var task in legacyTasks)
+        {
+            if (IsSamePhysicalPath(task.BasePath, physicalOutputPathResolver))
+            {
+                continue;
+            }
+
+            await QuarantineAndBlockAdmissionAsync(
+                connection,
+                transaction,
+                task.Id,
+                appliedAtUtc,
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        await DownloadStoreSchemaLifecycle
+            .RecordMigrationAsync(connection, transaction, 4, appliedAtUtc, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static async Task CreateAdmissionGateAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            CREATE TABLE IF NOT EXISTS download_upgrade_admission_gate (
+                singleton_id INTEGER PRIMARY KEY CHECK(singleton_id = 1),
+                remote_stopped_confirmed INTEGER NOT NULL DEFAULT 0
+                    CHECK(remote_stopped_confirmed IN (0, 1))
+            );
+            """;
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async Task<IReadOnlyList<LegacyUnfinishedTask>> ReadLegacyUnfinishedTasksAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            SELECT db.id, db.file_path
+            FROM download_base db
+            INNER JOIN downloading dl ON dl.id = db.id
+            WHERE NOT EXISTS (
+                      SELECT 1 FROM downloaded d
+                      WHERE d.id = db.id)
+            ORDER BY db.id
+            """;
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var tasks = new List<LegacyUnfinishedTask>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            tasks.Add(new LegacyUnfinishedTask(reader.GetString(0), reader.GetString(1)));
+        }
+
+        return tasks;
+    }
+
+    private static bool IsSamePhysicalPath(
+        string originalPath,
+        IPhysicalOutputPathResolver physicalOutputPathResolver)
+    {
+        try
+        {
+            var ignoreCase = DownloadOutputPathKey.UsesCaseInsensitiveComparison;
+            var originalKey = DownloadOutputPathKey.Create(originalPath, ignoreCase);
+            var physicalKey = DownloadOutputPathKey.Create(
+                physicalOutputPathResolver.ResolvePhysicalBasePath(originalPath),
+                ignoreCase);
+            return StringComparer.Ordinal.Equals(originalKey, physicalKey);
+        }
+        catch (Exception exception) when (exception is ArgumentException
+            or IOException
+            or NotSupportedException
+            or UnauthorizedAccessException
+            or System.Security.SecurityException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task QuarantineAndBlockAdmissionAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string taskId,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            INSERT INTO download_quarantine
+                (source_table, record_id, field_name, reason, quarantined_at_utc)
+            VALUES ('downloading', @record_id, 'file_path', @reason, @quarantined_at_utc)
+            ON CONFLICT(source_table, record_id) DO NOTHING;
+
+            INSERT INTO download_upgrade_admission_gate
+                (singleton_id, remote_stopped_confirmed)
+            VALUES (1, 0)
+            ON CONFLICT(singleton_id) DO NOTHING;
+            """;
+        command.Parameters.AddWithValue("@record_id", taskId);
+        command.Parameters.AddWithValue("@reason", QuarantineReason);
+        command.Parameters.AddWithValue(
+            "@quarantined_at_utc",
+            quarantinedAtUtc.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private sealed record LegacyUnfinishedTask(string Id, string BasePath);
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlReader.cs
@@ -1,6 +1,3 @@
-using DownKyi.Domain.Downloads;
-using Microsoft.Data.Sqlite;
-
 namespace DownKyi.Infrastructure.Downloads;
 
 internal static class DownloadTaskSqlReader
@@ -22,69 +19,4 @@ internal static class DownloadTaskSqlReader
         LEFT JOIN downloaded d ON d.id = db.id
         """;
 
-    public static async Task<IReadOnlyList<DownloadTask>> ReadManyAsync(
-        SqliteConnection connection,
-        SqliteCommand command,
-        string sourceTable,
-        DateTimeOffset quarantinedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        var tasks = new List<DownloadTask>();
-        var corrupt = new List<(string RecordId, DownloadRecordCorruptException Error)>();
-        using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
-        {
-            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-            {
-                var recordId = reader.GetString(reader.GetOrdinal("id"));
-                try
-                {
-                    tasks.Add(DownloadTaskRecordMapper.Read(reader));
-                }
-                catch (DownloadRecordCorruptException exception)
-                {
-                    corrupt.Add((recordId, exception));
-                }
-            }
-        }
-
-        foreach (var item in corrupt)
-        {
-            await QuarantineAsync(
-                    connection,
-                    sourceTable,
-                    item.RecordId,
-                    item.Error,
-                    quarantinedAtUtc,
-                    cancellationToken)
-                .ConfigureAwait(false);
-        }
-
-        return tasks;
-    }
-
-    public static async Task QuarantineAsync(
-        SqliteConnection connection,
-        string sourceTable,
-        string recordId,
-        DownloadRecordCorruptException error,
-        DateTimeOffset quarantinedAtUtc,
-        CancellationToken cancellationToken)
-    {
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            INSERT INTO download_quarantine
-                (source_table, record_id, field_name, reason, quarantined_at_utc)
-            VALUES (@source_table, @record_id, @field_name, @reason, @quarantined_at_utc)
-            ON CONFLICT(source_table, record_id) DO UPDATE SET
-                field_name = excluded.field_name,
-                reason = excluded.reason,
-                quarantined_at_utc = excluded.quarantined_at_utc
-            """;
-        command.Parameters.AddWithValue("@source_table", sourceTable);
-        command.Parameters.AddWithValue("@record_id", recordId);
-        command.Parameters.AddWithValue("@field_name", error.FieldName);
-        command.Parameters.AddWithValue("@reason", error.Message);
-        command.Parameters.AddWithValue("@quarantined_at_utc", quarantinedAtUtc.ToUnixTimeMilliseconds());
-        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-    }
 }

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreCommands.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreCommands.cs
@@ -1,0 +1,140 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreCommands(SqliteDownloadStoreDatabase database)
+{
+    private readonly SqliteDownloadStoreDatabase _database = database;
+
+    public Task<OperationResult> UpdateAsync(
+        DownloadTask task,
+        long expectedVersion,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(task);
+        ArgumentOutOfRangeException.ThrowIfNegative(expectedVersion);
+        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(expectedVersion, task.Version);
+
+        return _database.ExecuteTransactionAsync(
+            async (connection, transaction, token) =>
+            {
+                var updated = await DownloadTaskSqlWriter.UpdateBaseAsync(
+                    connection,
+                    transaction,
+                    task,
+                    expectedVersion,
+                    token).ConfigureAwait(false);
+                if (updated == 0)
+                {
+                    return DownloadStoreOperationResults.Conflict(
+                        task.Id,
+                        "has changed since it was loaded");
+                }
+
+                if (task.Phase == DownloadPhase.Deleted)
+                {
+                    await DownloadTaskSqlWriter
+                        .DeleteBaseAsync(connection, transaction, task.Id, token)
+                        .ConfigureAwait(false);
+                }
+                else
+                {
+                    await DownloadTaskSqlWriter
+                        .WriteStateRowAsync(connection, transaction, task, token)
+                        .ConfigureAwait(false);
+                }
+
+                return OperationResult.Success();
+            },
+            cancellationToken);
+    }
+
+    public Task<OperationResult> UpdateProgressAsync(
+        DownloadProgressWrite progressWrite,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(progressWrite);
+        return _database.ExecuteTransactionAsync(
+            async (connection, transaction, token) =>
+            {
+                using var versionCommand = connection.CreateCommand();
+                versionCommand.Transaction = transaction;
+                versionCommand.CommandText = """
+                    UPDATE download_base
+                    SET version = @target_version, updated_at_utc = @updated_at_utc
+                    WHERE id = @id AND version = @expected_version
+                    """;
+                versionCommand.Parameters.AddWithValue("@target_version", progressWrite.TargetVersion);
+                versionCommand.Parameters.AddWithValue(
+                    "@updated_at_utc",
+                    progressWrite.UpdatedAtUtc.ToUnixTimeMilliseconds());
+                versionCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
+                versionCommand.Parameters.AddWithValue("@expected_version", progressWrite.ExpectedVersion);
+                var changed = await versionCommand.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                if (changed == 0)
+                {
+                    return DownloadStoreOperationResults.Conflict(
+                        progressWrite.TaskId,
+                        "has changed since progress was sampled");
+                }
+
+                using var progressCommand = connection.CreateCommand();
+                progressCommand.Transaction = transaction;
+                progressCommand.CommandText = """
+                    UPDATE downloading
+                    SET progress = @progress,
+                        downloaded_bytes = @downloaded_bytes,
+                        total_bytes = @total_bytes,
+                        bytes_per_second = @bytes_per_second,
+                        downloading_file_size = @downloaded_size_text,
+                        speed_display = @speed_text,
+                        max_speed = MAX(max_speed, @bytes_per_second)
+                    WHERE id = @id
+                    """;
+                DownloadTaskSqlWriter.BindProgress(progressCommand, progressWrite.Progress);
+                progressCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
+                changed = await progressCommand.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                return changed == 0
+                    ? DownloadStoreOperationResults.NotFound(progressWrite.TaskId)
+                    : OperationResult.Success();
+            },
+            cancellationToken);
+    }
+
+    public async Task<OperationResult> DeleteAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "DELETE FROM download_base WHERE id = @id";
+        command.Parameters.AddWithValue("@id", taskId.Value);
+        var changed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return changed == 0
+            ? DownloadStoreOperationResults.NotFound(taskId)
+            : OperationResult.Success();
+    }
+
+    public Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken)
+    {
+        return _database.ExecuteTransactionAsync(
+            async (connection, transaction, token) =>
+            {
+                const string sql = """
+                    DELETE FROM download_base
+                    WHERE id IN (SELECT id FROM downloaded)
+                      AND id NOT IN (SELECT id FROM downloading);
+                    DELETE FROM downloaded;
+                    """;
+                using var command = connection.CreateCommand();
+                command.Transaction = transaction;
+                command.CommandText = sql;
+                await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
+                return OperationResult.Success();
+            },
+            cancellationToken);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
@@ -14,6 +14,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
     private readonly SqliteDownloadTaskStoreOptions _options;
     private readonly IClock _clock;
     private readonly ILogger _logger;
+    private readonly Type _disposedObjectType;
     private readonly string _connectionString;
     private readonly SemaphoreSlim _initializationGate = new(1, 1);
     private volatile bool _initialized;
@@ -22,11 +23,13 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
     public SqliteDownloadStoreDatabase(
         SqliteDownloadTaskStoreOptions options,
         IClock clock,
-        ILogger logger)
+        ILogger logger,
+        Type disposedObjectType)
     {
         _options = options;
         _clock = clock;
         _logger = logger;
+        _disposedObjectType = disposedObjectType;
         _connectionString = new SqliteConnectionStringBuilder
         {
             DataSource = options.DatabasePath,
@@ -100,7 +103,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(_disposed, _disposedObjectType);
         if (_initialized)
         {
             return;

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
@@ -1,3 +1,4 @@
+using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using DownKyi.Domain.Results;
 using Microsoft.Data.Sqlite;
@@ -13,6 +14,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
         "Removed {Count} orphaned downloading records.");
     private readonly SqliteDownloadTaskStoreOptions _options;
     private readonly IClock _clock;
+    private readonly IPhysicalOutputPathResolver _physicalOutputPathResolver;
     private readonly ILogger _logger;
     private readonly Type _disposedObjectType;
     private readonly string _connectionString;
@@ -23,11 +25,13 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
     public SqliteDownloadStoreDatabase(
         SqliteDownloadTaskStoreOptions options,
         IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
         ILogger logger,
         Type disposedObjectType)
     {
         _options = options;
         _clock = clock;
+        _physicalOutputPathResolver = physicalOutputPathResolver;
         _logger = logger;
         _disposedObjectType = disposedObjectType;
         _connectionString = new SqliteConnectionStringBuilder
@@ -126,6 +130,7 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
                 _options.DatabasePath,
                 databaseExisted,
                 _clock,
+                _physicalOutputPathResolver,
                 cancellationToken).ConfigureAwait(false);
             await RemoveOrphanedDownloadingRecordsAsync(connection, cancellationToken).ConfigureAwait(false);
             _initialized = true;

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
@@ -1,0 +1,193 @@
+using DownKyi.Application.Time;
+using DownKyi.Domain.Results;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreDatabase : IDisposable
+{
+    private static readonly Action<ILogger, int, Exception?> LogOrphanCleanup = LoggerMessage.Define<int>(
+        LogLevel.Information,
+        new EventId(1001, "DownloadStoreOrphanCleanup"),
+        "Removed {Count} orphaned downloading records.");
+    private readonly SqliteDownloadTaskStoreOptions _options;
+    private readonly IClock _clock;
+    private readonly ILogger _logger;
+    private readonly string _connectionString;
+    private readonly SemaphoreSlim _initializationGate = new(1, 1);
+    private volatile bool _initialized;
+    private bool _disposed;
+
+    public SqliteDownloadStoreDatabase(
+        SqliteDownloadTaskStoreOptions options,
+        IClock clock,
+        ILogger logger)
+    {
+        _options = options;
+        _clock = clock;
+        _logger = logger;
+        _connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = options.DatabasePath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = true,
+            DefaultTimeout = checked((int)Math.Ceiling(options.BusyTimeout.TotalSeconds))
+        }.ToString();
+    }
+
+    public Task InitializeAsync(CancellationToken cancellationToken) =>
+        EnsureInitializedAsync(cancellationToken);
+
+    public async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
+    {
+        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
+        return await OpenConnectionCoreAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task<OperationResult> ExecuteTransactionAsync(
+        Func<SqliteConnection, SqliteTransaction, CancellationToken, Task<OperationResult>> operation,
+        CancellationToken cancellationToken) =>
+        ExecuteTransactionCoreAsync(operation, immediate: false, cancellationToken);
+
+    public Task<OperationResult> ExecuteImmediateTransactionAsync(
+        Func<SqliteConnection, SqliteTransaction, CancellationToken, Task<OperationResult>> operation,
+        CancellationToken cancellationToken) =>
+        ExecuteTransactionCoreAsync(operation, immediate: true, cancellationToken);
+
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _initializationGate.Dispose();
+    }
+
+    private async Task<OperationResult> ExecuteTransactionCoreAsync(
+        Func<SqliteConnection, SqliteTransaction, CancellationToken, Task<OperationResult>> operation,
+        bool immediate,
+        CancellationToken cancellationToken)
+    {
+        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var transaction = immediate
+            ? BeginImmediateTransaction(connection)
+            : (SqliteTransaction)await connection
+                .BeginTransactionAsync(cancellationToken)
+                .ConfigureAwait(false);
+        try
+        {
+            var result = await operation(connection, transaction, cancellationToken).ConfigureAwait(false);
+            if (result.IsSuccess)
+            {
+                await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        if (_initialized)
+        {
+            return;
+        }
+
+        await _initializationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            var databaseExisted = File.Exists(_options.DatabasePath)
+                && new FileInfo(_options.DatabasePath).Length > 0;
+            Directory.CreateDirectory(Path.GetDirectoryName(_options.DatabasePath) ?? ".");
+            using var connection = await OpenConnectionCoreAsync(cancellationToken).ConfigureAwait(false);
+            await DownloadStoreSchema.InitializeAsync(
+                connection,
+                _options.DatabasePath,
+                databaseExisted,
+                _clock,
+                cancellationToken).ConfigureAwait(false);
+            await RemoveOrphanedDownloadingRecordsAsync(connection, cancellationToken).ConfigureAwait(false);
+            _initialized = true;
+        }
+        finally
+        {
+            _initializationGate.Release();
+        }
+    }
+
+    private async Task RemoveOrphanedDownloadingRecordsAsync(
+        SqliteConnection connection,
+        CancellationToken cancellationToken)
+    {
+        using var transaction = (SqliteTransaction)await connection
+            .BeginTransactionAsync(cancellationToken)
+            .ConfigureAwait(false);
+        try
+        {
+            using var command = connection.CreateCommand();
+            command.Transaction = transaction;
+            command.CommandText = """
+                DELETE FROM downloading
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM download_base
+                    WHERE download_base.id = downloading.id)
+                """;
+            var removed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+            if (removed > 0)
+            {
+                LogOrphanCleanup(_logger, removed, null);
+            }
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private async Task<SqliteConnection> OpenConnectionCoreAsync(CancellationToken cancellationToken)
+    {
+        var connection = new SqliteConnection(_connectionString);
+        try
+        {
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                PRAGMA foreign_keys = ON;
+                PRAGMA journal_mode = WAL;
+                PRAGMA synchronous = NORMAL;
+                PRAGMA temp_store = MEMORY;
+                """;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+            return connection;
+        }
+        catch
+        {
+            await connection.DisposeAsync().ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static SqliteTransaction BeginImmediateTransaction(SqliteConnection connection) =>
+        connection.BeginTransaction(deferred: false);
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
@@ -5,9 +5,11 @@ using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Infrastructure.Downloads;
 
-public sealed partial class SqliteDownloadTaskStore
+internal sealed class SqliteDownloadStoreOutputReservations(SqliteDownloadStoreDatabase database)
 {
-    public async Task<OperationResult> AddAsync(
+    private readonly SqliteDownloadStoreDatabase _database = database;
+
+    public Task<OperationResult> AddAsync(
         DownloadTask task,
         CancellationToken cancellationToken)
     {
@@ -17,46 +19,40 @@ public sealed partial class SqliteDownloadTaskStore
             throw new ArgumentException("A deleted task cannot be inserted.", nameof(task));
         }
 
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = BeginImmediateTransaction(connection);
-        try
-        {
-            if (task.Phase != DownloadPhase.Completed &&
-                await IsOutputPathReservedCoreAsync(
-                    connection,
-                    transaction,
-                    task.Output.BasePath,
-                    DownloadOutputPathKey.UsesCaseInsensitiveComparison,
-                    cancellationToken).ConfigureAwait(false))
+        return _database.ExecuteImmediateTransactionAsync(
+            async (connection, transaction, token) =>
             {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return OutputPathConflict();
-            }
+                try
+                {
+                    if (task.Phase != DownloadPhase.Completed &&
+                        await IsOutputPathReservedCoreAsync(
+                            connection,
+                            transaction,
+                            task.Output.BasePath,
+                            DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                            token).ConfigureAwait(false))
+                    {
+                        return DownloadStoreOperationResults.OutputPathConflict();
+                    }
 
-            await DownloadTaskSqlWriter
-                .InsertBaseAsync(connection, transaction, task, cancellationToken)
-                .ConfigureAwait(false);
-            await DownloadTaskSqlWriter
-                .WriteStateRowAsync(connection, transaction, task, cancellationToken)
-                .ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch (SqliteException exception) when (exception.SqliteErrorCode == 19)
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            return exception.Message.Contains(
-                "output_reservation_key",
-                StringComparison.OrdinalIgnoreCase)
-                ? OutputPathConflict()
-                : Conflict(task.Id, "already exists");
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
+                    await DownloadTaskSqlWriter
+                        .InsertBaseAsync(connection, transaction, task, token)
+                        .ConfigureAwait(false);
+                    await DownloadTaskSqlWriter
+                        .WriteStateRowAsync(connection, transaction, task, token)
+                        .ConfigureAwait(false);
+                    return OperationResult.Success();
+                }
+                catch (SqliteException exception) when (exception.SqliteErrorCode == 19)
+                {
+                    return exception.Message.Contains(
+                        "output_reservation_key",
+                        StringComparison.OrdinalIgnoreCase)
+                        ? DownloadStoreOperationResults.OutputPathConflict()
+                        : DownloadStoreOperationResults.Conflict(task.Id, "already exists");
+                }
+            },
+            cancellationToken);
     }
 
     public async Task<bool> IsOutputPathReservedAsync(
@@ -65,8 +61,7 @@ public sealed partial class SqliteDownloadTaskStore
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         return await IsOutputPathReservedCoreAsync(
             connection,
             transaction: null,
@@ -118,16 +113,4 @@ public sealed partial class SqliteDownloadTaskStore
         var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
         return Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture) != 0;
     }
-
-    private static OperationResult OutputPathConflict()
-    {
-        return OperationResult.Failure(new OperationError(
-            "download.store.output_path_reserved",
-            "The selected output path is already reserved by another active download.",
-            OperationErrorKind.Conflict));
-    }
-
-    private static SqliteTransaction BeginImmediateTransaction(SqliteConnection connection) =>
-        connection.BeginTransaction(deferred: false);
-
 }

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
@@ -1,5 +1,6 @@
 using DownKyi.Application.Downloads;
 using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
 using Microsoft.Data.Sqlite;
 
 namespace DownKyi.Infrastructure.Downloads;
@@ -32,6 +33,34 @@ internal sealed class SqliteDownloadStoreQuarantine(SqliteDownloadStoreDatabase 
         }
 
         return records;
+    }
+
+    public async Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT EXISTS (
+                SELECT 1 FROM download_upgrade_admission_gate
+                WHERE singleton_id = 1 AND remote_stopped_confirmed = 0)
+            """;
+        var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return Convert.ToInt64(result, System.Globalization.CultureInfo.InvariantCulture) != 0;
+    }
+
+    public async Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE download_upgrade_admission_gate
+            SET remote_stopped_confirmed = 1
+            WHERE singleton_id = 1
+            """;
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        return OperationResult.Success();
     }
 
     public static async Task RecordAsync(

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQuarantine.cs
@@ -1,0 +1,62 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreQuarantine(SqliteDownloadStoreDatabase database)
+{
+    private readonly SqliteDownloadStoreDatabase _database = database;
+
+    public async Task<IReadOnlyList<QuarantinedDownloadRecord>> GetRecordsAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT quarantine_id, source_table, record_id, field_name, reason, quarantined_at_utc
+            FROM download_quarantine
+            ORDER BY quarantine_id ASC
+            """;
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var records = new List<QuarantinedDownloadRecord>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            records.Add(new QuarantinedDownloadRecord(
+                reader.GetInt64(0),
+                reader.GetString(1),
+                reader.GetString(2),
+                reader.GetString(3),
+                reader.GetString(4),
+                DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(5))));
+        }
+
+        return records;
+    }
+
+    public static async Task RecordAsync(
+        SqliteConnection connection,
+        string sourceTable,
+        string recordId,
+        DownloadRecordCorruptException error,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO download_quarantine
+                (source_table, record_id, field_name, reason, quarantined_at_utc)
+            VALUES (@source_table, @record_id, @field_name, @reason, @quarantined_at_utc)
+            ON CONFLICT(source_table, record_id) DO UPDATE SET
+                field_name = excluded.field_name,
+                reason = excluded.reason,
+                quarantined_at_utc = excluded.quarantined_at_utc
+            """;
+        command.Parameters.AddWithValue("@source_table", sourceTable);
+        command.Parameters.AddWithValue("@record_id", recordId);
+        command.Parameters.AddWithValue("@field_name", error.FieldName);
+        command.Parameters.AddWithValue("@reason", error.Message);
+        command.Parameters.AddWithValue("@quarantined_at_utc", quarantinedAtUtc.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQueries.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreQueries.cs
@@ -1,0 +1,161 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Application.Time;
+using DownKyi.Domain.Downloads;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+internal sealed class SqliteDownloadStoreQueries(
+    SqliteDownloadStoreDatabase database,
+    IClock clock)
+{
+    private const int MaximumHistoryPageSize = 500;
+    private readonly SqliteDownloadStoreDatabase _database = database;
+    private readonly IClock _clock = clock;
+
+    public async Task<DownloadTask?> FindAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(taskId);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
+            WHERE db.id = @id
+              AND NOT EXISTS (
+                  SELECT 1 FROM download_quarantine q
+                  WHERE q.record_id = db.id
+                    AND q.source_table = CASE WHEN d.id IS NULL THEN 'downloading' ELSE 'downloaded' END)
+            """;
+        command.Parameters.AddWithValue("@id", taskId.Value);
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            return null;
+        }
+
+        try
+        {
+            return DownloadTaskRecordMapper.Read(reader);
+        }
+        catch (DownloadRecordCorruptException exception)
+        {
+            var isHistory = !await reader
+                .IsDBNullAsync(reader.GetOrdinal("finished_timestamp"), cancellationToken)
+                .ConfigureAwait(false);
+            var source = isHistory ? "downloaded" : "downloading";
+            await reader.DisposeAsync().ConfigureAwait(false);
+            await SqliteDownloadStoreQuarantine
+                .RecordAsync(connection, source, taskId.Value, exception, _clock.UtcNow, cancellationToken)
+                .ConfigureAwait(false);
+            return null;
+        }
+    }
+
+    public async Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
+            WHERE dl.id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM download_quarantine q
+                  WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+            ORDER BY db.main_title COLLATE NOCASE, db.[order] ASC, db.id ASC
+            """;
+        return await ReadManyAsync(
+            connection,
+            command,
+            "downloading",
+            _clock.UtcNow,
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<DownloadHistoryPage> GetHistoryPageAsync(
+        DownloadHistoryCursor? cursor,
+        int pageSize,
+        CancellationToken cancellationToken)
+    {
+        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(pageSize, MaximumHistoryPageSize);
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
+            WHERE d.id IS NOT NULL
+              AND (@cursor_timestamp IS NULL
+                   OR d.finished_timestamp < @cursor_timestamp
+                   OR (d.finished_timestamp = @cursor_timestamp AND d.id < @cursor_id))
+              AND NOT EXISTS (
+                  SELECT 1 FROM download_quarantine q
+                  WHERE q.source_table = 'downloaded' AND q.record_id = db.id)
+            ORDER BY d.finished_timestamp DESC, d.id DESC
+            LIMIT @limit
+            """;
+        command.Parameters.AddWithValue("@cursor_timestamp", cursor?.FinishedTimestamp ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@cursor_id", cursor?.TaskId.Value ?? string.Empty);
+        command.Parameters.AddWithValue("@limit", checked(pageSize + 1));
+        var items = (await ReadManyAsync(
+                connection,
+                command,
+                "downloaded",
+                _clock.UtcNow,
+                cancellationToken).ConfigureAwait(false))
+            .ToList();
+        var hasMore = items.Count > pageSize;
+        if (hasMore)
+        {
+            items.RemoveAt(items.Count - 1);
+        }
+
+        DownloadHistoryCursor? nextCursor = null;
+        if (hasMore && items.Count > 0)
+        {
+            var last = items[^1];
+            nextCursor = new DownloadHistoryCursor(last.Completion!.FinishedTimestamp, last.Id);
+        }
+
+        return new DownloadHistoryPage(items, nextCursor);
+    }
+
+    private static async Task<IReadOnlyList<DownloadTask>> ReadManyAsync(
+        SqliteConnection connection,
+        SqliteCommand command,
+        string sourceTable,
+        DateTimeOffset quarantinedAtUtc,
+        CancellationToken cancellationToken)
+    {
+        var tasks = new List<DownloadTask>();
+        var corrupt = new List<(string RecordId, DownloadRecordCorruptException Error)>();
+        using (var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var recordId = reader.GetString(reader.GetOrdinal("id"));
+                try
+                {
+                    tasks.Add(DownloadTaskRecordMapper.Read(reader));
+                }
+                catch (DownloadRecordCorruptException exception)
+                {
+                    corrupt.Add((recordId, exception));
+                }
+            }
+        }
+
+        foreach (var item in corrupt)
+        {
+            await SqliteDownloadStoreQuarantine
+                .RecordAsync(
+                    connection,
+                    sourceTable,
+                    item.RecordId,
+                    item.Error,
+                    quarantinedAtUtc,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        return tasks;
+    }
+}

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -16,7 +16,19 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
     private readonly SqliteDownloadStoreQuarantine _quarantine;
 
     public SqliteDownloadTaskStore(SqliteDownloadTaskStoreOptions options, IClock clock)
-        : this(options, clock, NullLogger<SqliteDownloadTaskStore>.Instance)
+        : this(
+            options,
+            clock,
+            new FileSystemPhysicalOutputPathResolver(),
+            NullLogger<SqliteDownloadTaskStore>.Instance)
+    {
+    }
+
+    public SqliteDownloadTaskStore(
+        SqliteDownloadTaskStoreOptions options,
+        IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver)
+        : this(options, clock, physicalOutputPathResolver, NullLogger<SqliteDownloadTaskStore>.Instance)
     {
     }
 
@@ -24,9 +36,19 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         SqliteDownloadTaskStoreOptions options,
         IClock clock,
         ILogger<SqliteDownloadTaskStore> logger)
+        : this(options, clock, new FileSystemPhysicalOutputPathResolver(), logger)
+    {
+    }
+
+    public SqliteDownloadTaskStore(
+        SqliteDownloadTaskStoreOptions options,
+        IClock clock,
+        IPhysicalOutputPathResolver physicalOutputPathResolver,
+        ILogger<SqliteDownloadTaskStore> logger)
     {
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(clock);
+        ArgumentNullException.ThrowIfNull(physicalOutputPathResolver);
         ArgumentNullException.ThrowIfNull(logger);
         if (options.BusyTimeout <= TimeSpan.Zero || options.BusyTimeout > TimeSpan.FromMinutes(1))
         {
@@ -36,6 +58,7 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
         _database = new SqliteDownloadStoreDatabase(
             options,
             clock,
+            physicalOutputPathResolver,
             logger,
             typeof(SqliteDownloadTaskStore));
         _quarantine = new SqliteDownloadStoreQuarantine(_database);
@@ -94,6 +117,16 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
     public async Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
         CancellationToken cancellationToken) =>
         await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false);
+
+    public async Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(
+        CancellationToken cancellationToken) =>
+        await _quarantine.IsLegacyUpgradeAdmissionBlockedAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+        CancellationToken cancellationToken) =>
+        await _quarantine.ConfirmLegacyRemoteTasksStoppedAsync(cancellationToken)
+            .ConfigureAwait(false);
 
     public void Dispose() => _database.Dispose();
 }

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -33,7 +33,11 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
             throw new ArgumentOutOfRangeException(nameof(options));
         }
 
-        _database = new SqliteDownloadStoreDatabase(options, clock, logger);
+        _database = new SqliteDownloadStoreDatabase(
+            options,
+            clock,
+            logger,
+            typeof(SqliteDownloadTaskStore));
         _quarantine = new SqliteDownloadStoreQuarantine(_database);
         _queries = new SqliteDownloadStoreQueries(_database, clock);
         _commands = new SqliteDownloadStoreCommands(_database);

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -2,26 +2,18 @@ using DownKyi.Application.Downloads;
 using DownKyi.Application.Time;
 using DownKyi.Domain.Downloads;
 using DownKyi.Domain.Results;
-using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Infrastructure.Downloads;
 
-public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
+public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
 {
-    private const int MaximumHistoryPageSize = 500;
-    private static readonly Action<ILogger, int, Exception?> LogOrphanCleanup = LoggerMessage.Define<int>(
-        LogLevel.Information,
-        new EventId(1001, "DownloadStoreOrphanCleanup"),
-        "Removed {Count} orphaned downloading records.");
-    private readonly SqliteDownloadTaskStoreOptions _options;
-    private readonly IClock _clock;
-    private readonly ILogger<SqliteDownloadTaskStore> _logger;
-    private readonly string _connectionString;
-    private readonly SemaphoreSlim _initializationGate = new(1, 1);
-    private volatile bool _initialized;
-    private bool _disposed;
+    private readonly SqliteDownloadStoreDatabase _database;
+    private readonly SqliteDownloadStoreQueries _queries;
+    private readonly SqliteDownloadStoreCommands _commands;
+    private readonly SqliteDownloadStoreOutputReservations _outputReservations;
+    private readonly SqliteDownloadStoreQuarantine _quarantine;
 
     public SqliteDownloadTaskStore(SqliteDownloadTaskStoreOptions options, IClock clock)
         : this(options, clock, NullLogger<SqliteDownloadTaskStore>.Instance)
@@ -41,421 +33,63 @@ public sealed partial class SqliteDownloadTaskStore : IDownloadTaskStore, IDispo
             throw new ArgumentOutOfRangeException(nameof(options));
         }
 
-        _options = options;
-        _clock = clock;
-        _logger = logger;
-        _connectionString = new SqliteConnectionStringBuilder
-        {
-            DataSource = options.DatabasePath,
-            Mode = SqliteOpenMode.ReadWriteCreate,
-            Pooling = true,
-            DefaultTimeout = checked((int)Math.Ceiling(options.BusyTimeout.TotalSeconds))
-        }.ToString();
+        _database = new SqliteDownloadStoreDatabase(options, clock, logger);
+        _quarantine = new SqliteDownloadStoreQuarantine(_database);
+        _queries = new SqliteDownloadStoreQueries(_database, clock);
+        _commands = new SqliteDownloadStoreCommands(_database);
+        _outputReservations = new SqliteDownloadStoreOutputReservations(_database);
     }
 
-    public Task InitializeAsync(CancellationToken cancellationToken)
-    {
-        return EnsureInitializedAsync(cancellationToken);
-    }
+    public Task InitializeAsync(CancellationToken cancellationToken) =>
+        _database.InitializeAsync(cancellationToken);
+
+    public async Task<OperationResult> AddAsync(DownloadTask task, CancellationToken cancellationToken) =>
+        await _outputReservations.AddAsync(task, cancellationToken).ConfigureAwait(false);
 
     public async Task<OperationResult> UpdateAsync(
         DownloadTask task,
         long expectedVersion,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(task);
-        ArgumentOutOfRangeException.ThrowIfNegative(expectedVersion);
-        ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual(expectedVersion, task.Version);
-
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        try
-        {
-            var updated = await DownloadTaskSqlWriter.UpdateBaseAsync(
-                connection,
-                transaction,
-                task,
-                expectedVersion,
-                cancellationToken).ConfigureAwait(false);
-            if (updated == 0)
-            {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return Conflict(task.Id, "has changed since it was loaded");
-            }
-
-            if (task.Phase == DownloadPhase.Deleted)
-            {
-                await DownloadTaskSqlWriter
-                    .DeleteBaseAsync(connection, transaction, task.Id, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-            else
-            {
-                await DownloadTaskSqlWriter
-                    .WriteStateRowAsync(connection, transaction, task, cancellationToken)
-                    .ConfigureAwait(false);
-            }
-
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
+        CancellationToken cancellationToken) =>
+        await _commands.UpdateAsync(task, expectedVersion, cancellationToken).ConfigureAwait(false);
 
     public async Task<OperationResult> UpdateProgressAsync(
         DownloadProgressWrite progressWrite,
-        CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(progressWrite);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
+        CancellationToken cancellationToken) =>
+        await _commands.UpdateProgressAsync(progressWrite, cancellationToken).ConfigureAwait(false);
+
+    public async Task<DownloadTask?> FindAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        await _queries.FindAsync(taskId, cancellationToken).ConfigureAwait(false);
+
+    public async Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken) =>
+        await _queries.GetUnfinishedAsync(cancellationToken).ConfigureAwait(false);
+
+    public async Task<bool> IsOutputPathReservedAsync(
+        string basePath,
+        bool ignoreCase,
+        CancellationToken cancellationToken) =>
+        await _outputReservations
+            .IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken)
             .ConfigureAwait(false);
-        try
-        {
-            using var versionCommand = connection.CreateCommand();
-            versionCommand.Transaction = transaction;
-            versionCommand.CommandText = """
-                UPDATE download_base
-                SET version = @target_version, updated_at_utc = @updated_at_utc
-                WHERE id = @id AND version = @expected_version
-                """;
-            versionCommand.Parameters.AddWithValue("@target_version", progressWrite.TargetVersion);
-            versionCommand.Parameters.AddWithValue("@updated_at_utc", progressWrite.UpdatedAtUtc.ToUnixTimeMilliseconds());
-            versionCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
-            versionCommand.Parameters.AddWithValue("@expected_version", progressWrite.ExpectedVersion);
-            var changed = await versionCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            if (changed == 0)
-            {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return Conflict(progressWrite.TaskId, "has changed since progress was sampled");
-            }
-
-            using var progressCommand = connection.CreateCommand();
-            progressCommand.Transaction = transaction;
-            progressCommand.CommandText = """
-                UPDATE downloading
-                SET progress = @progress,
-                    downloaded_bytes = @downloaded_bytes,
-                    total_bytes = @total_bytes,
-                    bytes_per_second = @bytes_per_second,
-                    downloading_file_size = @downloaded_size_text,
-                    speed_display = @speed_text,
-                    max_speed = MAX(max_speed, @bytes_per_second)
-                WHERE id = @id
-                """;
-            DownloadTaskSqlWriter.BindProgress(progressCommand, progressWrite.Progress);
-            progressCommand.Parameters.AddWithValue("@id", progressWrite.TaskId.Value);
-            changed = await progressCommand.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            if (changed == 0)
-            {
-                await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-                return NotFound(progressWrite.TaskId);
-            }
-
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
-
-    public async Task<DownloadTask?> FindAsync(DownloadTaskId taskId, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(taskId);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
-            WHERE db.id = @id
-              AND NOT EXISTS (
-                  SELECT 1 FROM download_quarantine q
-                  WHERE q.record_id = db.id
-                    AND q.source_table = CASE WHEN d.id IS NULL THEN 'downloading' ELSE 'downloaded' END)
-            """;
-        command.Parameters.AddWithValue("@id", taskId.Value);
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        if (!await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            return null;
-        }
-
-        try
-        {
-            return DownloadTaskRecordMapper.Read(reader);
-        }
-        catch (DownloadRecordCorruptException exception)
-        {
-            var isHistory = !await reader
-                .IsDBNullAsync(reader.GetOrdinal("finished_timestamp"), cancellationToken)
-                .ConfigureAwait(false);
-            var source = isHistory ? "downloaded" : "downloading";
-            await reader.DisposeAsync().ConfigureAwait(false);
-            await DownloadTaskSqlReader
-                .QuarantineAsync(connection, source, taskId.Value, exception, _clock.UtcNow, cancellationToken)
-                .ConfigureAwait(false);
-            return null;
-        }
-    }
-
-    public async Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
-            WHERE dl.id IS NOT NULL
-              AND NOT EXISTS (
-                  SELECT 1 FROM download_quarantine q
-                  WHERE q.source_table = 'downloading' AND q.record_id = db.id)
-            ORDER BY db.main_title COLLATE NOCASE, db.[order] ASC, db.id ASC
-            """;
-        return await DownloadTaskSqlReader
-            .ReadManyAsync(connection, command, "downloading", _clock.UtcNow, cancellationToken)
-            .ConfigureAwait(false);
-    }
 
     public async Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,
-        CancellationToken cancellationToken)
-    {
-        ArgumentOutOfRangeException.ThrowIfLessThan(pageSize, 1);
-        ArgumentOutOfRangeException.ThrowIfGreaterThan(pageSize, MaximumHistoryPageSize);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = DownloadTaskSqlReader.SelectColumns + "\n" + """
-            WHERE d.id IS NOT NULL
-              AND (@cursor_timestamp IS NULL
-                   OR d.finished_timestamp < @cursor_timestamp
-                   OR (d.finished_timestamp = @cursor_timestamp AND d.id < @cursor_id))
-              AND NOT EXISTS (
-                  SELECT 1 FROM download_quarantine q
-                  WHERE q.source_table = 'downloaded' AND q.record_id = db.id)
-            ORDER BY d.finished_timestamp DESC, d.id DESC
-            LIMIT @limit
-            """;
-        command.Parameters.AddWithValue("@cursor_timestamp", cursor?.FinishedTimestamp ?? (object)DBNull.Value);
-        command.Parameters.AddWithValue("@cursor_id", cursor?.TaskId.Value ?? string.Empty);
-        command.Parameters.AddWithValue("@limit", checked(pageSize + 1));
-        var items = (await DownloadTaskSqlReader.ReadManyAsync(
-                connection,
-                command,
-                "downloaded",
-                _clock.UtcNow,
-                cancellationToken).ConfigureAwait(false))
-            .ToList();
-        var hasMore = items.Count > pageSize;
-        if (hasMore)
-        {
-            items.RemoveAt(items.Count - 1);
-        }
+        CancellationToken cancellationToken) =>
+        await _queries.GetHistoryPageAsync(cursor, pageSize, cancellationToken).ConfigureAwait(false);
 
-        DownloadHistoryCursor? nextCursor = null;
-        if (hasMore && items.Count > 0)
-        {
-            var last = items[^1];
-            nextCursor = new DownloadHistoryCursor(last.Completion!.FinishedTimestamp, last.Id);
-        }
+    public async Task<OperationResult> DeleteAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken) =>
+        await _commands.DeleteAsync(taskId, cancellationToken).ConfigureAwait(false);
 
-        return new DownloadHistoryPage(items, nextCursor);
-    }
-
-    public async Task<OperationResult> DeleteAsync(DownloadTaskId taskId, CancellationToken cancellationToken)
-    {
-        ArgumentNullException.ThrowIfNull(taskId);
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = "DELETE FROM download_base WHERE id = @id";
-        command.Parameters.AddWithValue("@id", taskId.Value);
-        var changed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-        return changed == 0 ? NotFound(taskId) : OperationResult.Success();
-    }
-
-    public async Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        try
-        {
-            const string sql = """
-                DELETE FROM download_base
-                WHERE id IN (SELECT id FROM downloaded)
-                  AND id NOT IN (SELECT id FROM downloading);
-                DELETE FROM downloaded;
-                """;
-            using var command = connection.CreateCommand();
-            command.Transaction = transaction;
-            command.CommandText = sql;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            return OperationResult.Success();
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
+    public async Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken) =>
+        await _commands.ClearHistoryAsync(cancellationToken).ConfigureAwait(false);
 
     public async Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
-        CancellationToken cancellationToken)
-    {
-        await EnsureInitializedAsync(cancellationToken).ConfigureAwait(false);
-        using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        using var command = connection.CreateCommand();
-        command.CommandText = """
-            SELECT quarantine_id, source_table, record_id, field_name, reason, quarantined_at_utc
-            FROM download_quarantine
-            ORDER BY quarantine_id ASC
-            """;
-        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        var records = new List<QuarantinedDownloadRecord>();
-        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
-        {
-            records.Add(new QuarantinedDownloadRecord(
-                reader.GetInt64(0),
-                reader.GetString(1),
-                reader.GetString(2),
-                reader.GetString(3),
-                reader.GetString(4),
-                DateTimeOffset.FromUnixTimeMilliseconds(reader.GetInt64(5))));
-        }
+        CancellationToken cancellationToken) =>
+        await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false);
 
-        return records;
-    }
-
-    public void Dispose()
-    {
-        if (_disposed)
-        {
-            return;
-        }
-
-        _disposed = true;
-        _initializationGate.Dispose();
-    }
-
-    private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
-    {
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        if (_initialized)
-        {
-            return;
-        }
-
-        await _initializationGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            if (_initialized)
-            {
-                return;
-            }
-
-            var databaseExisted = File.Exists(_options.DatabasePath)
-                && new FileInfo(_options.DatabasePath).Length > 0;
-            Directory.CreateDirectory(Path.GetDirectoryName(_options.DatabasePath) ?? ".");
-            using var connection = await OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-            await DownloadStoreSchema.InitializeAsync(
-                connection,
-                _options.DatabasePath,
-                databaseExisted,
-                _clock,
-                cancellationToken).ConfigureAwait(false);
-            await RemoveOrphanedDownloadingRecordsAsync(connection, cancellationToken).ConfigureAwait(false);
-            _initialized = true;
-        }
-        finally
-        {
-            _initializationGate.Release();
-        }
-    }
-
-    private async Task RemoveOrphanedDownloadingRecordsAsync(
-        SqliteConnection connection,
-        CancellationToken cancellationToken)
-    {
-        using var transaction = (SqliteTransaction)await connection
-            .BeginTransactionAsync(cancellationToken)
-            .ConfigureAwait(false);
-        try
-        {
-            using var command = connection.CreateCommand();
-            command.Transaction = transaction;
-            command.CommandText = """
-                DELETE FROM downloading
-                WHERE NOT EXISTS (
-                    SELECT 1
-                    FROM download_base
-                    WHERE download_base.id = downloading.id)
-                """;
-            var removed = await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-            if (removed > 0)
-            {
-                LogOrphanCleanup(_logger, removed, null);
-            }
-        }
-        catch
-        {
-            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
-            throw;
-        }
-    }
-
-    private async Task<SqliteConnection> OpenConnectionAsync(CancellationToken cancellationToken)
-    {
-        var connection = new SqliteConnection(_connectionString);
-        try
-        {
-            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
-            using var command = connection.CreateCommand();
-            command.CommandText = """
-                PRAGMA foreign_keys = ON;
-                PRAGMA journal_mode = WAL;
-                PRAGMA synchronous = NORMAL;
-                PRAGMA temp_store = MEMORY;
-                """;
-            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
-            return connection;
-        }
-        catch
-        {
-            await connection.DisposeAsync().ConfigureAwait(false);
-            throw;
-        }
-    }
-
-    private static OperationResult Conflict(DownloadTaskId taskId, string reason)
-    {
-        return OperationResult.Failure(new OperationError(
-            "download.store.conflict",
-            $"Download task '{taskId.Value}' {reason}.",
-            OperationErrorKind.Conflict));
-    }
-
-    private static OperationResult NotFound(DownloadTaskId taskId)
-    {
-        return OperationResult.Failure(new OperationError(
-            "download.store.not_found",
-            $"Download task '{taskId.Value}' was not found.",
-            OperationErrorKind.NotFound));
-    }
-
+    public void Dispose() => _database.Dispose();
 }

--- a/tests/DownKyi.Application.Tests/DownloadAddCoordinatorTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadAddCoordinatorTests.cs
@@ -10,6 +10,7 @@ public sealed class DownloadAddCoordinatorTests
         var addWasCalled = false;
 
         var result = await DownloadAddCoordinator.AddToDownloadIfDirectorySelectedAsync(
+            () => Task.FromResult(true),
             () => Task.FromResult<string?>(null),
             _ =>
             {
@@ -28,6 +29,7 @@ public sealed class DownloadAddCoordinatorTests
         string? receivedDirectory = null;
 
         var result = await DownloadAddCoordinator.AddToDownloadIfDirectorySelectedAsync(
+            () => Task.FromResult(true),
             () => Task.FromResult<string?>("D:\\Downloads"),
             directory =>
             {
@@ -38,5 +40,30 @@ public sealed class DownloadAddCoordinatorTests
 
         Assert.Equal(2, result);
         Assert.Equal("D:\\Downloads", receivedDirectory);
+    }
+
+    [Fact]
+    public async Task BlockedAdmissionStopsBeforeDirectorySelectionAndBatchAdd()
+    {
+        var directorySelectionCount = 0;
+        var addCount = 0;
+
+        var result = await DownloadAddCoordinator.AddToDownloadIfDirectorySelectedAsync(
+            () => Task.FromResult(false),
+            () =>
+            {
+                directorySelectionCount++;
+                return Task.FromResult<string?>("D:\\Downloads");
+            },
+            _ =>
+            {
+                addCount++;
+                return Task.FromResult(2);
+            },
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+        Assert.Equal(0, directorySelectionCount);
+        Assert.Equal(0, addCount);
     }
 }

--- a/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
@@ -230,6 +230,51 @@ public sealed class DownloadTaskApplicationServiceTests
         Assert.Equal(1, store.LegacyRemoteStopConfirmationCount);
     }
 
+    [Fact]
+    public async Task BlockedLegacyUpgradeRejectsQueuedTaskBeforeStoreAddAndAllowsSameSessionAfterConfirmation()
+    {
+        var store = new RecordingStore { LegacyUpgradeAdmissionBlocked = true };
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+
+        var admission = await service.CheckNewDownloadAdmissionAsync(
+            TestContext.Current.CancellationToken);
+        var blocked = await service.AddAsync(
+            CreateTask(),
+            TestContext.Current.CancellationToken);
+
+        Assert.False(admission.IsSuccess);
+        Assert.True(DownloadAdmissionErrors.IsLegacyUpgradeBlocked(admission.Error));
+        Assert.False(blocked.IsSuccess);
+        Assert.True(DownloadAdmissionErrors.IsLegacyUpgradeBlocked(blocked.Error));
+        Assert.Equal(0, store.AddCount);
+        Assert.Null(store.Current);
+
+        Assert.True((await service.ConfirmLegacyRemoteTasksStoppedAsync(
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await service.AddAsync(
+            CreateTask(),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.Equal(1, store.AddCount);
+    }
+
+    [Fact]
+    public async Task BlockedLegacyUpgradeDoesNotRejectCompletedHistoryImport()
+    {
+        var store = new RecordingStore { LegacyUpgradeAdmissionBlocked = true };
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+        var started = CreateTask().Start(Epoch.AddSeconds(1)).RequireValue();
+        var completed = started.Complete(
+            new DownloadCompletion(1, "finished", null),
+            Epoch.AddSeconds(2)).RequireValue();
+
+        var result = await service.AddAsync(completed, TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(1, store.AddCount);
+        Assert.Same(completed, store.Current);
+        Assert.True(store.LegacyUpgradeAdmissionBlocked);
+    }
+
     private static DownloadTask CreateTask()
     {
         return DownloadTask.Create(
@@ -277,6 +322,8 @@ public sealed class DownloadTaskApplicationServiceTests
 
         public int LegacyRemoteStopConfirmationCount { get; private set; }
 
+        public int AddCount { get; private set; }
+
         public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<OperationResult> AddAsync(DownloadTask task, CancellationToken cancellationToken)
@@ -284,6 +331,7 @@ public sealed class DownloadTaskApplicationServiceTests
             cancellationToken.ThrowIfCancellationRequested();
             lock (_sync)
             {
+                AddCount++;
                 if (Current != null)
                 {
                     return Task.FromResult(OperationResult.Failure(new OperationError(

--- a/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
@@ -214,6 +214,22 @@ public sealed class DownloadTaskApplicationServiceTests
         Assert.Same(task, store.Current);
     }
 
+    [Fact]
+    public async Task LegacyUpgradeAdmissionStateAndConfirmationDelegateToStore()
+    {
+        var store = new RecordingStore { LegacyUpgradeAdmissionBlocked = true };
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+
+        Assert.True(await service.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.True((await service.ConfirmLegacyRemoteTasksStoppedAsync(
+            TestContext.Current.CancellationToken)).IsSuccess);
+
+        Assert.False(await service.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(1, store.LegacyRemoteStopConfirmationCount);
+    }
+
     private static DownloadTask CreateTask()
     {
         return DownloadTask.Create(
@@ -256,6 +272,10 @@ public sealed class DownloadTaskApplicationServiceTests
         public DownloadTask? Current { get; private set; }
 
         public List<long> ExpectedVersions { get; } = [];
+
+        public bool LegacyUpgradeAdmissionBlocked { get; set; }
+
+        public int LegacyRemoteStopConfirmationCount { get; private set; }
 
         public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
@@ -322,6 +342,18 @@ public sealed class DownloadTaskApplicationServiceTests
             string basePath,
             bool ignoreCase,
             CancellationToken cancellationToken) => Task.FromResult(false);
+
+        public Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(
+            CancellationToken cancellationToken) =>
+            Task.FromResult(LegacyUpgradeAdmissionBlocked);
+
+        public Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+            CancellationToken cancellationToken)
+        {
+            LegacyRemoteStopConfirmationCount++;
+            LegacyUpgradeAdmissionBlocked = false;
+            return Task.FromResult(OperationResult.Success());
+        }
 
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,

--- a/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
+++ b/tests/DownKyi.Architecture.Tests/DownKyi.Architecture.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\DownKyi.Infrastructure\DownKyi.Infrastructure.csproj" />
     <ProjectReference Include="..\..\tools\DownKyi.CentralTestRunner\DownKyi.CentralTestRunner.csproj" />
   </ItemGroup>
 

--- a/tests/DownKyi.Architecture.Tests/DownloadAdmissionArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadAdmissionArchitectureTests.cs
@@ -1,0 +1,122 @@
+namespace DownKyi.Architecture.Tests;
+
+public sealed class DownloadAdmissionArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+
+    [Fact]
+    public void ApplicationOwnsLegacyGatePolicyAndQueuedPersistenceEnforcement()
+    {
+        var service = ReadSource(
+            "src", "DownKyi.Application", "Downloads", "DownloadTaskApplicationService.cs");
+        var errors = ReadSource(
+            "src", "DownKyi.Application", "Downloads", "DownloadAdmissionErrors.cs");
+        var addStart = service.IndexOf(
+            "public async Task<OperationResult<DownloadTask>> AddAsync",
+            StringComparison.Ordinal);
+        var gateCheck = service.IndexOf(
+            "CheckNewDownloadAdmissionAsync(cancellationToken)",
+            addStart,
+            StringComparison.Ordinal);
+        var storeAdd = service.IndexOf("_store.AddAsync(task", addStart, StringComparison.Ordinal);
+
+        Assert.True(addStart >= 0 && gateCheck > addStart && storeAdd > gateCheck);
+        Assert.Contains("task.Phase == DownloadPhase.Queued", service, StringComparison.Ordinal);
+        Assert.Contains("IsLegacyUpgradeAdmissionBlockedAsync", service, StringComparison.Ordinal);
+        Assert.Contains("OperationErrorKind.Conflict", errors, StringComparison.Ordinal);
+        Assert.DoesNotContain("DownKyi.Infrastructure", service, StringComparison.Ordinal);
+        Assert.DoesNotContain("download_upgrade_admission_gate", service, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DesktopOnlyPresentsAndDelegatesTheApplicationGateResult()
+    {
+        var desktopRoot = Path.Combine(RepositoryRoot, "src", "DownKyi.Desktop");
+        var sources = Directory.EnumerateFiles(desktopRoot, "*.cs", SearchOption.AllDirectories)
+            .Select(path => (Path: path, Source: File.ReadAllText(path)))
+            .ToArray();
+        var presenter = sources.Single(item =>
+            item.Path.EndsWith("LegacyDownloadAdmissionPresenter.cs", StringComparison.Ordinal));
+
+        Assert.Contains("_tasks.CheckNewDownloadAdmissionAsync", presenter.Source, StringComparison.Ordinal);
+        Assert.Contains("_tasks", presenter.Source, StringComparison.Ordinal);
+        Assert.Contains("ConfirmLegacyRemoteTasksStoppedAsync", presenter.Source, StringComparison.Ordinal);
+        Assert.Contains("IAppDialogService", presenter.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("IDownloadTaskStore", presenter.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("DownKyi.Infrastructure", presenter.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Aria2cNet", presenter.Source, StringComparison.Ordinal);
+        Assert.DoesNotContain("download_upgrade_admission_gate", presenter.Source, StringComparison.Ordinal);
+        Assert.True(File.ReadLines(presenter.Path).Count() <= 100);
+
+        Assert.Equal(1, sources.Count(item =>
+            item.Source.Contains("CheckNewDownloadAdmissionAsync", StringComparison.Ordinal)));
+        Assert.Equal(1, sources.Count(item =>
+            item.Source.Contains("ConfirmLegacyRemoteTasksStoppedAsync", StringComparison.Ordinal)));
+        Assert.DoesNotContain(sources, item =>
+            item.Source.Contains("IsLegacyUpgradeAdmissionBlockedAsync", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void EveryDesktopAddEntryUsesSharedPreflightBeforeDirectorySelection()
+    {
+        var helper = ReadSource(
+            "src", "DownKyi.Application", "Downloads", "DownloadAddCoordinator.cs");
+        var content = ReadSource(
+            "src", "DownKyi.Desktop", "Services", "Media", "ContentDownloadCoordinator.cs");
+        var video = ReadSource(
+            "src", "DownKyi.Desktop", "Services", "Video", "VideoDetailDownloadCoordinator.cs");
+        var session = ReadSource(
+            "src", "DownKyi.Desktop", "Services", "Download", "AddToDownloadService.cs");
+
+        Assert.True(
+            helper.IndexOf("ensureAdmissionAsync()", StringComparison.Ordinal)
+            < helper.IndexOf("selectDirectoryAsync()", StringComparison.Ordinal));
+        Assert.Contains("addToDownloadSession.EnsureAdmissionAsync", content, StringComparison.Ordinal);
+        Assert.Contains("addService.EnsureAdmissionAsync", video, StringComparison.Ordinal);
+        Assert.Contains("_admissionPresenter.EnsureAdmissionAsync", session, StringComparison.Ordinal);
+        Assert.True(File.ReadLines(Path.Combine(
+            RepositoryRoot,
+            "src", "DownKyi.Desktop", "Services", "Download", "AddToDownloadService.cs")).Count() <= 350);
+    }
+
+    [Fact]
+    public void BlockedCopyExplainsUncertaintyRemoteRiskAndCancelBehavior()
+    {
+        var resources = ReadSource(
+            "src", "DownKyi.Desktop", "Languages", "Default.axaml");
+        var start = resources.IndexOf(
+            "x:Key=\"LegacyDownloadAdmissionBlocked\"",
+            StringComparison.Ordinal);
+        var end = resources.IndexOf("</system:String>", start, StringComparison.Ordinal);
+        var copy = resources[start..end];
+
+        Assert.Contains("保存位置不安全或已经变化", copy, StringComparison.Ordinal);
+        Assert.Contains("无法确认", copy, StringComparison.Ordinal);
+        Assert.Contains("远端 aria2 可能仍在写入文件", copy, StringComparison.Ordinal);
+        Assert.Contains("避免两个 aria2 同时写入", copy, StringComparison.Ordinal);
+        Assert.Contains("停止这些旧任务", copy, StringComparison.Ordinal);
+        Assert.Contains("取消或关闭不会解除阻止", copy, StringComparison.Ordinal);
+        Assert.DoesNotContain("一定在远端", copy, StringComparison.Ordinal);
+    }
+
+    private static string ReadSource(params string[] segments)
+    {
+        return File.ReadAllText(Path.Combine([RepositoryRoot, .. segments]));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
@@ -1,14 +1,20 @@
+using DownKyi.Infrastructure.Downloads;
+
 namespace DownKyi.Architecture.Tests;
 
 public sealed class DownloadStoreSchemaArchitectureTests
 {
+    private const string MigrationOwnerNamespace = "DownKyi.Infrastructure.Downloads";
+    private const string MigrationOwnerPrefix = "DownloadStoreSchemaV";
+    private const string MigrationOwnerSuffix = "Migration";
     private static readonly string RepositoryRoot = FindRepositoryRoot();
-    private static readonly string[] MigrationOwners =
-    [
-        "DownloadStoreSchemaV1Migration",
-        "DownloadStoreSchemaV2Migration",
-        "DownloadStoreSchemaV3Migration"
-    ];
+    private static readonly string[] MigrationOwners = typeof(SqliteDownloadTaskStoreOptions)
+        .Assembly
+        .GetTypes()
+        .Where(IsMigrationOwner)
+        .Select(type => type.Name)
+        .Order(StringComparer.Ordinal)
+        .ToArray();
 
     [Fact]
     public void CoordinatorOwnsUpgradeOrderWithoutOwningMigrationSql()
@@ -44,6 +50,17 @@ public sealed class DownloadStoreSchemaArchitectureTests
     }
 
     [Fact]
+    public void VersionOwnerDiscoveryIncludesFutureVersionsAndRejectsLookalikes()
+    {
+        Assert.NotEmpty(MigrationOwners);
+        Assert.True(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV4Migration"));
+        Assert.False(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV0Migration"));
+        Assert.False(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV04Migration"));
+        Assert.False(IsMigrationOwner(MigrationOwnerNamespace, "DownloadStoreSchemaV4MigrationHelper"));
+        Assert.False(IsMigrationOwner("DownKyi.Infrastructure.Other", "DownloadStoreSchemaV4Migration"));
+    }
+
+    [Fact]
     public void VersionOwnersDoNotDependOnOneAnother()
     {
         foreach (var owner in MigrationOwners)
@@ -65,6 +82,39 @@ public sealed class DownloadStoreSchemaArchitectureTests
             "DownKyi.Infrastructure",
             "Downloads",
             fileName));
+    }
+
+    private static bool IsMigrationOwner(Type type)
+    {
+        return type.DeclaringType is null && IsMigrationOwner(type.Namespace, type.Name);
+    }
+
+    private static bool IsMigrationOwner(string? typeNamespace, string typeName)
+    {
+        if (!string.Equals(typeNamespace, MigrationOwnerNamespace, StringComparison.Ordinal)
+            || !typeName.StartsWith(MigrationOwnerPrefix, StringComparison.Ordinal)
+            || !typeName.EndsWith(MigrationOwnerSuffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var version = typeName.AsSpan(
+            MigrationOwnerPrefix.Length,
+            typeName.Length - MigrationOwnerPrefix.Length - MigrationOwnerSuffix.Length);
+        if (version.IsEmpty || version[0] == '0')
+        {
+            return false;
+        }
+
+        foreach (var character in version)
+        {
+            if (character is < '0' or > '9')
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static string FindRepositoryRoot()

--- a/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
@@ -21,7 +21,7 @@ public sealed class DownloadStoreSchemaArchitectureTests
     {
         var source = ReadDownloadSource("DownloadStoreSchema.cs");
 
-        Assert.Contains("public const int CurrentVersion = 3", source, StringComparison.Ordinal);
+        Assert.Contains("public const int CurrentVersion = 4", source, StringComparison.Ordinal);
         Assert.Contains("BeginTransactionAsync", source, StringComparison.Ordinal);
         Assert.Contains("CommitAsync", source, StringComparison.Ordinal);
         Assert.Contains("RollbackAsync", source, StringComparison.Ordinal);
@@ -72,6 +72,29 @@ public sealed class DownloadStoreSchemaArchitectureTests
                 otherOwners,
                 otherOwner => Assert.DoesNotContain(otherOwner, source, StringComparison.Ordinal));
         }
+    }
+
+    [Fact]
+    public void VersionFourOwnsOnlyLegacyClassificationQuarantineAndAdmissionState()
+    {
+        var source = ReadDownloadSource("DownloadStoreSchemaV4Migration.cs");
+
+        Assert.Contains("IPhysicalOutputPathResolver", source, StringComparison.Ordinal);
+        Assert.Contains("DownloadOutputPathKey.Create", source, StringComparison.Ordinal);
+        Assert.Contains("download_quarantine", source, StringComparison.Ordinal);
+        Assert.Contains("download_upgrade_admission_gate", source, StringComparison.Ordinal);
+        Assert.Contains("NOT EXISTS (", source, StringComparison.Ordinal);
+        Assert.Contains("FROM downloaded", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("UPDATE download_base", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("UPDATE downloading", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("DELETE FROM", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("File.Delete", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Directory.Delete", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("File.Move", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Directory.Move", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Aria2", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(".Stop", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ResetAsync", source, StringComparison.OrdinalIgnoreCase);
     }
 
     private static string ReadDownloadSource(string fileName)

--- a/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/DownloadStoreSchemaArchitectureTests.cs
@@ -1,0 +1,85 @@
+namespace DownKyi.Architecture.Tests;
+
+public sealed class DownloadStoreSchemaArchitectureTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string[] MigrationOwners =
+    [
+        "DownloadStoreSchemaV1Migration",
+        "DownloadStoreSchemaV2Migration",
+        "DownloadStoreSchemaV3Migration"
+    ];
+
+    [Fact]
+    public void CoordinatorOwnsUpgradeOrderWithoutOwningMigrationSql()
+    {
+        var source = ReadDownloadSource("DownloadStoreSchema.cs");
+
+        Assert.Contains("public const int CurrentVersion = 3", source, StringComparison.Ordinal);
+        Assert.Contains("BeginTransactionAsync", source, StringComparison.Ordinal);
+        Assert.Contains("CommitAsync", source, StringComparison.Ordinal);
+        Assert.Contains("RollbackAsync", source, StringComparison.Ordinal);
+        Assert.Contains("BackupAsync", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CommandText", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CREATE TABLE", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("ALTER TABLE", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("CREATE INDEX", source, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("UPDATE downloading", source, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VersionOwnersAreNamedNonPartialAndReceiveTheCompleteMigrationContext()
+    {
+        foreach (var owner in MigrationOwners)
+        {
+            var source = ReadDownloadSource($"{owner}.cs");
+
+            Assert.Contains($"internal static class {owner}", source, StringComparison.Ordinal);
+            Assert.DoesNotContain($"partial class {owner}", source, StringComparison.Ordinal);
+            Assert.Contains("SqliteConnection connection", source, StringComparison.Ordinal);
+            Assert.Contains("SqliteTransaction transaction", source, StringComparison.Ordinal);
+            Assert.Contains("DateTimeOffset appliedAtUtc", source, StringComparison.Ordinal);
+            Assert.Contains("CancellationToken cancellationToken", source, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void VersionOwnersDoNotDependOnOneAnother()
+    {
+        foreach (var owner in MigrationOwners)
+        {
+            var source = ReadDownloadSource($"{owner}.cs");
+            var otherOwners = MigrationOwners.Where(candidate => candidate != owner);
+
+            Assert.All(
+                otherOwners,
+                otherOwner => Assert.DoesNotContain(otherOwner, source, StringComparison.Ordinal));
+        }
+    }
+
+    private static string ReadDownloadSource(string fileName)
+    {
+        return File.ReadAllText(Path.Combine(
+            RepositoryRoot,
+            "src",
+            "DownKyi.Infrastructure",
+            "Downloads",
+            fileName));
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ModuleBoundaryBaselineTests.cs
@@ -264,22 +264,35 @@ public sealed class ModuleBoundaryBaselineTests
     }
 
     [Fact]
-    public void SqliteDownloadStoreCoordinatesDedicatedRecordAndCommandOwners()
+    public void SqliteDownloadStoreCoordinatesDedicatedPersistenceOwners()
     {
         var downloadRoot = Path.Combine(RepositoryRoot, "src", "DownKyi.Infrastructure", "Downloads");
         var storeSource = File.ReadAllText(Path.Combine(downloadRoot, "SqliteDownloadTaskStore.cs"));
+        var querySource = File.ReadAllText(Path.Combine(downloadRoot, "SqliteDownloadStoreQueries.cs"));
+        var commandSource = File.ReadAllText(Path.Combine(downloadRoot, "SqliteDownloadStoreCommands.cs"));
+        var reservationSource = File.ReadAllText(Path.Combine(
+            downloadRoot,
+            "SqliteDownloadStoreOutputReservations.cs"));
+        var quarantineSource = File.ReadAllText(Path.Combine(
+            downloadRoot,
+            "SqliteDownloadStoreQuarantine.cs"));
         var mapperSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskRecordMapper.cs"));
         var readerSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskSqlReader.cs"));
         var writerSource = File.ReadAllText(Path.Combine(downloadRoot, "DownloadTaskSqlWriter.cs"));
 
-        Assert.Contains("DownloadTaskRecordMapper.Read", storeSource, StringComparison.Ordinal);
-        Assert.Contains("DownloadTaskSqlReader.ReadManyAsync", storeSource, StringComparison.Ordinal);
-        Assert.Contains("DownloadTaskSqlWriter", storeSource, StringComparison.Ordinal);
-        Assert.Contains("WriteStateRowAsync", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreQueries", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreCommands", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreOutputReservations", storeSource, StringComparison.Ordinal);
+        Assert.Contains("SqliteDownloadStoreQuarantine", storeSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskRecordMapper.Read", querySource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlReader.SelectColumns", querySource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlWriter", commandSource, StringComparison.Ordinal);
+        Assert.Contains("DownloadTaskSqlWriter", reservationSource, StringComparison.Ordinal);
         Assert.DoesNotContain("DownloadTask.Restore", storeSource, StringComparison.Ordinal);
         Assert.DoesNotContain("INSERT INTO downloading", storeSource, StringComparison.Ordinal);
         Assert.Contains("DownloadTask.Restore", mapperSource, StringComparison.Ordinal);
-        Assert.Contains("INSERT INTO download_quarantine", readerSource, StringComparison.Ordinal);
+        Assert.Contains("SELECT", readerSource, StringComparison.Ordinal);
+        Assert.Contains("INSERT INTO download_quarantine", quarantineSource, StringComparison.Ordinal);
         Assert.Contains("INSERT INTO downloading", writerSource, StringComparison.Ordinal);
     }
 

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -3,9 +3,54 @@ namespace DownKyi.Architecture.Tests;
 public sealed class SqliteDownloadTaskStoreArchitectureTests
 {
     private const string FacadeFile = "SqliteDownloadTaskStore.cs";
+    private const string Facade = "SqliteDownloadTaskStore";
     private const string Database = "SqliteDownloadStoreDatabase";
     private static readonly string RepositoryRoot = FindRepositoryRoot();
     private static readonly string[] SqlMarkers = ["SELECT ", "INSERT ", "UPDATE ", "DELETE ", "PRAGMA "];
+    private static readonly string[] ForbiddenOwnerTokens =
+    [
+        Facade,
+        "IServiceProvider",
+        "IServiceScope",
+        "IServiceScopeFactory",
+        "ServiceProvider",
+        "GetService",
+        "GetRequiredService",
+        "CreateScope",
+        "ActivatorUtilities",
+        "Reflection",
+        "BindingFlags",
+        "MethodInfo",
+        "PropertyInfo",
+        "FieldInfo",
+        "ConstructorInfo",
+        "Assembly",
+        "Activator",
+        "dynamic"
+    ];
+    private static readonly Dictionary<string, string> ExpectedFacadeDelegations = new(StringComparer.Ordinal)
+    {
+        ["InitializeAsync"] = "_database.InitializeAsync(cancellationToken)",
+        ["AddAsync"] = "await _outputReservations.AddAsync(task, cancellationToken).ConfigureAwait(false)",
+        ["UpdateAsync"] =
+            "await _commands.UpdateAsync(task, expectedVersion, cancellationToken).ConfigureAwait(false)",
+        ["UpdateProgressAsync"] =
+            "await _commands.UpdateProgressAsync(progressWrite, cancellationToken).ConfigureAwait(false)",
+        ["FindAsync"] = "await _queries.FindAsync(taskId, cancellationToken).ConfigureAwait(false)",
+        ["GetUnfinishedAsync"] =
+            "await _queries.GetUnfinishedAsync(cancellationToken).ConfigureAwait(false)",
+        ["IsOutputPathReservedAsync"] =
+            "await _outputReservations.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken)" +
+            ".ConfigureAwait(false)",
+        ["GetHistoryPageAsync"] =
+            "await _queries.GetHistoryPageAsync(cursor, pageSize, cancellationToken).ConfigureAwait(false)",
+        ["DeleteAsync"] = "await _commands.DeleteAsync(taskId, cancellationToken).ConfigureAwait(false)",
+        ["ClearHistoryAsync"] =
+            "await _commands.ClearHistoryAsync(cancellationToken).ConfigureAwait(false)",
+        ["GetQuarantinedRecordsAsync"] =
+            "await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false)",
+        ["Dispose"] = "_database.Dispose()"
+    };
     private static readonly string[] Collaborators =
     [
         "SqliteDownloadStoreQueries",
@@ -38,6 +83,7 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         Assert.All(
             Collaborators,
             collaborator => Assert.Contains($"new {collaborator}", source, StringComparison.Ordinal));
+        Assert.Empty(FindFacadeDelegationViolations(source, ExpectedFacadeDelegations));
     }
 
     [Fact]
@@ -63,6 +109,52 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         Assert.All(
             Collaborators,
             collaborator => Assert.DoesNotContain(collaborator, database, StringComparison.Ordinal));
+
+        foreach (var owner in Collaborators.Append(Database))
+        {
+            Assert.Empty(FindForbiddenOwnerDependencyViolations(
+                owner,
+                ReadDownloadSource($"{owner}.cs")));
+        }
+    }
+
+    [Fact]
+    public void FacadeDelegationRuleRejectsPolicyControlFlow()
+    {
+        const string source = """
+            public sealed class SqliteDownloadTaskStore
+            {
+                public async Task AddAsync(object task, CancellationToken cancellationToken) =>
+                    task is null
+                        ? throw new ArgumentNullException(nameof(task))
+                        : await _outputReservations.AddAsync(task, cancellationToken).ConfigureAwait(false);
+            }
+            """;
+        var expected = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["AddAsync"] = ExpectedFacadeDelegations["AddAsync"]
+        };
+
+        var violations = FindFacadeDelegationViolations(source, expected);
+
+        Assert.Contains(violations, violation => violation.Contains("AddAsync", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("SqliteDownloadTaskStore", "public facade")]
+    [InlineData("IServiceProvider", "service resolution")]
+    [InlineData("GetRequiredService", "service resolution")]
+    [InlineData("BindingFlags", "reflection")]
+    [InlineData("DownloadStoreContext", "general context")]
+    public void OwnerDependencyRuleRejectsForbiddenTypeTokens(string token, string expectedReason)
+    {
+        var source = $"internal sealed class Owner {{ private {token} _dependency; }}";
+
+        var violations = FindForbiddenOwnerDependencyViolations("Owner", source);
+
+        Assert.Contains(violations, violation =>
+            violation.Contains(token, StringComparison.Ordinal) &&
+            violation.Contains(expectedReason, StringComparison.Ordinal));
     }
 
     [Fact]
@@ -97,6 +189,221 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
 
     private static string ReadDownloadSource(string fileName) =>
         File.ReadAllText(Path.Combine(DownloadSourceRoot, fileName));
+
+    private static List<string> FindFacadeDelegationViolations(
+        string source,
+        IReadOnlyDictionary<string, string> expectedDelegations)
+    {
+        var tokens = Tokenize(source);
+        var violations = new List<string>();
+        var found = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < tokens.Count; index++)
+        {
+            if (tokens[index] != "public")
+            {
+                continue;
+            }
+
+            var delimiter = FindHeaderDelimiter(tokens, index + 1);
+            if (delimiter < 0 || tokens[delimiter] != "(")
+            {
+                continue;
+            }
+
+            var methodName = tokens[delimiter - 1];
+            if (methodName == Facade)
+            {
+                continue;
+            }
+
+            if (!expectedDelegations.TryGetValue(methodName, out var expectedExpression))
+            {
+                violations.Add($"Facade has unexpected public method '{methodName}'.");
+                continue;
+            }
+
+            found.Add(methodName);
+            var closeParenthesis = FindMatchingParenthesis(tokens, delimiter);
+            if (closeParenthesis < 0 || closeParenthesis + 1 >= tokens.Count ||
+                tokens[closeParenthesis + 1] != "=>")
+            {
+                violations.Add($"Facade method '{methodName}' must be expression-bodied delegation.");
+                continue;
+            }
+
+            var semicolon = tokens.IndexOf(";", closeParenthesis + 2);
+            if (semicolon < 0)
+            {
+                violations.Add($"Facade method '{methodName}' has no terminating semicolon.");
+                continue;
+            }
+
+            var actual = tokens.GetRange(closeParenthesis + 2, semicolon - closeParenthesis - 2);
+            var expected = Tokenize(expectedExpression);
+            if (!actual.SequenceEqual(expected, StringComparer.Ordinal))
+            {
+                violations.Add(
+                    $"Facade method '{methodName}' must only delegate to its assigned owner. " +
+                    $"Expected '{string.Join(' ', expected)}'; actual '{string.Join(' ', actual)}'.");
+            }
+        }
+
+        foreach (var missing in expectedDelegations.Keys.Except(found, StringComparer.Ordinal))
+        {
+            violations.Add($"Facade method '{missing}' is missing.");
+        }
+
+        return violations;
+    }
+
+    private static List<string> FindForbiddenOwnerDependencyViolations(
+        string owner,
+        string source)
+    {
+        var identifiers = Tokenize(source)
+            .Where(token => token.Length > 0 && (char.IsLetter(token[0]) || token[0] == '_'))
+            .ToHashSet(StringComparer.Ordinal);
+        var violations = new List<string>();
+        foreach (var token in ForbiddenOwnerTokens.Where(identifiers.Contains))
+        {
+            var reason = token switch
+            {
+                Facade => "public facade",
+                "IServiceProvider" or "IServiceScope" or "IServiceScopeFactory" or "ServiceProvider" or
+                    "GetService" or "GetRequiredService" or "CreateScope" or "ActivatorUtilities" =>
+                    "service resolution",
+                _ => "reflection"
+            };
+            violations.Add($"{owner} references forbidden {reason} token '{token}'.");
+        }
+
+        foreach (var context in identifiers.Where(identifier => identifier.EndsWith("Context", StringComparison.Ordinal)))
+        {
+            violations.Add($"{owner} references forbidden general context token '{context}'.");
+        }
+
+        return violations;
+    }
+
+    private static int FindHeaderDelimiter(List<string> tokens, int start)
+    {
+        for (var index = start; index < tokens.Count; index++)
+        {
+            if (tokens[index] is "(" or "{" or ";" or "=>")
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static int FindMatchingParenthesis(List<string> tokens, int openParenthesis)
+    {
+        var depth = 0;
+        for (var index = openParenthesis; index < tokens.Count; index++)
+        {
+            if (tokens[index] == "(")
+            {
+                depth++;
+            }
+            else if (tokens[index] == ")" && --depth == 0)
+            {
+                return index;
+            }
+        }
+
+        return -1;
+    }
+
+    private static List<string> Tokenize(string source)
+    {
+        var tokens = new List<string>();
+        for (var index = 0; index < source.Length;)
+        {
+            if (char.IsWhiteSpace(source[index]))
+            {
+                index++;
+                continue;
+            }
+
+            if (source[index] == '/' && index + 1 < source.Length && source[index + 1] == '/')
+            {
+                index = source.IndexOf('\n', index + 2);
+                if (index < 0)
+                {
+                    break;
+                }
+
+                continue;
+            }
+
+            if (source[index] == '/' && index + 1 < source.Length && source[index + 1] == '*')
+            {
+                var endComment = source.IndexOf("*/", index + 2, StringComparison.Ordinal);
+                index = endComment < 0 ? source.Length : endComment + 2;
+                continue;
+            }
+
+            if (source[index] is '"' or '\'')
+            {
+                index = SkipLiteral(source, index, source[index]);
+                continue;
+            }
+
+            if (char.IsLetter(source[index]) || source[index] == '_')
+            {
+                var start = index++;
+                while (index < source.Length &&
+                       (char.IsLetterOrDigit(source[index]) || source[index] == '_'))
+                {
+                    index++;
+                }
+
+                tokens.Add(source[start..index]);
+                continue;
+            }
+
+            if (source[index] == '=' && index + 1 < source.Length && source[index + 1] == '>')
+            {
+                tokens.Add("=>");
+                index += 2;
+                continue;
+            }
+
+            tokens.Add(source[index].ToString());
+            index++;
+        }
+
+        return tokens;
+    }
+
+    private static int SkipLiteral(string source, int start, char delimiter)
+    {
+        var quoteCount = delimiter == '"'
+            ? source.AsSpan(start).IndexOfAnyExcept('"')
+            : 1;
+        if (quoteCount >= 3)
+        {
+            var rawDelimiter = new string('"', quoteCount);
+            var rawEnd = source.IndexOf(rawDelimiter, start + quoteCount, StringComparison.Ordinal);
+            return rawEnd < 0 ? source.Length : rawEnd + quoteCount;
+        }
+
+        for (var index = start + 1; index < source.Length; index++)
+        {
+            if (source[index] == '\\')
+            {
+                index++;
+            }
+            else if (source[index] == delimiter)
+            {
+                return index + 1;
+            }
+        }
+
+        return source.Length;
+    }
 
     private static string FindRepositoryRoot()
     {

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -1,0 +1,116 @@
+namespace DownKyi.Architecture.Tests;
+
+public sealed class SqliteDownloadTaskStoreArchitectureTests
+{
+    private const string FacadeFile = "SqliteDownloadTaskStore.cs";
+    private const string Database = "SqliteDownloadStoreDatabase";
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string[] SqlMarkers = ["SELECT ", "INSERT ", "UPDATE ", "DELETE ", "PRAGMA "];
+    private static readonly string[] Collaborators =
+    [
+        "SqliteDownloadStoreQueries",
+        "SqliteDownloadStoreCommands",
+        "SqliteDownloadStoreOutputReservations",
+        "SqliteDownloadStoreQuarantine"
+    ];
+
+    [Fact]
+    public void FacadeIsNonPartialAndContainsNoSql()
+    {
+        var source = ReadDownloadSource(FacadeFile);
+
+        Assert.Contains("public sealed class SqliteDownloadTaskStore", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("partial class SqliteDownloadTaskStore", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CommandText", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Microsoft.Data.Sqlite", source, StringComparison.Ordinal);
+        Assert.All(
+            SqlMarkers,
+            sql => Assert.DoesNotContain(sql, source, StringComparison.OrdinalIgnoreCase));
+        Assert.False(File.Exists(Path.Combine(DownloadSourceRoot, "SqliteDownloadTaskStore.OutputReservations.cs")));
+    }
+
+    [Fact]
+    public void FacadeDelegatesToExplicitCollaborators()
+    {
+        var source = ReadDownloadSource(FacadeFile);
+
+        Assert.Contains($"new {Database}", source, StringComparison.Ordinal);
+        Assert.All(
+            Collaborators,
+            collaborator => Assert.Contains($"new {collaborator}", source, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void CollaboratorsDependOnDatabaseWithoutPeerCoupling()
+    {
+        foreach (var collaborator in Collaborators)
+        {
+            var source = ReadDownloadSource($"{collaborator}.cs");
+            Assert.Contains($"internal sealed class {collaborator}", source, StringComparison.Ordinal);
+            Assert.Contains(Database, source, StringComparison.Ordinal);
+            Assert.DoesNotContain($"partial class {collaborator}", source, StringComparison.Ordinal);
+
+            var forbiddenPeers = Collaborators.Where(peer =>
+                peer != collaborator &&
+                !(collaborator == "SqliteDownloadStoreQueries" &&
+                  peer == "SqliteDownloadStoreQuarantine"));
+            Assert.All(
+                forbiddenPeers,
+                peer => Assert.DoesNotContain(peer, source, StringComparison.Ordinal));
+        }
+
+        var database = ReadDownloadSource($"{Database}.cs");
+        Assert.All(
+            Collaborators,
+            collaborator => Assert.DoesNotContain(collaborator, database, StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void DatabaseOwnsConnectionsInitializationAndStoreTransactionBoundaries()
+    {
+        var database = ReadDownloadSource($"{Database}.cs");
+        Assert.Contains("new SqliteConnection", database, StringComparison.Ordinal);
+        Assert.Contains("SemaphoreSlim", database, StringComparison.Ordinal);
+        Assert.Contains("DownloadStoreSchema.InitializeAsync", database, StringComparison.Ordinal);
+        Assert.Contains("RemoveOrphanedDownloadingRecordsAsync", database, StringComparison.Ordinal);
+        Assert.Contains("BeginTransaction", database, StringComparison.Ordinal);
+        Assert.Contains("CommitAsync", database, StringComparison.Ordinal);
+        Assert.Contains("RollbackAsync", database, StringComparison.Ordinal);
+
+        foreach (var file in new[] { FacadeFile }.Concat(Collaborators.Select(name => $"{name}.cs")))
+        {
+            var source = ReadDownloadSource(file);
+            Assert.DoesNotContain("new SqliteConnection", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("BeginTransaction", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("CommitAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("RollbackAsync", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("SemaphoreSlim", source, StringComparison.Ordinal);
+            Assert.DoesNotContain("DownloadStoreSchema.InitializeAsync", source, StringComparison.Ordinal);
+        }
+    }
+
+    private static string DownloadSourceRoot => Path.Combine(
+        RepositoryRoot,
+        "src",
+        "DownKyi.Infrastructure",
+        "Downloads");
+
+    private static string ReadDownloadSource(string fileName) =>
+        File.ReadAllText(Path.Combine(DownloadSourceRoot, fileName));
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root.");
+    }
+}

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -191,6 +191,23 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
     }
 
     [Fact]
+    public void OwnerDependencyRuleRejectsNullConditionalReflectionInvocationSequence()
+    {
+        const string source = """
+            internal sealed class Owner
+            {
+                public object? Build(object target) =>
+                    target.GetType().GetMethod("Build")?.Invoke(target, parameters: null);
+            }
+            """;
+
+        var violations = FindForbiddenOwnerDependencyViolations("Owner", source);
+
+        Assert.Contains(violations, violation =>
+            violation.Contains("GetType().GetMethod(...).Invoke", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void OwnerDependencyRuleIgnoresReflectionWordsInCommentsAndLiterals()
     {
         const string source = """"
@@ -358,6 +375,11 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
 
             var cursor = lookupClose + 1;
             while (cursor < tokens.Count && tokens[cursor] == "!")
+            {
+                cursor++;
+            }
+
+            if (cursor + 1 < tokens.Count && tokens[cursor] == "?" && tokens[cursor + 1] == ".")
             {
                 cursor++;
             }

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -28,6 +28,22 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         "Activator",
         "dynamic"
     ];
+    private static readonly HashSet<string> ReflectionLookups =
+    [
+        "GetMethod",
+        "GetProperty",
+        "GetField",
+        "GetConstructor",
+        "GetEvent",
+        "GetMember"
+    ];
+    private static readonly HashSet<string> ReflectionInvocations =
+    [
+        "Invoke",
+        "GetValue",
+        "SetValue",
+        "CreateDelegate"
+    ];
     private static readonly Dictionary<string, string> ExpectedFacadeDelegations = new(StringComparer.Ordinal)
     {
         ["InitializeAsync"] = "_database.InitializeAsync(cancellationToken)",
@@ -158,6 +174,38 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
     }
 
     [Fact]
+    public void OwnerDependencyRuleRejectsReflectionLookupInvocationSequence()
+    {
+        const string source = """
+            internal sealed class Owner
+            {
+                public object? Build(object target) =>
+                    target.GetType().GetMethod("Build")!.Invoke(target, parameters: null);
+            }
+            """;
+
+        var violations = FindForbiddenOwnerDependencyViolations("Owner", source);
+
+        Assert.Contains(violations, violation =>
+            violation.Contains("GetType().GetMethod(...).Invoke", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void OwnerDependencyRuleIgnoresReflectionWordsInCommentsAndLiterals()
+    {
+        const string source = """"
+            internal sealed class Owner
+            {
+                // target.GetType().GetMethod("Build")!.Invoke(...)
+                private const string Text = "GetType GetMethod Invoke";
+                private const string RawText = """target.GetType().GetMethod("Build")!.Invoke(...)""";
+            }
+            """";
+
+        Assert.Empty(FindForbiddenOwnerDependencyViolations("Owner", source));
+    }
+
+    [Fact]
     public void DatabaseOwnsConnectionsInitializationAndStoreTransactionBoundaries()
     {
         var database = ReadDownloadSource($"{Database}.cs");
@@ -260,7 +308,8 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         string owner,
         string source)
     {
-        var identifiers = Tokenize(source)
+        var tokens = Tokenize(source);
+        var identifiers = tokens
             .Where(token => token.Length > 0 && (char.IsLetter(token[0]) || token[0] == '_'))
             .ToHashSet(StringComparer.Ordinal);
         var violations = new List<string>();
@@ -282,7 +331,45 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
             violations.Add($"{owner} references forbidden general context token '{context}'.");
         }
 
+        AddReflectionSequenceViolations(owner, tokens, violations);
+
         return violations;
+    }
+
+    private static void AddReflectionSequenceViolations(
+        string owner,
+        List<string> tokens,
+        List<string> violations)
+    {
+        for (var index = 0; index + 5 < tokens.Count; index++)
+        {
+            if (tokens[index] != "GetType" || tokens[index + 1] != "(" || tokens[index + 2] != ")" ||
+                tokens[index + 3] != "." || !ReflectionLookups.Contains(tokens[index + 4]) ||
+                tokens[index + 5] != "(")
+            {
+                continue;
+            }
+
+            var lookupClose = FindMatchingParenthesis(tokens, index + 5);
+            if (lookupClose < 0)
+            {
+                continue;
+            }
+
+            var cursor = lookupClose + 1;
+            while (cursor < tokens.Count && tokens[cursor] == "!")
+            {
+                cursor++;
+            }
+
+            if (cursor + 2 < tokens.Count && tokens[cursor] == "." &&
+                ReflectionInvocations.Contains(tokens[cursor + 1]) && tokens[cursor + 2] == "(")
+            {
+                violations.Add(
+                    $"{owner} uses forbidden reflection call sequence " +
+                    $"'GetType().{tokens[index + 4]}(...).{tokens[cursor + 1]}(...)'.");
+            }
+        }
     }
 
     private static int FindHeaderDelimiter(List<string> tokens, int start)

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -65,6 +65,12 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
             "await _commands.ClearHistoryAsync(cancellationToken).ConfigureAwait(false)",
         ["GetQuarantinedRecordsAsync"] =
             "await _quarantine.GetRecordsAsync(cancellationToken).ConfigureAwait(false)",
+        ["IsLegacyUpgradeAdmissionBlockedAsync"] =
+            "await _quarantine.IsLegacyUpgradeAdmissionBlockedAsync(cancellationToken)" +
+            ".ConfigureAwait(false)",
+        ["ConfirmLegacyRemoteTasksStoppedAsync"] =
+            "await _quarantine.ConfirmLegacyRemoteTasksStoppedAsync(cancellationToken)" +
+            ".ConfigureAwait(false)",
         ["Dispose"] = "_database.Dispose()"
     };
     private static readonly string[] Collaborators =

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -120,17 +120,62 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
     }
 
     [Fact]
-    public async Task VersionThreePhysicalResolverFailureQuarantinesAndBlocksAdmission()
+    public async Task VersionThreePhysicalAliasCollisionQuarantinesEntireGroupOnly()
     {
-        var originalPath = Path.Combine(_directory, "unresolved", "video");
-        await CreateVersionThreeDatabaseAsync(CreatePausedTask("unresolved", originalPath));
-        var before = await ReadStoredStateAsync("unresolved");
-        using var store = CreateStore(new StubPhysicalOutputPathResolver(
-            _ => throw new IOException("Synthetic resolver failure.")));
+        var physicalPath = Path.Combine(_directory, "physical", "video");
+        var aliasPath = Path.Combine(_directory, "alias", "video");
+        var otherPath = Path.Combine(_directory, "other", "video");
+        await CreateVersionThreeDatabaseAsync(
+            CreatePausedTask("physical", physicalPath),
+            CreatePausedTask("alias", aliasPath),
+            CreatePausedTask("other", otherPath));
+        var physicalBefore = await ReadStoredStateAsync("physical");
+        var aliasBefore = await ReadStoredStateAsync("alias");
+        var otherBefore = await ReadStoredStateAsync("other");
+        var resolutionCalls = new Dictionary<string, int>(StringComparer.Ordinal);
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(path =>
+        {
+            resolutionCalls[path] = resolutionCalls.GetValueOrDefault(path) + 1;
+            return path == aliasPath ? physicalPath : path;
+        }));
 
         await store.InitializeAsync(TestContext.Current.CancellationToken);
 
-        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(3, resolutionCalls.Count);
+        Assert.All(resolutionCalls.Values, count => Assert.Equal(1, count));
+        Assert.Equal(
+            "other",
+            Assert.Single(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken)).Id.Value);
+        Assert.Equal(
+            ["alias", "physical"],
+            (await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken))
+                .Select(record => record.RecordId));
+        Assert.True(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(physicalBefore, await ReadStoredStateAsync("physical"));
+        Assert.Equal(aliasBefore, await ReadStoredStateAsync("alias"));
+        Assert.Equal(otherBefore, await ReadStoredStateAsync("other"));
+    }
+
+    [Fact]
+    public async Task VersionThreePhysicalResolverFailureQuarantinesAndBlocksAdmission()
+    {
+        var originalPath = Path.Combine(_directory, "unresolved", "video");
+        var safePath = Path.Combine(_directory, "safe", "video");
+        await CreateVersionThreeDatabaseAsync(
+            CreatePausedTask("unresolved", originalPath),
+            CreatePausedTask("safe", safePath));
+        var before = await ReadStoredStateAsync("unresolved");
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(
+            path => path == originalPath
+                ? throw new IOException("Synthetic resolver failure.")
+                : path));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            "safe",
+            Assert.Single(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken)).Id.Value);
         Assert.Equal(
             "unresolved",
             Assert.Single(

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -399,6 +399,20 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             (long)(await findProbe.ExecuteScalarAsync(TestContext.Current.CancellationToken))!);
     }
 
+    [Fact]
+    public async Task DisposedStoreReportsThePublicStoreAsObjectName()
+    {
+        var store = CreateStore();
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+        store.Dispose();
+
+        var operation = store.GetUnfinishedAsync(TestContext.Current.CancellationToken);
+        var exception = await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await operation.ConfigureAwait(true));
+
+        Assert.Equal(typeof(SqliteDownloadTaskStore).FullName, exception.ObjectName);
+    }
+
     public void Dispose()
     {
         using var connection = new SqliteConnection(new SqliteConnectionStringBuilder

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -24,7 +24,11 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(true);
         using var version = connection.CreateCommand();
         version.CommandText = "PRAGMA user_version";
-        Assert.Equal(3L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(4L, await version.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        Assert.True(await TableExistsAsync("download_upgrade_admission_gate"));
+        Assert.Equal(1, await CountSchemaMigrationAsync(4));
+        Assert.False(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
     }
 
     [Fact]
@@ -46,6 +50,224 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         Assert.Single(Directory.GetFiles(
             Path.Combine(_directory, "Backup"),
             "download.db.schema-v0-*.bak"));
+    }
+
+    [Fact]
+    public async Task VersionThreeEquivalentPhysicalPathRemainsAvailableWithoutBlockingAdmission()
+    {
+        var originalPath = Path.Combine(_directory, "equivalent", "video");
+        var equivalentPath = Path.Combine(originalPath, ".") + Path.DirectorySeparatorChar;
+        if (Path.DirectorySeparatorChar != Path.AltDirectorySeparatorChar)
+        {
+            equivalentPath = equivalentPath.Replace(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+        }
+
+        if (DownloadOutputPathKey.UsesCaseInsensitiveComparison)
+        {
+            equivalentPath = equivalentPath.ToUpperInvariant();
+        }
+
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("equivalent", originalPath));
+        var resolutionCalls = 0;
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(_ =>
+        {
+            resolutionCalls++;
+            return equivalentPath;
+        }));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, resolutionCalls);
+        Assert.Equal(
+            "equivalent",
+            Assert.Single(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken)).Id.Value);
+        Assert.Empty(await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+        Assert.False(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(originalPath, (await ReadStoredStateAsync("equivalent")).Path);
+    }
+
+    [Fact]
+    public async Task VersionThreePhysicalPathChangeQuarantinesWithoutMutatingTaskOrFiles()
+    {
+        var originalPath = Path.Combine(_directory, "logical", "video");
+        var physicalPath = Path.Combine(_directory, "physical", "video");
+        var partialPath = Path.Combine(_directory, "logical", "video.download");
+        var ariaPath = Path.Combine(_directory, "logical", "video.aria2");
+        Directory.CreateDirectory(Path.GetDirectoryName(partialPath)!);
+        await File.WriteAllTextAsync(partialPath, "partial", TestContext.Current.CancellationToken);
+        await File.WriteAllTextAsync(ariaPath, "aria", TestContext.Current.CancellationToken);
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("changed", originalPath));
+        var before = await ReadStoredStateAsync("changed");
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(_ => physicalPath));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        var quarantine = Assert.Single(
+            await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("changed", quarantine.RecordId);
+        Assert.Equal("downloading", quarantine.SourceTable);
+        Assert.Equal("file_path", quarantine.FieldName);
+        Assert.Equal("legacy-output-path-unverified", quarantine.Reason);
+        Assert.True(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(before, await ReadStoredStateAsync("changed"));
+        Assert.True(File.Exists(partialPath));
+        Assert.True(File.Exists(ariaPath));
+    }
+
+    [Fact]
+    public async Task VersionThreePhysicalResolverFailureQuarantinesAndBlocksAdmission()
+    {
+        var originalPath = Path.Combine(_directory, "unresolved", "video");
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("unresolved", originalPath));
+        var before = await ReadStoredStateAsync("unresolved");
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(
+            _ => throw new IOException("Synthetic resolver failure.")));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(
+            "unresolved",
+            Assert.Single(
+                await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken)).RecordId);
+        Assert.True(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(before, await ReadStoredStateAsync("unresolved"));
+    }
+
+    [Fact]
+    public async Task VersionThreeCompletedTaskIsSkippedAndExistingQuarantineStillBlocksPathRisk()
+    {
+        var completed = CreateCompletedTask(
+            "completed",
+            123,
+            Path.Combine(_directory, "completed", "video"));
+        var quarantined = CreatePausedTask(
+            "already-quarantined",
+            Path.Combine(_directory, "quarantined", "video"));
+        await CreateVersionThreeDatabaseAsync(completed, quarantined);
+        await InsertPreexistingQuarantineAsync("already-quarantined");
+        var completedBefore = await ReadStoredStateAsync("completed");
+        var quarantinedBefore = await ReadStoredStateAsync("already-quarantined");
+        var resolvedPaths = new List<string>();
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(path =>
+        {
+            resolvedPaths.Add(path);
+            return path + "-physical";
+        }));
+
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal([quarantined.Output.BasePath], resolvedPaths);
+        Assert.Equal(
+            "completed",
+            Assert.Single((await store.GetHistoryPageAsync(
+                null,
+                10,
+                TestContext.Current.CancellationToken)).Items).Id.Value);
+        Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        var quarantine = Assert.Single(
+            await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+        Assert.Equal("already-quarantined", quarantine.RecordId);
+        Assert.Equal("preexisting-corrupt-record", quarantine.Reason);
+        Assert.True(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(completedBefore, await ReadStoredStateAsync("completed"));
+        Assert.Equal(quarantinedBefore, await ReadStoredStateAsync("already-quarantined"));
+    }
+
+    [Fact]
+    public async Task VersionFourMigrationAndRestartAreIdempotentAcrossMultipleLegacyTasks()
+    {
+        var safePath = Path.Combine(_directory, "safe", "video");
+        await CreateVersionThreeDatabaseAsync(
+            CreatePausedTask("unsafe-a", Path.Combine(_directory, "logical-a", "video")),
+            CreatePausedTask("safe", safePath),
+            CreatePausedTask("unsafe-b", Path.Combine(_directory, "logical-b", "video")));
+        using (var first = CreateStore(new StubPhysicalOutputPathResolver(path =>
+               path == safePath ? path : path + "-physical")))
+        {
+            await first.InitializeAsync(TestContext.Current.CancellationToken);
+            await first.InitializeAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(
+                ["unsafe-a", "unsafe-b"],
+                (await first.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken))
+                    .Select(record => record.RecordId));
+            Assert.True(await first.IsLegacyUpgradeAdmissionBlockedAsync(
+                TestContext.Current.CancellationToken));
+        }
+
+        using var reopened = CreateStore(new StubPhysicalOutputPathResolver(
+            _ => throw new InvalidOperationException("Version four must not rescan.")));
+        await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(
+            ["unsafe-a", "unsafe-b"],
+            (await reopened.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken))
+                .Select(record => record.RecordId));
+        Assert.Equal(
+            "safe",
+            Assert.Single(await reopened.GetUnfinishedAsync(TestContext.Current.CancellationToken)).Id.Value);
+        Assert.True(await reopened.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Equal(1, await CountSchemaMigrationAsync(4));
+    }
+
+    [Fact]
+    public async Task ConfirmationOnlyReleasesAdmissionGateAndPersistsAcrossRestart()
+    {
+        var originalPath = Path.Combine(_directory, "confirm-logical", "video");
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("confirm", originalPath));
+        var before = await ReadStoredStateAsync("confirm");
+        using (var store = CreateStore(new StubPhysicalOutputPathResolver(path => path + "-physical")))
+        {
+            await store.InitializeAsync(TestContext.Current.CancellationToken);
+            Assert.True((await store.ConfirmLegacyRemoteTasksStoppedAsync(
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.False(await store.IsLegacyUpgradeAdmissionBlockedAsync(
+                TestContext.Current.CancellationToken));
+            Assert.Empty(await store.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+            Assert.Single(await store.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(before, await ReadStoredStateAsync("confirm"));
+        }
+
+        using var reopened = CreateStore(new StubPhysicalOutputPathResolver(
+            _ => throw new InvalidOperationException("Version four must not rescan.")));
+        Assert.False(await reopened.IsLegacyUpgradeAdmissionBlockedAsync(
+            TestContext.Current.CancellationToken));
+        Assert.Empty(await reopened.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(
+            "confirm",
+            Assert.Single(
+                await reopened.GetQuarantinedRecordsAsync(TestContext.Current.CancellationToken)).RecordId);
+        Assert.Equal(before, await ReadStoredStateAsync("confirm"));
+    }
+
+    [Fact]
+    public async Task VersionFourFailureRollsBackQuarantineGateLedgerAndUserVersion()
+    {
+        var originalPath = Path.Combine(_directory, "rollback-logical", "video");
+        await CreateVersionThreeDatabaseAsync(CreatePausedTask("rollback", originalPath));
+        await CreateQuarantineFailureTriggerAsync();
+        var before = await ReadStoredStateAsync("rollback");
+        using var store = CreateStore(new StubPhysicalOutputPathResolver(path => path + "-physical"));
+
+        await Assert.ThrowsAsync<SqliteException>(() =>
+            store.InitializeAsync(TestContext.Current.CancellationToken));
+
+        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.False(await TableExistsAsync("download_upgrade_admission_gate"));
+        Assert.Equal(0, await CountSchemaMigrationAsync(4));
+        Assert.Equal(0, await CountQuarantineRecordsAsync());
+        Assert.Equal(before, await ReadStoredStateAsync("rollback"));
+        Assert.Single(Directory.GetFiles(
+            Path.Combine(_directory, "Backup"),
+            "download.db.schema-v3-*.bak"));
     }
 
     [Fact]
@@ -129,7 +351,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             await reopened.InitializeAsync(TestContext.Current.CancellationToken);
         }
 
-        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.Equal(4, await ReadSchemaVersionAsync());
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
     }
 
@@ -142,7 +364,7 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
 
         await store.InitializeAsync(TestContext.Current.CancellationToken);
 
-        Assert.Equal(3, await ReadSchemaVersionAsync());
+        Assert.Equal(4, await ReadSchemaVersionAsync());
         Assert.Equal(1, await CountDownloadBaseRecordAsync("legacy-resume"));
         Assert.Equal(1, await CountDownloadingRecordAsync("legacy-resume"));
         Assert.Equal(0, await CountDownloadingRecordAsync("orphaned-download"));
@@ -429,21 +651,22 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         }
     }
 
-    private SqliteDownloadTaskStore CreateStore()
+    private SqliteDownloadTaskStore CreateStore(IPhysicalOutputPathResolver? resolver = null)
     {
         Directory.CreateDirectory(_directory);
         return new SqliteDownloadTaskStore(
             new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
-            _clock);
+            _clock,
+            resolver ?? new StubPhysicalOutputPathResolver(static path => path));
     }
 
-    private DownloadTask CreatePausedTask(string id)
+    private DownloadTask CreatePausedTask(string id, string? outputPath = null)
     {
         var task = DownloadTask.Create(
             new DownloadTaskId(id),
             CreateMetadata(id),
             CreatePlan(),
-            new DownloadOutput(Path.Combine(_directory, id), "1 GB"),
+            new DownloadOutput(outputPath ?? Path.Combine(_directory, id), "1 GB"),
             _clock.UtcNow);
         task = task.Start(_clock.UtcNow.AddSeconds(1)).RequireValue();
         task = task.UpdateTransferState(
@@ -466,13 +689,16 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             _clock.UtcNow);
     }
 
-    private DownloadTask CreateCompletedTask(string id, long finishedTimestamp)
+    private DownloadTask CreateCompletedTask(
+        string id,
+        long finishedTimestamp,
+        string? outputPath = null)
     {
         var task = DownloadTask.Create(
             new DownloadTaskId(id),
             CreateMetadata(id),
             CreatePlan(),
-            new DownloadOutput(Path.Combine(_directory, id), "1 GB"),
+            new DownloadOutput(outputPath ?? Path.Combine(_directory, id), "1 GB"),
             _clock.UtcNow);
         task = task.Start(_clock.UtcNow.AddSeconds(1)).RequireValue();
         return task.Complete(
@@ -548,6 +774,123 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         using var command = connection.CreateCommand();
         command.CommandText = "PRAGMA user_version";
         return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken).ConfigureAwait(false))!;
+    }
+
+    private async Task CreateVersionThreeDatabaseAsync(params DownloadTask[] tasks)
+    {
+        using (var store = CreateStore())
+        {
+            await store.InitializeAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+            foreach (var task in tasks)
+            {
+                Assert.True((await store.AddAsync(
+                    task,
+                    TestContext.Current.CancellationToken).ConfigureAwait(false)).IsSuccess);
+            }
+        }
+
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            DROP TABLE download_upgrade_admission_gate;
+            DELETE FROM download_schema_migrations WHERE version = 4;
+            PRAGMA user_version = 3;
+            """;
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task InsertPreexistingQuarantineAsync(string id)
+    {
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            INSERT INTO download_quarantine
+                (source_table, record_id, field_name, reason, quarantined_at_utc)
+            VALUES ('downloading', @id, 'need_download_content',
+                    'preexisting-corrupt-record', @now)
+            """;
+        command.Parameters.AddWithValue("@id", id);
+        command.Parameters.AddWithValue("@now", _clock.UtcNow.ToUnixTimeMilliseconds());
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task CreateQuarantineFailureTriggerAsync()
+    {
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            CREATE TRIGGER reject_version_four_quarantine
+            BEFORE INSERT ON download_quarantine
+            BEGIN
+                SELECT RAISE(ABORT, 'synthetic version four failure');
+            END;
+            """;
+        await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<StoredDownloadState> ReadStoredStateAsync(string id)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT db.file_path, dl.gid, dl.download_files, dl.downloaded_files,
+                   d.finished_timestamp
+            FROM download_base db
+            LEFT JOIN downloading dl ON dl.id = db.id
+            LEFT JOIN downloaded d ON d.id = db.id
+            WHERE db.id = @id
+            """;
+        command.Parameters.AddWithValue("@id", id);
+        using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        Assert.True(await reader.ReadAsync(TestContext.Current.CancellationToken).ConfigureAwait(false));
+        var gidIsNull = await reader.IsDBNullAsync(1, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        var downloadFilesIsNull = await reader.IsDBNullAsync(2, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        var downloadedFilesIsNull = await reader.IsDBNullAsync(3, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        var finishedTimestampIsNull = await reader.IsDBNullAsync(4, TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        return new StoredDownloadState(
+            reader.GetString(0),
+            gidIsNull ? null : reader.GetString(1),
+            downloadFilesIsNull ? null : reader.GetString(2),
+            downloadedFilesIsNull ? null : reader.GetString(3),
+            finishedTimestampIsNull ? null : reader.GetInt64(4));
+    }
+
+    private async Task<bool> TableExistsAsync(string tableName)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT EXISTS (
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'table' AND name = @name)
+            """;
+        command.Parameters.AddWithValue("@name", tableName);
+        return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false))! != 0;
+    }
+
+    private async Task<long> CountSchemaMigrationAsync(int version)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM download_schema_migrations WHERE version = @version";
+        command.Parameters.AddWithValue("@version", version);
+        return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false))!;
+    }
+
+    private async Task<long> CountQuarantineRecordsAsync()
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT COUNT(*) FROM download_quarantine";
+        return (long)(await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false))!;
     }
 
     private async Task CorruptRequestedAssetsAsync(string id, string sensitiveValue)
@@ -683,4 +1026,17 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             return Task.Delay(delay, cancellationToken);
         }
     }
+
+    private sealed class StubPhysicalOutputPathResolver(Func<string, string> resolve)
+        : IPhysicalOutputPathResolver
+    {
+        public string ResolvePhysicalBasePath(string logicalBasePath) => resolve(logicalBasePath);
+    }
+
+    private sealed record StoredDownloadState(
+        string Path,
+        string? Gid,
+        string? DownloadFiles,
+        string? DownloadedFiles,
+        long? FinishedTimestamp);
 }

--- a/tests/DownKyi.Tests/ContentDownloadCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/ContentDownloadCoordinatorTests.cs
@@ -62,6 +62,31 @@ public sealed class ContentDownloadCoordinatorTests
     }
 
     [Fact]
+    public async Task BlockedAdmissionRejectsWholeBatchBeforeDirectoryOrItemWork()
+    {
+        var session = new RecordingSession(@"D:\Downloads", admissionAllowed: false);
+        var factory = new RecordingFactory(session);
+        var infoServiceFactory = new RecordingInfoServiceFactory();
+        var coordinator = new ContentDownloadCoordinator(factory, infoServiceFactory);
+
+        var result = await coordinator.AddAsync(
+            [
+                new ContentDownloadItem("BV17x411w7KC", DownloadInfoKind.Video, true),
+                new ContentDownloadItem("BV1xx411c7mD", DownloadInfoKind.Video, true)
+            ],
+            onlySelected: true,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+        Assert.Equal(1, session.AdmissionCheckCount);
+        Assert.Equal(0, session.DirectorySelectionCount);
+        Assert.Equal(0, session.SetInfoCount);
+        Assert.Equal(0, session.ParseCount);
+        Assert.Equal(0, session.AddCount);
+        Assert.Empty(infoServiceFactory.CreatedKinds);
+    }
+
+    [Fact]
     public async Task MixedItemsShareOneDirectorySelectionAndQueueInOrder()
     {
         var session = new RecordingSession(@"D:\Downloads");
@@ -124,8 +149,12 @@ public sealed class ContentDownloadCoordinatorTests
 
     }
 
-    private sealed class RecordingSession(string? directory) : IAddToDownloadSession
+    private sealed class RecordingSession(
+        string? directory,
+        bool admissionAllowed = true) : IAddToDownloadSession
     {
+        public int AdmissionCheckCount { get; private set; }
+
         public int DirectorySelectionCount { get; private set; }
 
         public int SetInfoCount { get; private set; }
@@ -135,6 +164,13 @@ public sealed class ContentDownloadCoordinatorTests
         public int ParseCount { get; private set; }
 
         public int AddCount { get; private set; }
+
+        public Task<bool> EnsureAdmissionAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AdmissionCheckCount++;
+            return Task.FromResult(admissionAllowed);
+        }
 
         public Task<string?> SetDirectory(CancellationToken cancellationToken = default)
         {

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -28,7 +28,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
         var listState = new DownloadListState();
         var queue = new RecordingDownloadTaskQueue();
-        using var admission = new DownloadTaskAdmissionService(listState, tasks, projections, queue);
+        using var admission = CreateAdmission(listState, tasks, projections, queue);
         var basePath = Path.Combine(_directory, "same-output");
         var first = CreateItem("first", basePath);
         var second = CreateItem("second", basePath);
@@ -56,7 +56,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -89,7 +89,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -123,7 +123,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -148,7 +148,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -167,6 +167,149 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
         Assert.Equal(basePath, item.DownloadBase.FilePath);
         Assert.Empty(await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task CollisionResolutionPreservesRawCandidateSpelling()
+    {
+        var basePath = Path.Combine(_directory, "cafe\u0301-output");
+
+        var resolved = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+            basePath,
+            autoAddNumberSuffix: true,
+            static (_, _) => Task.FromResult(false),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(Path.GetFullPath(basePath), resolved, ignoreCase: false);
+    }
+
+    [Fact]
+    public async Task AdmissionFreezesPhysicalPathBeforeReservationPersistenceProjectionAndQueue()
+    {
+        Directory.CreateDirectory(_directory);
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore);
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var queue = new AdmissionObservingQueue(listState, projections);
+        var logicalBasePath = Path.Combine(_directory, "logical-alias", "cafe\u0301-output");
+        var frozenBasePath = Path.Combine(_directory, "physical-target", "cafe\u0301-output");
+        var resolver = new RecordingPhysicalOutputPathResolver(_ => frozenBasePath);
+        using var admission = CreateAdmission(listState, tasks, projections, queue, resolver);
+        var item = CreateItem("frozen", logicalBasePath);
+
+        await admission.AdmitAsync(item, true, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        var persisted = Assert.Single(await tasks.GetUnfinishedAsync(
+            TestContext.Current.CancellationToken));
+        var taskId = new DownloadTaskId(item.DownloadBase.Id);
+        Assert.Equal([logicalBasePath], resolver.Inputs);
+        Assert.Equal([frozenBasePath], store.ReservationPaths);
+        Assert.Equal(frozenBasePath, item.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal(frozenBasePath, persisted.Output.BasePath, ignoreCase: false);
+        Assert.Equal(
+            frozenBasePath,
+            projections.GetRequiredSnapshot(taskId).Output.BasePath,
+            ignoreCase: false);
+        Assert.Same(item, Assert.Single(listState.Downloading));
+        Assert.Equal(taskId, Assert.Single(queue.Enqueued));
+        Assert.Equal([frozenBasePath], queue.ObservedPaths);
+        Assert.DoesNotContain(
+            logicalBasePath,
+            new[] { item.DownloadBase.FilePath, persisted.Output.BasePath },
+            StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public async Task ResolverFailureHasNoPersistenceListOrQueueSideEffects()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        var logicalBasePath = Path.Combine(_directory, "broken-alias", "output");
+        var resolver = new RecordingPhysicalOutputPathResolver(
+            _ => throw new IOException("Alias resolution failed."));
+        using var admission = CreateAdmission(listState, tasks, projections, queue, resolver);
+        var item = CreateItem("unresolved", logicalBasePath);
+
+        await Assert.ThrowsAsync<IOException>(() => admission.AdmitAsync(
+            item,
+            true,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal([logicalBasePath], resolver.Inputs);
+        Assert.Equal(logicalBasePath, item.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Empty(await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(listState.Downloading);
+        Assert.Empty(queue.Enqueued);
+    }
+
+    [Fact]
+    public async Task PersistenceFailureDoesNotPublishToListOrQueue()
+    {
+        Directory.CreateDirectory(_directory);
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore) { RejectAdds = true };
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        using var admission = CreateAdmission(listState, tasks, projections, queue);
+        var item = CreateItem("rejected", Path.Combine(_directory, "rejected-output"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => admission.AdmitAsync(
+            item,
+            true,
+            TestContext.Current.CancellationToken));
+
+        Assert.Empty(await innerStore.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(listState.Downloading);
+        Assert.Empty(queue.Enqueued);
+    }
+
+    [Fact]
+    public async Task AliasesSharePhysicalCollisionSequenceAndRemainFrozenAfterRetarget()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var frozenBasePath = Path.Combine(_directory, "physical-target", "output");
+        var currentTarget = frozenBasePath;
+        var resolver = new RecordingPhysicalOutputPathResolver(_ => currentTarget);
+        using var admission = CreateAdmission(
+            new DownloadListState(),
+            tasks,
+            projections,
+            new RecordingDownloadTaskQueue(),
+            resolver);
+        var first = CreateItem("first-alias", Path.Combine(_directory, "alias-a", "output"));
+        var second = CreateItem("second-alias", Path.Combine(_directory, "alias-b", "output"));
+
+        await admission.AdmitAsync(first, true, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+        currentTarget = Path.Combine(_directory, "retargeted", "output");
+        Assert.Equal(frozenBasePath, first.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal(
+            frozenBasePath,
+            projections.GetRequiredSnapshot(new DownloadTaskId(first.DownloadBase.Id)).Output.BasePath,
+            ignoreCase: false);
+        currentTarget = frozenBasePath;
+        await admission.AdmitAsync(second, true, TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(frozenBasePath, first.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal($"{frozenBasePath}(1)", second.DownloadBase.FilePath, ignoreCase: false);
+        Assert.Equal(2, resolver.Inputs.Count);
     }
 
     [Fact]
@@ -202,7 +345,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
-        using var admission = new DownloadTaskAdmissionService(
+        using var admission = CreateAdmission(
             new DownloadListState(),
             tasks,
             projections,
@@ -224,6 +367,21 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         return new SqliteDownloadTaskStore(
             new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
             new SystemClock());
+    }
+
+    private static DownloadTaskAdmissionService CreateAdmission(
+        DownloadListState listState,
+        IDownloadTaskApplicationService tasks,
+        DownloadTaskProjectionStore projections,
+        IDownloadTaskQueue queue,
+        IPhysicalOutputPathResolver? resolver = null)
+    {
+        return new DownloadTaskAdmissionService(
+            listState,
+            tasks,
+            projections,
+            queue,
+            resolver ?? new FileSystemPhysicalOutputPathResolver());
     }
 
     private static DownloadingItem CreateItem(string id, string basePath)
@@ -249,16 +407,24 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
     private sealed class CountingDownloadTaskStore(IDownloadTaskStore inner) : IDownloadTaskStore
     {
+        public bool RejectAdds { get; init; }
+
         public int GetUnfinishedCallCount { get; private set; }
 
         public int ReservationProbeCount { get; private set; }
+
+        public List<string> ReservationPaths { get; } = [];
 
         public Task InitializeAsync(CancellationToken cancellationToken) =>
             inner.InitializeAsync(cancellationToken);
 
         public Task<OperationResult> AddAsync(
             DownloadTask task,
-            CancellationToken cancellationToken) => inner.AddAsync(task, cancellationToken);
+            CancellationToken cancellationToken) => RejectAdds
+                ? Task.FromResult(OperationResult.Failure(new OperationError(
+                    "test.persistence_rejected",
+                    "Persistence rejected the task.")))
+                : inner.AddAsync(task, cancellationToken);
 
         public Task<OperationResult> UpdateAsync(
             DownloadTask task,
@@ -288,6 +454,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             CancellationToken cancellationToken)
         {
             ReservationProbeCount++;
+            ReservationPaths.Add(basePath);
             return inner.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
         }
 
@@ -306,6 +473,46 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
         public Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
             CancellationToken cancellationToken) => inner.GetQuarantinedRecordsAsync(cancellationToken);
+    }
+
+    private sealed class RecordingPhysicalOutputPathResolver(Func<string, string> resolve)
+        : IPhysicalOutputPathResolver
+    {
+        public List<string> Inputs { get; } = [];
+
+        public string ResolvePhysicalBasePath(string logicalBasePath)
+        {
+            Inputs.Add(logicalBasePath);
+            return resolve(logicalBasePath);
+        }
+    }
+
+    private sealed class AdmissionObservingQueue(
+        DownloadListState listState,
+        DownloadTaskProjectionStore projections) : IDownloadTaskQueue
+    {
+        public List<DownloadTaskId> Enqueued { get; } = [];
+
+        public List<string> ObservedPaths { get; } = [];
+
+        public Task EnqueueAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var listItem = Assert.Single(
+                listState.Downloading,
+                item => item.DownloadBase.Id == taskId.Value);
+            Assert.Equal(
+                listItem.DownloadBase.FilePath,
+                projections.GetRequiredSnapshot(taskId).Output.BasePath,
+                ignoreCase: false);
+            Enqueued.Add(taskId);
+            ObservedPaths.Add(listItem.DownloadBase.FilePath);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> CancelAsync(DownloadTaskId taskId) => Task.FromResult(true);
     }
 
     public void Dispose()

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -381,7 +381,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             tasks,
             projections,
             queue,
-            resolver ?? new FileSystemPhysicalOutputPathResolver());
+            resolver ?? new RecordingPhysicalOutputPathResolver(static path => path));
     }
 
     private static DownloadingItem CreateItem(string id, string basePath)

--- a/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
+++ b/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
@@ -6,6 +6,7 @@ using DownKyi.Infrastructure.Time;
 using DownKyi.Models;
 using DownKyi.Services.Download;
 using DownKyi.ViewModels.DownloadManager;
+using Microsoft.Data.Sqlite;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Tests;
@@ -72,21 +73,18 @@ public sealed class DurlDownloadIdentityTests
     }
 
     [Fact]
-    public async Task PlaybackStageDoesNotRewriteFrozenBasePathWhenDirectoryPreparationFails()
+    public async Task PlaybackStageUsesLegacySeparatorsWithoutRewritingFrozenBasePath()
     {
         var directory = Path.Combine(
             Path.GetTempPath(),
             "downkyi-playback-path-tests",
             Guid.NewGuid().ToString("N"));
+        var databasePath = Path.Combine(directory, "download.db");
         Directory.CreateDirectory(directory);
         try
         {
-            var blockedDirectory = Path.Combine(directory, "blocked");
-            await File.WriteAllTextAsync(
-                blockedDirectory,
-                "not a directory",
-                TestContext.Current.CancellationToken);
-            var frozenBasePath = Path.Combine(blockedDirectory, "frozen\\alias");
+            var frozenBasePath = Path.Combine(directory, "legacy\\nested\\video");
+            var expectedDirectory = Path.Combine(directory, "legacy", "nested");
             var downloadBase = new DownloadBase
             {
                 Id = "frozen-playback-path",
@@ -98,25 +96,36 @@ public sealed class DurlDownloadIdentityTests
                 Downloading = new Downloading
                 {
                     Id = downloadBase.Id,
-                    DownloadBase = downloadBase
+                    DownloadBase = downloadBase,
+                    DownloadStatus = DownloadStatus.WaitForDownload
                 },
                 PlayUrl = new PlayUrl()
             };
             using var store = new SqliteDownloadTaskStore(
-                new SqliteDownloadTaskStoreOptions(Path.Combine(directory, "download.db")),
+                new SqliteDownloadTaskStoreOptions(databasePath),
                 new SystemClock());
             using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
             using var settings = new TestSettingsStore();
+            var taskId = new DownloadTaskId(downloadBase.Id);
+            var stateWriter = new DownloadTaskStateWriter(tasks);
+            var task = DownloadTaskProjectionMapper.CreateNewTask(
+                downloading,
+                DateTimeOffset.UnixEpoch);
+            Assert.True((await tasks.AddAsync(
+                task,
+                TestContext.Current.CancellationToken).ConfigureAwait(true)).IsSuccess);
+            await stateWriter.StartAsync(taskId, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
             var stage = new ResolvePlaybackStage(
                 new TestDesktopInteractionContext().Notifications,
-                new DownloadActivityPresenter(new DownloadTaskStateWriter(tasks)),
+                new DownloadActivityPresenter(stateWriter),
                 new DownloadPlaybackResolver(
                     new TestWbiKeyProvider(),
                     TimeProvider.System,
                     new TestBilibiliApiClient()),
                 NullLogger<ResolvePlaybackStage>.Instance);
             var context = new DownloadExecutionContext(
-                new DownloadTaskId(downloadBase.Id),
+                taskId,
                 downloading,
                 settings.Store.Current,
                 static (_, token) => token.ThrowIfCancellationRequested());
@@ -125,11 +134,20 @@ public sealed class DurlDownloadIdentityTests
                 context,
                 TestContext.Current.CancellationToken);
 
-            Assert.False(result.IsSuccess);
+            Assert.True(result.IsSuccess);
+            Assert.Equal(expectedDirectory, context.DownloadDirectory);
             Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
         }
         finally
         {
+            using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+            {
+                DataSource = databasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = true,
+                DefaultTimeout = 5
+            }.ToString());
+            SqliteConnection.ClearPool(connection);
             Directory.Delete(directory, recursive: true);
         }
     }

--- a/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
+++ b/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
@@ -1,5 +1,7 @@
 using DownKyi.Core.BiliApi.VideoStream.Models;
+using DownKyi.Models;
 using DownKyi.Services.Download;
+using DownKyi.ViewModels.DownloadManager;
 
 namespace DownKyi.Tests;
 
@@ -62,5 +64,20 @@ public sealed class DurlDownloadIdentityTests
         Assert.Equal(
             Path.Combine("downloads", "nested"),
             ResolvePlaybackStage.GetDownloadDirectoryPath(filePath));
+    }
+
+    [Fact]
+    public void PlaybackPathResolutionDoesNotRewriteFrozenBasePath()
+    {
+        var frozenBasePath = Path.Combine("downloads", "cafe\u0301", "video");
+        var downloading = new DownloadingItem
+        {
+            DownloadBase = new DownloadBase { FilePath = frozenBasePath }
+        };
+
+        var directory = ResolvePlaybackStage.GetDownloadDirectoryPath(downloading);
+
+        Assert.Equal(Path.GetDirectoryName(frozenBasePath), directory);
+        Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
     }
 }

--- a/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
+++ b/tests/DownKyi.Tests/DurlDownloadIdentityTests.cs
@@ -1,7 +1,12 @@
+using DownKyi.Application.Downloads;
 using DownKyi.Core.BiliApi.VideoStream.Models;
+using DownKyi.Domain.Downloads;
+using DownKyi.Infrastructure.Downloads;
+using DownKyi.Infrastructure.Time;
 using DownKyi.Models;
 using DownKyi.Services.Download;
 using DownKyi.ViewModels.DownloadManager;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Tests;
 
@@ -67,17 +72,65 @@ public sealed class DurlDownloadIdentityTests
     }
 
     [Fact]
-    public void PlaybackPathResolutionDoesNotRewriteFrozenBasePath()
+    public async Task PlaybackStageDoesNotRewriteFrozenBasePathWhenDirectoryPreparationFails()
     {
-        var frozenBasePath = Path.Combine("downloads", "cafe\u0301", "video");
-        var downloading = new DownloadingItem
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "downkyi-playback-path-tests",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        try
         {
-            DownloadBase = new DownloadBase { FilePath = frozenBasePath }
-        };
+            var blockedDirectory = Path.Combine(directory, "blocked");
+            await File.WriteAllTextAsync(
+                blockedDirectory,
+                "not a directory",
+                TestContext.Current.CancellationToken);
+            var frozenBasePath = Path.Combine(blockedDirectory, "frozen\\alias");
+            var downloadBase = new DownloadBase
+            {
+                Id = "frozen-playback-path",
+                FilePath = frozenBasePath
+            };
+            var downloading = new DownloadingItem
+            {
+                DownloadBase = downloadBase,
+                Downloading = new Downloading
+                {
+                    Id = downloadBase.Id,
+                    DownloadBase = downloadBase
+                },
+                PlayUrl = new PlayUrl()
+            };
+            using var store = new SqliteDownloadTaskStore(
+                new SqliteDownloadTaskStoreOptions(Path.Combine(directory, "download.db")),
+                new SystemClock());
+            using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+            using var settings = new TestSettingsStore();
+            var stage = new ResolvePlaybackStage(
+                new TestDesktopInteractionContext().Notifications,
+                new DownloadActivityPresenter(new DownloadTaskStateWriter(tasks)),
+                new DownloadPlaybackResolver(
+                    new TestWbiKeyProvider(),
+                    TimeProvider.System,
+                    new TestBilibiliApiClient()),
+                NullLogger<ResolvePlaybackStage>.Instance);
+            var context = new DownloadExecutionContext(
+                new DownloadTaskId(downloadBase.Id),
+                downloading,
+                settings.Store.Current,
+                static (_, token) => token.ThrowIfCancellationRequested());
 
-        var directory = ResolvePlaybackStage.GetDownloadDirectoryPath(downloading);
+            var result = await stage.ExecuteAsync(
+                context,
+                TestContext.Current.CancellationToken);
 
-        Assert.Equal(Path.GetDirectoryName(frozenBasePath), directory);
-        Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
+            Assert.False(result.IsSuccess);
+            Assert.Equal(frozenBasePath, downloading.DownloadBase.FilePath, ignoreCase: false);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
     }
 }

--- a/tests/DownKyi.Tests/LegacyDownloadAdmissionPresenterTests.cs
+++ b/tests/DownKyi.Tests/LegacyDownloadAdmissionPresenterTests.cs
@@ -1,0 +1,179 @@
+using DownKyi.Application.Desktop;
+using DownKyi.Application.Downloads;
+using DownKyi.Domain.Downloads;
+using DownKyi.Domain.Results;
+using DownKyi.Infrastructure.Time;
+using DownKyi.Services.Download;
+
+namespace DownKyi.Tests;
+
+public sealed class LegacyDownloadAdmissionPresenterTests
+{
+    [Fact]
+    public async Task CancelLeavesGateBlockedWithoutCallingConfirmation()
+    {
+        var store = new GateStore();
+        using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+        var dialogs = new RecordingDialogService(AppDialogOutcome.Canceled);
+        var presenter = new LegacyDownloadAdmissionPresenter(tasks, dialogs);
+
+        var allowed = await presenter.EnsureAdmissionAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(allowed);
+        Assert.True(store.Blocked);
+        Assert.Equal(0, store.ConfirmationCount);
+        var request = Assert.Single(dialogs.Requests);
+        Assert.Equal(AppDialog.Alert, request.Dialog);
+        Assert.Equal(2, request.Parameters?["button_number"]);
+    }
+
+    [Fact]
+    public async Task ConfirmationOnlyReleasesGateAndAllowsSameSessionWithoutAnotherDialog()
+    {
+        var store = new GateStore();
+        using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+        var dialogs = new RecordingDialogService(AppDialogOutcome.Accepted);
+        var presenter = new LegacyDownloadAdmissionPresenter(tasks, dialogs);
+
+        Assert.True(await presenter.EnsureAdmissionAsync(TestContext.Current.CancellationToken));
+        Assert.True(await presenter.EnsureAdmissionAsync(TestContext.Current.CancellationToken));
+
+        Assert.False(store.Blocked);
+        Assert.Equal(1, store.ConfirmationCount);
+        Assert.Single(dialogs.Requests);
+        Assert.Equal(0, store.TaskAddCount);
+        Assert.Equal(0, store.QuarantineQueryCount);
+    }
+
+    [Fact]
+    public async Task FailedConfirmationShowsExistingErrorAndLeavesGateBlocked()
+    {
+        var store = new GateStore
+        {
+            ConfirmationResult = OperationResult.Failure(new OperationError(
+                "download.store.confirmation_failed",
+                "The confirmation could not be persisted."))
+        };
+        using var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+        var dialogs = new RecordingDialogService(
+            AppDialogOutcome.Accepted,
+            AppDialogOutcome.Accepted);
+        var presenter = new LegacyDownloadAdmissionPresenter(tasks, dialogs);
+
+        var allowed = await presenter.EnsureAdmissionAsync(TestContext.Current.CancellationToken);
+
+        Assert.False(allowed);
+        Assert.True(store.Blocked);
+        Assert.Equal(1, store.ConfirmationCount);
+        Assert.Equal(2, dialogs.Requests.Count);
+        Assert.Equal(
+            "The confirmation could not be persisted.",
+            dialogs.Requests[1].Parameters?["message"]);
+        Assert.Equal(0, store.TaskAddCount);
+        Assert.Equal(0, store.QuarantineQueryCount);
+    }
+
+    private sealed class RecordingDialogService(params AppDialogOutcome[] outcomes)
+        : IAppDialogService
+    {
+        private int _nextOutcome;
+
+        public List<AppDialogRequest> Requests { get; } = [];
+
+        public Task<AppDialogResult> ShowAsync(
+            AppDialogRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            var outcome = outcomes[Math.Min(_nextOutcome, outcomes.Length - 1)];
+            _nextOutcome++;
+            return Task.FromResult(new AppDialogResult(
+                outcome,
+                new Dictionary<string, object?>()));
+        }
+    }
+
+    private sealed class GateStore : IDownloadTaskStore
+    {
+        public bool Blocked { get; private set; } = true;
+
+        public OperationResult ConfirmationResult { get; init; } = OperationResult.Success();
+
+        public int ConfirmationCount { get; private set; }
+
+        public int TaskAddCount { get; private set; }
+
+        public int QuarantineQueryCount { get; private set; }
+
+        public Task InitializeAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task<OperationResult> AddAsync(
+            DownloadTask task,
+            CancellationToken cancellationToken)
+        {
+            TaskAddCount++;
+            return Task.FromResult(OperationResult.Success());
+        }
+
+        public Task<OperationResult> UpdateAsync(
+            DownloadTask task,
+            long expectedVersion,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(OperationResult.Success());
+
+        public Task<OperationResult> UpdateProgressAsync(
+            DownloadProgressWrite progressWrite,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(OperationResult.Success());
+
+        public Task<DownloadTask?> FindAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken) => Task.FromResult<DownloadTask?>(null);
+
+        public Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<DownloadTask>>([]);
+
+        public Task<bool> IsOutputPathReservedAsync(
+            string basePath,
+            bool ignoreCase,
+            CancellationToken cancellationToken) => Task.FromResult(false);
+
+        public Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(
+            CancellationToken cancellationToken) => Task.FromResult(Blocked);
+
+        public Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(
+            CancellationToken cancellationToken)
+        {
+            ConfirmationCount++;
+            if (ConfirmationResult.IsSuccess)
+            {
+                Blocked = false;
+            }
+
+            return Task.FromResult(ConfirmationResult);
+        }
+
+        public Task<DownloadHistoryPage> GetHistoryPageAsync(
+            DownloadHistoryCursor? cursor,
+            int pageSize,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(new DownloadHistoryPage([], null));
+
+        public Task<OperationResult> DeleteAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken) =>
+            Task.FromResult(OperationResult.Success());
+
+        public Task<OperationResult> ClearHistoryAsync(CancellationToken cancellationToken) =>
+            Task.FromResult(OperationResult.Success());
+
+        public Task<IReadOnlyList<QuarantinedDownloadRecord>> GetQuarantinedRecordsAsync(
+            CancellationToken cancellationToken)
+        {
+            QuarantineQueryCount++;
+            return Task.FromResult<IReadOnlyList<QuarantinedDownloadRecord>>([]);
+        }
+    }
+}

--- a/tests/DownKyi.Tests/VideoDetailDownloadCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/VideoDetailDownloadCoordinatorTests.cs
@@ -1,5 +1,6 @@
 using DownKyi.Core.BiliApi.VideoStream;
 using DownKyi.Presentation;
+using DownKyi.Services;
 using DownKyi.Services.Download;
 using DownKyi.Services.Video;
 
@@ -42,15 +43,81 @@ public sealed class VideoDetailDownloadCoordinatorTests
         Assert.Equal(0, factory.CreateCount);
     }
 
-    private sealed class RecordingFactory : IAddToDownloadServiceFactory
+    [Fact]
+    public async Task BlockedAdmissionStopsBeforeVideoDetailDirectorySelection()
+    {
+        var session = new RecordingSession();
+        var factory = new RecordingFactory(session);
+        var coordinator = new VideoDetailDownloadCoordinator(factory);
+
+        var result = await coordinator.AddAsync(
+            "BV17x411w7KC",
+            new VideoInfoView(),
+            [],
+            isAll: false,
+            TestContext.Current.CancellationToken);
+
+        Assert.Null(result);
+        Assert.Equal(1, session.AdmissionCheckCount);
+        Assert.Equal(0, session.DirectorySelectionCount);
+        Assert.Equal(0, session.AddCount);
+    }
+
+    private sealed class RecordingFactory(IAddToDownloadSession? session = null)
+        : IAddToDownloadServiceFactory
     {
         public int CreateCount { get; private set; }
 
         public IAddToDownloadSession Create(PlayStreamType streamType)
         {
             CreateCount++;
-            throw new InvalidOperationException("A download service should not have been created.");
+            return session
+                ?? throw new InvalidOperationException("A download service should not have been created.");
         }
 
+    }
+
+    private sealed class RecordingSession : IAddToDownloadSession
+    {
+        public int AdmissionCheckCount { get; private set; }
+
+        public int DirectorySelectionCount { get; private set; }
+
+        public int AddCount { get; private set; }
+
+        public Task<bool> EnsureAdmissionAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            AdmissionCheckCount++;
+            return Task.FromResult(false);
+        }
+
+        public Task<string?> SetDirectory(CancellationToken cancellationToken = default)
+        {
+            DirectorySelectionCount++;
+            return Task.FromResult<string?>(@"D:\Downloads");
+        }
+
+        public void SetVideoInfoService(IInfoService videoInfoService) =>
+            throw new NotSupportedException();
+
+        public void GetVideo(VideoInfoView videoInfoView, IList<VideoSection> videoSections) =>
+            throw new NotSupportedException();
+
+        public void GetVideo() => throw new NotSupportedException();
+
+        public Task ParseVideoAsync(
+            IInfoService videoInfoService,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<int> AddToDownload(
+            string? directory,
+            bool isAll = false,
+            CancellationToken cancellationToken = default)
+        {
+            AddCount++;
+            return Task.FromResult(1);
+        }
     }
 }

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -345,6 +345,7 @@ public sealed class VideoTagLoadingTests : IDisposable
             Service = new AddToDownloadService(
                 DownKyi.Core.BiliApi.VideoStream.PlayStreamType.Video,
                 _admission,
+                new LegacyDownloadAdmissionPresenter(_taskService, Dialogs),
                 duplicatePolicy,
                 new DownloadMovieMetadataBuilder(Logger),
                 _settings,

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -10,6 +10,7 @@ using DownKyi.Presentation;
 using DownKyi.Services;
 using DownKyi.Services.Download;
 using DownKyi.Services.Video;
+using DownKyi.Utils;
 using Microsoft.Extensions.Logging;
 using CoreVideoPage = DownKyi.Core.BiliApi.Video.Models.VideoPage;
 using VideoPage = DownKyi.Presentation.VideoPage;
@@ -206,12 +207,62 @@ public sealed class VideoTagLoadingTests : IDisposable
         Assert.Null(Assert.Single(context.ListState.Downloading).Metadata);
     }
 
-    private DownloadTestContext CreateContext(bool generateMetadata)
+    [Fact]
+    public async Task ResolverFailureIsReportedAndDoesNotBlockNextAdmission()
+    {
+        var resolver = new FailFirstPhysicalOutputPathResolver();
+        using var context = CreateContext(generateMetadata: false, resolver);
+        var first = CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([]));
+        first.Cid = 1;
+        first.Name = "first";
+        var second = CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([]));
+        second.Cid = 2;
+        second.Name = "second";
+        context.Prepare(first, second);
+
+        var added = await context.Service
+            .AddToDownload(_directory, cancellationToken: TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal(1, added);
+        Assert.Equal(2, resolver.CallCount);
+        Assert.Equal(1, context.Store.AddCount);
+        Assert.Equal("second", Assert.Single(context.ListState.Downloading).DownloadBase.Name);
+        Assert.Single(context.Queue.Enqueued);
+        var request = Assert.Single(context.Dialogs.Requests);
+        Assert.Equal(AppDialog.Alert, request.Dialog);
+        var message = Assert.IsType<string>(request.Parameters!["message"]);
+        Assert.Equal(DictionaryResource.GetString("DirectoryError"), message);
+        Assert.DoesNotContain(_directory, message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task UnknownResolverFailureKeepsExistingFailureBehavior()
+    {
+        using var context = CreateContext(
+            generateMetadata: false,
+            new UnknownFailurePhysicalOutputPathResolver());
+        context.Prepare(CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([])));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => context.Service.AddToDownload(
+            _directory,
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, context.Store.AddCount);
+        Assert.Empty(context.ListState.Downloading);
+        Assert.Empty(context.Queue.Enqueued);
+        Assert.Empty(context.Dialogs.Requests);
+    }
+
+    private DownloadTestContext CreateContext(
+        bool generateMetadata,
+        IPhysicalOutputPathResolver? resolver = null)
     {
         Directory.CreateDirectory(_directory);
         return new DownloadTestContext(
             Path.Combine(_directory, $"settings-{Guid.NewGuid():N}.json"),
-            generateMetadata);
+            generateMetadata,
+            resolver);
     }
 
     private static VideoPage CreatePage(
@@ -254,7 +305,10 @@ public sealed class VideoTagLoadingTests : IDisposable
         private readonly DownloadTaskProjectionStore _projectionStore;
         private readonly DownloadTaskAdmissionService _admission;
 
-        public DownloadTestContext(string settingsPath, bool generateMetadata)
+        public DownloadTestContext(
+            string settingsPath,
+            bool generateMetadata,
+            IPhysicalOutputPathResolver? resolver)
         {
             _settings = new DownKyi.Core.Settings.SettingsStore(settingsPath);
             _settings.Update(settings => settings with
@@ -274,6 +328,7 @@ public sealed class VideoTagLoadingTests : IDisposable
             ListState = new DownloadListState();
             Queue = new RecordingDownloadTaskQueue();
             Logger = new RecordingLogger<DownloadMovieMetadataBuilder>();
+            Dialogs = new RecordingDialogService();
             var desktop = new TestDesktopInteractionContext();
             var client = new TestBilibiliApiClient();
             _admission = new DownloadTaskAdmissionService(
@@ -281,12 +336,12 @@ public sealed class VideoTagLoadingTests : IDisposable
                 _taskService,
                 _projectionStore,
                 Queue,
-                new FileSystemPhysicalOutputPathResolver());
+                resolver ?? new FileSystemPhysicalOutputPathResolver());
             var duplicatePolicy = new DownloadDuplicatePolicy(
                 ListState,
                 _projectionStore,
                 desktop.Notifications,
-                desktop.Dialogs);
+                Dialogs);
             Service = new AddToDownloadService(
                 DownKyi.Core.BiliApi.VideoStream.PlayStreamType.Video,
                 _admission,
@@ -296,7 +351,7 @@ public sealed class VideoTagLoadingTests : IDisposable
                 new VideoTagProvider(client),
                 new TestWbiKeyProvider(),
                 client,
-                desktop.Dialogs,
+                Dialogs,
                 new RecordingLogger<AddToDownloadService>());
         }
 
@@ -310,7 +365,9 @@ public sealed class VideoTagLoadingTests : IDisposable
 
         public RecordingLogger<DownloadMovieMetadataBuilder> Logger { get; }
 
-        public void Prepare(VideoPage page)
+        public RecordingDialogService Dialogs { get; }
+
+        public void Prepare(params VideoPage[] pages)
         {
             Service.GetVideo(
                 new VideoInfoView
@@ -325,7 +382,7 @@ public sealed class VideoTagLoadingTests : IDisposable
                         Id = 1,
                         IsSelected = true,
                         Title = "section",
-                        VideoPages = [page]
+                        VideoPages = pages
                     }
                 ]);
         }
@@ -336,6 +393,46 @@ public sealed class VideoTagLoadingTests : IDisposable
             _projectionStore.Dispose();
             _taskService.Dispose();
             _settings.Dispose();
+        }
+    }
+
+    private sealed class RecordingDialogService : IAppDialogService
+    {
+        public List<AppDialogRequest> Requests { get; } = [];
+
+        public Task<AppDialogResult> ShowAsync(
+            AppDialogRequest request,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Requests.Add(request);
+            return Task.FromResult(new AppDialogResult(
+                AppDialogOutcome.Canceled,
+                new Dictionary<string, object?>()));
+        }
+    }
+
+    private sealed class FailFirstPhysicalOutputPathResolver : IPhysicalOutputPathResolver
+    {
+        public int CallCount { get; private set; }
+
+        public string ResolvePhysicalBasePath(string logicalBasePath)
+        {
+            CallCount++;
+            if (CallCount == 1)
+            {
+                throw new IOException("Unable to resolve physical output path.");
+            }
+
+            return logicalBasePath;
+        }
+    }
+
+    private sealed class UnknownFailurePhysicalOutputPathResolver : IPhysicalOutputPathResolver
+    {
+        public string ResolvePhysicalBasePath(string logicalBasePath)
+        {
+            throw new InvalidOperationException("Unexpected resolver failure.");
         }
     }
 

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -4,6 +4,7 @@ using DownKyi.Application.Desktop;
 using DownKyi.Application.Downloads;
 using DownKyi.Domain.Downloads;
 using DownKyi.Domain.Results;
+using DownKyi.Infrastructure.Downloads;
 using DownKyi.Infrastructure.Time;
 using DownKyi.Presentation;
 using DownKyi.Services;
@@ -279,7 +280,8 @@ public sealed class VideoTagLoadingTests : IDisposable
                 ListState,
                 _taskService,
                 _projectionStore,
-                Queue);
+                Queue,
+                new FileSystemPhysicalOutputPathResolver());
             var duplicatePolicy = new DownloadDuplicatePolicy(
                 ListState,
                 _projectionStore,


### PR DESCRIPTION
Atomic integration for the v1.1.3 download-path safety stack. Commit order preserves the reviewed modules: #231 freezes the physical output path at admission; #232 separates schema migrations; #233 separates the SQLite task-store owners; #235 quarantines unsafe legacy unfinished tasks and persists the global admission gate; the final Q2 commit presents and enforces that gate for all queued new downloads. This avoids merging #231 alone while its legacy P1 is still unresolved. Completed-history import remains allowed. No automatic legacy path/GID/transfer rewrite, no old-task or partial-file deletion, and no aria2 stop/reset/orchestration. Component evidence: Q1 and S1/S2 exact-head CI/reviews were clean; Q2 focused 41/41, full Architecture 302/302, strict Release build 0 warnings/errors, format 0/981 changed, cached diff clean, Q2 exact-head natural CI green and independent clean review. After retargeting to main, integrated merge-ref CI and a fresh full main..head review are required before merge.