### PR TITLE
fix(downloads): fail closed on bootstrap failures

### DIFF
--- a/src/DownKyi.Application/Desktop/IAppDialogService.cs
+++ b/src/DownKyi.Application/Desktop/IAppDialogService.cs
@@ -7,7 +7,8 @@ public enum AppDialog
     ParsingSelector = 2,
     AlreadyDownloaded = 3,
     NewVersionAvailable = 4,
-    LegacyUpgrade = 5
+    LegacyUpgrade = 5,
+    DownloadRuntimeFailure = 6
 }
 
 public enum AppDialogOutcome

--- a/src/DownKyi.Application/Diagnostics/IApplicationLogService.cs
+++ b/src/DownKyi.Application/Diagnostics/IApplicationLogService.cs
@@ -8,6 +8,8 @@ public interface IApplicationLogService
 
     ApplicationLogMetrics GetMetrics();
 
+    string RedactDiagnosticText(string? text);
+
     Task FlushAsync(CancellationToken cancellationToken = default);
 
     Task<string> ExportDiagnosticLogAsync(CancellationToken cancellationToken = default);

--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -145,6 +145,21 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
         return MutateAsync(taskId, (task, now) => task.Fail(failure, now), cancellationToken);
     }
 
+    public Task<OperationResult<DownloadTask>> FailIfDispatchableAsync(
+        DownloadTaskId taskId,
+        DownloadFailure failure,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return MutateAsync(
+            taskId,
+            static task => task.Phase is DownloadPhase.Queued
+                or DownloadPhase.Downloading
+                or DownloadPhase.Pausing,
+            (task, now) => task.Fail(failure, now),
+            cancellationToken);
+    }
+
     public Task<OperationResult<DownloadTask>> CompleteAsync(
         DownloadTaskId taskId,
         DownloadCompletion completion,
@@ -360,12 +375,24 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
         _disposed = true;
     }
 
+    private Task<OperationResult<DownloadTask>> MutateAsync(
+        DownloadTaskId taskId,
+        Func<DownloadTask, DateTimeOffset, OperationResult<DownloadTask>> transition,
+        CancellationToken cancellationToken) =>
+        MutateAsync(
+            taskId,
+            static _ => true,
+            transition,
+            cancellationToken);
+
     private async Task<OperationResult<DownloadTask>> MutateAsync(
         DownloadTaskId taskId,
+        Func<DownloadTask, bool> shouldTransition,
         Func<DownloadTask, DateTimeOffset, OperationResult<DownloadTask>> transition,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(taskId);
+        ArgumentNullException.ThrowIfNull(shouldTransition);
         ArgumentNullException.ThrowIfNull(transition);
         ObjectDisposedException.ThrowIf(_disposed, this);
         var gate = _taskGates.GetOrAdd(taskId, static _ => new SemaphoreSlim(1, 1));
@@ -381,6 +408,11 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
                         "download.store.not_found",
                         $"Download task '{taskId.Value}' was not found.",
                         OperationErrorKind.NotFound));
+                }
+
+                if (!shouldTransition(current))
+                {
+                    return OperationResult.Success(current);
                 }
 
                 var now = LaterOf(_clock.UtcNow, current.UpdatedAtUtc);

--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -136,6 +136,18 @@ public sealed class DownloadTaskApplicationService : IDownloadTaskApplicationSer
         CancellationToken cancellationToken) =>
         MutateAsync(taskId, static (task, now) => task.RecoverInterrupted(now), cancellationToken);
 
+    public Task<OperationResult<DownloadTask>> ReconcileInterruptedAsync(
+        DownloadTaskId taskId,
+        long snapshotVersion,
+        CancellationToken cancellationToken) =>
+        MutateAsync(
+            taskId,
+            static task => task.Phase is DownloadPhase.Downloading or DownloadPhase.Pausing,
+            (task, now) => task.Phase == DownloadPhase.Pausing && task.Version != snapshotVersion
+                ? task.ConfirmPaused(now)
+                : task.RecoverInterrupted(now),
+            cancellationToken);
+
     public Task<OperationResult<DownloadTask>> FailAsync(
         DownloadTaskId taskId,
         DownloadFailure failure,

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -59,6 +59,11 @@ public interface IDownloadTaskApplicationService
         DownloadTaskId taskId,
         CancellationToken cancellationToken);
 
+    Task<OperationResult<DownloadTask>> ReconcileInterruptedAsync(
+        DownloadTaskId taskId,
+        long snapshotVersion,
+        CancellationToken cancellationToken);
+
     Task<OperationResult<DownloadTask>> FailAsync(
         DownloadTaskId taskId,
         DownloadFailure failure,

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -64,6 +64,11 @@ public interface IDownloadTaskApplicationService
         DownloadFailure failure,
         CancellationToken cancellationToken);
 
+    Task<OperationResult<DownloadTask>> FailIfDispatchableAsync(
+        DownloadTaskId taskId,
+        DownloadFailure failure,
+        CancellationToken cancellationToken);
+
     Task<OperationResult<DownloadTask>> CompleteAsync(
         DownloadTaskId taskId,
         DownloadCompletion completion,

--- a/src/DownKyi.Desktop/Composition/DesktopComposition.cs
+++ b/src/DownKyi.Desktop/Composition/DesktopComposition.cs
@@ -99,6 +99,8 @@ internal static class DesktopComposition
         services.AddSingleton<DownloadTaskQueueGateway>();
         services.AddSingleton<IDownloadTaskQueue>(provider =>
             provider.GetRequiredService<DownloadTaskQueueGateway>());
+        services.AddSingleton<IDownloadRuntimeAvailability>(provider =>
+            provider.GetRequiredService<DownloadTaskQueueGateway>());
         services.AddSingleton<DownloadTaskAdmissionService>();
         services.AddSingleton<LegacyDownloadAdmissionPresenter>();
         services.AddSingleton<DownloadListState>();

--- a/src/DownKyi.Desktop/Composition/DesktopComposition.cs
+++ b/src/DownKyi.Desktop/Composition/DesktopComposition.cs
@@ -204,11 +204,13 @@ internal static class DesktopComposition
         services.AddTransient<ViewAlreadyDownloadedDialogViewModel>();
         services.AddTransient<NewVersionAvailableDialogViewModel>();
         services.AddTransient<ViewUpgradingDialogViewModel>();
+        services.AddTransient<DownloadRuntimeFailureDialogViewModel>();
         services.AddTransient<ViewAlertDialog>();
         services.AddTransient<ViewDownloadSetter>();
         services.AddTransient<ViewParsingSelector>();
         services.AddTransient<ViewAlreadyDownloadedDialog>();
         services.AddTransient<NewVersionAvailableDialog>();
         services.AddTransient<ViewUpgradingDialog>();
+        services.AddTransient<DownloadRuntimeFailureDialog>();
     }
 }

--- a/src/DownKyi.Desktop/Languages/Default.axaml
+++ b/src/DownKyi.Desktop/Languages/Default.axaml
@@ -338,6 +338,12 @@
     <system:String x:Key="Info">信息</system:String>
     <system:String x:Key="Warning">警告</system:String>
     <system:String x:Key="Error">错误</system:String>
+    <system:String x:Key="DownloadRuntimeFailureTitle">下载系统无法启动</system:String>
+    <system:String x:Key="DownloadRuntimeFailureMessage">应用仍可继续使用，但本次运行无法下载。请复制下面的错误信息，并在 GitHub 建立议题。</system:String>
+    <system:String x:Key="CopyErrorDetails">复制错误信息</system:String>
+    <system:String x:Key="ErrorDetailsCopied">错误信息已复制</system:String>
+    <system:String x:Key="CreateGitHubIssue">在 GitHub 建立议题</system:String>
+    <system:String x:Key="OpenGitHubIssueFailed">无法打开 GitHub，请手动前往项目议题页面。</system:String>
     <system:String x:Key="Allow">确定</system:String>
     <system:String x:Key="ActionUpdate">前往下载</system:String>
     <system:String x:Key="SkipCurrentVersion">跳过此版本</system:String>

--- a/src/DownKyi.Desktop/Languages/Default.axaml
+++ b/src/DownKyi.Desktop/Languages/Default.axaml
@@ -156,6 +156,7 @@
     <system:String x:Key="Pausing">暂停中……</system:String>
     <system:String x:Key="Waiting">等待中……</system:String>
     <system:String x:Key="DownloadFailed">下载失败</system:String>
+    <system:String x:Key="DownloadRuntimeUnavailable">下载服务启动失败，请重新启动应用并查看日志。</system:String>
     <system:String x:Key="TotalDownloading1">正在下载</system:String>
     <system:String x:Key="TotalDownloading2">个视频！</system:String>
     <system:String x:Key="PauseAllDownloading">全部暂停</system:String>

--- a/src/DownKyi.Desktop/Platform/AvaloniaDialogService.cs
+++ b/src/DownKyi.Desktop/Platform/AvaloniaDialogService.cs
@@ -144,6 +144,9 @@ internal sealed class AvaloniaDialogService : IAppDialogService
                 typeof(NewVersionAvailableDialog),
                 typeof(NewVersionAvailableDialogViewModel)),
             AppDialog.LegacyUpgrade => (typeof(ViewUpgradingDialog), typeof(ViewUpgradingDialogViewModel)),
+            AppDialog.DownloadRuntimeFailure => (
+                typeof(DownloadRuntimeFailureDialog),
+                typeof(DownloadRuntimeFailureDialogViewModel)),
             _ => throw new ArgumentOutOfRangeException(nameof(dialog), dialog, null)
         };
     }

--- a/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
+++ b/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
@@ -278,6 +278,17 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
                         .ConfigureAwait(true);
                     addedCount++;
                 }
+                catch (DownloadRuntimeUnavailableException exception)
+                {
+                    _logger.LogWarningMessage("Download task admission rejected because runtime is unavailable.", exception);
+                    var alert = new AlertService(_dialogService);
+                    await alert
+                        .ShowError(
+                            DictionaryResource.GetString("DownloadRuntimeUnavailable"),
+                            cancellationToken)
+                        .ConfigureAwait(true);
+                    break;
+                }
                 catch (IOException exception)
                 {
                     _logger.LogWarningMessage("Download task admission failed.", exception);

--- a/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
+++ b/src/DownKyi.Desktop/Services/Download/AddToDownloadService.cs
@@ -287,7 +287,7 @@ internal sealed class AddToDownloadService : IAddToDownloadSession
                             DictionaryResource.GetString("DownloadRuntimeUnavailable"),
                             cancellationToken)
                         .ConfigureAwait(true);
-                    break;
+                    return addedCount;
                 }
                 catch (IOException exception)
                 {

--- a/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
@@ -59,18 +59,19 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             }).ConfigureAwait(false);
 
             _historyLoadTask = LoadRemainingHistoryAsync(cancellationToken);
-            _downloadRuntime = _downloadRuntimeFactory.Create();
-            if (_downloadRuntime != null)
-            {
-                await _downloadRuntime.StartAsync(cancellationToken).ConfigureAwait(false);
-                await _queueGateway
-                    .AttachAsync(_downloadRuntime, cancellationToken)
-                    .ConfigureAwait(false);
-                await QueueStartupTasksAsync(
-                    state.UnfinishedTasks,
-                    _downloadRuntime,
-                    cancellationToken).ConfigureAwait(false);
-            }
+            _downloadRuntime = _downloadRuntimeFactory.Create()
+                ?? throw new InvalidOperationException("The download runtime factory returned no runtime.");
+            await _downloadRuntime.StartAsync(cancellationToken).ConfigureAwait(false);
+            await _queueGateway
+                .AttachAsync(_downloadRuntime, cancellationToken)
+                .ConfigureAwait(false);
+            await QueueStartupTasksAsync(
+                state.UnfinishedTasks,
+                _downloadRuntime,
+                cancellationToken).ConfigureAwait(false);
+            await _queueGateway
+                .MarkReadyAsync(_downloadRuntime, cancellationToken)
+                .ConfigureAwait(false);
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -80,8 +81,34 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
         catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
             or InvalidOperationException or SqliteException)
         {
+            var pendingTasks = _queueGateway.MarkFaulted(exception);
             await CleanupFailedRuntimeAsync().ConfigureAwait(false);
+            await MarkPendingTasksFailedAsync(pendingTasks).ConfigureAwait(false);
             _logger.LogErrorMessage("Download bootstrap failed.", exception);
+        }
+    }
+
+    private async Task MarkPendingTasksFailedAsync(IReadOnlyList<DownloadTaskId> pendingTasks)
+    {
+        foreach (var taskId in pendingTasks)
+        {
+            try
+            {
+                await _stateWriter.FailAsync(
+                    taskId,
+                    new DownloadFailure(
+                        "download.runtime.unavailable",
+                        "Download runtime is unavailable.",
+                        true),
+                    CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
+                or InvalidOperationException or SqliteException)
+            {
+                _logger.LogErrorMessage(
+                    "Pending download task could not be failed after bootstrap failure.",
+                    exception);
+            }
         }
     }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
@@ -78,8 +78,7 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             await CleanupFailedRuntimeAsync().ConfigureAwait(false);
             return;
         }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
