### PR TITLE
docs: distinguish current and target architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,8 +5,8 @@
 ## 閱讀入口
 
 - 模組、呼叫關係與穩定契約：`docs/ai-knowledge-graph.md`
-- 目前尚未完成的工作：`docs/refactoring-live-plan.md`
-- 模組邊界審查：`docs/design-docs/module-boundary-naming-audit.md`
+- 穩定的 release 與驗證政策：`docs/refactoring-live-plan.md`
+- 歷史模組邊界 audit snapshot：`docs/design-docs/module-boundary-naming-audit.md`
 - 建置、測試、發布與外部 binary：`docs/maintenance.md`
 - 驗證及回滾：`docs/operations/verification-and-rollback.md`
 
@@ -39,8 +39,8 @@ flowchart TD
 - `DownKyi.exe` 只含 `Program.cs`，只引用 `DownKyi.Desktop`，不持有 UI、套件、資源或生命週期實作。
 - `DownKyi.Desktop` 是 Avalonia App、Views、ViewModels、`Presentation` projections、desktop adapters、Host composition 與 desktop runtime owner。Service contracts 不再引用 `DownKyi.ViewModels`。
 - `DownKyi.Core` 不含 `.axaml`、Avalonia 或 QRCoder；登入 API 留在 Core，QR bitmap renderer 與 Bilibili image dictionaries 位於 Desktop。
-- `DownKyi.Domain.DownloadTask` 已是持久化狀態轉換的權威；worker 與 pipeline 入口使用 `DownloadTaskId`，但 orchestrator channel 與部分 media stage 仍暫時持有 UI projection。
-- `DownKyi.Application` 已擁有 Bilibili HTTP/buvid/cookie、logging 與 physical output path contracts；`DownKyi.Infrastructure` 已擁有 async `IHttpClientFactory` transport、single-flight buvid provider、SQLite、write-behind、filesystem physical output path resolver，以及私有 NLog logging sink、retention 與 diagnostic exporter。aria2、FFmpeg 與其餘 file system ownership 尚待後續切片。
+- `DownKyi.Domain.DownloadTask` 已是持久化狀態轉換的權威；orchestrator channels、workers 與 pipeline 入口都使用 `DownloadTaskId`，但 `DownloadExecutionContext` 與部分 media stages 仍暫時持有 `DownloadingItem` UI projection。
+- `DownKyi.Application` 已擁有 Bilibili HTTP/buvid/cookie、logging 與 physical output path contracts；`DownKyi.Infrastructure` 已擁有 async `IHttpClientFactory` transport、single-flight buvid provider、SQLite、write-behind、filesystem physical output path resolver，以及私有 NLog logging sink、retention 與 diagnostic exporter。aria2 與 FFmpeg 實作目前仍主要位於 `DownKyi.Core`，其 runtime adapters 與其餘 file-system workflow 仍位於 Desktop/Core；將這些實作收斂至 Infrastructure 是目標 ownership，不是目前已實作的狀態。
 - Prism、DryIoc、EventAggregator、RegionManager 和 ContainerLocator 已從 production source 移除，不得重新引入。
 
 ## 目前啟動鏈
@@ -121,6 +121,8 @@ flowchart LR
 佇列已不再掃描 UI collection；新增、續傳與一次性啟動恢復都直接傳遞 `DownloadTaskId`。啟動查詢在同一份結果中提供 Domain snapshots 與 UI projections，runtime 只使用前者。`DownloadPipeline` 只建立單次 execution context 並依序執行 typed stages；階段失敗會立即停止並經 typed state writer 標記失敗。Presenter、projector 與 projection models 已由 Desktop 擁有，`DownloadListState` 只公開穩定的 `ReadOnlyObservableCollection<T>`。剩餘過渡債是 media execution context 仍讀取 `DownloadingItem` 作為播放流與畫面上下文，後續需改為明確 execution input，而不是讓 UI projection 進入 runtime。
 
 ## 目標拓樸
