### PR TITLE
ci: retry isolated build-test timeouts once

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,6 +38,7 @@ jobs:
   build-test:
     name: Build and test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/retry-timed-out-quality.yml
+++ b/.github/workflows/retry-timed-out-quality.yml
@@ -1,0 +1,100 @@
+name: Retry timed-out Strict PR CI job
+
+on:
+  workflow_run:
+    workflows:
+      - Strict PR CI
+    types:
+      - completed
+
+permissions:
+  actions: write
+
+concurrency:
+  group: retry-timed-out-strict-pr-ci-${{ github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  retry-single-timeout:
+    name: Retry one timed-out build-test job
+    if: >-
+      ${{
+        github.event.workflow_run.run_attempt == 1 &&
+        github.event.workflow_run.conclusion != 'success'
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Retry eligible job
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const eventRun = context.payload.workflow_run;
+            const expectedBuildTests = [
+              "Build and test (windows-latest)",
+              "Build and test (ubuntu-latest)",
+              "Build and test (macos-latest)",
+            ];
+            const readRun = async () => (await github.request(
+              "GET /repos/{owner}/{repo}/actions/runs/{run_id}",
+              { owner, repo, run_id: eventRun.id },
+            )).data;
+            const isOriginalCompletedRun = (run) =>
+              run.id === eventRun.id &&
+              run.path === ".github/workflows/quality.yml" &&
+              run.head_sha === eventRun.head_sha &&
+              run.status === "completed" &&
+              run.run_attempt === 1;
+
+            const liveRun = await readRun();
+            if (!isOriginalCompletedRun(liveRun)) {
+              core.info("No retry: the triggering run is no longer the original completed attempt.");
+              return;
+            }
+
+            const jobs = await github.paginate(
+              "GET /repos/{owner}/{repo}/actions/runs/{run_id}/attempts/{attempt_number}/jobs",
+              { owner, repo, run_id: eventRun.id, attempt_number: 1, per_page: 100 },
+            );
+            const buildJobs = jobs.filter((job) => job.name.startsWith("Build and test ("));
+            const exactMatrix =
+              buildJobs.length === expectedBuildTests.length &&
+              expectedBuildTests.every(
+                (name) => buildJobs.filter((job) => job.name === name).length === 1,
+              );
+            if (!exactMatrix) {
+              core.info("No retry: the build-test matrix does not match the guarded policy.");
+              return;
+            }
+
+            const timedOut = buildJobs.filter(
+              (job) => job.status === "completed" && job.conclusion === "timed_out",
+            );
+            if (timedOut.length !== 1) {
+              core.info(`No retry: expected one timed-out build-test job, found ${timedOut.length}.`);
+              return;
+            }
+
+            const timedOutJob = timedOut[0];
+            const otherUnsuccessful = jobs.filter(
+              (job) =>
+                job.id !== timedOutJob.id &&
+                (job.status !== "completed" || job.conclusion !== "success"),
+            );
+            if (otherUnsuccessful.length !== 0) {
+              core.info("No retry: another job was unsuccessful or inconclusive.");
+              return;
+            }
+
+            const recheck = await readRun();
+            if (!isOriginalCompletedRun(recheck)) {
+              core.info("No retry: another retry started before the final check.");
+              return;
+            }
+
+            core.info(`Retrying ${timedOutJob.name} (${timedOutJob.id}) for ${eventRun.head_sha}.`);
+            await github.request(
+              "POST /repos/{owner}/{repo}/actions/jobs/{job_id}/rerun",
+              { owner, repo, job_id: timedOutJob.id },
+            );

--- a/tests/DownKyi.Architecture.Tests/AgentEnvironmentArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AgentEnvironmentArchitectureTests.cs
@@ -90,6 +90,60 @@ public sealed class AgentEnvironmentArchitectureTests
     }
 
     [Fact]
+    public void ContinuousIntegrationBoundsAndRetriesOnlyAnIsolatedBuildTestTimeout()
+    {
+        var qualityWorkflow = Read(".github/workflows/quality.yml");
+        var buildTest = Slice(qualityWorkflow, "  build-test:", "  aria2-tls-security:");
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(
+            buildTest,
+            @"(?m)^    timeout-minutes: 20\r?$"));
+        Assert.Contains("fail-fast: false", buildTest, StringComparison.Ordinal);
+        Assert.Contains("- windows-latest", buildTest, StringComparison.Ordinal);
+        Assert.Contains("- ubuntu-latest", buildTest, StringComparison.Ordinal);
+        Assert.Contains("- macos-latest", buildTest, StringComparison.Ordinal);
+        Assert.DoesNotMatch(
+            new System.Text.RegularExpressions.Regex(@"(?m)^\s+needs\s*:", System.Text.RegularExpressions.RegexOptions.CultureInvariant),
+            qualityWorkflow);
+
+        var retryWorkflow = Read(".github/workflows/retry-timed-out-quality.yml");
+        Assert.Contains("workflow_run:", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("- Strict PR CI", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("types:\n      - completed", retryWorkflow.Replace("\r\n", "\n", StringComparison.Ordinal), StringComparison.Ordinal);
+        Assert.Matches(
+            new System.Text.RegularExpressions.Regex(
+                @"(?m)^permissions:\r?$\n^  actions: write\r?$\n^\r?$\n^concurrency:",
+                System.Text.RegularExpressions.RegexOptions.CultureInvariant),
+            retryWorkflow);
+        Assert.Contains("github.event.workflow_run.run_attempt == 1", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("github.event.workflow_run.conclusion != 'success'", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("retry-timed-out-strict-pr-ci-${{ github.event.workflow_run.id }}", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("cancel-in-progress: false", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("/attempts/{attempt_number}/jobs", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("attempt_number: 1", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("run.path === \".github/workflows/quality.yml\"", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("run.head_sha === eventRun.head_sha", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("run.status === \"completed\"", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("run.run_attempt === 1", retryWorkflow, StringComparison.Ordinal);
+        Assert.Equal(2, System.Text.RegularExpressions.Regex.Count(retryWorkflow, @"await readRun\(\)"));
+        Assert.Contains("Build and test (windows-latest)", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("Build and test (ubuntu-latest)", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("Build and test (macos-latest)", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("buildJobs.length === expectedBuildTests.length", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("timedOut.length !== 1", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("job.conclusion !== \"success\"", retryWorkflow, StringComparison.Ordinal);
+        Assert.Single(System.Text.RegularExpressions.Regex.Matches(
+            retryWorkflow,
+            @"POST /repos/\{owner\}/\{repo\}/actions/jobs/\{job_id\}/rerun"));
+        Assert.Contains("actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("actions/checkout", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("download-artifact", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("actions/cache", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("pull_request_target", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("rerun-failed-jobs", retryWorkflow, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("actions/runs/{run_id}/rerun", retryWorkflow, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public void KnowledgeStructureHasNavigableEntryPoints()
     {
         AssertPathsExist(
@@ -267,6 +321,14 @@ public sealed class AgentEnvironmentArchitectureTests
     private static string Read(string relativePath)
     {
         return File.ReadAllText(Path.Combine(RepositoryRoot, PathFromRepository(relativePath)));
+    }
+
+    private static string Slice(string value, string startMarker, string endMarker)
+    {
+        var start = value.IndexOf(startMarker, StringComparison.Ordinal);
+        var end = value.IndexOf(endMarker, start + startMarker.Length, StringComparison.Ordinal);
+        Assert.True(start >= 0 && end > start, $"Could not slice from {startMarker} to {endMarker}.");
+        return value[start..end];
     }
 
     private static string PathFromRepository(string path)


### PR DESCRIPTION
## Summary
- cap each cross-platform `Build and test` matrix job at 20 minutes
- after a completed first attempt, rerun exactly one isolated timed-out build-test job on a fresh GitHub-hosted runner
- refuse automatic retry for ordinary failures, multiple timeouts, matrix drift, inconclusive jobs, or later attempts
- keep the privileged controller metadata-only and pin its sole action by commit SHA

## Verification
- focused AgentEnvironmentArchitectureTests: 11 passed
- strict Release build: 0 warnings, 0 errors
- formal Windows test solution: 8 projects passed
- dotnet format: passed
- module-boundary audit: passed
- actionlint v1.7.12: passed
- vulnerable packages: none
- deprecated packages: none
- Gitleaks 8.30.1: 0 findings
- git diff --check: passed

## Scope
No product code or CentralTestRunner behavior changed.