### PR TITLE
Recover downloads only after workers stop

### DIFF
--- a/src/DownKyi.Desktop/Services/Download/DownloadShutdownCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadShutdownCoordinator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -41,7 +42,10 @@ internal static class DownloadShutdownCoordinator
             }
             finally
             {
-                await recoverStateAsync().ConfigureAwait(false);
+                if (workerTasks.All(static task => task.IsCompleted))
+                {
+                    await recoverStateAsync().ConfigureAwait(false);
+                }
             }
         }
     }

--- a/tests/DownKyi.Tests/DownloadShutdownCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadShutdownCoordinatorTests.cs
@@ -72,7 +72,7 @@ public sealed class DownloadShutdownCoordinatorTests
     }
 
     [Fact]
-    public async Task StopAsyncFailsClosedWhenOwnedWorkerMissesTimeout()
+    public async Task StopAsyncWorkerTimeoutDoesNotRecoverWhileWorkerIsStillRunning()
     {
         var workerCompletion = new TaskCompletionSource(
             TaskCreationOptions.RunContinuationsAsynchronously);
@@ -94,7 +94,7 @@ public sealed class DownloadShutdownCoordinatorTests
                     }));
 
             Assert.True(timeoutObserved);
-            Assert.Equal(1, recoveryCount);
+            Assert.Equal(0, recoveryCount);
             Assert.False(workerCompletion.Task.IsCompleted);
         }
         finally


### PR DESCRIPTION
## Why

A deterministic current-main reproduction showed that shutdown recovery could mark a durable download as Queued while its old worker was still alive. The late worker then remained able to mutate both durable state and filesystem/backend identity.

## Change

- Recover interrupted downloads during shutdown only after every owned worker is terminal.
- Keep a timed-out, still-running worker task in its persisted Downloading state so the existing next-start bootstrap recovery remains the sole later handoff point.
- Update the focused timeout contract test.

This changes two existing owner/test files only; it adds no new timer, service, state registry, or lifecycle abstraction.

## Validation

- Focused DownloadShutdownCoordinatorTests via script/test-project.ps1
- dotnet restore
- release/version validation
- strict Release build (0 warnings, 0 errors)
- formal Windows test solution (8 selected projects passed; existing packaged aria2 TLS test skipped because DOWNKYI_ARIA2_BINARY was absent)
- dotnet format verify
- module-boundary audit
- actionlint 1.7.12
- vulnerable and deprecated package audits
- gitleaks 8.30.1
- git diff --check