### PR TITLE
fix: allow video-only DASH downloads

### DIFF
--- a/src/DownKyi.Desktop/Services/Download/DownloadAudioSelection.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadAudioSelection.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using DownKyi.Core.BiliApi.VideoStream.Models;
+
+namespace DownKyi.Services.Download;
+
+internal static class DownloadAudioSelection
+{
+    public static PlayUrlDashVideo? Select(int audioCodecId, PlayUrl? playUrl)
+    {
+        var dash = playUrl?.Dash;
+        if (dash == null)
+        {
+            return null;
+        }
+
+        var selected = dash.Audio?.FirstOrDefault(item => item.Id == audioCodecId);
+        if (audioCodecId == 30250)
+        {
+            var dolbyAudio = dash.Dolby?.Audio;
+            return dolbyAudio is { Count: > 0 } ? dolbyAudio[0] : selected;
+        }
+
+        if (audioCodecId == 30251)
+        {
+            var flacAudio = dash.Flac?.Audio;
+            return HasMediaAddress(flacAudio) ? flacAudio : selected;
+        }
+
+        return selected;
+    }
+
+    public static bool HasAnyAudio(PlayUrlDash? dash)
+    {
+        return dash?.Audio is { Count: > 0 } ||
+               dash?.Dolby?.Audio is { Count: > 0 } ||
+               HasMediaAddress(dash?.Flac?.Audio);
+    }
+
+    private static bool HasMediaAddress(PlayUrlDashVideo? media)
+    {
+        return media != null &&
+               (!string.IsNullOrWhiteSpace(media.BaseAddress) ||
+                media.BackupUrl.Any(url => !string.IsNullOrWhiteSpace(url)));
+    }
+}