+
+本節以及後文的「目標」描述是未來 dependency/ownership 方向，不代表目前程式已搬移完成。現行 owner 以上方「目前拓樸」與「目前的正確事實」為準。
 
 ```text
 DownKyi.exe
@@ -241,7 +243,7 @@ address failure rather than a reason to downgrade. The six-RID real-binary gate,
 legacy `UseSsl` migration and third-party binary evidence are documented in
 `docs/operations/aria2-security.md`.
 
-## 邊界規則
+## 邊界規則（現行限制與目標 ownership）
 
 ### Domain
 
@@ -258,8 +260,8 @@ legacy `UseSsl` migration and third-party binary evidence are documented in
 
 ### Infrastructure
 
-- 實作 Application ports。
-- 擁有 SQLite、HTTP、aria2、FFmpeg、file system 與 logging sink 的生命週期。
+- 目前實作 Application ports，並擁有 SQLite、Bilibili HTTP/buvid、physical output path resolver 與 logging sink 生命週期。
+- 目標是再接手 aria2、FFmpeg 與其餘 file-system implementation；在該搬移發生前，Core/Desktop 仍是這些實作的現行 owner。
 - 不依賴 Desktop types 或 UI collections。
 
 ### Desktop

--- a/docs/design-docs/module-boundary-naming-audit.md
+++ b/docs/design-docs/module-boundary-naming-audit.md
@@ -1,13 +1,15 @@
 # DownKyi Module Boundary And Naming Audit
 
-Status: maintained verified audit
-Last verified: 2026-07-29
-Verification base: integration merge `fb8c9220cea18a79e42b521005f0bcb983c1241e`
-Verification branch: `release/v1.1.0-integration`
+Status: historical verified snapshot; not current repository status
+Snapshot verified: 2026-07-29
+Snapshot base: integration merge `fb8c9220cea18a79e42b521005f0bcb983c1241e`
+Snapshot branch: `release/v1.1.0-integration`
 
-## 結論
+Reading rule: 本文保留當時 audit 的 finding、數據與 release context。下文的「目前」、「現在」與 status 都只相對於上述 snapshot，不是當前 `main` 的 implemented state。現行 owner 與 dependency direction 請以根層 `ARCHITECTURE.md`、`docs/ai-knowledge-graph.md` 與可重現 audit output 為準。
 
-附件報告指出的七類問題大多成立，但原始證據已被後續重構取代。以目前工作樹重新量測後，Desktop 已成為實際 UI owner、Core 已 headless、下載佇列、HTTP 與 logging 邊界也已收斂；剩餘主要缺口是 media execution context 仍讀取一個 UI projection，以及 aria2、FFmpeg 與 filesystem 的最終 Infrastructure ownership。
+## 歷史結論
+
+附件報告指出的七類問題大多成立，但原始證據已被後續重構取代。以該 snapshot 工作樹重新量測後，Desktop 已成為實際 UI owner、Core 已 headless、下載佇列、HTTP 與 logging 邊界也已收斂；當時剩餘的主要缺口是 media execution context 仍讀取一個 UI projection，以及 aria2、FFmpeg 與 filesystem 的最終 Infrastructure ownership。
 
 Gate 1-9 已在 stacked release-hardening branch 完成，並由 `fb8c922` 无冲突整合到从最新 `main` 建立的 v1.1.0 integration branch。尚不得建立 tag：integration PR、最终同 SHA 跨平台 package rehearsal、artifact/checksum 检查与 main 合并仍是发布阻塞项。
 

--- a/docs/testing/README.md
+++ b/docs/testing/README.md
@@ -10,6 +10,7 @@
 - `DownKyi.Tests`：executable compatibility 與 end-to-end service tests。
 - `DownKyi.Architecture.Tests`：重要 dependency direction 與 repository wiring。
 - `DownKyi.Windows.Tests`：Windows process、Job Object 與 native handle 行為。
+- `DownKyi.Linux.Tests`：Linux process、signal 與 descendant lifecycle 行為。
 - `DownKyi.MacOS.Tests`：macOS system Bash、signing 與 packaging 行為。
 
 ## Formal Test Entry
@@ -18,10 +19,13 @@
 `script/test-project.ps1` 與 `script/test-solution.ps1` 經由
 `script/test-project-runner.ps1` 呼叫它。Runner 擁有：
 
-- 明確的 test-project allowlist 與 `DownKyiTestPlatforms` platform selection；
+- 對 `tests` 下所有 `*.Tests.csproj` 的自動 discovery（排除 `bin`/`obj`）；
+- 每個 discovered project 無條件宣告的 `DownKyiTestPlatforms` platform selection；
 - canonical invocation 與 slice/test identity；
-- `docs/testing/test-runner-policy.json` 中必要的 xUnit in-process routing；
+- `docs/testing/test-runner-policy.json` 中必要的 xUnit in-process routing exceptions；
 - per-project TRX validation 與 target exit result。
+
+`test-runner-policy.json` 不是 test-project registry 或 allowlist。新增 test project 會被自動發現，必須宣告 `DownKyiTestPlatforms`；只有需要偏離預設 VSTest 路由的專案才加入 policy exception。
 
 正式 PowerShell boundary 每次先 build CentralTestRunner，再執行目前
 repository state 的 runner。不要直接新增平行的 `dotnet test` / `vstest`


### PR DESCRIPTION
## Result

The repository documentation now clearly separates current implementation, future target ownership, and historical audit evidence.

## Changes

- label the module-boundary audit as a historical snapshot instead of current repository status
- distinguish Infrastructure's current SQLite/HTTP/path/logging ownership from the future aria2/FFmpeg/filesystem target
- document that test projects are discovered automatically and that `test-runner-policy.json` contains routing exceptions rather than a project allowlist
- include the existing Linux platform test project in the testing overview

No production behavior changes.

## Verification

Validated on exact commit `72f3e8b5cf531c2ccdafcab68f81228d823bc587` based on `origin/main` at `7cccc84d8bb03c123f41e2a88e9d2aeb4cb042cd`:

- repository formal runner against `AgentEnvironmentArchitectureTests`, `CentralTestRunnerRecorderTests`, and `TestPlatformOwnershipArchitectureTests`: 22 passed, 0 failed
- focused Release builds: 0 warnings, 0 errors
- `git diff --check`