-            or InvalidOperationException or SqliteException)
+        catch (Exception exception) when (IsBootstrapFailure(exception))
         {
             var pendingTasks = _queueGateway.MarkFaulted(exception);
             await CleanupFailedRuntimeAsync().ConfigureAwait(false);
@@ -94,12 +93,8 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
         {
             try
             {
-                await _stateWriter.FailAsync(
+                await _stateWriter.FailRuntimeUnavailableAsync(
                     taskId,
-                    new DownloadFailure(
-                        "download.runtime.unavailable",
-                        "Download runtime is unavailable.",
-                        true),
                     CancellationToken.None).ConfigureAwait(false);
             }
             catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
@@ -145,8 +140,7 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
         {
             await runtime.StopAsync(CancellationToken.None).ConfigureAwait(false);
         }
-        catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
-            or InvalidOperationException or SqliteException)
+        catch (Exception exception) when (IsBootstrapFailure(exception))
         {
             _logger.LogErrorMessage("Failed download runtime cleanup also failed.", exception);
         }
@@ -169,6 +163,15 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             downloadingState.Projections,
             await downloadedItemsTask.ConfigureAwait(false));
     }
+
+    private static bool IsBootstrapFailure(Exception exception) =>
+        exception is IOException
+            or UnauthorizedAccessException
+            or InvalidOperationException
+            or SqliteException
+            or TimeoutException
+            or System.Net.Http.HttpRequestException
+            or Newtonsoft.Json.JsonException;
 
     private async Task LoadRemainingHistoryAsync(CancellationToken cancellationToken)
     {

--- a/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
@@ -216,7 +216,10 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             if (task.Phase is DownloadPhase.Downloading or DownloadPhase.Pausing)
             {
                 task = await _stateWriter
-                    .RecoverInterruptedAsync(taskId, cancellationToken)
+                    .ReconcileInterruptedAsync(
+                        taskId,
+                        restoredTask.Version,
+                        cancellationToken)
                     .ConfigureAwait(false);
             }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
@@ -49,9 +49,11 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
+        IReadOnlyList<DownloadTask> startupTasks = [];
         try
         {
             var state = await LoadStartupStateAsync(cancellationToken).ConfigureAwait(false);
+            startupTasks = state.UnfinishedTasks;
             await _uiDispatcher.InvokeAsync(() =>
             {
                 _downloadLists.AddDownloadingRange(state.DownloadingItems);
@@ -82,14 +84,20 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
         {
             var pendingTasks = _queueGateway.MarkFaulted(exception);
             await CleanupFailedRuntimeAsync().ConfigureAwait(false);
-            await MarkPendingTasksFailedAsync(pendingTasks).ConfigureAwait(false);
+            var ownedTaskIds = startupTasks
+                .Where(IsRunnableStartupTask)
+                .Select(task => task.Id)
+                .Concat(pendingTasks)
+                .Distinct()
+                .ToArray();
+            await MarkOwnedTasksFailedAsync(ownedTaskIds).ConfigureAwait(false);
             _logger.LogErrorMessage("Download bootstrap failed.", exception);
         }
     }
 
-    private async Task MarkPendingTasksFailedAsync(IReadOnlyList<DownloadTaskId> pendingTasks)
+    private async Task MarkOwnedTasksFailedAsync(IReadOnlyList<DownloadTaskId> taskIds)
     {
-        foreach (var taskId in pendingTasks)
+        foreach (var taskId in taskIds)
         {
             try
             {
@@ -101,11 +109,14 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
                 or InvalidOperationException or SqliteException)
             {
                 _logger.LogErrorMessage(
-                    "Pending download task could not be failed after bootstrap failure.",
+                    "Owned download task could not be failed after bootstrap failure.",
                     exception);
             }
         }
     }
+
+    private static bool IsRunnableStartupTask(DownloadTask task) =>
+        task.Phase is DownloadPhase.Queued or DownloadPhase.Downloading or DownloadPhase.Pausing;
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
@@ -171,6 +182,7 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             or SqliteException
             or TimeoutException
             or System.Net.Http.HttpRequestException
+            or System.ComponentModel.Win32Exception
             or Newtonsoft.Json.JsonException;
 
     private async Task LoadRemainingHistoryAsync(CancellationToken cancellationToken)

--- a/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadBootstrapHostedService.cs
@@ -80,18 +80,17 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             await CleanupFailedRuntimeAsync().ConfigureAwait(false);
             return;
         }
-        catch (Exception exception) when (IsBootstrapFailure(exception))
+        catch (Exception exception) when (IsRecoverableBoundaryFailure(exception))
         {
+            _logger.LogErrorMessage("Download bootstrap failed.", exception);
             var pendingTasks = _queueGateway.MarkFaulted(exception);
             await CleanupFailedRuntimeAsync().ConfigureAwait(false);
             var ownedTaskIds = startupTasks
-                .Where(IsRunnableStartupTask)
                 .Select(task => task.Id)
                 .Concat(pendingTasks)
                 .Distinct()
                 .ToArray();
             await MarkOwnedTasksFailedAsync(ownedTaskIds).ConfigureAwait(false);
-            _logger.LogErrorMessage("Download bootstrap failed.", exception);
         }
     }
 
@@ -101,12 +100,11 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
         {
             try
             {
-                await _stateWriter.FailRuntimeUnavailableAsync(
+                await _stateWriter.FailRuntimeUnavailableIfDispatchableAsync(
                     taskId,
                     CancellationToken.None).ConfigureAwait(false);
             }
-            catch (Exception exception) when (exception is IOException or UnauthorizedAccessException
-                or InvalidOperationException or SqliteException)
+            catch (Exception exception) when (IsRecoverableBoundaryFailure(exception))
             {
                 _logger.LogErrorMessage(
                     "Owned download task could not be failed after bootstrap failure.",
@@ -114,9 +112,6 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             }
         }
     }
-
-    private static bool IsRunnableStartupTask(DownloadTask task) =>
-        task.Phase is DownloadPhase.Queued or DownloadPhase.Downloading or DownloadPhase.Pausing;
 
     public async Task StopAsync(CancellationToken cancellationToken)
     {
@@ -151,7 +146,7 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
         {
             await runtime.StopAsync(CancellationToken.None).ConfigureAwait(false);
         }
-        catch (Exception exception) when (IsBootstrapFailure(exception))
+        catch (Exception exception) when (IsRecoverableBoundaryFailure(exception))
         {
             _logger.LogErrorMessage("Failed download runtime cleanup also failed.", exception);
         }
@@ -175,15 +170,10 @@ internal sealed class DownloadBootstrapHostedService : IHostedService, IDisposab
             await downloadedItemsTask.ConfigureAwait(false));
     }
 
-    private static bool IsBootstrapFailure(Exception exception) =>
-        exception is IOException
-            or UnauthorizedAccessException
-            or InvalidOperationException
-            or SqliteException
-            or TimeoutException
-            or System.Net.Http.HttpRequestException
-            or System.ComponentModel.Win32Exception
-            or Newtonsoft.Json.JsonException;
+    private static bool IsRecoverableBoundaryFailure(Exception exception) =>
+        exception is not OutOfMemoryException
+            and not StackOverflowException
+            and not AccessViolationException;
 
     private async Task LoadRemainingHistoryAsync(CancellationToken cancellationToken)
     {

--- a/src/DownKyi.Desktop/Services/Download/DownloadManagerCoordinator.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadManagerCoordinator.cs
@@ -62,6 +62,7 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
     private readonly DownloadTaskProjectionStore _storage;
     private readonly DownloadTaskStateWriter _stateWriter;
     private readonly IDownloadTaskQueue _taskQueue;
+    private readonly IDownloadRuntimeAvailability _runtimeAvailability;
     private readonly DownloadTaskFileService _fileService;
     private readonly DownloadListState _downloadLists;
     private readonly IPlatformLauncher _platformLauncher;
@@ -70,6 +71,7 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         DownloadTaskProjectionStore storage,
         DownloadTaskStateWriter stateWriter,
         IDownloadTaskQueue taskQueue,
+        IDownloadRuntimeAvailability runtimeAvailability,
         DownloadTaskFileService fileService,
         DownloadListState downloadLists,
         IPlatformLauncher platformLauncher)
@@ -77,6 +79,8 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         _storage = storage ?? throw new ArgumentNullException(nameof(storage));
         _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _taskQueue = taskQueue ?? throw new ArgumentNullException(nameof(taskQueue));
+        _runtimeAvailability = runtimeAvailability
+            ?? throw new ArgumentNullException(nameof(runtimeAvailability));
         _fileService = fileService ?? throw new ArgumentNullException(nameof(fileService));
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _platformLauncher = platformLauncher ?? throw new ArgumentNullException(nameof(platformLauncher));
@@ -115,10 +119,7 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
                 or DownloadStatus.Pause
                 or DownloadStatus.DownloadFailed)
             {
-                var resumed = await _stateWriter.ResumeAsync(
-                    GetTaskId(item),
-                    cancellationToken).ConfigureAwait(true);
-                await _taskQueue.EnqueueAsync(resumed.Id, CancellationToken.None).ConfigureAwait(true);
+                await ResumeAndEnqueueAsync(GetTaskId(item), cancellationToken).ConfigureAwait(true);
             }
         }
     }
@@ -133,8 +134,7 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
             or DownloadStatus.Pause
             or DownloadStatus.DownloadFailed)
         {
-            var resumed = await _stateWriter.ResumeAsync(taskId, cancellationToken).ConfigureAwait(true);
-            await _taskQueue.EnqueueAsync(resumed.Id, CancellationToken.None).ConfigureAwait(true);
+            await ResumeAndEnqueueAsync(taskId, cancellationToken).ConfigureAwait(true);
             return;
         }
 
@@ -271,6 +271,25 @@ internal sealed class DownloadManagerCoordinator : IDownloadManagerCoordinator
         }
 
         return DownloadArtifactOpenResult.NotFound;
+    }
+
+    private async Task ResumeAndEnqueueAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken)
+    {
+        _runtimeAvailability.EnsureAcceptingTasks();
+        var resumed = await _stateWriter.ResumeAsync(taskId, cancellationToken).ConfigureAwait(true);
+        try
+        {
+            await _taskQueue.EnqueueAsync(resumed.Id, CancellationToken.None).ConfigureAwait(true);
+        }
+        catch (DownloadRuntimeUnavailableException)
+        {
+            await _stateWriter.FailRuntimeUnavailableAsync(
+                resumed.Id,
+                CancellationToken.None).ConfigureAwait(true);
+            throw;
+        }
     }
 
     private static ImmutableArray<string> GetSelectedSuffixes(DownloadBase downloadBase)

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
@@ -12,6 +12,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
     private readonly DownloadListState _downloadLists;
     private readonly IDownloadTaskApplicationService _tasks;
     private readonly DownloadTaskProjectionStore _projections;
+    private readonly DownloadTaskStateWriter _stateWriter;
     private readonly IDownloadTaskQueue _taskQueue;
     private readonly IDownloadRuntimeAvailability _runtimeAvailability;
     private readonly IPhysicalOutputPathResolver _physicalOutputPathResolver;
@@ -22,6 +23,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         DownloadListState downloadLists,
         IDownloadTaskApplicationService tasks,
         DownloadTaskProjectionStore projections,
+        DownloadTaskStateWriter stateWriter,
         IDownloadTaskQueue taskQueue,
         IDownloadRuntimeAvailability runtimeAvailability,
         IPhysicalOutputPathResolver physicalOutputPathResolver)
@@ -29,6 +31,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
         _projections = projections ?? throw new ArgumentNullException(nameof(projections));
+        _stateWriter = stateWriter ?? throw new ArgumentNullException(nameof(stateWriter));
         _taskQueue = taskQueue ?? throw new ArgumentNullException(nameof(taskQueue));
         _runtimeAvailability = runtimeAvailability
             ?? throw new ArgumentNullException(nameof(runtimeAvailability));
@@ -46,7 +49,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         await _admissionGate.WaitAsync(cancellationToken).ConfigureAwait(true);
         try
         {
-            _runtimeAvailability.EnsureReady();
+            _runtimeAvailability.EnsureAcceptingTasks();
             var physicalBasePath = _physicalOutputPathResolver.ResolvePhysicalBasePath(
                 item.DownloadBase.FilePath);
             var admittedBasePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
@@ -70,20 +73,9 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
             }
             catch (DownloadRuntimeUnavailableException)
             {
-                var failure = await _tasks.FailAsync(
+                await _stateWriter.FailRuntimeUnavailableAsync(
                     taskId,
-                    new DownloadFailure(
-                        "download.runtime.unavailable",
-                        "Download runtime is unavailable.",
-                        true),
                     CancellationToken.None).ConfigureAwait(true);
-                if (!failure.IsSuccess)
-                {
-                    throw new InvalidOperationException(
-                        failure.Error?.Message
-                            ?? "The unavailable download runtime state could not be persisted.");
-                }
-
                 throw;
             }
         }

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
@@ -13,6 +13,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
     private readonly IDownloadTaskApplicationService _tasks;
     private readonly DownloadTaskProjectionStore _projections;
     private readonly IDownloadTaskQueue _taskQueue;