--- a/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
@@ -107,11 +107,22 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
         {
             var audio = SelectAudio(context);
             if (audio == null &&
-                !HasAnyAudio(context.PlayUrl?.Dash) &&
+                !DownloadAudioSelection.HasAnyAudio(context.PlayUrl?.Dash) &&
                 context.NeedsVideo)
             {
-                _logger.LogWarningMessage(
-                    "Playback does not provide an audio stream; continuing with the requested video.");
+                var completedAudio = TryGetCompletedAudioTransfer(context);
+                if (completedAudio != null)
+                {
+                    context.AudioFile = completedAudio.FilePath;
+                    context.AudioTransferKey = completedAudio.Key;
+                    _logger.LogInformationMessage(
+                        "Playback does not provide an audio stream; reusing the completed audio transfer.");
+                }
+                else
+                {
+                    _logger.LogWarningMessage(
+                        "Playback does not provide an audio stream; continuing with the requested video.");
+                }
             }
             else
             {
@@ -349,40 +360,38 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
         DownloadExecutionContext context,
         PlayUrl? playUrl)
     {
-        var audioCodec = context.Input.Metadata.AudioCodec;
-        var dash = playUrl?.Dash;
-        if (dash == null)
+        return DownloadAudioSelection.Select(context.Input.Metadata.AudioCodec.Id, playUrl);
+    }
+
+    private DownloadedMediaTransfer? TryGetCompletedAudioTransfer(
+        DownloadExecutionContext context)
+    {
+        var path = context.DownloadDirectory;
+        if (string.IsNullOrWhiteSpace(path))
         {
             return null;
         }
 
-        if (audioCodec.Id == 30250)
+        var keyPrefix = DownloadTransferKey.Create(
+            context.Input.Metadata.AudioCodec.Id,
+            string.Empty);
+        var snapshot = _projectionStore.GetRequiredSnapshot(context.TaskId);
+        foreach (var key in snapshot.Transfer.CompletedFileKeys.Where(
+                     key => key.StartsWith(keyPrefix, StringComparison.Ordinal)))
         {
-            var dolbyAudio = dash.Dolby?.Audio;
-            return dolbyAudio is { Count: > 0 } ? dolbyAudio[0] : null;
+            if (!snapshot.Plan.TransferFiles.TryGetValue(key, out var fileName))
+            {
+                continue;
+            }
+
+            var completedFile = Path.Combine(path, fileName);
+            if (IsDownloadedMediaFileUsable(completedFile))
+            {
+                return new DownloadedMediaTransfer(key, completedFile);
+            }
         }
 
-        if (audioCodec.Id == 30251)
-        {
-            var flacAudio = dash.Flac?.Audio;
-            return HasMediaAddress(flacAudio) ? flacAudio : null;
-        }
-
-        return dash.Audio.FirstOrDefault(item => item.Id == audioCodec.Id);
-    }
-
-    private static bool HasAnyAudio(PlayUrlDash? dash)
-    {
-        return dash?.Audio.Count > 0 ||
-               dash?.Dolby?.Audio.Count > 0 ||
-               HasMediaAddress(dash?.Flac?.Audio);
-    }
-
-    private static bool HasMediaAddress(PlayUrlDashVideo? media)
-    {
-        return media != null &&
-               (!string.IsNullOrWhiteSpace(media.BaseAddress) ||
-                media.BackupUrl.Any(url => !string.IsNullOrWhiteSpace(url)));
+        return null;
     }
 
     internal static PlayUrlDashVideo? SelectVideo(DownloadExecutionContext context)

--- a/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadMediaStage.cs
@@ -105,21 +105,32 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
     {
         if (context.NeedsAudio)
         {
-            _presenter.ShowDownloadingAudio(context);
-            var result = await DownloadMediaFileAsync(
-                context,
-                SelectAudio(context),
-                playUrl => SelectAudio(context, playUrl),
-                cancellationToken).ConfigureAwait(true);
-            if (!result.TryGetValue(out var audioTransfer))
+            var audio = SelectAudio(context);
+            if (audio == null &&
+                !HasAnyAudio(context.PlayUrl?.Dash) &&
+                context.NeedsVideo)
             {
-                return DownloadStageResult.Failure(
-                    result.Error?.Code ?? "download.media.audio",
-                    result.Error?.Message ?? "Audio transfer failed.");
+                _logger.LogWarningMessage(
+                    "Playback does not provide an audio stream; continuing with the requested video.");
             }
+            else
+            {
+                _presenter.ShowDownloadingAudio(context);
+                var result = await DownloadMediaFileAsync(
+                    context,
+                    audio,
+                    playUrl => SelectAudio(context, playUrl),
+                    cancellationToken).ConfigureAwait(true);
+                if (!result.TryGetValue(out var audioTransfer))
+                {
+                    return DownloadStageResult.Failure(
+                        result.Error?.Code ?? "download.media.audio",
+                        result.Error?.Message ?? "Audio transfer failed.");
+                }
 
-            context.AudioFile = audioTransfer.FilePath;
-            context.AudioTransferKey = audioTransfer.Key;
+                context.AudioFile = audioTransfer.FilePath;
+                context.AudioTransferKey = audioTransfer.Key;
+            }
         }
 
         context.EnsureActive(cancellationToken);
@@ -329,7 +340,7 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
             "Invalid transfer artifacts could not be removed safely."));
     }
 
-    private static PlayUrlDashVideo? SelectAudio(DownloadExecutionContext context)
+    internal static PlayUrlDashVideo? SelectAudio(DownloadExecutionContext context)
     {
         return SelectAudio(context, context.PlayUrl);
     }
@@ -340,24 +351,38 @@ internal sealed class DownloadMediaStage : IDownloadPipelineStage
     {
         var audioCodec = context.Input.Metadata.AudioCodec;
         var dash = playUrl?.Dash;
-        if (dash?.Audio is not { Count: > 0 } audio)
+        if (dash == null)
         {
             return null;
         }
 
-        var selected = audio.FirstOrDefault(item => item.Id == audioCodec.Id);
-        if (audioCodec.Id == 30250 &&
-            dash.Dolby?.Audio is { Count: > 0 } dolbyAudio)
+        if (audioCodec.Id == 30250)
         {
-            selected = dolbyAudio[0];
+            var dolbyAudio = dash.Dolby?.Audio;
+            return dolbyAudio is { Count: > 0 } ? dolbyAudio[0] : null;
         }
 
-        if (audioCodec.Id == 30251 && dash.Flac?.Audio is { } flacAudio)
+        if (audioCodec.Id == 30251)
         {
-            selected = flacAudio;
+            var flacAudio = dash.Flac?.Audio;
+            return HasMediaAddress(flacAudio) ? flacAudio : null;
         }
 
-        return selected;
+        return dash.Audio.FirstOrDefault(item => item.Id == audioCodec.Id);
+    }
+
+    private static bool HasAnyAudio(PlayUrlDash? dash)
+    {
+        return dash?.Audio.Count > 0 ||
+               dash?.Dolby?.Audio.Count > 0 ||
+               HasMediaAddress(dash?.Flac?.Audio);
+    }
+
+    private static bool HasMediaAddress(PlayUrlDashVideo? media)
+    {
+        return media != null &&
+               (!string.IsNullOrWhiteSpace(media.BaseAddress) ||
+                media.BackupUrl.Any(url => !string.IsNullOrWhiteSpace(url)));
     }
 
     internal static PlayUrlDashVideo? SelectVideo(DownloadExecutionContext context)

