### PR TITLE
Fix CI timeout retry classification

### DIFF
--- a/.github/workflows/retry-timed-out-quality.yml
+++ b/.github/workflows/retry-timed-out-quality.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   actions: write
+  checks: read
 
 concurrency:
   group: retry-timed-out-strict-pr-ci-${{ github.event.workflow_run.id }}
@@ -68,9 +69,24 @@ jobs:
               return;
             }
 
-            const timedOut = buildJobs.filter(
-              (job) => job.status === "completed" && job.conclusion === "timed_out",
+            const cancelledBuildJobs = buildJobs.filter(
+              (job) => job.status === "completed" && job.conclusion === "cancelled",
             );
+            const timedOut = [];
+            for (const job of cancelledBuildJobs) {
+              const annotations = await github.paginate(
+                "GET /repos/{owner}/{repo}/check-runs/{check_run_id}/annotations",
+                { owner, repo, check_run_id: job.id, per_page: 100 },
+              );
+              const hasTimeoutAnnotation = annotations.some(
+                (annotation) =>
+                  annotation.annotation_level === "failure" &&
+                  annotation.message === "The job has exceeded the maximum execution time of 20m0s",
+              );
+              if (hasTimeoutAnnotation) {
+                timedOut.push(job);
+              }
+            }
             if (timedOut.length !== 1) {
               core.info(`No retry: expected one timed-out build-test job, found ${timedOut.length}.`);
               return;

--- a/tests/DownKyi.Architecture.Tests/AgentEnvironmentArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AgentEnvironmentArchitectureTests.cs
@@ -111,7 +111,7 @@ public sealed class AgentEnvironmentArchitectureTests
         Assert.Contains("types:\n      - completed", retryWorkflow.Replace("\r\n", "\n", StringComparison.Ordinal), StringComparison.Ordinal);
         Assert.Matches(
             new System.Text.RegularExpressions.Regex(
-                @"(?m)^permissions:\r?$\n^  actions: write\r?$\n^\r?$\n^concurrency:",
+                @"(?m)^permissions:\r?$\n^  actions: write\r?$\n^  checks: read\r?$\n^\r?$\n^concurrency:",
                 System.Text.RegularExpressions.RegexOptions.CultureInvariant),
             retryWorkflow);
         Assert.Contains("github.event.workflow_run.run_attempt == 1", retryWorkflow, StringComparison.Ordinal);
@@ -129,8 +129,15 @@ public sealed class AgentEnvironmentArchitectureTests
         Assert.Contains("Build and test (ubuntu-latest)", retryWorkflow, StringComparison.Ordinal);
         Assert.Contains("Build and test (macos-latest)", retryWorkflow, StringComparison.Ordinal);
         Assert.Contains("buildJobs.length === expectedBuildTests.length", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("job.conclusion === \"cancelled\"", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("/check-runs/{check_run_id}/annotations", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("annotation.annotation_level === \"failure\"", retryWorkflow, StringComparison.Ordinal);
+        Assert.Contains("The job has exceeded the maximum execution time of 20m0s", retryWorkflow, StringComparison.Ordinal);
         Assert.Contains("timedOut.length !== 1", retryWorkflow, StringComparison.Ordinal);
         Assert.Contains("job.conclusion !== \"success\"", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("job.conclusion === \"timed_out\"", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("job.started_at", retryWorkflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("job.completed_at", retryWorkflow, StringComparison.Ordinal);
         Assert.Single(System.Text.RegularExpressions.Regex.Matches(
             retryWorkflow,
             @"POST /repos/\{owner\}/\{repo\}/actions/jobs/\{job_id\}/rerun"));


### PR DESCRIPTION
## Why

A real 20-minute macOS timeout on PR #244 proved that GitHub reports a job-level timeout as cancelled, while the retry workflow expected 	imed_out. The runner was terminated, but no replacement runner was requested.

## Change

Treat a cancelled build-test job as retryable only when its GitHub check-run annotations contain the exact system failure The job has exceeded the maximum execution time of 20m0s. Add only the required checks: read permission. Manual cancellation, ordinary failures, multiple timeouts, and later attempts remain ineligible. No product code changes.

## Validation

- Focused architecture contract: 1 passed
- Restore: passed
- Release version contract: passed (1.1.3)
- Strict Release build: passed, 0 warnings/errors
- Format verification: passed
- Module-boundary audit: passed
- actionlint 1.7.12: passed
- Vulnerable/deprecated package audits: passed, none found
- Gitleaks 8.30.1: 1,139 candidates, 0 findings
- git diff --check: passed

The full local solution test did not start its first assembly because the test process returned invalid JSON. It was not rerun or treated as green; hosted exact-head CI remains required.