+    private readonly IDownloadRuntimeAvailability _runtimeAvailability;
     private readonly IPhysicalOutputPathResolver _physicalOutputPathResolver;
     private readonly SemaphoreSlim _admissionGate = new(1, 1);
     private bool _disposed;
@@ -22,12 +23,15 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         IDownloadTaskApplicationService tasks,
         DownloadTaskProjectionStore projections,
         IDownloadTaskQueue taskQueue,
+        IDownloadRuntimeAvailability runtimeAvailability,
         IPhysicalOutputPathResolver physicalOutputPathResolver)
     {
         _downloadLists = downloadLists ?? throw new ArgumentNullException(nameof(downloadLists));
         _tasks = tasks ?? throw new ArgumentNullException(nameof(tasks));
         _projections = projections ?? throw new ArgumentNullException(nameof(projections));
         _taskQueue = taskQueue ?? throw new ArgumentNullException(nameof(taskQueue));
+        _runtimeAvailability = runtimeAvailability
+            ?? throw new ArgumentNullException(nameof(runtimeAvailability));
         _physicalOutputPathResolver = physicalOutputPathResolver
             ?? throw new ArgumentNullException(nameof(physicalOutputPathResolver));
     }
@@ -42,6 +46,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
         await _admissionGate.WaitAsync(cancellationToken).ConfigureAwait(true);
         try
         {
+            _runtimeAvailability.EnsureReady();
             var physicalBasePath = _physicalOutputPathResolver.ResolvePhysicalBasePath(
                 item.DownloadBase.FilePath);
             var admittedBasePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
@@ -58,9 +63,29 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
 
             // Once persisted, admission must finish even if the originating UI operation is canceled.
             _downloadLists.AddDownloading(item);
-            await _taskQueue.EnqueueAsync(
-                new DownloadTaskId(item.DownloadBase.Id),
-                CancellationToken.None).ConfigureAwait(true);
+            var taskId = new DownloadTaskId(item.DownloadBase.Id);
+            try
+            {
+                await _taskQueue.EnqueueAsync(taskId, CancellationToken.None).ConfigureAwait(true);
+            }
+            catch (DownloadRuntimeUnavailableException)
+            {
+                var failure = await _tasks.FailAsync(
+                    taskId,
+                    new DownloadFailure(
+                        "download.runtime.unavailable",
+                        "Download runtime is unavailable.",
+                        true),
+                    CancellationToken.None).ConfigureAwait(true);
+                if (!failure.IsSuccess)
+                {
+                    throw new InvalidOperationException(
+                        failure.Error?.Message
+                            ?? "The unavailable download runtime state could not be persisted.");
+                }
+
+                throw;
+            }
         }
         finally
         {

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
@@ -129,11 +129,11 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue, IDownloadRu
         }
     }
 
-    public void EnsureReady()
+    public void EnsureAcceptingTasks()
     {
         lock (_sync)
         {
-            if (_state != DownloadRuntimeState.Ready || _runtime == null)
+            if (_state == DownloadRuntimeState.Faulted)
             {
                 throw CreateUnavailableException();
             }

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
@@ -7,13 +7,40 @@ using DownKyi.Domain.Downloads;
 
 namespace DownKyi.Services.Download;
 
-internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
+internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue, IDownloadRuntimeAvailability
 {
     private readonly Lock _sync = new();
     private readonly HashSet<DownloadTaskId> _pending = [];
     private IDownloadRuntime? _runtime;
+    private DownloadRuntimeState _state = DownloadRuntimeState.Initializing;
+    private Exception? _terminalFailure;
 
-    public async Task AttachAsync(
+    public Task AttachAsync(
+        IDownloadRuntime runtime,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(runtime);
+        cancellationToken.ThrowIfCancellationRequested();
+        lock (_sync)
+        {
+            if (_state == DownloadRuntimeState.Faulted)
+            {
+                throw CreateUnavailableException();
+            }
+
+            if (_runtime != null && !ReferenceEquals(_runtime, runtime))
+            {
+                throw new InvalidOperationException("A download runtime is already attached.");
+            }
+
+            _runtime = runtime;
+            _state = DownloadRuntimeState.Attaching;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task MarkReadyAsync(
         IDownloadRuntime runtime,
         CancellationToken cancellationToken)
     {
@@ -21,21 +48,36 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
         DownloadTaskId[] pending;
         lock (_sync)
         {
-            if (_runtime != null && !ReferenceEquals(_runtime, runtime))
+            if (!ReferenceEquals(_runtime, runtime)
+                || _state != DownloadRuntimeState.Attaching)
             {
-                throw new InvalidOperationException("A download runtime is already attached.");
+                throw new InvalidOperationException("The download runtime is not attached for startup.");
             }
 
-            _runtime = runtime;
             pending = [.. _pending];
             _pending.Clear();
         }
 
         try
         {
-            foreach (var taskId in pending)
+            while (true)
             {
-                await runtime.EnqueueAsync(taskId, cancellationToken).ConfigureAwait(false);
+                foreach (var taskId in pending)
+                {
+                    await runtime.EnqueueAsync(taskId, cancellationToken).ConfigureAwait(false);
+                }
+
+                lock (_sync)
+                {
+                    if (_pending.Count == 0)
+                    {
+                        _state = DownloadRuntimeState.Ready;
+                        return;
+                    }
+
+                    pending = [.. _pending];
+                    _pending.Clear();
+                }
             }
         }
         catch
@@ -44,7 +86,7 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
             {
                 if (ReferenceEquals(_runtime, runtime))
                 {
-                    _runtime = null;
+                    _state = DownloadRuntimeState.Attaching;
                 }
 
                 foreach (var taskId in pending)
@@ -65,6 +107,35 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
             if (ReferenceEquals(_runtime, runtime))
             {
                 _runtime = null;
+                if (_state != DownloadRuntimeState.Faulted)
+                {
+                    _state = DownloadRuntimeState.Initializing;
+                }
+            }
+        }
+    }
+
+    public IReadOnlyList<DownloadTaskId> MarkFaulted(Exception exception)
+    {
+        ArgumentNullException.ThrowIfNull(exception);
+        lock (_sync)
+        {
+            _runtime = null;
+            _state = DownloadRuntimeState.Faulted;
+            _terminalFailure ??= exception;
+            var pending = _pending.ToArray();
+            _pending.Clear();
+            return pending;
+        }
+    }
+
+    public void EnsureReady()
+    {
+        lock (_sync)
+        {
+            if (_state != DownloadRuntimeState.Ready || _runtime == null)
+            {
+                throw CreateUnavailableException();
             }
         }
     }
@@ -78,8 +149,13 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
         IDownloadRuntime? runtime;
         lock (_sync)
         {
+            if (_state == DownloadRuntimeState.Faulted)
+            {
+                throw CreateUnavailableException();
+            }
+
             runtime = _runtime;
-            if (runtime == null)
+            if (_state != DownloadRuntimeState.Ready || runtime == null)
             {
                 _pending.Add(taskId);
                 return;
@@ -97,10 +173,12 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
                 if (ReferenceEquals(_runtime, runtime))
                 {
                     _runtime = null;
+                    _state = DownloadRuntimeState.Faulted;
+                    _terminalFailure ??= exception;
                 }
-
-                _pending.Add(taskId);
             }
+
+            throw CreateUnavailableException();
         }
     }
 
@@ -117,6 +195,22 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue
         return runtime == null
             ? Task.FromResult(false)
             : runtime.CancelAsync(taskId);
+    }
+
+    private DownloadRuntimeUnavailableException CreateUnavailableException()
+    {
+        var message = _state == DownloadRuntimeState.Faulted
+            ? "The download runtime failed to start and is unavailable."
+            : "The download runtime is still initializing and is unavailable.";
+        return new DownloadRuntimeUnavailableException(message, _terminalFailure);
+    }
+
+    private enum DownloadRuntimeState
+    {
+        Initializing,
+        Attaching,
+        Ready,
+        Faulted
     }
 
 }

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskQueueGateway.cs
@@ -11,6 +11,8 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue, IDownloadRu
 {
     private readonly Lock _sync = new();
     private readonly HashSet<DownloadTaskId> _pending = [];
+    private readonly TaskCompletionSource<DownloadRuntimeStartupOutcome> _startupOutcome =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
     private IDownloadRuntime? _runtime;
     private DownloadRuntimeState _state = DownloadRuntimeState.Initializing;
     private Exception? _terminalFailure;
@@ -72,6 +74,7 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue, IDownloadRu
                     if (_pending.Count == 0)
                     {
                         _state = DownloadRuntimeState.Ready;
+                        _startupOutcome.TrySetResult(DownloadRuntimeStartupOutcome.Ready());
                         return;
                     }
 
@@ -123,6 +126,8 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue, IDownloadRu
             _runtime = null;
             _state = DownloadRuntimeState.Faulted;
             _terminalFailure ??= exception;
+            _startupOutcome.TrySetResult(
+                DownloadRuntimeStartupOutcome.Faulted(_terminalFailure));
             var pending = _pending.ToArray();
             _pending.Clear();
             return pending;
@@ -138,6 +143,12 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue, IDownloadRu
                 throw CreateUnavailableException();
             }
         }
+    }
+
+    public Task<DownloadRuntimeStartupOutcome> WaitForStartupOutcomeAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return _startupOutcome.Task.WaitAsync(cancellationToken);
     }
 
     public async Task EnqueueAsync(
@@ -175,6 +186,8 @@ internal sealed class DownloadTaskQueueGateway : IDownloadTaskQueue, IDownloadRu
                     _runtime = null;
                     _state = DownloadRuntimeState.Faulted;
                     _terminalFailure ??= exception;
+                    _startupOutcome.TrySetResult(
+                        DownloadRuntimeStartupOutcome.Faulted(_terminalFailure));
                 }
             }
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskStateWriter.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskStateWriter.cs
@@ -57,6 +57,17 @@ internal sealed class DownloadTaskStateWriter
         CancellationToken cancellationToken = default) =>
         RequireAsync(_tasks.FailAsync(taskId, failure, cancellationToken));
 
+    public Task<DownloadTask> FailRuntimeUnavailableAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        FailAsync(
+            taskId,
+            new DownloadFailure(
+                "download.runtime.unavailable",
+                "Download runtime is unavailable.",
+                true),
+            cancellationToken);
+
     public Task<DownloadTask> CompleteAsync(
         DownloadTaskId taskId,
         DownloadCompletion completion,

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskStateWriter.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskStateWriter.cs
@@ -51,6 +51,15 @@ internal sealed class DownloadTaskStateWriter
         CancellationToken cancellationToken = default) =>
         RequireAsync(_tasks.RecoverInterruptedAsync(taskId, cancellationToken));
 
+    public Task<DownloadTask> ReconcileInterruptedAsync(
+        DownloadTaskId taskId,
+        long snapshotVersion,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.ReconcileInterruptedAsync(
+            taskId,
+            snapshotVersion,
+            cancellationToken));
+
     public Task<DownloadTask> FailAsync(
         DownloadTaskId taskId,
         DownloadFailure failure,

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskStateWriter.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskStateWriter.cs
@@ -62,11 +62,16 @@ internal sealed class DownloadTaskStateWriter
         CancellationToken cancellationToken = default) =>
         FailAsync(
             taskId,
-            new DownloadFailure(
-                "download.runtime.unavailable",
-                "Download runtime is unavailable.",
-                true),
+            CreateRuntimeUnavailableFailure(),
             cancellationToken);
+
+    public Task<DownloadTask> FailRuntimeUnavailableIfDispatchableAsync(
+        DownloadTaskId taskId,
+        CancellationToken cancellationToken = default) =>
+        RequireAsync(_tasks.FailIfDispatchableAsync(
+            taskId,
+            CreateRuntimeUnavailableFailure(),
+            cancellationToken));
 
     public Task<DownloadTask> CompleteAsync(
         DownloadTaskId taskId,
@@ -152,6 +157,12 @@ internal sealed class DownloadTaskStateWriter
         return await _tasks.FindAsync(taskId, cancellationToken).ConfigureAwait(false)
             ?? throw new InvalidOperationException($"Download task '{taskId.Value}' was not found.");
     }
+
+    private static DownloadFailure CreateRuntimeUnavailableFailure() =>
+        new(
+            "download.runtime.unavailable",
+            "Download runtime is unavailable.",
+            true);
 
     private static async Task<DownloadTask> RequireAsync(
         Task<OperationResult<DownloadTask>> operation)

--- a/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
+++ b/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
@@ -14,7 +14,7 @@ internal interface IDownloadTaskQueue
 
 internal interface IDownloadRuntimeAvailability
 {
-    void EnsureReady();
+    void EnsureAcceptingTasks();
 }
 
 internal sealed class DownloadRuntimeUnavailableException : InvalidOperationException