--- a/tests/DownKyi.Tests/DownloadPipelineStageTests.cs
+++ b/tests/DownKyi.Tests/DownloadPipelineStageTests.cs
@@ -178,6 +178,49 @@ public sealed class DownloadPipelineStageTests
     }
 
     [Fact]
+    public async Task MediaStageDownloadsVideoWhenAudioCollectionIsNull()
+    {
+        var playUrl = CreateVideoOnlyPlayUrl();
+        playUrl.Dash.Audio = null!;
+        using var fixture = await MediaStageFixture.CreateAsync(
+            playUrl,
+            downloadAudio: true,
+            downloadVideo: true).ConfigureAwait(true);
+
+        var result = await fixture.Stage.ExecuteAsync(
+            fixture.Context,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(fixture.Context.AudioFile);
+        Assert.NotNull(fixture.Context.VideoFile);
+        var request = Assert.Single(fixture.Backend.Requests);
+        Assert.Equal("https://example.invalid/video", Assert.Single(request.Urls));
+    }
+
+    [Fact]
+    public async Task MediaStageReusesCompletedAudioWhenPlaybackNoLongerProvidesAudio()
+    {
+        using var fixture = await MediaStageFixture.CreateAsync(
+            CreateVideoOnlyPlayUrl(),
+            downloadAudio: true,
+            downloadVideo: true).ConfigureAwait(true);
+        var completedAudio = await fixture.AddCompletedAudioTransferAsync()
+            .ConfigureAwait(true);
+
+        var result = await fixture.Stage.ExecuteAsync(
+            fixture.Context,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(completedAudio.FilePath, fixture.Context.AudioFile);
+        Assert.Equal(completedAudio.Key, fixture.Context.AudioTransferKey);
+        Assert.NotNull(fixture.Context.VideoFile);
+        var request = Assert.Single(fixture.Backend.Requests);
+        Assert.Equal("https://example.invalid/video", Assert.Single(request.Urls));
+    }
+
+    [Fact]
     public async Task MediaStageRejectsAudioOnlyRequestWhenSourceHasNoAudio()
     {
         using var fixture = await MediaStageFixture.CreateAsync(
@@ -266,6 +309,29 @@ public sealed class DownloadPipelineStageTests
             });
 
         Assert.Same(flac, DownloadMediaStage.SelectAudio(context));
+    }
+
+    [Theory]
+    [InlineData(30250)]
+    [InlineData(30251)]
+    public void MediaStageFallsBackToOrdinaryAudioWhenSpecialDescriptorIsUnavailable(
+        int audioCodecId)
+    {
+        using var settings = new TestSettingsStore();
+        var ordinary = new PlayUrlDashVideo
+        {
+            Id = audioCodecId,
+            BaseAddress = "https://example.invalid/ordinary-audio"
+        };
+        var context = CreateContext(
+            settings.Store.Current,
+            audioCodecId: audioCodecId,
+            playUrl: new PlayUrl
+            {
+                Dash = new PlayUrlDash { Audio = [ordinary] }
+            });
+
+        Assert.Same(ordinary, DownloadMediaStage.SelectAudio(context));
     }
 
     [Fact]
@@ -411,6 +477,29 @@ public sealed class DownloadPipelineStageTests
         public DownloadMediaStage Stage { get; }
 
         public DownloadExecutionContext Context { get; }
+
+        public async Task<(string Key, string FilePath)> AddCompletedAudioTransferAsync()
+        {
+            const string fileName = "completed-audio.m4s";
+            var filePath = Path.Combine(_directory, fileName);
+            await File.WriteAllBytesAsync(
+                filePath,
+                [1, 2, 3],
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+            var key = DownloadTransferKey.Create(30280, "mp4a.40.2");
+            var recorded = await _tasks.RecordTransferFileAsync(
+                Context.TaskId,
+                key,
+                fileName,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+            Assert.True(recorded.IsSuccess, recorded.Error?.Message);
+            var completed = await _tasks.CompleteTransferFileAsync(
+                Context.TaskId,
+                key,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+            Assert.True(completed.IsSuccess, completed.Error?.Message);
+            return (key, filePath);
+        }
 
         public static async Task<MediaStageFixture> CreateAsync(
             PlayUrl playUrl,

--- a/tests/DownKyi.Tests/DownloadPipelineStageTests.cs
+++ b/tests/DownKyi.Tests/DownloadPipelineStageTests.cs
@@ -1,10 +1,15 @@
+using DownKyi.Application.Downloads;
 using DownKyi.Core.BiliApi.VideoStream.Models;
 using DownKyi.Core.Settings;
 using DownKyi.Domain.Downloads;
 using DownKyi.Domain.Results;
+using DownKyi.Infrastructure.Downloads;
+using DownKyi.Infrastructure.Time;
 using DownKyi.Models;
 using DownKyi.Services.Download;
 using DownKyi.ViewModels.DownloadManager;
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace DownKyi.Tests;
 
@@ -154,6 +159,116 @@ public sealed class DownloadPipelineStageTests
     }
 
     [Fact]
+    public async Task MediaStageDownloadsVideoWhenRequestedAudioIsUnavailable()
+    {
+        using var fixture = await MediaStageFixture.CreateAsync(
+            CreateVideoOnlyPlayUrl(),
+            downloadAudio: true,
+            downloadVideo: true).ConfigureAwait(true);
+
+        var result = await fixture.Stage.ExecuteAsync(
+            fixture.Context,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(fixture.Context.AudioFile);
+        Assert.NotNull(fixture.Context.VideoFile);
+        var request = Assert.Single(fixture.Backend.Requests);
+        Assert.Equal("https://example.invalid/video", Assert.Single(request.Urls));
+    }
+
+    [Fact]
+    public async Task MediaStageRejectsAudioOnlyRequestWhenSourceHasNoAudio()
+    {
+        using var fixture = await MediaStageFixture.CreateAsync(
+            CreateVideoOnlyPlayUrl(),
+            downloadAudio: true,
+            downloadVideo: false).ConfigureAwait(true);
+
+        var result = await fixture.Stage.ExecuteAsync(
+            fixture.Context,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.media.descriptor", result.Error?.Code);
+        Assert.Empty(fixture.Backend.Requests);
+    }
+
+    [Fact]
+    public async Task MediaStageRejectsMissingSelectedAudioWhenSourceHasOtherAudio()
+    {
+        var playUrl = CreateVideoOnlyPlayUrl();
+        playUrl.Dash.Audio =
+        [
+            new PlayUrlDashVideo
+            {
+                Id = 30280,
+                Codecs = "mp4a.40.2",
+                BaseAddress = "https://example.invalid/audio"
+            }
+        ];
+        using var fixture = await MediaStageFixture.CreateAsync(
+            playUrl,
+            downloadAudio: true,
+            downloadVideo: true,
+            selectedAudioId: 30232).ConfigureAwait(true);
+
+        var result = await fixture.Stage.ExecuteAsync(
+            fixture.Context,
+            TestContext.Current.CancellationToken);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("download.media.descriptor", result.Error?.Code);
+        Assert.Empty(fixture.Backend.Requests);
+    }
+
+    [Fact]
+    public void MediaStageSelectsDolbyWhenOrdinaryAudioIsUnavailable()
+    {
+        using var settings = new TestSettingsStore();
+        var dolby = new PlayUrlDashVideo
+        {
+            Id = 30250,
+            BaseAddress = "https://example.invalid/dolby"
+        };
+        var context = CreateContext(
+            settings.Store.Current,
+            audioCodecId: 30250,
+            playUrl: new PlayUrl
+            {
+                Dash = new PlayUrlDash
+                {
+                    Dolby = new PlayUrlDashDolby { Audio = [dolby] }
+                }
+            });
+
+        Assert.Same(dolby, DownloadMediaStage.SelectAudio(context));
+    }
+
+    [Fact]
+    public void MediaStageSelectsFlacWhenOrdinaryAudioIsUnavailable()
+    {
+        using var settings = new TestSettingsStore();
+        var flac = new PlayUrlDashVideo
+        {
+            Id = 30251,
+            BaseAddress = "https://example.invalid/flac"
+        };
+        var context = CreateContext(
+            settings.Store.Current,
+            audioCodecId: 30251,
+            playUrl: new PlayUrl
+            {
+                Dash = new PlayUrlDash
+                {
+                    Flac = new PlayUrlDashFlac { Audio = flac }
+                }
+            });
+
+        Assert.Same(flac, DownloadMediaStage.SelectAudio(context));
+    }
+
+    [Fact]
     public void MuxStageSelectsOutputFromRequestedStreamShape()
     {
         using var settings = new TestSettingsStore();
@@ -238,6 +353,204 @@ public sealed class DownloadPipelineStageTests
             }
         };
         return DownloadExecutionContextTestFactory.Create(downloading, settings);
+    }
+
+    private static PlayUrl CreateVideoOnlyPlayUrl()
+    {
+        return new PlayUrl
+        {
+            Dash = new PlayUrlDash
+            {
+                Video =
+                [
+                    new PlayUrlDashVideo
+                    {
+                        Id = 80,
+                        CodecId = 7,
+                        Codecs = "avc1",
+                        BaseAddress = "https://example.invalid/video"
+                    }
+                ]
+            }
+        };
+    }
+
+    private sealed class MediaStageFixture : IDisposable
+    {
+        private readonly string _directory;
+        private readonly string _databasePath;
+        private readonly SqliteDownloadTaskStore _store;
+        private readonly DownloadTaskApplicationService _tasks;
+        private readonly DownloadTaskProjectionStore _projections;
+        private readonly TestSettingsStore _settings;
+
+        private MediaStageFixture(
+            string directory,
+            string databasePath,
+            SqliteDownloadTaskStore store,
+            DownloadTaskApplicationService tasks,
+            DownloadTaskProjectionStore projections,
+            TestSettingsStore settings,
+            RecordingMediaBackend backend,
+            DownloadMediaStage stage,
+            DownloadExecutionContext context)
+        {
+            _directory = directory;
+            _databasePath = databasePath;
+            _store = store;
+            _tasks = tasks;
+            _projections = projections;
+            _settings = settings;
+            Backend = backend;
+            Stage = stage;
+            Context = context;
+        }
+
+        public RecordingMediaBackend Backend { get; }
+
+        public DownloadMediaStage Stage { get; }
+
+        public DownloadExecutionContext Context { get; }
+
+        public static async Task<MediaStageFixture> CreateAsync(
+            PlayUrl playUrl,
+            bool downloadAudio,
+            bool downloadVideo,
+            int selectedAudioId = 30280)
+        {
+            var directory = Path.Combine(
+                Path.GetTempPath(),
+                $"downkyi-media-stage-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(directory);
+            var databasePath = Path.Combine(directory, "download.db");
+            var store = new SqliteDownloadTaskStore(
+                new SqliteDownloadTaskStoreOptions(databasePath),
+                new SystemClock());
+            var tasks = new DownloadTaskApplicationService(store, new SystemClock());
+            var projections = new DownloadTaskProjectionStore(tasks, new SystemClock());
+            var settings = new TestSettingsStore();
+            var stateWriter = new DownloadTaskStateWriter(tasks);
+            var taskId = new DownloadTaskId($"media-stage-{Guid.NewGuid():N}");
+            var downloadBase = new DownloadBase
+            {
+                Id = taskId.Value,
+                FilePath = Path.Combine(directory, "output"),
+                NeedDownloadContent = new DownloadContentSelection(
+                    Audio: downloadAudio,
+                    Video: downloadVideo,
+                    Danmaku: false,
+                    Subtitle: false,
+                    Cover: false),
+                VideoCodecName = "H.264/AVC"
+            };
+            downloadBase.Resolution.Id = 80;
+            downloadBase.AudioCodec.Id = selectedAudioId;
+            var downloading = new DownloadingItem
+            {
+                DownloadBase = downloadBase,
+                Downloading = new Downloading
+                {
+                    Id = taskId.Value,
+                    DownloadBase = downloadBase,
+                    DownloadStatus = DownloadStatus.WaitForDownload
+                },
+                PlayUrl = playUrl
+            };
+            await projections.AddDownloadingAsync(
+                downloading,
+                TestContext.Current.CancellationToken).ConfigureAwait(true);
+            await stateWriter.StartAsync(taskId, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+            downloading.Downloading.DownloadStatus = DownloadStatus.Downloading;
+            var context = DownloadExecutionContextTestFactory.Create(
+                downloading,
+                settings.Store.Current);
+            context.DownloadDirectory = directory;
+            var backend = new RecordingMediaBackend();
+            var stage = new DownloadMediaStage(
+                projections,
+                stateWriter,
+                new DownloadTransferCoordinator(
+                    backend,
+                    new DownloadRetryPolicy(),
+                    TimeProvider.System,
+                    NullLogger<DownloadTransferCoordinator>.Instance),
+                new DownloadPlaybackResolver(
+                    new TestWbiKeyProvider(),
+                    TimeProvider.System,
+                    new TestBilibiliApiClient()),
+                new DownloadActivityPresenter(projections, stateWriter),
+                NullLogger<DownloadMediaStage>.Instance);
+            return new MediaStageFixture(
+                directory,
+                databasePath,
+                store,
+                tasks,
+                projections,
+                settings,
+                backend,
+                stage,
+                context);
+        }
+
+        public void Dispose()
+        {
+            Backend.Dispose();
+            _projections.Dispose();
+            _tasks.Dispose();
+            _store.Dispose();
+            _settings.Dispose();
+            using var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+            {
+                DataSource = _databasePath,
+                Mode = SqliteOpenMode.ReadWriteCreate,
+                Pooling = true,
+                DefaultTimeout = 5
+            }.ToString());
+            SqliteConnection.ClearPool(connection);
+            Directory.Delete(_directory, recursive: true);
+        }
+    }
+
+    private sealed class RecordingMediaBackend : ITransferBackend
+    {
+        public List<DownloadTransferRequest> Requests { get; } = [];
+
+        public string Name => "recording-media";
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<DownloadTransferResult> ResetAsync(
+            string? backendIdentity,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(DownloadTransferResult.Succeeded());
+        }
+
+        public async Task<DownloadTransferResult> TransferAsync(DownloadTransferRequest request)
+        {
+            Requests.Add(request);
+            await File.WriteAllBytesAsync(
+                Path.Combine(request.Directory, request.FileName),
+                [1, 2, 3],
+                request.CancellationToken).ConfigureAwait(true);
+            return DownloadTransferResult.Succeeded();
+        }
+
+        public void Dispose()
+        {
+        }
     }
 
     private sealed class RecordingStage(


### PR DESCRIPTION
## Summary

- continue the requested video download when a DASH source provides no audio stream
- preserve the typed failure for audio-only requests and for stale/mismatched audio selections
- allow Dolby and FLAC selection when the ordinary DASH audio list is empty
- cover the media stage with video-only, audio-only, mismatched-selection, Dolby, and FLAC regressions

## Root cause

`DownloadMediaStage` treated persisted `downloadAudio` user intent as proof that the source had an audio stream. For a video-only DASH response, `SelectAudio()` returned `null`, and `DownloadMediaFileAsync()` failed with `download.media.descriptor` before the video transfer, Aria2, or FFmpeg could run.

The effective decision is now made at runtime: skip unavailable audio only when video is also requested and the playback source has no audio capability. Audio-only requests and selection mismatches still fail instead of silently changing the user's request.

No new persistent file or settings history is introduced.

## Verification

- strict Release build with all .NET analyzers enabled and warnings as errors: 0 warnings, 0 errors
- `DownloadPipelineStageTests`: passed
- CentralTestRunner solution suite: passed all 8 selected Windows test projects
- existing packaged Aria2 TLS integration test skipped because `DOWNKYI_ARIA2_BINARY` is not configured
- `dotnet format --verify-no-changes`: passed
- module-boundary audit: passed
- actionlint 1.7.12: passed
- NuGet vulnerable/deprecated package audits: no findings
- Gitleaks 8.30.1: 1,142 candidate files, 0 findings
- `git diff --check`: passed

Fixes #240
