### PR TITLE
fix(macos): avoid Hardened Runtime for ad-hoc signing

### DIFF
--- a/.github/workflows/macos-adhoc-package.yml
+++ b/.github/workflows/macos-adhoc-package.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - '.github/workflows/macos-adhoc-package.yml'
       - 'DownKyi/**'
+      - 'DownKyi.Core/**'
       - 'src/**'
       - 'Directory.Build.*'
       - 'Directory.Packages.props'
@@ -12,6 +13,8 @@ on:
       - 'version.txt'
       - 'script/aria2.sh'
       - 'script/ffmpeg.sh'
+      - 'script/ffmpeg-assets.py'
+      - 'script/validate-publish-output.ps1'
       - 'script/assets/**'
       - 'script/macos/**'
       - 'tests/DownKyi.MacOS.Tests/**'

--- a/.github/workflows/macos-adhoc-package.yml
+++ b/.github/workflows/macos-adhoc-package.yml
@@ -1,0 +1,123 @@
+name: macOS ad-hoc package launch
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/macos-adhoc-package.yml'
+      - 'DownKyi/**'
+      - 'src/**'
+      - 'Directory.Build.*'
+      - 'Directory.Packages.props'
+      - 'global.json'
+      - 'version.txt'
+      - 'script/aria2.sh'
+      - 'script/ffmpeg.sh'
+      - 'script/assets/**'
+      - 'script/macos/**'
+      - 'tests/DownKyi.MacOS.Tests/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  DOTNET_CLI_TELEMETRY_OPTOUT: '1'
+  DOTNET_NOLOGO: '1'
+
+jobs:
+  package-launch-arm64:
+    name: Package and launch (macOS 26 arm64, ad-hoc)
+    runs-on: macos-26
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Record runner identity
+        run: |
+          sw_vers
+          uname -m
+      - name: Install packaging tools
+        run: |
+          export HOMEBREW_NO_AUTO_UPDATE=true
+          brew untap aws/tap || true
+          brew install create-dmg tree
+      - name: Install .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+      - name: Install Python for FFmpeg manifest verification
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Read version
+        id: version
+        run: echo "content=$(tr -d '\r\n' < version.txt)" >> "$GITHUB_OUTPUT"
+      - name: Download runtime dependencies
+        working-directory: ./script
+        run: |
+          chmod +x aria2.sh ffmpeg.sh
+          ./aria2.sh osx-arm64
+          ./ffmpeg.sh mac arm64
+      - name: Publish arm64 app
+        run: |
+          dotnet restore DownKyi/DownKyi.csproj -r osx-arm64
+          dotnet publish DownKyi/DownKyi.csproj --no-restore --self-contained -r osx-arm64 -c Release -p:DebugType=None -p:DebugSymbols=false
+      - name: Package app bundle
+        working-directory: ./script/macos
+        run: |
+          chmod +x package.sh set-bundle-version.sh
+          ./package.sh arm64 ${{ steps.version.outputs.content }}
+      - name: Validate packaged runtime
+        shell: pwsh
+        run: |
+          ./script/validate-publish-output.ps1 `
+            -PublishDirectory "DownKyi/bin/Release/net10.0/osx-arm64/publish" `
+            -RuntimeIdentifier "osx-arm64" `
+            -ExpectedVersion "${{ steps.version.outputs.content }}" `
+            -OutputPath "script/macos/publish-manifest-osx-arm64.json"
+      - name: Ad-hoc sign app
+        working-directory: ./script/macos
+        env:
+          MACOS_ADHOC_SIGNING: 'true'
+        run: |
+          chmod +x codesign-common.sh prepare-app-layout.sh sign.sh verify-app.sh verify-app-launch.sh verify-dmg-contents.sh verify-runtime-architecture.sh
+          ./sign.sh
+      - name: Verify ad-hoc policy and bundle integrity
+        working-directory: ./script/macos
+        run: |
+          details="$(codesign -dvvv '哔哩下载姬.app' 2>&1)"
+          printf '%s\n' "$details"
+          if printf '%s\n' "$details" | grep -Eq 'flags=.*runtime'; then
+            echo '::error::Ad-hoc app unexpectedly enables Hardened Runtime.'
+            exit 1
+          fi
+          ./verify-app.sh
+      - name: Create DMG
+        working-directory: ./script/macos
+        run: |
+          create-dmg \
+            --hdiutil-quiet \
+            --icon 哔哩下载姬.app 165 175 \
+            --icon-size 120 \
+            --app-drop-link 495 175 \
+            --window-size 660 400 \
+            DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg 哔哩下载姬.app
+      - name: Verify mounted and copied app launch
+        working-directory: ./script/macos
+        env:
+          MACOS_VERIFY_GATEKEEPER: 'false'
+        run: ./verify-dmg-contents.sh DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg ${{ steps.version.outputs.content }} osx-arm64
+      - name: Hash DMG
+        shell: pwsh
+        run: |
+          $package = "script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg"
+          $hash = (Get-FileHash -LiteralPath $package -Algorithm SHA256).Hash.ToLowerInvariant()
+          "$hash  $([IO.Path]::GetFileName($package))" | Set-Content -LiteralPath "$package.sha256" -Encoding ascii
+      - name: Upload verified DMG
+        uses: actions/upload-artifact@v7
+        with:
+          name: DownKyi-${{ steps.version.outputs.content }}-osx-arm64-adhoc-macos26
+          path: |
+            script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg
+            script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg.sha256
+            script/macos/publish-manifest-osx-arm64.json