--- a/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
+++ b/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
@@ -15,6 +15,41 @@ internal interface IDownloadTaskQueue
 internal interface IDownloadRuntimeAvailability
 {
     void EnsureAcceptingTasks();
+
+    Task<DownloadRuntimeStartupOutcome> WaitForStartupOutcomeAsync(
+        CancellationToken cancellationToken = default);
+}
+
+internal enum DownloadRuntimeStartupState
+{
+    Ready,
+    Faulted
+}
+
+internal sealed record DownloadRuntimeStartupOutcome
+{
+    private DownloadRuntimeStartupOutcome(
+        DownloadRuntimeStartupState state,
+        Exception? failure)
+    {
+        State = state;
+        Failure = failure;
+    }
+
+    public DownloadRuntimeStartupState State { get; }
+
+    public Exception? Failure { get; }
+
+    public static DownloadRuntimeStartupOutcome Ready() =>
+        new(DownloadRuntimeStartupState.Ready, null);
+
+    public static DownloadRuntimeStartupOutcome Faulted(Exception failure)
+    {
+        ArgumentNullException.ThrowIfNull(failure);
+        return new DownloadRuntimeStartupOutcome(
+            DownloadRuntimeStartupState.Faulted,
+            failure);
+    }
 }
 
 internal sealed class DownloadRuntimeUnavailableException : InvalidOperationException

--- a/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
+++ b/src/DownKyi.Desktop/Services/Download/IDownloadRuntime.cs
@@ -12,6 +12,28 @@ internal interface IDownloadTaskQueue
     Task<bool> CancelAsync(DownloadTaskId taskId);
 }
 
+internal interface IDownloadRuntimeAvailability
+{
+    void EnsureReady();
+}
+
+internal sealed class DownloadRuntimeUnavailableException : InvalidOperationException
+{
+    public DownloadRuntimeUnavailableException()
+    {
+    }
+
+    public DownloadRuntimeUnavailableException(string message)
+        : base(message)
+    {
+    }
+
+    public DownloadRuntimeUnavailableException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}
+
 internal interface IDownloadRuntime : IDownloadTaskQueue, IDisposable
 {
     Task StartAsync(CancellationToken cancellationToken = default);

--- a/src/DownKyi.Desktop/ViewModels/Dialogs/DownloadRuntimeFailureDialogViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/Dialogs/DownloadRuntimeFailureDialogViewModel.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using DownKyi.Application.Desktop;
+using DownKyi.Application.Diagnostics;
+using DownKyi.Commands;
+using DownKyi.Models;
+using DownKyi.Utils;
+using Microsoft.Extensions.Logging;
+
+namespace DownKyi.ViewModels.Dialogs;
+
+internal sealed class DownloadRuntimeFailureDialogViewModel : BaseDialogViewModel
+{
+    private readonly IApplicationLogService _logService;
+    private readonly IClipboardService _clipboardService;
+    private readonly IPlatformLauncher _platformLauncher;
+    private readonly IUserNotificationService _notifications;
+    private readonly ILogger<DownloadRuntimeFailureDialogViewModel> _logger;
+    private DownKyiAsyncDelegateCommand? _copyErrorDetailsCommand;
+    private DownKyiAsyncDelegateCommand? _createGitHubIssueCommand;
+    private string _diagnosticText = string.Empty;
+
+    public DownloadRuntimeFailureDialogViewModel(
+        IApplicationLogService logService,
+        IClipboardService clipboardService,
+        IPlatformLauncher platformLauncher,
+        IUserNotificationService notifications,
+        ILogger<DownloadRuntimeFailureDialogViewModel> logger)
+    {
+        _logService = logService ?? throw new ArgumentNullException(nameof(logService));
+        _clipboardService = clipboardService
+            ?? throw new ArgumentNullException(nameof(clipboardService));
+        _platformLauncher = platformLauncher
+            ?? throw new ArgumentNullException(nameof(platformLauncher));
+        _notifications = notifications ?? throw new ArgumentNullException(nameof(notifications));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        Title = DictionaryResource.GetString("DownloadRuntimeFailureTitle");
+    }
+
+    public string DiagnosticText
+    {
+        get => _diagnosticText;
+        private set => SetProperty(ref _diagnosticText, value);
+    }
+
+    public DownKyiAsyncDelegateCommand CopyErrorDetailsCommand =>
+        _copyErrorDetailsCommand ??= new DownKyiAsyncDelegateCommand(
+            CopyErrorDetailsAsync,
+            _logger);
+
+    public DownKyiAsyncDelegateCommand CreateGitHubIssueCommand =>
+        _createGitHubIssueCommand ??= new DownKyiAsyncDelegateCommand(
+            CreateGitHubIssueAsync,
+            _logger);
+
+    public override void OnDialogOpened(AppDialogRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var failure = GetRequiredParameter<Exception>(request, "failure");
+        DiagnosticText = CreateDiagnosticText(failure);
+    }
+
+    internal async Task CopyErrorDetailsAsync()
+    {
+        await _clipboardService.SetTextAsync(DiagnosticText).ConfigureAwait(true);
+        _notifications.Show(DictionaryResource.GetString("ErrorDetailsCopied"));
+    }
+
+    internal async Task CreateGitHubIssueAsync()
+    {
+        var title = Uri.EscapeDataString("Download system failed to initialize");
+        var issueUri = new Uri(
+            $"https://github.com/{AppConstant.RepoOwner}/{AppConstant.RepoName}/issues/new?title={title}");
+        if (!await _platformLauncher.OpenUriAsync(issueUri).ConfigureAwait(true))
+        {
+            _notifications.Show(DictionaryResource.GetString("OpenGitHubIssueFailed"));
+        }
+    }
+
+    private string CreateDiagnosticText(Exception failure)
+    {
+        var exceptionText = _logService.RedactDiagnosticText(failure.ToString());
+        var operatingSystem = _logService.RedactDiagnosticText(
+            RuntimeInformation.OSDescription);
+        return $"""
+            DownKyi version: {new AppInfo().VersionName}
+            Operating system: {operatingSystem}
+            Architecture: {RuntimeInformation.OSArchitecture}
+            Failure boundary: Download bootstrap
+
+            {exceptionText}
+            """;
+    }
+}

--- a/src/DownKyi.Desktop/ViewModels/MainWindowViewModel.cs
+++ b/src/DownKyi.Desktop/ViewModels/MainWindowViewModel.cs
@@ -13,6 +13,7 @@ using DownKyi.Core.Settings;
 using DownKyi.Models;
 using DownKyi.Platform;
 using DownKyi.Services;
+using DownKyi.Services.Download;
 using Microsoft.Extensions.Logging;
 
 namespace DownKyi.ViewModels;
@@ -27,6 +28,7 @@ internal sealed class MainWindowViewModel : ObservableObject, IDisposable
     private readonly IClipboardMonitor _clipboardMonitor;
     private readonly SearchService _searchService;
     private readonly VersionCheckerService _versionChecker;
+    private readonly IDownloadRuntimeAvailability _downloadRuntimeAvailability;
     private readonly ILogger<MainWindowViewModel> _logger;
     private readonly CancellationTokenSource _lifetimeCancellation = new();
     private readonly CancellationToken _lifetimeToken;
@@ -131,6 +133,7 @@ internal sealed class MainWindowViewModel : ObservableObject, IDisposable
         IClipboardMonitor clipboardMonitor,
         SearchService searchService,
         VersionCheckerService versionChecker,
+        IDownloadRuntimeAvailability downloadRuntimeAvailability,
         ILogger<MainWindowViewModel> logger)
     {
         _navigationService = navigationService ?? throw new ArgumentNullException(nameof(navigationService));
@@ -140,6 +143,8 @@ internal sealed class MainWindowViewModel : ObservableObject, IDisposable
         _clipboardMonitor = clipboardMonitor ?? throw new ArgumentNullException(nameof(clipboardMonitor));
         _searchService = searchService ?? throw new ArgumentNullException(nameof(searchService));
         _versionChecker = versionChecker ?? throw new ArgumentNullException(nameof(versionChecker));
+        _downloadRuntimeAvailability = downloadRuntimeAvailability
+            ?? throw new ArgumentNullException(nameof(downloadRuntimeAvailability));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _lifetimeToken = _lifetimeCancellation.Token;
 
@@ -283,6 +288,12 @@ internal sealed class MainWindowViewModel : ObservableObject, IDisposable
             return;
         }
 
+        await ShowDownloadRuntimeFailureDialogAsync().ConfigureAwait(true);
+        if (_lifetimeToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         await CheckForUpdatesAsync().ConfigureAwait(true);
     }
 
@@ -312,6 +323,37 @@ internal sealed class MainWindowViewModel : ObservableObject, IDisposable
         catch (InvalidOperationException e)
         {
             _logger.LogErrorMessage("Legacy upgrade dialog failed to open.", e);
+        }
+    }
+
+    private async Task ShowDownloadRuntimeFailureDialogAsync()
+    {
+        try
+        {
+            var outcome = await _downloadRuntimeAvailability
+                .WaitForStartupOutcomeAsync(_lifetimeToken)
+                .ConfigureAwait(true);
+            if (outcome.State == DownloadRuntimeStartupState.Ready)
+            {
+                return;
+            }
+
+            var failure = outcome.Failure
+                ?? throw new InvalidOperationException(
+                    "The faulted download startup outcome has no failure.");
+            await _dialogService.ShowAsync(
+                new AppDialogRequest(
+                    AppDialog.DownloadRuntimeFailure,
+                    new Dictionary<string, object?> { ["failure"] = failure }),
+                _lifetimeToken).ConfigureAwait(true);
+        }
+        catch (OperationCanceledException) when (_lifetimeToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (InvalidOperationException e)
+        {
+            _logger.LogErrorMessage("Download runtime failure dialog failed to open.", e);
         }
     }
 

--- a/src/DownKyi.Desktop/Views/Dialogs/DownloadRuntimeFailureDialog.axaml
+++ b/src/DownKyi.Desktop/Views/Dialogs/DownloadRuntimeFailureDialog.axaml
@@ -1,0 +1,67 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vmd="clr-namespace:DownKyi.ViewModels.Dialogs"
+             x:Class="DownKyi.Views.Dialogs.DownloadRuntimeFailureDialog"
+             x:DataType="vmd:DownloadRuntimeFailureDialogViewModel"
+             Width="640"
+             Height="470">
+    <Border Background="{DynamicResource BrushBackground}"
+            CornerRadius="8"
+            BorderBrush="{DynamicResource BrushPrimary}"
+            BorderThickness="1">
+        <Grid Margin="16" RowDefinitions="Auto,Auto,*,Auto">
+            <Grid Grid.Row="0"
+                  Margin="0,0,0,16"
+                  WindowDecorationProperties.ElementRole="TitleBar">
+                <StackPanel Orientation="Horizontal"
+                            VerticalAlignment="Center"
+                            Spacing="8">
+                    <PathIcon Width="20"
+                              Height="20"
+                              Data="M12,2 C6.48,2 2,6.48 2,12 C2,17.52 6.48,22 12,22 C17.52,22 22,17.52 22,12 C22,6.48 17.52,2 12,2 M13,17 L11,17 L11,15 L13,15 L13,17 M13,13 L11,13 L11,7 L13,7 L13,13" />
+                    <TextBlock Text="{DynamicResource DownloadRuntimeFailureTitle}"
+                               FontSize="18"
+                               FontWeight="Bold" />
+                </StackPanel>
+                <Button HorizontalAlignment="Right"
+                        ToolTip.Tip="{DynamicResource Close}"
+                        Theme="{StaticResource ImageBtnStyle}"
+                        WindowDecorationProperties.ElementRole="User"
+                        Command="{Binding CloseCommand}">
+                    <PathIcon Data="{Binding CloseIcon.Data}"
+                              Width="16"
+                              Height="16" />
+                </Button>
+            </Grid>
+
+            <TextBlock Grid.Row="1"
+                       Margin="0,0,0,12"
+                       Text="{DynamicResource DownloadRuntimeFailureMessage}"
+                       TextWrapping="Wrap" />
+
+            <TextBox Grid.Row="2"
+                     Text="{Binding DiagnosticText, Mode=OneWay}"
+                     IsReadOnly="True"
+                     AcceptsReturn="True"
+                     TextWrapping="NoWrap"
+                     ScrollViewer.HorizontalScrollBarVisibility="Auto"
+                     ScrollViewer.VerticalScrollBarVisibility="Auto" />
+
+            <StackPanel Grid.Row="3"
+                        Margin="0,16,0,0"
+                        Orientation="Horizontal"
+                        HorizontalAlignment="Right"
+                        Spacing="12">
+                <Button MinWidth="110"
+                        Content="{DynamicResource CopyErrorDetails}"
+                        Command="{Binding CopyErrorDetailsCommand}" />
+                <Button MinWidth="140"
+                        Content="{DynamicResource CreateGitHubIssue}"
+                        Command="{Binding CreateGitHubIssueCommand}" />
+                <Button MinWidth="90"
+                        Content="{DynamicResource Close}"
+                        Command="{Binding CloseCommand}" />
+            </StackPanel>
+        </Grid>
+    </Border>
+</UserControl>

--- a/src/DownKyi.Desktop/Views/Dialogs/DownloadRuntimeFailureDialog.axaml.cs
+++ b/src/DownKyi.Desktop/Views/Dialogs/DownloadRuntimeFailureDialog.axaml.cs
@@ -1,0 +1,11 @@
+using Avalonia.Controls;
+
+namespace DownKyi.Views.Dialogs;
+
+internal partial class DownloadRuntimeFailureDialog : UserControl
+{
+    public DownloadRuntimeFailureDialog()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/DownKyi.Infrastructure/Logging/ApplicationLogProvider.cs
+++ b/src/DownKyi.Infrastructure/Logging/ApplicationLogProvider.cs
@@ -11,6 +11,7 @@ public sealed class ApplicationLogProvider :
     IAsyncDisposable
 {
     private readonly ApplicationLogOptions _options;
+    private readonly ISensitiveDataRedactor _redactor;
     private readonly ApplicationLogRecordFactory _recordFactory;
     private readonly ApplicationRecentLogBuffer _recentBuffer;
     private readonly NLogAsyncRollingFileSink _sink;
@@ -37,6 +38,7 @@ public sealed class ApplicationLogProvider :
     {
         ValidateOptions(options);
         _options = options with { LogDirectory = Path.GetFullPath(options.LogDirectory) };
+        _redactor = redactor ?? throw new ArgumentNullException(nameof(redactor));
         _recordFactory = new ApplicationLogRecordFactory(redactor, timeProvider);
         _recentBuffer = new ApplicationRecentLogBuffer(_options.RecentEventCapacity);
         _sink = new NLogAsyncRollingFileSink(_options);
@@ -85,6 +87,11 @@ public sealed class ApplicationLogProvider :
             (double)retention.RetainedBytes / _options.MaxTotalBytes,
             retention.LastMaintenanceUtc,
             retention.MalformedExportRecords);
+    }
+
+    public string RedactDiagnosticText(string? text)
+    {
+        return _redactor.Redact(text);
     }
 
     public async Task FlushAsync(CancellationToken cancellationToken = default)

--- a/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
@@ -81,6 +81,29 @@ public sealed class DownloadTaskApplicationServiceTests
     }
 
     [Fact]
+    public async Task InterruptedReconciliationPreservesNewerPauseIntent()
+    {
+        var store = new RecordingStore();
+        using var service = new DownloadTaskApplicationService(store, new AdvancingClock());
+        var task = CreateTask();
+        await service.AddAsync(task, TestContext.Current.CancellationToken);
+        var snapshot = (await service.StartAsync(
+            task.Id,
+            TestContext.Current.CancellationToken)).RequireValue();
+        await service.PauseAsync(task.Id, TestContext.Current.CancellationToken);
+
+        var result = await service.ReconcileInterruptedAsync(
+            task.Id,
+            snapshot.Version,
+            TestContext.Current.CancellationToken);
+
+        var reconciled = result.RequireValue();
+        Assert.Equal(DownloadPhase.Paused, reconciled.Phase);
+        Assert.Equal(3, reconciled.Version);
+        Assert.Equal([0L, 1L, 2L], store.ExpectedVersions);
+    }
+
+    [Fact]
     public async Task ArtifactClaimsPreservePriorPathsAndBackendIdentity()
     {
         var store = new RecordingStore();

--- a/tests/DownKyi.Tests/AvaloniaApplicationLifecycleTests.cs
+++ b/tests/DownKyi.Tests/AvaloniaApplicationLifecycleTests.cs
@@ -251,6 +251,8 @@ public sealed class AvaloniaApplicationLifecycleTests
             return new ApplicationLogMetrics(0, 0, 0, 0, 0, 0, 0, 0, null);
         }
 
+        public string RedactDiagnosticText(string? text) => text ?? string.Empty;
+
         public Task FlushAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -324,6 +324,86 @@ public sealed class DownloadBootstrapHostedServiceTests
             Assert.Single(listState.Downloading).Downloading.DownloadStatus);
     }
 
+    [Fact]
+    public async Task StartupRecoveryPreservesPauseMadeAfterSnapshot()
+    {
+        var task = CreateTask("paused-during-recovery")
+            .Start(DateTimeOffset.UnixEpoch.AddSeconds(1))
+            .RequireValue();
+        using var runtime = new BlockingSuccessfulStartRuntime();
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(
+            new EmptyDownloadTaskStore([task]),
+            clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        var stateWriter = new DownloadTaskStateWriter(tasks);
+        var queueGateway = new DownloadTaskQueueGateway();
+        using var service = new DownloadBootstrapHostedService(
+            new DownloadListState(),
+            storage,
+            stateWriter,
+            new RecordingRuntimeFactory(runtime),
+            queueGateway,
+            new ImmediateUiDispatcher(),
+            NullLogger<DownloadBootstrapHostedService>.Instance);
+
+        var startup = service.StartAsync(TestContext.Current.CancellationToken);
+        await runtime.StartEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await stateWriter.PauseAsync(task.Id, TestContext.Current.CancellationToken);
+        runtime.AllowStart.TrySetResult();
+        await startup.ConfigureAwait(true);
+
+        var persisted = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            task.Id,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Paused, persisted.Phase);
+        Assert.Empty(runtime.Enqueued);
+        Assert.Equal(
+            DownloadRuntimeStartupState.Ready,
+            (await queueGateway.WaitForStartupOutcomeAsync(
+                TestContext.Current.CancellationToken)).State);
+    }
+
+    [Fact]
+    public async Task StartupRecoveryPreservesDeletionMadeAfterSnapshot()
+    {
+        var task = CreateTask("deleted-during-recovery")
+            .Start(DateTimeOffset.UnixEpoch.AddSeconds(1))
+            .RequireValue();
+        using var runtime = new BlockingSuccessfulStartRuntime();
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(
+            new EmptyDownloadTaskStore([task]),
+            clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        var stateWriter = new DownloadTaskStateWriter(tasks);
+        var queueGateway = new DownloadTaskQueueGateway();
+        using var service = new DownloadBootstrapHostedService(
+            new DownloadListState(),
+            storage,
+            stateWriter,
+            new RecordingRuntimeFactory(runtime),
+            queueGateway,
+            new ImmediateUiDispatcher(),
+            NullLogger<DownloadBootstrapHostedService>.Instance);
+
+        var startup = service.StartAsync(TestContext.Current.CancellationToken);
+        await runtime.StartEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await stateWriter.DeleteAsync(task.Id, TestContext.Current.CancellationToken);
+        runtime.AllowStart.TrySetResult();
+        await startup.ConfigureAwait(true);
+
+        var persisted = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            task.Id,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Deleted, persisted.Phase);
+        Assert.Empty(runtime.Enqueued);
+        Assert.Equal(
+            DownloadRuntimeStartupState.Ready,
+            (await queueGateway.WaitForStartupOutcomeAsync(
+                TestContext.Current.CancellationToken)).State);
+    }
+
     private static DownloadTask CreateTask(string id)
     {
         return DownloadTask.Create(
@@ -487,6 +567,44 @@ public sealed class DownloadBootstrapHostedServiceTests
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> CancelAsync(DownloadTaskId taskId) => Task.FromResult(false);
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class BlockingSuccessfulStartRuntime : IDownloadRuntime
+    {
+        public TaskCompletionSource StartEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource AllowStart { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public List<DownloadTaskId> Enqueued { get; } = [];
+
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            StartEntered.TrySetResult();
+            await AllowStart.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Enqueued.Add(taskId);
             return Task.CompletedTask;
         }
 

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -184,6 +184,46 @@ public sealed class DownloadBootstrapHostedServiceTests
         Assert.IsType<DownloadRuntimeUnavailableException>(exception);
     }
 
+    [Theory]
+    [InlineData("timeout")]
+    [InlineData("http")]
+    [InlineData("json")]
+    public async Task RuntimeStartupFailureFaultsGateway(string failureKind)
+    {
+        using var runtime = new RecordingDownloadRuntime(
+            startFailure: CreateRuntimeStartupFailure(failureKind));
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(new EmptyDownloadTaskStore(), clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        var queueGateway = new DownloadTaskQueueGateway();
+        using var service = new DownloadBootstrapHostedService(
+            new DownloadListState(),
+            storage,
+            new DownloadTaskStateWriter(tasks),
+            new RecordingRuntimeFactory(runtime),
+            queueGateway,
+            new ImmediateUiDispatcher(),
+            NullLogger<DownloadBootstrapHostedService>.Instance);
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() =>
+            queueGateway.EnqueueAsync(
+                new DownloadTaskId($"after-{failureKind}-failure"),
+                TestContext.Current.CancellationToken));
+        Assert.True(runtime.Ended);
+        Assert.True(runtime.Disposed);
+    }
+
+    private static Exception CreateRuntimeStartupFailure(string failureKind) => failureKind switch
+    {
+        "timeout" => new TimeoutException("Synthetic runtime readiness timeout."),
+        "http" => new HttpRequestException("Synthetic runtime RPC failure."),
+        "json" => new Newtonsoft.Json.JsonSerializationException(
+            "Synthetic runtime RPC response failure."),
+        _ => throw new ArgumentOutOfRangeException(nameof(failureKind), failureKind, null)
+    };
+
     private static DownloadTask CreateTask(string id)
     {
         return DownloadTask.Create(
@@ -224,7 +264,9 @@ public sealed class DownloadBootstrapHostedServiceTests
         }
     }
 
-    private sealed class RecordingDownloadRuntime(bool failOnEnqueue = false) : IDownloadRuntime
+    private sealed class RecordingDownloadRuntime(
+        bool failOnEnqueue = false,
+        Exception? startFailure = null) : IDownloadRuntime
     {
         public List<DownloadTaskId> Enqueued { get; } = [];
 
@@ -237,6 +279,11 @@ public sealed class DownloadBootstrapHostedServiceTests
         public Task StartAsync(CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (startFailure != null)
+            {
+                throw startFailure;
+            }
+
             Started = true;
             return Task.CompletedTask;
         }

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -199,6 +199,8 @@ public sealed class DownloadBootstrapHostedServiceTests
     [InlineData("http")]
     [InlineData("json")]
     [InlineData("win32")]
+    [InlineData("task-canceled")]
+    [InlineData("unexpected")]
     public async Task RuntimeStartupFailureFaultsGateway(string failureKind)
     {
         using var runtime = new RecordingDownloadRuntime(
@@ -279,8 +281,48 @@ public sealed class DownloadBootstrapHostedServiceTests
             "Synthetic runtime RPC response failure."),
         "win32" => new System.ComponentModel.Win32Exception(
             "Synthetic operating system process startup failure."),
+        "task-canceled" => new TaskCanceledException(
+            "Synthetic HttpClient timeout."),
+        "unexpected" => new FormatException(
+            "Synthetic failure outside the former exception allowlist."),
         _ => throw new ArgumentOutOfRangeException(nameof(failureKind), failureKind, null)
     };
+
+    [Fact]
+    public async Task TerminalBootstrapFailurePreservesTaskPausedAfterStartupSnapshot()
+    {
+        var task = CreateTask("paused-during-startup");
+        using var runtime = new BlockingFailingStartRuntime();
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(
+            new EmptyDownloadTaskStore([task]),
+            clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        var stateWriter = new DownloadTaskStateWriter(tasks);
+        var listState = new DownloadListState();
+        using var service = new DownloadBootstrapHostedService(
+            listState,
+            storage,
+            stateWriter,
+            new RecordingRuntimeFactory(runtime),
+            new DownloadTaskQueueGateway(),
+            new ImmediateUiDispatcher(),
+            NullLogger<DownloadBootstrapHostedService>.Instance);
+
+        var startup = service.StartAsync(TestContext.Current.CancellationToken);
+        await runtime.StartEntered.Task.WaitAsync(TestContext.Current.CancellationToken);
+        await stateWriter.PauseAsync(task.Id, TestContext.Current.CancellationToken);
+        runtime.FailStartup.TrySetResult();
+        await startup.ConfigureAwait(true);
+
+        var persisted = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            task.Id,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Paused, persisted.Phase);
+        Assert.Equal(
+            DownloadStatus.Pause,
+            Assert.Single(listState.Downloading).Downloading.DownloadStatus);
+    }
 
     private static DownloadTask CreateTask(string id)
     {
@@ -413,6 +455,42 @@ public sealed class DownloadBootstrapHostedServiceTests
         {
             return Task.FromResult(false);
         }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class BlockingFailingStartRuntime : IDownloadRuntime
+    {
+        public TaskCompletionSource StartEntered { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource FailStartup { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task StartAsync(CancellationToken cancellationToken = default)
+        {
+            StartEntered.TrySetResult();
+            await FailStartup.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            throw new TimeoutException("Synthetic delayed runtime startup failure.");
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task EnqueueAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> CancelAsync(DownloadTaskId taskId) => Task.FromResult(false);
 
         public void Dispose()
         {

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -4,6 +4,7 @@ using DownKyi.Domain.Downloads;
 using DownKyi.Domain.Results;
 using DownKyi.Infrastructure.Downloads;
 using DownKyi.Infrastructure.Time;
+using DownKyi.Models;
 using DownKyi.Platform;
 using DownKyi.Services.Download;
 using Microsoft.Data.Sqlite;
@@ -165,9 +166,10 @@ public sealed class DownloadBootstrapHostedServiceTests
             new EmptyDownloadTaskStore([CreateTask("startup-task")]),
             clock);
         using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
         var queueGateway = new DownloadTaskQueueGateway();
         using var service = new DownloadBootstrapHostedService(
-            new DownloadListState(),
+            listState,
             storage,
             new DownloadTaskStateWriter(tasks),
             new RecordingRuntimeFactory(runtime),
@@ -180,20 +182,32 @@ public sealed class DownloadBootstrapHostedServiceTests
         var exception = await Record.ExceptionAsync(() => queueGateway.EnqueueAsync(
             new DownloadTaskId("admitted-after-terminal-failure"),
             TestContext.Current.CancellationToken));
+        var startupTask = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            new DownloadTaskId("startup-task"),
+            TestContext.Current.CancellationToken));
 
         Assert.IsType<DownloadRuntimeUnavailableException>(exception);
+        Assert.Equal(DownloadPhase.Failed, startupTask.Phase);
+        Assert.Equal("download.runtime.unavailable", startupTask.Failure?.Code);
+        Assert.Equal(
+            DownloadStatus.DownloadFailed,
+            Assert.Single(listState.Downloading).Downloading.DownloadStatus);
     }
 
     [Theory]
     [InlineData("timeout")]
     [InlineData("http")]
     [InlineData("json")]
+    [InlineData("win32")]
     public async Task RuntimeStartupFailureFaultsGateway(string failureKind)
     {
         using var runtime = new RecordingDownloadRuntime(
             startFailure: CreateRuntimeStartupFailure(failureKind));
         var clock = new FixedClock();
-        using var tasks = new DownloadTaskApplicationService(new EmptyDownloadTaskStore(), clock);
+        var startupTask = CreateTask($"startup-{failureKind}");
+        using var tasks = new DownloadTaskApplicationService(
+            new EmptyDownloadTaskStore([startupTask]),
+            clock);
         using var storage = new DownloadTaskProjectionStore(tasks, clock);
         var queueGateway = new DownloadTaskQueueGateway();
         using var service = new DownloadBootstrapHostedService(
@@ -211,8 +225,50 @@ public sealed class DownloadBootstrapHostedServiceTests
             queueGateway.EnqueueAsync(
                 new DownloadTaskId($"after-{failureKind}-failure"),
                 TestContext.Current.CancellationToken));
+        var persisted = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            startupTask.Id,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Failed, persisted.Phase);
+        Assert.Equal("download.runtime.unavailable", persisted.Failure?.Code);
         Assert.True(runtime.Ended);
         Assert.True(runtime.Disposed);
+    }
+
+    [Fact]
+    public async Task TerminalBootstrapFailurePreservesNonRunnableStartupTasks()
+    {
+        var transitionTime = DateTimeOffset.UnixEpoch.AddSeconds(1);
+        var paused = CreateTask("paused").Pause(transitionTime).RequireValue();
+        var failed = CreateTask("failed").Fail(
+            new DownloadFailure("download.existing", "Existing failure.", true),
+            transitionTime).RequireValue();
+        using var runtime = new RecordingDownloadRuntime(
+            startFailure: new TimeoutException("Synthetic runtime readiness timeout."));
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(
+            new EmptyDownloadTaskStore([paused, failed]),
+            clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        using var service = new DownloadBootstrapHostedService(
+            new DownloadListState(),
+            storage,
+            new DownloadTaskStateWriter(tasks),
+            new RecordingRuntimeFactory(runtime),
+            new DownloadTaskQueueGateway(),
+            new ImmediateUiDispatcher(),
+            NullLogger<DownloadBootstrapHostedService>.Instance);
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        var persistedPaused = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            paused.Id,
+            TestContext.Current.CancellationToken));
+        var persistedFailed = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            failed.Id,
+            TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Paused, persistedPaused.Phase);
+        Assert.Equal(DownloadPhase.Failed, persistedFailed.Phase);
+        Assert.Equal("download.existing", persistedFailed.Failure?.Code);
     }
 
     private static Exception CreateRuntimeStartupFailure(string failureKind) => failureKind switch
@@ -221,6 +277,8 @@ public sealed class DownloadBootstrapHostedServiceTests
         "http" => new HttpRequestException("Synthetic runtime RPC failure."),
         "json" => new Newtonsoft.Json.JsonSerializationException(
             "Synthetic runtime RPC response failure."),
+        "win32" => new System.ComponentModel.Win32Exception(
+            "Synthetic operating system process startup failure."),
         _ => throw new ArgumentOutOfRangeException(nameof(failureKind), failureKind, null)
     };
 
@@ -387,6 +445,9 @@ public sealed class DownloadBootstrapHostedServiceTests
     private sealed class EmptyDownloadTaskStore(
         IReadOnlyList<DownloadTask>? unfinished = null) : IDownloadTaskStore
     {
+        private readonly Dictionary<DownloadTaskId, DownloadTask> _tasks =
+            (unfinished ?? []).ToDictionary(task => task.Id);
+
         public Task InitializeAsync(CancellationToken cancellationToken)
         {
             return Task.CompletedTask;
@@ -394,6 +455,7 @@ public sealed class DownloadBootstrapHostedServiceTests
 
         public Task<OperationResult> AddAsync(DownloadTask task, CancellationToken cancellationToken)
         {
+            _tasks[task.Id] = task;
             return Task.FromResult(OperationResult.Success());
         }
 
@@ -402,6 +464,7 @@ public sealed class DownloadBootstrapHostedServiceTests
             long expectedVersion,
             CancellationToken cancellationToken)
         {
+            _tasks[task.Id] = task;
             return Task.FromResult(OperationResult.Success());
         }
 
@@ -414,12 +477,13 @@ public sealed class DownloadBootstrapHostedServiceTests
 
         public Task<DownloadTask?> FindAsync(DownloadTaskId taskId, CancellationToken cancellationToken)
         {
-            return Task.FromResult<DownloadTask?>(null);
+            _tasks.TryGetValue(taskId, out var task);
+            return Task.FromResult(task);
         }
 
         public Task<IReadOnlyList<DownloadTask>> GetUnfinishedAsync(CancellationToken cancellationToken)
         {
-            return Task.FromResult(unfinished ?? (IReadOnlyList<DownloadTask>)Array.Empty<DownloadTask>());
+            return Task.FromResult<IReadOnlyList<DownloadTask>>([.. _tasks.Values]);
         }
 
         public Task<bool> IsOutputPathReservedAsync(
@@ -437,6 +501,7 @@ public sealed class DownloadBootstrapHostedServiceTests
 
         public Task<OperationResult> DeleteAsync(DownloadTaskId taskId, CancellationToken cancellationToken)
         {
+            _tasks.Remove(taskId);
             return Task.FromResult(OperationResult.Success());
         }
 

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -156,6 +156,34 @@ public sealed class DownloadBootstrapHostedServiceTests
         Assert.True(runtime.Disposed);
     }
 
+    [Fact]
+    public async Task TerminalBootstrapFailureDoesNotAcceptNewPendingTasks()
+    {
+        using var runtime = new RecordingDownloadRuntime(failOnEnqueue: true);
+        var clock = new FixedClock();
+        using var tasks = new DownloadTaskApplicationService(
+            new EmptyDownloadTaskStore([CreateTask("startup-task")]),
+            clock);
+        using var storage = new DownloadTaskProjectionStore(tasks, clock);
+        var queueGateway = new DownloadTaskQueueGateway();
+        using var service = new DownloadBootstrapHostedService(
+            new DownloadListState(),
+            storage,
+            new DownloadTaskStateWriter(tasks),
+            new RecordingRuntimeFactory(runtime),
+            queueGateway,
+            new ImmediateUiDispatcher(),
+            NullLogger<DownloadBootstrapHostedService>.Instance);
+
+        await service.StartAsync(TestContext.Current.CancellationToken);
+
+        var exception = await Record.ExceptionAsync(() => queueGateway.EnqueueAsync(
+            new DownloadTaskId("admitted-after-terminal-failure"),
+            TestContext.Current.CancellationToken));
+
+        Assert.IsType<DownloadRuntimeUnavailableException>(exception);
+    }
+
     private static DownloadTask CreateTask(string id)
     {
         return DownloadTask.Create(

--- a/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
@@ -368,5 +368,14 @@ public sealed class DownloadManagerCoordinatorTests
             throw new DownloadRuntimeUnavailableException(
                 "Synthetic unavailable download runtime.");
         }
+
+        public Task<DownloadRuntimeStartupOutcome> WaitForStartupOutcomeAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(DownloadRuntimeStartupOutcome.Faulted(
+                new DownloadRuntimeUnavailableException(
+                    "Synthetic unavailable download runtime.")));
+        }
     }
 }

--- a/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
+++ b/tests/DownKyi.Tests/DownloadManagerCoordinatorTests.cs
@@ -50,6 +50,55 @@ public sealed class DownloadManagerCoordinatorTests
     }
 
     [Fact]