--- a/script/macos/sign.sh
+++ b/script/macos/sign.sh
@@ -18,7 +18,7 @@ fi
 codesign_app_path() {
   local path="$1"
   if [ "$SIGNING_IDENTITY" = "-" ]; then
-    codesign --force --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$path"
+    codesign --force --sign "$SIGNING_IDENTITY" "$path"
   else
     codesign --force --timestamp --options=runtime --entitlements "$ENTITLEMENTS" --sign "$SIGNING_IDENTITY" "$path"
   fi

--- a/script/macos/verify-dmg-contents.sh
+++ b/script/macos/verify-dmg-contents.sh
@@ -6,6 +6,7 @@ DMG_PATH="${1:?DMG path is required.}"
 EXPECTED_VERSION="${2:?Expected release version is required.}"
 EXPECTED_RUNTIME_IDENTIFIER="${3:?Expected runtime identifier is required.}"
 MOUNT_POINT="$(mktemp -d "${TMPDIR:-/tmp}/downkyi-dmg.XXXXXX")"
+COPY_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/downkyi-installed-app.XXXXXX")"
 ATTACHED=false
 
 cleanup() {
@@ -13,6 +14,7 @@ cleanup() {
     hdiutil detach "$MOUNT_POINT" -quiet || hdiutil detach "$MOUNT_POINT" -force -quiet || true
   fi
   rmdir "$MOUNT_POINT" 2>/dev/null || true
+  rm -rf -- "$COPY_ROOT"
 }
 trap cleanup EXIT
 
@@ -37,3 +39,10 @@ fi
 
 "$SCRIPT_DIR/verify-app.sh" "$APP_PATH"
 "$SCRIPT_DIR/verify-app-launch.sh" "$APP_PATH"
+
+COPIED_APP_PATH="$COPY_ROOT/$(basename "$APP_PATH")"
+/usr/bin/ditto "$APP_PATH" "$COPIED_APP_PATH"
+
+"$SCRIPT_DIR/verify-runtime-architecture.sh" "$COPIED_APP_PATH" "$EXPECTED_RUNTIME_IDENTIFIER"
+"$SCRIPT_DIR/verify-app.sh" "$COPIED_APP_PATH"
+"$SCRIPT_DIR/verify-app-launch.sh" "$COPIED_APP_PATH"

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -518,6 +518,26 @@ public sealed class ReleaseWorkflowArchitectureTests
     }
 
     [Fact]
+    public void MacAdHocPackageWorkflowUsesMacOs26Arm64WithoutAppleCredentials()
+    {
+        var workflow = File.ReadAllText(
+            Path.Combine(RepositoryRoot, ".github", "workflows", "macos-adhoc-package.yml"));
+
+        Assert.Contains("runs-on: macos-26", workflow, StringComparison.Ordinal);
+        Assert.Contains("MACOS_ADHOC_SIGNING: 'true'", workflow, StringComparison.Ordinal);
+        Assert.Contains("dotnet publish", workflow, StringComparison.Ordinal);
+        Assert.Contains("./sign.sh", workflow, StringComparison.Ordinal);
+        Assert.Contains("./verify-app.sh", workflow, StringComparison.Ordinal);
+        Assert.Contains("flags=.*runtime", workflow, StringComparison.Ordinal);
+        Assert.Contains("create-dmg", workflow, StringComparison.Ordinal);
+        Assert.Contains("./verify-dmg-contents.sh", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("secrets.", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("notarytool", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("stapler", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain("spctl", workflow, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void V112RecoverySeparatesControlPlaneFromImmutableReleaseSubject()
     {
         var workflow = File.ReadAllText(

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -411,6 +411,8 @@ public sealed class ReleaseWorkflowArchitectureTests
             Path.Combine(RepositoryRoot, "script", "macos", "verify-app-launch.sh"));
         var verifyDmgScript = File.ReadAllText(
             Path.Combine(RepositoryRoot, "script", "macos", "verify-dmg.sh"));
+        var verifyDmgContentsScript = File.ReadAllText(
+            Path.Combine(RepositoryRoot, "script", "macos", "verify-dmg-contents.sh"));
 
         Assert.DoesNotContain(
             "MACOS_SIGNING_REQUIRED",
@@ -472,6 +474,47 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("codesign --verify --verbose=2", verifyDmgScript, StringComparison.Ordinal);
         Assert.Contains("xcrun stapler validate", verifyDmgScript, StringComparison.Ordinal);
         Assert.Contains("spctl --assess --type open --context context:primary-signature", verifyDmgScript, StringComparison.Ordinal);
+        Assert.Contains("/usr/bin/ditto \"$APP_PATH\" \"$COPIED_APP_PATH\"", verifyDmgContentsScript, StringComparison.Ordinal);
+        Assert.Contains("verify-app.sh\" \"$COPIED_APP_PATH\"", verifyDmgContentsScript, StringComparison.Ordinal);
+        Assert.Contains("verify-app-launch.sh\" \"$COPIED_APP_PATH\"", verifyDmgContentsScript, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MacBuildKeepsCredentialFreePackagingAndLaunchValidation()
+    {
+        var workflow = File.ReadAllText(
+            Path.Combine(RepositoryRoot, ".github", "workflows", "build.yml"));
+        var macSteps = GetWorkflowSteps(workflow, "  build-macos:");
+
+        Assert.Contains("MACOS_ADHOC_SIGNING: ${{ env.HAS_MACOS_SIGNING != 'true' }}", workflow, StringComparison.Ordinal);
+        foreach (var stepName in new[]
+                 {
+                     "Run macOS packaging regressions",
+                     "Build ${{ matrix.cpu }}",
+                     "Package app",
+                     "Sign app",
+                     "Verify app signature",
+                     "Create DMG",
+                     "Verify packaged DMG contents and launch app"
+                 })
+        {
+            AssertStepHasNoCondition(macSteps, stepName);
+        }
+
+        foreach (var stepName in new[]
+                 {
+                     "Import certificate",
+                     "Resolve signing identity",
+                     "Notarize app",
+                     "Verify notarized app",
+                     "Sign DMG",
+                     "Verify signed DMG",
+                     "Notarize DMG",
+                     "Verify notarized DMG"
+                 })
+        {
+            AssertStepCondition(macSteps, stepName, "${{ env.HAS_MACOS_SIGNING == 'true' }}");
+        }
     }
 
     [Fact]

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -525,6 +525,22 @@ public sealed class ReleaseWorkflowArchitectureTests
 
         Assert.Contains("runs-on: macos-26", workflow, StringComparison.Ordinal);
         Assert.Contains("MACOS_ADHOC_SIGNING: 'true'", workflow, StringComparison.Ordinal);
+        foreach (var packageInput in new[]
+                 {
+                     "DownKyi/**",
+                     "DownKyi.Core/**",
+                     "src/**",
+                     "script/aria2.sh",
+                     "script/ffmpeg.sh",
+                     "script/ffmpeg-assets.py",
+                     "script/validate-publish-output.ps1",
+                     "script/assets/**",
+                     "script/macos/**"
+                 })
+        {
+            Assert.Contains($"- '{packageInput}'", workflow, StringComparison.Ordinal);
+        }
+
         Assert.Contains("dotnet publish", workflow, StringComparison.Ordinal);
         Assert.Contains("./sign.sh", workflow, StringComparison.Ordinal);
         Assert.Contains("./verify-app.sh", workflow, StringComparison.Ordinal);

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -522,6 +522,13 @@ public sealed class ReleaseWorkflowArchitectureTests
     {
         var workflow = File.ReadAllText(
             Path.Combine(RepositoryRoot, ".github", "workflows", "macos-adhoc-package.yml"));
+        var lines = workflow.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var pullRequest = GetYamlBlock(lines, "  pull_request:", 2);
+        var pathBlock = GetYamlBlock(pullRequest.ToArray(), "    paths:", 4);
+        var triggerPaths = pathBlock
+            .Where(line => GetIndent(line) == 6 && line.TrimStart().StartsWith("- ", StringComparison.Ordinal))
+            .Select(line => line.Trim()[2..].Trim('\'', '"'))
+            .ToHashSet(StringComparer.Ordinal);
 
         Assert.Contains("runs-on: macos-26", workflow, StringComparison.Ordinal);
         Assert.Contains("MACOS_ADHOC_SIGNING: 'true'", workflow, StringComparison.Ordinal);
@@ -538,7 +545,7 @@ public sealed class ReleaseWorkflowArchitectureTests
                      "script/macos/**"
                  })
         {
-            Assert.Contains($"- '{packageInput}'", workflow, StringComparison.Ordinal);
+            Assert.Contains(packageInput, triggerPaths);
         }
 
         Assert.Contains("dotnet publish", workflow, StringComparison.Ordinal);

--- a/tests/DownKyi.MacOS.Tests/MacBundleLayoutTests.cs
+++ b/tests/DownKyi.MacOS.Tests/MacBundleLayoutTests.cs
@@ -100,6 +100,17 @@ public sealed class MacBundleLayoutTests
                 "BundleProbe.runtimeconfig.json")));
 
             AssertSuccess(RunSigningScript(correctedApp));
+            AssertAdHocSignatureDoesNotEnableHardenedRuntime(correctedApp);
+            AssertAdHocSignatureDoesNotEnableHardenedRuntime(Path.Combine(
+                correctedApp,
+                "Contents",
+                "MacOS",
+                "BundleProbe"));
+            AssertAdHocSignatureDoesNotEnableHardenedRuntime(Path.Combine(
+                correctedApp,
+                "Contents",
+                "MacOS",
+                "libhostfxr.dylib"));
             AssertSuccess(Run(
                 "/bin/bash",
                 RepositoryRoot,
@@ -110,6 +121,46 @@ public sealed class MacBundleLayoutTests
                 Path.Combine(correctedApp, "Contents", "MacOS", "BundleProbe"),
                 fixtureRoot);
             AssertSuccess(launch);
+        }
+        finally
+        {
+            Directory.Delete(fixtureRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void LaunchVerificationReportsRuntimeLoaderExit130()
+    {
+        var fixtureRoot = Path.Combine(Path.GetTempPath(), $"downkyi-launch-failure-{Guid.NewGuid():N}");
+        var appPath = Path.Combine(fixtureRoot, "Test.app");
+        var executableDirectory = Path.Combine(appPath, "Contents", "MacOS");
+        var executablePath = Path.Combine(executableDirectory, "TestApp");
+        Directory.CreateDirectory(executableDirectory);
+
+        try
+        {
+            File.WriteAllText(
+                executablePath,
+                "#!/bin/bash\necho 'Failed to load libhostfxr.dylib' >&2\necho 'mapping process and mapped file (non-platform) have different Team IDs' >&2\nexit 130\n",
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            AssertSuccess(Run("/bin/chmod", fixtureRoot, "+x", executablePath));
+
+            var result = Run(
+                "/bin/bash",
+                RepositoryRoot,
+                new Dictionary<string, string?>
+                {
+                    ["MACOS_EXECUTABLE_NAME"] = "TestApp",
+                    ["MACOS_LAUNCH_SECONDS"] = "1"
+                },
+                Path.Combine(RepositoryRoot, "script", "macos", "verify-app-launch.sh"),
+                appPath);
+
+            Assert.NotEqual(0, result.ExitCode);
+            var output = result.StandardOutput + result.StandardError;
+            Assert.Contains("status 130", output, StringComparison.Ordinal);
+            Assert.Contains("libhostfxr.dylib", output, StringComparison.Ordinal);
+            Assert.Contains("different Team IDs", output, StringComparison.Ordinal);
         }
         finally
         {
@@ -169,6 +220,19 @@ public sealed class MacBundleLayoutTests
             },
             Path.Combine(RepositoryRoot, "script", "macos", "sign.sh"),
             appPath);
+    }
+
+    private static void AssertAdHocSignatureDoesNotEnableHardenedRuntime(string path)
+    {
+        var result = Run("/usr/bin/codesign", RepositoryRoot, "-dv", "--verbose=4", path);
+        AssertSuccess(result);
+
+        var codeDirectory = (result.StandardOutput + result.StandardError)
+            .Replace("\r\n", "\n", StringComparison.Ordinal)
+            .Split('\n')
+            .Single(line => line.StartsWith("CodeDirectory ", StringComparison.Ordinal));
+        Assert.Contains("adhoc", codeDirectory, StringComparison.Ordinal);
+        Assert.DoesNotContain("runtime", codeDirectory, StringComparison.Ordinal);
     }
 
     private static void CreateAppBundle(string appPath, string publishDirectory)

--- a/tests/DownKyi.MacOS.Tests/MacSigningScriptTests.cs
+++ b/tests/DownKyi.MacOS.Tests/MacSigningScriptTests.cs
@@ -18,6 +18,8 @@ public sealed class MacSigningScriptTests
         Assert.All(calls, arguments =>
         {
             Assert.DoesNotContain("--timestamp", arguments);
+            Assert.DoesNotContain("--options=runtime", arguments);
+            Assert.DoesNotContain("--entitlements", arguments);
             AssertCodesignIdentity(arguments, "-");
         });
     }
@@ -32,6 +34,8 @@ public sealed class MacSigningScriptTests
         Assert.All(calls, arguments =>
         {
             Assert.Contains("--timestamp", arguments);
+            Assert.Contains("--options=runtime", arguments);
+            Assert.Contains("--entitlements", arguments);
             AssertCodesignIdentity(arguments, identity);
         });
     }


### PR DESCRIPTION
Fixes #237

## Root cause

The v1.1.3 release used ad-hoc signing without a Team ID but still applied `--options=runtime` to the app, main executable, and nested signable files. Hardened Runtime enabled Library Validation, and macOS 26 rejected `libhostfxr.dylib` with `mapping process and mapped file (non-platform) have different Team IDs`, causing exit 130 before UI startup.

## Change

- Ad-hoc mode now uses `codesign --force --sign -` without Hardened Runtime or production entitlements.
- Developer ID mode keeps timestamping, Hardened Runtime, and entitlements unchanged.
- DMG validation now launches both the mounted app and a `ditto`-copied app from a fresh local directory.
- macOS regressions assert real ad-hoc CodeDirectory flags, preserve Developer ID policy, and prove launch validation reports `libhostfxr` / Team ID / exit-130 failures.
- Architecture coverage keeps build, package, ad-hoc sign, strict verification, and launch validation available without Apple credentials, while notarization, stapling, and Gatekeeper trust remain Developer-ID-only.

## Local validation

Full local validation head: `2a45c00dd12012d95be0b9d36fcf58595862e926`

Current-main review-fix head: `8b066104710ac11426c57d0fa80a56d90519edd6`

Focused validation after rebase and review fix: ReleaseWorkflowArchitectureTests 20/20, actionlint 1.7.12 PASS, `git diff --check` PASS.

- Release version contract: PASS
- Strict Release solution build: PASS, 0 warnings / 0 errors
- CentralTestRunner solution selection on Windows: PASS, 8/8 applicable projects
- `dotnet format --verify-no-changes`: PASS
- Module boundary audit: PASS
- actionlint 1.7.12: PASS
- Vulnerable packages: none
- Deprecated packages: none
- Gitleaks 8.30.1: 1,142 candidates, 0 findings
- Shell syntax: PASS
- `git diff --check`: PASS

## Required hosted evidence

The macOS jobs must still prove the changed ad-hoc signature has no `runtime` flag and that strict verification plus mounted/copied-app launch pass. A credential-free pass is ad-hoc integrity/launch assurance, not Apple trusted-distribution assurance. Developer ID notarization and Gatekeeper validation remain conditional on real Apple credentials.