+    public async Task RuntimeFailureDuringResumeDoesNotLeaveTaskQueued()
+    {
+        using var context = new CoordinatorContext(new RuntimeUnavailableTaskQueue());
+        var item = context.CreateDownloadingItem("resume-runtime-failure", DownloadStatus.WaitForDownload);
+        context.State.AddDownloading(item);
+        await context.Storage.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+        var taskId = new DownloadTaskId(item.DownloadBase.Id);
+        await context.StateWriter.StartAsync(taskId, TestContext.Current.CancellationToken);
+        await context.StateWriter.FailAsync(
+            taskId,
+            new DownloadFailure("download.synthetic", "Synthetic failure.", true),
+            TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() =>
+            context.Coordinator.ToggleAsync(item, TestContext.Current.CancellationToken));
+
+        var persisted = Assert.IsType<DownloadTask>(
+            await context.Store.FindAsync(taskId, TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Failed, persisted.Phase);
+        Assert.Equal("download.runtime.unavailable", persisted.Failure?.Code);
+    }
+
+    [Fact]
+    public async Task UnavailableRuntimeRejectsResumeBeforeStateTransition()
+    {
+        using var context = new CoordinatorContext(
+            runtimeAvailability: new UnavailableDownloadRuntimeAvailability());
+        var item = context.CreateDownloadingItem(
+            "resume-known-runtime-failure",
+            DownloadStatus.WaitForDownload);
+        context.State.AddDownloading(item);
+        await context.Storage.AddDownloadingAsync(item, TestContext.Current.CancellationToken);
+        var taskId = new DownloadTaskId(item.DownloadBase.Id);
+        await context.StateWriter.StartAsync(taskId, TestContext.Current.CancellationToken);
+        await context.StateWriter.FailAsync(
+            taskId,
+            new DownloadFailure("download.synthetic", "Synthetic failure.", true),
+            TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() =>
+            context.Coordinator.ToggleAsync(item, TestContext.Current.CancellationToken));
+
+        var persisted = Assert.IsType<DownloadTask>(
+            await context.Store.FindAsync(taskId, TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Failed, persisted.Phase);
+        Assert.Equal("download.synthetic", persisted.Failure?.Code);
+    }
+
+    [Fact]
     public async Task DeleteCanBeRetriedAfterAFormerFileCleanupLeftTaskCanceled()
     {
         using var context = new CoordinatorContext();
@@ -163,7 +212,9 @@ public sealed class DownloadManagerCoordinatorTests
             Guid.NewGuid().ToString("N"));
         private readonly string _databasePath;
 
-        public CoordinatorContext()
+        public CoordinatorContext(
+            IDownloadTaskQueue? taskQueue = null,
+            IDownloadRuntimeAvailability? runtimeAvailability = null)
         {
             Directory.CreateDirectory(_directory);
             _databasePath = Path.Combine(_directory, "download.db");
@@ -183,7 +234,8 @@ public sealed class DownloadManagerCoordinatorTests
             Coordinator = new DownloadManagerCoordinator(
                 Storage,
                 StateWriter,
-                Queue,
+                taskQueue ?? Queue,
+                runtimeAvailability ?? new ReadyDownloadRuntimeAvailability(),
                 fileService,
                 State,
                 Launcher);
@@ -289,6 +341,32 @@ public sealed class DownloadManagerCoordinatorTests
         {
             cancellationToken.ThrowIfCancellationRequested();
             return Task.FromResult(true);
+        }
+    }
+
+    private sealed class RuntimeUnavailableTaskQueue : IDownloadTaskQueue
+    {
+        public Task EnqueueAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new DownloadRuntimeUnavailableException(
+                "Synthetic unavailable download runtime.");
+        }
+
+        public Task<bool> CancelAsync(DownloadTaskId taskId)
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    private sealed class UnavailableDownloadRuntimeAvailability : IDownloadRuntimeAvailability
+    {
+        public void EnsureAcceptingTasks()
+        {
+            throw new DownloadRuntimeUnavailableException(
+                "Synthetic unavailable download runtime.");
         }
     }
 }

--- a/tests/DownKyi.Tests/DownloadRuntimeFailureDialogViewModelTests.cs
+++ b/tests/DownKyi.Tests/DownloadRuntimeFailureDialogViewModelTests.cs
@@ -1,0 +1,116 @@
+using DownKyi.Application.Desktop;
+using DownKyi.Application.Diagnostics;
+using DownKyi.ViewModels.Dialogs;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace DownKyi.Tests;
+
+public sealed class DownloadRuntimeFailureDialogViewModelTests
+{
+    [Fact]
+    public async Task DialogCopiesRedactedDiagnosticAndOpensNewIssuePage()
+    {
+        var logs = new RedactingLogService();
+        var clipboard = new RecordingClipboardService();
+        var launcher = new RecordingPlatformLauncher();
+        var notifications = new RecordingNotificationService();
+        var viewModel = new DownloadRuntimeFailureDialogViewModel(
+            logs,
+            clipboard,
+            launcher,
+            notifications,
+            NullLogger<DownloadRuntimeFailureDialogViewModel>.Instance);
+        viewModel.OnDialogOpened(new AppDialogRequest(
+            AppDialog.DownloadRuntimeFailure,
+            new Dictionary<string, object?>
+            {
+                ["failure"] = new InvalidOperationException("secret-path")
+            }));
+
+        await viewModel.CopyErrorDetailsAsync();
+        await viewModel.CreateGitHubIssueAsync();
+
+        Assert.Equal(viewModel.DiagnosticText, clipboard.Text);
+        Assert.Contains("Download bootstrap", viewModel.DiagnosticText, StringComparison.Ordinal);
+        Assert.Contains("[redacted]", viewModel.DiagnosticText, StringComparison.Ordinal);
+        Assert.DoesNotContain("secret-path", viewModel.DiagnosticText, StringComparison.Ordinal);
+        Assert.Equal("github.com", launcher.Uri?.Host);
+        Assert.Equal("/crazysmile-PhD/downkyicore/issues/new", launcher.Uri?.AbsolutePath);
+        Assert.Contains("title=", launcher.Uri?.Query, StringComparison.Ordinal);
+        Assert.Single(notifications.Messages);
+    }
+
+    private sealed class RedactingLogService : IApplicationLogService
+    {
+        public string LogDirectory => string.Empty;
+
+        public IReadOnlyList<ApplicationLogRecord> GetRecentEvents() => [];
+
+        public ApplicationLogMetrics GetMetrics() =>
+            new(0, 0, 0, 0, 0, 0, 0, 0, null);
+
+        public string RedactDiagnosticText(string? text) =>
+            (text ?? string.Empty).Replace("secret-path", "[redacted]", StringComparison.Ordinal);
+
+        public Task FlushAsync(CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<string> ExportDiagnosticLogAsync(
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class RecordingClipboardService : IClipboardService
+    {
+        public string? Text { get; private set; }
+
+        public Task SetTextAsync(
+            string text,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Text = text;
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class RecordingPlatformLauncher : IPlatformLauncher
+    {
+        public Uri? Uri { get; private set; }
+
+        public Task<bool> OpenUriAsync(
+            Uri uri,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            Uri = uri;
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> OpenFileAsync(
+            string path,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public Task<bool> OpenFolderAsync(
+            string path,
+            CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+    }
+
+    private sealed class RecordingNotificationService : IUserNotificationService
+    {
+        public event EventHandler<UserNotificationEventArgs>? NotificationRaised
+        {
+            add { }
+            remove { }
+        }
+
+        public List<string> Messages { get; } = [];
+
+        public void Show(string message)
+        {
+            Messages.Add(message);
+        }
+    }
+}

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -276,6 +276,63 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RuntimeUnavailableRejectsAdmissionBeforePersistence()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var gateway = new DownloadTaskQueueGateway();
+        gateway.MarkFaulted(new InvalidOperationException("Synthetic bootstrap failure."));
+        using var admission = CreateAdmission(
+            listState,
+            tasks,
+            projections,
+            gateway,
+            runtimeAvailability: gateway);
+        var item = CreateItem("runtime-unavailable", Path.Combine(_directory, "output"));
+
+        await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() => admission.AdmitAsync(
+            item,
+            true,
+            TestContext.Current.CancellationToken));
+
+        Assert.Empty(await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Empty(listState.Downloading);
+    }
+
+    [Fact]
+    public async Task RuntimeFailureAfterPersistenceMarksCommittedTaskFailed()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        using var admission = CreateAdmission(
+            listState,
+            tasks,
+            projections,
+            new RuntimeUnavailableQueue());
+        var item = CreateItem("runtime-failed-after-commit", Path.Combine(_directory, "output"));
+
+        await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() => admission.AdmitAsync(
+            item,
+            true,
+            TestContext.Current.CancellationToken));
+
+        var persisted = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            new DownloadTaskId(item.DownloadBase.Id),
+            TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Failed, persisted.Phase);
+        Assert.Equal("download.runtime.unavailable", persisted.Failure?.Code);
+        Assert.Equal(DownloadStatus.DownloadFailed, Assert.Single(listState.Downloading).Downloading.DownloadStatus);
+    }
+
+    [Fact]
     public async Task AliasesSharePhysicalCollisionSequenceAndRemainFrozenAfterRetarget()
     {
         Directory.CreateDirectory(_directory);
@@ -374,13 +431,15 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         IDownloadTaskApplicationService tasks,
         DownloadTaskProjectionStore projections,
         IDownloadTaskQueue queue,
-        IPhysicalOutputPathResolver? resolver = null)
+        IPhysicalOutputPathResolver? resolver = null,
+        IDownloadRuntimeAvailability? runtimeAvailability = null)
     {
         return new DownloadTaskAdmissionService(
             listState,
             tasks,
             projections,
             queue,
+            runtimeAvailability ?? new ReadyDownloadRuntimeAvailability(),
             resolver ?? new RecordingPhysicalOutputPathResolver(static path => path));
     }
 
@@ -513,6 +572,18 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         }
 
         public Task<bool> CancelAsync(DownloadTaskId taskId) => Task.FromResult(true);
+    }
+
+    private sealed class RuntimeUnavailableQueue : IDownloadTaskQueue
+    {
+        public Task EnqueueAsync(
+            DownloadTaskId taskId,
+            CancellationToken cancellationToken = default)
+        {
+            throw new DownloadRuntimeUnavailableException("Synthetic runtime failure.");
+        }
+
+        public Task<bool> CancelAsync(DownloadTaskId taskId) => Task.FromResult(false);
     }
 
     public void Dispose()

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -304,6 +304,37 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task InitializingRuntimeOwnsAdmissionUntilBootstrapCompletes()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var listState = new DownloadListState();
+        var gateway = new DownloadTaskQueueGateway();
+        using var admission = CreateAdmission(
+            listState,
+            tasks,
+            projections,
+            gateway,
+            runtimeAvailability: gateway);
+        var item = CreateItem("runtime-initializing", Path.Combine(_directory, "output"));
+
+        await admission.AdmitAsync(item, true, TestContext.Current.CancellationToken);
+
+        var persisted = Assert.IsType<DownloadTask>(await tasks.FindAsync(
+            new DownloadTaskId(item.DownloadBase.Id),
+            TestContext.Current.CancellationToken));
+        Assert.Equal(DownloadPhase.Queued, persisted.Phase);
+        Assert.Same(item, Assert.Single(listState.Downloading));
+        Assert.Equal(
+            persisted.Id,
+            Assert.Single(gateway.MarkFaulted(
+                new InvalidOperationException("Synthetic terminal bootstrap failure."))));
+    }
+
+    [Fact]
     public async Task RuntimeFailureAfterPersistenceMarksCommittedTaskFailed()
     {
         Directory.CreateDirectory(_directory);
@@ -438,6 +469,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             listState,
             tasks,
             projections,
+            new DownloadTaskStateWriter(tasks),
             queue,
             runtimeAvailability ?? new ReadyDownloadRuntimeAvailability(),
             resolver ?? new RecordingPhysicalOutputPathResolver(static path => path));

--- a/tests/DownKyi.Tests/DownloadTaskQueueGatewayTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskQueueGatewayTests.cs
@@ -21,6 +21,10 @@ public sealed class DownloadTaskQueueGatewayTests
         await gateway.MarkReadyAsync(runtime, TestContext.Current.CancellationToken);
 
         Assert.Equal(taskId, Assert.Single(runtime.Enqueued));
+        var outcome = await gateway.WaitForStartupOutcomeAsync(
+            TestContext.Current.CancellationToken);
+        Assert.Equal(DownloadRuntimeStartupState.Ready, outcome.State);
+        Assert.Null(outcome.Failure);
     }
 
     [Fact]
@@ -45,14 +49,18 @@ public sealed class DownloadTaskQueueGatewayTests
         var pendingTask = new DownloadTaskId("pending-before-failure");
         await gateway.EnqueueAsync(pendingTask, TestContext.Current.CancellationToken);
 
-        var returned = gateway.MarkFaulted(
-            new InvalidOperationException("Synthetic bootstrap failure."));
+        var failure = new InvalidOperationException("Synthetic bootstrap failure.");
+        var returned = gateway.MarkFaulted(failure);
 
         Assert.Equal(pendingTask, Assert.Single(returned));
         Assert.Throws<DownloadRuntimeUnavailableException>(() => gateway.EnsureAcceptingTasks());
         await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() => gateway.EnqueueAsync(
             new DownloadTaskId("after-failure"),
             TestContext.Current.CancellationToken));
+        var outcome = await gateway.WaitForStartupOutcomeAsync(
+            TestContext.Current.CancellationToken);
+        Assert.Equal(DownloadRuntimeStartupState.Faulted, outcome.State);
+        Assert.Same(failure, outcome.Failure);
     }
 
     private sealed class RecordingRuntime : IDownloadRuntime

--- a/tests/DownKyi.Tests/DownloadTaskQueueGatewayTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskQueueGatewayTests.cs
@@ -6,7 +6,7 @@ namespace DownKyi.Tests;
 public sealed class DownloadTaskQueueGatewayTests
 {
     [Fact]
-    public async Task TasksAdmittedBeforeRuntimeStartAreFlushedOnceOnAttach()
+    public async Task TasksAdmittedBeforeRuntimeStartAreFlushedOnceOnReady()
     {
         var gateway = new DownloadTaskQueueGateway();
         var taskId = new DownloadTaskId("early-task");
@@ -17,6 +17,8 @@ public sealed class DownloadTaskQueueGatewayTests
         Assert.Empty(runtime.Enqueued);
 
         await gateway.AttachAsync(runtime, TestContext.Current.CancellationToken);
+        Assert.Empty(runtime.Enqueued);
+        await gateway.MarkReadyAsync(runtime, TestContext.Current.CancellationToken);
 
         Assert.Equal(taskId, Assert.Single(runtime.Enqueued));
     }
@@ -31,8 +33,26 @@ public sealed class DownloadTaskQueueGatewayTests
         await gateway.EnqueueAsync(taskId, TestContext.Current.CancellationToken);
         Assert.False(await gateway.CancelAsync(taskId));
         await gateway.AttachAsync(runtime, TestContext.Current.CancellationToken);
+        await gateway.MarkReadyAsync(runtime, TestContext.Current.CancellationToken);
 
         Assert.Empty(runtime.Enqueued);
+    }
+
+    [Fact]
+    public async Task TerminalFailureReturnsPendingTasksAndRejectsFurtherAdmission()
+    {
+        var gateway = new DownloadTaskQueueGateway();
+        var pendingTask = new DownloadTaskId("pending-before-failure");
+        await gateway.EnqueueAsync(pendingTask, TestContext.Current.CancellationToken);
+
+        var returned = gateway.MarkFaulted(
+            new InvalidOperationException("Synthetic bootstrap failure."));
+
+        Assert.Equal(pendingTask, Assert.Single(returned));
+        Assert.Throws<DownloadRuntimeUnavailableException>(() => gateway.EnsureReady());
+        await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() => gateway.EnqueueAsync(
+            new DownloadTaskId("after-failure"),
+            TestContext.Current.CancellationToken));
     }
 
     private sealed class RecordingRuntime : IDownloadRuntime

--- a/tests/DownKyi.Tests/DownloadTaskQueueGatewayTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskQueueGatewayTests.cs
@@ -49,7 +49,7 @@ public sealed class DownloadTaskQueueGatewayTests
             new InvalidOperationException("Synthetic bootstrap failure."));
 
         Assert.Equal(pendingTask, Assert.Single(returned));
-        Assert.Throws<DownloadRuntimeUnavailableException>(() => gateway.EnsureReady());
+        Assert.Throws<DownloadRuntimeUnavailableException>(() => gateway.EnsureAcceptingTasks());
         await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() => gateway.EnqueueAsync(
             new DownloadTaskId("after-failure"),
             TestContext.Current.CancellationToken));

--- a/tests/DownKyi.Tests/RecordingDownloadTaskQueue.cs
+++ b/tests/DownKyi.Tests/RecordingDownloadTaskQueue.cs
@@ -36,4 +36,11 @@ internal sealed class ReadyDownloadRuntimeAvailability : IDownloadRuntimeAvailab
     public void EnsureAcceptingTasks()
     {
     }
+
+    public Task<DownloadRuntimeStartupOutcome> WaitForStartupOutcomeAsync(
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(DownloadRuntimeStartupOutcome.Ready());
+    }
 }

--- a/tests/DownKyi.Tests/RecordingDownloadTaskQueue.cs
+++ b/tests/DownKyi.Tests/RecordingDownloadTaskQueue.cs
@@ -30,3 +30,10 @@ internal sealed class RecordingDownloadTaskQueue : IDownloadTaskQueue
         return Task.FromResult(true);
     }
 }
+
+internal sealed class ReadyDownloadRuntimeAvailability : IDownloadRuntimeAvailability
+{
+    public void EnsureReady()
+    {
+    }
+}

--- a/tests/DownKyi.Tests/RecordingDownloadTaskQueue.cs
+++ b/tests/DownKyi.Tests/RecordingDownloadTaskQueue.cs
@@ -33,7 +33,7 @@ internal sealed class RecordingDownloadTaskQueue : IDownloadTaskQueue
 
 internal sealed class ReadyDownloadRuntimeAvailability : IDownloadRuntimeAvailability
 {
-    public void EnsureReady()
+    public void EnsureAcceptingTasks()
     {
     }
 }

--- a/tests/DownKyi.Tests/StartupDialogOrderingTests.cs
+++ b/tests/DownKyi.Tests/StartupDialogOrderingTests.cs
@@ -3,6 +3,7 @@ using DownKyi.Application.Desktop;
 using DownKyi.Core.Settings;
 using DownKyi.Platform;
 using DownKyi.Services;
+using DownKyi.Services.Download;
 using DownKyi.ViewModels;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -39,6 +40,7 @@ public sealed class StartupDialogOrderingTests
             clipboard,
             new SearchService(settings.Store, navigation),
             new VersionCheckerService(httpClient, "owner", "repo"),
+            new RuntimeAvailabilityStub(),
             NullLogger<MainWindowViewModel>.Instance);
 
         var startup = viewModel.RunStartupDialogsAsync();
@@ -87,6 +89,7 @@ public sealed class StartupDialogOrderingTests
             clipboard,
             new SearchService(settings.Store, navigation),
             new VersionCheckerService(httpClient, "owner", "repo"),
+            new RuntimeAvailabilityStub(),
             NullLogger<MainWindowViewModel>.Instance);
 
         var startup = viewModel.RunStartupDialogsAsync();
@@ -101,6 +104,59 @@ public sealed class StartupDialogOrderingTests
         Assert.Equal(0, handler.RequestCount);
     }
 
+    [Fact]
+    public async Task DownloadFailureDialogWaitsForLegacyDialogAndPrecedesUpdateDialog()
+    {
+        using var settings = new TestSettingsStore();
+        settings.Store.Update(current => current with
+        {
+            About = current.About with
+            {
+                AutoUpdateWhenLaunch = AllowStatus.Yes,
+                IsReceiveBetaVersion = AllowStatus.No,
+                SkipVersionOnLaunch = string.Empty
+            }
+        });
+        var navigation = new NavigationStub();
+        var dialogs = new OrderedDialogService();
+        using var handler = new ReleaseHandler();
+        using var httpClient = new HttpClient(handler, disposeHandler: false)
+        {
+            BaseAddress = new Uri("https://api.github.test/")
+        };
+        using var clipboard = new ClipboardMonitorStub();
+        var failure = new InvalidOperationException("Synthetic download bootstrap failure.");
+        using var viewModel = new MainWindowViewModel(
+            navigation,
+            new NotificationStub(),
+            dialogs,
+            settings.Store,
+            clipboard,
+            new SearchService(settings.Store, navigation),
+            new VersionCheckerService(httpClient, "owner", "repo"),
+            new RuntimeAvailabilityStub(DownloadRuntimeStartupOutcome.Faulted(failure)),
+            NullLogger<MainWindowViewModel>.Instance);
+
+        var startup = viewModel.RunStartupDialogsAsync();
+        await dialogs.LegacyDialogStarted.Task
+            .WaitAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(true);
+
+        Assert.Equal([AppDialog.LegacyUpgrade], dialogs.Requests);
+
+        dialogs.CompleteLegacyDialog();
+        await startup.ConfigureAwait(true);
+
+        Assert.Equal(
+            [
+                AppDialog.LegacyUpgrade,
+                AppDialog.DownloadRuntimeFailure,
+                AppDialog.NewVersionAvailable
+            ],
+            dialogs.Requests);
+        Assert.Same(failure, dialogs.DownloadRuntimeFailure);
+    }
+
     private sealed class OrderedDialogService : IAppDialogService
     {
         private readonly TaskCompletionSource<AppDialogResult> _legacyCompletion =
@@ -110,6 +166,8 @@ public sealed class StartupDialogOrderingTests
             new(TaskCreationOptions.RunContinuationsAsynchronously);
 
         public List<AppDialog> Requests { get; } = [];
+
+        public Exception? DownloadRuntimeFailure { get; private set; }
 
         public Task<AppDialogResult> ShowAsync(
             AppDialogRequest request,
@@ -121,6 +179,12 @@ public sealed class StartupDialogOrderingTests
             {
                 LegacyDialogStarted.TrySetResult();
                 return _legacyCompletion.Task.WaitAsync(cancellationToken);
+            }
+
+            if (request.Dialog == AppDialog.DownloadRuntimeFailure)
+            {
+                DownloadRuntimeFailure = Assert.IsAssignableFrom<Exception>(
+                    request.Parameters?["failure"]);
             }
 
             return Task.FromResult(new AppDialogResult(
@@ -180,6 +244,32 @@ public sealed class StartupDialogOrderingTests
 
         public void Show(string message)
         {
+        }
+    }
+
+    private sealed class RuntimeAvailabilityStub : IDownloadRuntimeAvailability
+    {
+        private readonly DownloadRuntimeStartupOutcome _outcome;
+
+        public RuntimeAvailabilityStub()
+            : this(DownloadRuntimeStartupOutcome.Ready())
+        {
+        }
+
+        public RuntimeAvailabilityStub(DownloadRuntimeStartupOutcome outcome)
+        {
+            _outcome = outcome;
+        }
+
+        public void EnsureAcceptingTasks()
+        {
+        }
+
+        public Task<DownloadRuntimeStartupOutcome> WaitForStartupOutcomeAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_outcome);
         }
     }
 

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -370,6 +370,7 @@ public sealed class VideoTagLoadingTests : IDisposable
                 _taskService,
                 _projectionStore,
                 Queue,
+                new ReadyDownloadRuntimeAvailability(),
                 resolver ?? new FileSystemPhysicalOutputPathResolver());
             var duplicatePolicy = new DownloadDuplicatePolicy(
                 ListState,

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -288,15 +288,40 @@ public sealed class VideoTagLoadingTests : IDisposable
         Assert.Empty(context.Dialogs.Requests);
     }
 
+    [Fact]
+    public async Task RuntimeFailureStopsAdmissionAcrossRemainingSections()
+    {
+        using var context = CreateContext(
+            generateMetadata: false,
+            runtimeAvailability: new UnavailableDownloadRuntimeAvailability());
+        context.PrepareSections(
+            [CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([]))],
+            [CreatePage(_ => Task.FromResult<IReadOnlyList<string>>([]))]);
+
+        var added = await context.Service.AddToDownload(
+            _directory,
+            isAll: true,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(0, added);
+        Assert.Equal(0, context.Store.AddCount);
+        Assert.Empty(context.ListState.Downloading);
+        Assert.Single(context.Dialogs.Requests);
+    }
+
     private DownloadTestContext CreateContext(
         bool generateMetadata,
-        IPhysicalOutputPathResolver? resolver = null)
+        IPhysicalOutputPathResolver? resolver = null,
+        IDownloadTaskQueue? taskQueue = null,
+        IDownloadRuntimeAvailability? runtimeAvailability = null)
     {
         Directory.CreateDirectory(_directory);
         return new DownloadTestContext(
             Path.Combine(_directory, $"settings-{Guid.NewGuid():N}.json"),
             generateMetadata,
-            resolver);
+            resolver,
+            taskQueue,
+            runtimeAvailability);
     }
 
     private static VideoPage CreatePage(
@@ -342,7 +367,9 @@ public sealed class VideoTagLoadingTests : IDisposable
         public DownloadTestContext(
             string settingsPath,
             bool generateMetadata,
-            IPhysicalOutputPathResolver? resolver)
+            IPhysicalOutputPathResolver? resolver,
+            IDownloadTaskQueue? taskQueue,
+            IDownloadRuntimeAvailability? runtimeAvailability)
         {
             _settings = new DownKyi.Core.Settings.SettingsStore(settingsPath);
             _settings.Update(settings => settings with
@@ -369,8 +396,9 @@ public sealed class VideoTagLoadingTests : IDisposable
                 ListState,
                 _taskService,
                 _projectionStore,
-                Queue,
-                new ReadyDownloadRuntimeAvailability(),
+                new DownloadTaskStateWriter(_taskService),
+                taskQueue ?? Queue,
+                runtimeAvailability ?? new ReadyDownloadRuntimeAvailability(),
                 resolver ?? new FileSystemPhysicalOutputPathResolver());
             var duplicatePolicy = new DownloadDuplicatePolicy(
                 ListState,
@@ -423,6 +451,24 @@ public sealed class VideoTagLoadingTests : IDisposable
                 ]);
         }
 
+        public void PrepareSections(params VideoPage[][] sections)
+        {
+            Service.GetVideo(
+                new VideoInfoView
+                {
+                    Title = "video",
+                    Description = "description",
+                    VideoZone = "Technology"
+                },
+                sections.Select((pages, index) => new VideoSection
+                {
+                    Id = index + 1,
+                    IsSelected = true,
+                    Title = $"section-{index + 1}",
+                    VideoPages = pages
+                }).ToArray());
+        }
+
         public void Dispose()
         {
             _admission.Dispose();
@@ -469,6 +515,15 @@ public sealed class VideoTagLoadingTests : IDisposable
         public string ResolvePhysicalBasePath(string logicalBasePath)
         {
             throw new InvalidOperationException("Unexpected resolver failure.");
+        }
+    }
+
+    private sealed class UnavailableDownloadRuntimeAvailability : IDownloadRuntimeAvailability
+    {
+        public void EnsureAcceptingTasks()
+        {
+            throw new DownloadRuntimeUnavailableException(
+                "Synthetic unavailable download runtime.");
         }
     }
 

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -525,6 +525,15 @@ public sealed class VideoTagLoadingTests : IDisposable
             throw new DownloadRuntimeUnavailableException(
                 "Synthetic unavailable download runtime.");
         }
+
+        public Task<DownloadRuntimeStartupOutcome> WaitForStartupOutcomeAsync(
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(DownloadRuntimeStartupOutcome.Faulted(
+                new DownloadRuntimeUnavailableException(
+                    "Synthetic unavailable download runtime.")));
+        }
     }
 
     private sealed class RecordingTagProvider(


### PR DESCRIPTION
## Problem

Download bootstrap can fail after the desktop window is available. The queue gateway previously could not distinguish temporary initialization from a terminal failure, so later admissions could remain permanently Queued. Startup recovery could also overwrite a task changed by the user after the initial database snapshot.

This is a reproducible download-lifecycle defect. It remains separate from PR #250 and does not claim to identify or fix the unconfirmed 31-second managed crash.

## Fix

- keep runtime availability in the existing queue gateway owner: Initializing, Attaching, Ready, or Faulted
- convert every recoverable non-shutdown bootstrap exception into the terminal Faulted state instead of maintaining an exception allowlist
- publish Ready only after runtime startup, attach, startup-task recovery, and pending admission flush succeed
- reject new admission after a terminal bootstrap failure and transition already-owned dispatchable tasks to a typed Failed state
- re-read durable task state under the existing per-task gate before failure compensation, preserving a later user Pause
- reconcile interrupted startup tasks under that same gate with the snapshot version, so a later Pause becomes Paused and later terminal states are not recovered or re-enqueued
- surface one ordered startup dialog containing redacted, copyable diagnostics and a button that opens the DownKyiCore GitHub new-issue page

## Evidence

Exact local head: `0be671cb7a8a55f22efb21848cd987da841d3db1`

- strict Release solution build with all analyzers and warnings treated as errors: passed, 0 warnings / 0 errors
- formal CentralTestRunner Windows matrix: passed 8 of 8 applicable projects
- focused reconciliation and bootstrap tests: 16 passed
- Architecture tests: 318 passed
- Core tests: 233 passed
- Domain tests: 18 passed
- Infrastructure tests: 92 passed
- Windows tests: 19 passed
- format verification: passed
- module-boundary audit: passed
- Gitleaks 8.30.1 candidate scan: passed, 0 findings

The packaged aria2 TLS integration test remains conditionally skipped locally because `DOWNKYI_ARIA2_BINARY` is not configured. Hosted exact-head CI, including the macOS package job, remains required before merge.

## Scope

No signing, Hardened Runtime, Library Validation, libhostfxr, transfer timeout, automatic retry, or 31-second crash behavior is changed.