### PR TITLE
Fix macOS aria2 post-sign integrity and final-artifact gates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -620,9 +620,12 @@ jobs:
             -RuntimeIdentifier "osx-${{ matrix.cpu }}" `
             -ExpectedVersion "${{ steps.version.outputs.content }}" `
             -OutputPath "script/macos/publish-manifest-osx-${{ matrix.cpu }}.json"
+      - name: Verify pre-sign aria2 supply-chain boundary
+        run: /bin/bash ./aria2-runtime-integrity.sh verify 哔哩下载姬.app osx-${{ matrix.cpu }}
+        working-directory: ./script/macos
       - name: Sign app
         run: |
-          chmod +x codesign-common.sh prepare-app-layout.sh sign.sh verify-app.sh verify-app-launch.sh sign-dmg.sh verify-dmg.sh verify-dmg-contents.sh verify-runtime-architecture.sh
+          chmod +x codesign-common.sh prepare-app-layout.sh sign.sh verify-app.sh verify-app-launch.sh sign-dmg.sh verify-dmg.sh verify-dmg-contents.sh verify-runtime-architecture.sh aria2-runtime-integrity.sh verify-aria2-runtime-readiness.sh
           ./sign.sh
         working-directory: ./script/macos
         env:
@@ -630,6 +633,7 @@ jobs:
       - name: Verify app signature
         run: |
           ./verify-app.sh
+          ./aria2-runtime-integrity.sh verify 哔哩下载姬.app osx-${{ matrix.cpu }}
         working-directory: ./script/macos
       - name: Notarize app
         if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
@@ -643,6 +647,7 @@ jobs:
         if: ${{ env.HAS_MACOS_SIGNING == 'true' }}
         run: |
           ./verify-app.sh
+          ./aria2-runtime-integrity.sh verify 哔哩下载姬.app osx-${{ matrix.cpu }}
         working-directory: ./script/macos
         env:
           MACOS_VERIFY_GATEKEEPER: true

--- a/.github/workflows/macos-adhoc-package.yml
+++ b/.github/workflows/macos-adhoc-package.yml
@@ -28,10 +28,20 @@ env:
   DOTNET_NOLOGO: '1'
 
 jobs:
-  package-launch-arm64:
-    name: Package and launch (macOS 26 arm64, ad-hoc)
-    runs-on: macos-26
-    timeout-minutes: 20
+  package-launch:
+    name: Package and launch (${{ matrix.runtime }}, ad-hoc)
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - cpu: x64
+            runtime: osx-x64
+            os: macos-15-intel
+          - cpu: arm64
+            runtime: osx-arm64
+            os: macos-26
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -52,38 +62,48 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      - name: Run macOS packaging regressions
+        shell: pwsh
+        run: >
+          ./script/test-project.ps1
+          -ProjectPath ./tests/DownKyi.MacOS.Tests/DownKyi.MacOS.Tests.csproj
+          -Configuration Release
+          -ResultsDirectory ./artifacts/test-results/macos-packaging-${{ matrix.cpu }}
       - name: Read version
         id: version
         run: echo "content=$(tr -d '\r\n' < version.txt)" >> "$GITHUB_OUTPUT"
-      - name: Download runtime dependencies
+      - name: Download and verify upstream runtime dependencies
         working-directory: ./script
         run: |
           chmod +x aria2.sh ffmpeg.sh
-          ./aria2.sh osx-arm64
-          ./ffmpeg.sh mac arm64
-      - name: Publish arm64 app
+          ./aria2.sh osx-${{ matrix.cpu }}
+          ./ffmpeg.sh mac ${{ matrix.cpu }}
+      - name: Publish ${{ matrix.cpu }} app
         run: |
-          dotnet restore DownKyi/DownKyi.csproj -r osx-arm64
-          dotnet publish DownKyi/DownKyi.csproj --no-restore --self-contained -r osx-arm64 -c Release -p:DebugType=None -p:DebugSymbols=false
+          dotnet restore DownKyi/DownKyi.csproj -r osx-${{ matrix.cpu }}
+          dotnet publish DownKyi/DownKyi.csproj --no-restore --self-contained -r osx-${{ matrix.cpu }} -c Release -p:DebugType=None -p:DebugSymbols=false
       - name: Package app bundle
         working-directory: ./script/macos
         run: |
           chmod +x package.sh set-bundle-version.sh
-          ./package.sh arm64 ${{ steps.version.outputs.content }}
+          ./package.sh ${{ matrix.cpu }} ${{ steps.version.outputs.content }}
       - name: Validate packaged runtime
         shell: pwsh
         run: |
           ./script/validate-publish-output.ps1 `
-            -PublishDirectory "DownKyi/bin/Release/net10.0/osx-arm64/publish" `
-            -RuntimeIdentifier "osx-arm64" `
+            -PublishDirectory "DownKyi/bin/Release/net10.0/osx-${{ matrix.cpu }}/publish" `
+            -RuntimeIdentifier "osx-${{ matrix.cpu }}" `
             -ExpectedVersion "${{ steps.version.outputs.content }}" `
-            -OutputPath "script/macos/publish-manifest-osx-arm64.json"
+            -OutputPath "script/macos/publish-manifest-osx-${{ matrix.cpu }}.json"
+      - name: Verify pre-sign aria2 supply-chain boundary
+        working-directory: ./script/macos
+        run: /bin/bash ./aria2-runtime-integrity.sh verify 哔哩下载姬.app osx-${{ matrix.cpu }}
       - name: Ad-hoc sign app
         working-directory: ./script/macos
         env:
           MACOS_ADHOC_SIGNING: 'true'
         run: |
-          chmod +x codesign-common.sh prepare-app-layout.sh sign.sh verify-app.sh verify-app-launch.sh verify-dmg-contents.sh verify-runtime-architecture.sh
+          chmod +x codesign-common.sh prepare-app-layout.sh sign.sh verify-app.sh verify-app-launch.sh verify-dmg-contents.sh verify-runtime-architecture.sh aria2-runtime-integrity.sh verify-aria2-runtime-readiness.sh
           ./sign.sh
       - name: Verify ad-hoc policy and bundle integrity
         working-directory: ./script/macos
@@ -95,6 +115,7 @@ jobs:
             exit 1
           fi
           ./verify-app.sh
+          ./aria2-runtime-integrity.sh verify 哔哩下载姬.app osx-${{ matrix.cpu }}
       - name: Create DMG
         working-directory: ./script/macos
         run: |
@@ -104,23 +125,23 @@ jobs:
             --icon-size 120 \
             --app-drop-link 495 175 \
             --window-size 660 400 \
-            DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg 哔哩下载姬.app
+            DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg 哔哩下载姬.app
       - name: Verify mounted and copied app launch
         working-directory: ./script/macos
         env:
           MACOS_VERIFY_GATEKEEPER: 'false'
-        run: ./verify-dmg-contents.sh DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg ${{ steps.version.outputs.content }} osx-arm64
+        run: ./verify-dmg-contents.sh DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg ${{ steps.version.outputs.content }} osx-${{ matrix.cpu }}
       - name: Hash DMG
         shell: pwsh
         run: |
-          $package = "script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg"
+          $package = "script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg"
           $hash = (Get-FileHash -LiteralPath $package -Algorithm SHA256).Hash.ToLowerInvariant()
           "$hash  $([IO.Path]::GetFileName($package))" | Set-Content -LiteralPath "$package.sha256" -Encoding ascii
       - name: Upload verified DMG
         uses: actions/upload-artifact@v7
         with:
-          name: DownKyi-${{ steps.version.outputs.content }}-osx-arm64-adhoc-macos26
+          name: DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}-adhoc-${{ matrix.os }}
           path: |
-            script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg
-            script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-arm64.dmg.sha256
-            script/macos/publish-manifest-osx-arm64.json
+            script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg
+            script/macos/DownKyi-${{ steps.version.outputs.content }}-osx-${{ matrix.cpu }}.dmg.sha256
+            script/macos/publish-manifest-osx-${{ matrix.cpu }}.json

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -238,7 +238,10 @@ Release packaging downloads aria2 and FFmpeg from the scripts in `script/`.
   `--stop-with-process` on every OS and also joins a kill-on-close Windows Job
   Object, so an abrupt App termination cannot leave a local child running.
   Custom remote aria2 endpoints are not started or terminated by this owner;
-  non-loopback RPC requires HTTPS and does not follow redirects.
+  non-loopback RPC requires HTTPS and does not follow redirects. Custom Aria is
+  compatible only with endpoints whose `aria2.getVersion().enabledFeatures`
+  includes `downkyi-secure-redirect-v2`; generic aria2 and Motrix remain
+  unsupported because they cannot prove the required redirect protection.
 - aria2 task headers are per-transfer. Cookie can be attached only to an exact
   HTTPS `bilibili.com` host or subdomain. The actual patched transfer engine
   rejects scheme downgrade and credential-bearing cross-origin redirects before

--- a/docs/operations/aria2-security.md
+++ b/docs/operations/aria2-security.md
@@ -57,7 +57,11 @@ flowchart LR
 - Packaged aria2 starts only after its SHA-256 sidecar matches the executable.
   Both packaged and custom endpoints must report
   `downkyi-secure-redirect-v2` through `aria2.getVersion().enabledFeatures`;
-  missing integrity or capability evidence fails closed.
+  missing integrity or capability evidence fails closed. Consequently, the
+  Custom Aria setting supports only a DownKyi-compatible aria2 fork that
+  advertises this capability. Generic upstream aria2 and Motrix are not
+  supported endpoints; the setting UI and bootstrap diagnostic must state this
+  requirement rather than presenting them as generic-compatible alternatives.
 - RPC error code `33` identifies HTTPS downgrade rejection and `34` identifies
   sensitive-header cross-origin rejection. These machine codes remain stable
   when aria2 exhausts a URI and replaces the human-readable status message.

--- a/script/macos/aria2-runtime-integrity.sh
+++ b/script/macos/aria2-runtime-integrity.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+MODE="${1:?Mode is required: verify or refresh.}"
+APP_PATH="${2:?App bundle path is required.}"
+RUNTIME_IDENTIFIER="${3:-}"
+ARIA_EXECUTABLE="$APP_PATH/Contents/MacOS/aria2/aria2c"
+CHECKSUM_LINK="$ARIA_EXECUTABLE.sha256"
+CHECKSUM_TARGET="$APP_PATH/Contents/Resources/dotnet/aria2/aria2c.sha256"
+EXPECTED_LINK_TARGET="../../Resources/dotnet/aria2/aria2c.sha256"
+
+fail() {
+  echo "::error::aria2 runtime integrity invariant failed: $*" >&2
+  exit 1
+}
+
+sha256_file() {
+  shasum -a 256 "$1" | awk '{ print tolower($1) }'
+}
+
+if [ "$MODE" != "verify" ] && [ "$MODE" != "refresh" ]; then
+  fail "unsupported mode '$MODE'; expected verify or refresh."
+fi
+
+if [ ! -d "$APP_PATH/Contents" ]; then
+  fail "app bundle Contents directory is missing: $APP_PATH/Contents"
+fi
+
+if [ ! -f "$ARIA_EXECUTABLE" ] || [ -L "$ARIA_EXECUTABLE" ]; then
+  fail "aria2 executable is missing or is not a regular bundled file: $ARIA_EXECUTABLE"
+fi
+
+if [ ! -x "$ARIA_EXECUTABLE" ]; then
+  fail "aria2 executable permission is missing: $ARIA_EXECUTABLE"
+fi
+
+if [ ! -L "$CHECKSUM_LINK" ]; then
+  fail "runtime checksum path must remain a symlink: $CHECKSUM_LINK"
+fi
+
+ACTUAL_LINK_TARGET="$(readlink "$CHECKSUM_LINK")"
+if [ "$ACTUAL_LINK_TARGET" != "$EXPECTED_LINK_TARGET" ]; then
+  fail "runtime checksum symlink target is '$ACTUAL_LINK_TARGET', expected '$EXPECTED_LINK_TARGET'."
+fi
+
+if [ ! -f "$CHECKSUM_TARGET" ] || [ -L "$CHECKSUM_TARGET" ]; then
+  fail "runtime checksum target is missing or is not a regular file: $CHECKSUM_TARGET"
+fi
+
+if [ ! "$CHECKSUM_LINK" -ef "$CHECKSUM_TARGET" ]; then
+  fail "runtime checksum symlink does not resolve to the canonical Resources target."
+fi
+
+if [ "$MODE" = "refresh" ]; then
+  if codesign -d "$APP_PATH" >/dev/null 2>&1; then
+    fail "refusing to modify the runtime checksum after the outer app signature is sealed."
+  fi
+
+  FINAL_SHA256="$(sha256_file "$ARIA_EXECUTABLE")"
+  printf '%s' "$FINAL_SHA256" >"$CHECKSUM_LINK"
+  echo "[INFO] Refreshed runtime aria2 checksum after nested signing."
+fi
+
+CHECKSUM_TEXT="$(<"$CHECKSUM_LINK")"
+if [[ ! "$CHECKSUM_TEXT" =~ ^[[:xdigit:]]{64}$ ]]; then
+  fail "runtime checksum sidecar must contain exactly one 64-character SHA-256 digest."
+fi
+
+EXPECTED_SHA256="$(printf '%s' "$CHECKSUM_TEXT" | tr '[:upper:]' '[:lower:]')"
+ACTUAL_SHA256="$(sha256_file "$ARIA_EXECUTABLE")"
+if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
+  fail "final aria2 executable SHA-256 '$ACTUAL_SHA256' does not match runtime sidecar '$EXPECTED_SHA256'."
+fi
+
+if [ -n "$RUNTIME_IDENTIFIER" ]; then
+  case "$RUNTIME_IDENTIFIER" in
+    osx-x64) EXPECTED_ARCHITECTURE="x86_64" ;;
+    osx-arm64) EXPECTED_ARCHITECTURE="arm64" ;;
+    *) fail "unsupported macOS runtime identifier: $RUNTIME_IDENTIFIER" ;;
+  esac
+
+  ACTUAL_ARCHITECTURE="$(lipo -archs "$ARIA_EXECUTABLE" 2>/dev/null || true)"
+  if [ "$ACTUAL_ARCHITECTURE" != "$EXPECTED_ARCHITECTURE" ]; then
+    fail "aria2 executable architecture is '$ACTUAL_ARCHITECTURE', expected '$EXPECTED_ARCHITECTURE' for $RUNTIME_IDENTIFIER."
+  fi
+fi
+
+echo "[INFO] Final aria2 runtime integrity verified${RUNTIME_IDENTIFIER:+ for $RUNTIME_IDENTIFIER}."

--- a/script/macos/aria2-runtime-integrity.sh
+++ b/script/macos/aria2-runtime-integrity.sh
@@ -8,6 +8,7 @@ ARIA_EXECUTABLE="$APP_PATH/Contents/MacOS/aria2/aria2c"
 CHECKSUM_LINK="$ARIA_EXECUTABLE.sha256"
 CHECKSUM_TARGET="$APP_PATH/Contents/Resources/dotnet/aria2/aria2c.sha256"
 EXPECTED_LINK_TARGET="../../Resources/dotnet/aria2/aria2c.sha256"
+OUTER_RESOURCE_SEAL="$APP_PATH/Contents/_CodeSignature/CodeResources"
 
 fail() {
   echo "::error::aria2 runtime integrity invariant failed: $*" >&2
@@ -52,7 +53,7 @@ if [ ! "$CHECKSUM_LINK" -ef "$CHECKSUM_TARGET" ]; then
 fi
 
 if [ "$MODE" = "refresh" ]; then
-  if codesign -d "$APP_PATH" >/dev/null 2>&1; then
+  if [ -e "$OUTER_RESOURCE_SEAL" ] || [ -L "$OUTER_RESOURCE_SEAL" ]; then
     fail "refusing to modify the runtime checksum after the outer app signature is sealed."
   fi
 

--- a/script/macos/sign.sh
+++ b/script/macos/sign.sh
@@ -35,6 +35,10 @@ find "$APP_NAME/Contents" -type f -print0 | while IFS= read -r -d '' file; do
   fi
 done
 
+# codesign mutates Mach-O bytes. Finalize the runtime digest only after every
+# nested binary is signed and before the main executable and outer app seal it.
+/bin/bash "$SCRIPT_DIR/aria2-runtime-integrity.sh" refresh "$APP_NAME"
+
 echo "[INFO] Signing main executable $MAIN_EXECUTABLE"
 codesign_app_path "$MAIN_EXECUTABLE"
 

--- a/script/macos/sign.sh
+++ b/script/macos/sign.sh
@@ -15,6 +15,10 @@ if [ ! -f "$MAIN_EXECUTABLE" ]; then
   exit 1
 fi
 
+# Keep the upstream/runtime sidecar valid until this transaction is ready to
+# mutate nested Mach-O bytes. Direct callers receive the same pre-sign gate as CI.
+/bin/bash "$SCRIPT_DIR/aria2-runtime-integrity.sh" verify "$APP_NAME"
+
 codesign_app_path() {
   local path="$1"
   if [ "$SIGNING_IDENTITY" = "-" ]; then

--- a/script/macos/verify-aria2-runtime-readiness.sh
+++ b/script/macos/verify-aria2-runtime-readiness.sh
@@ -58,6 +58,17 @@ SHUTDOWN_RESPONSE="$PROBE_ROOT/shutdown-response.json"
 
 umask 077
 printf 'rpc-secret=%s\n' "$RPC_SECRET" >"$RPC_CONFIG"
+
+# DHT is not compiled into every trusted aria2 build. When those options are
+# available, keep their persistent state inside the disposable probe boundary.
+ARIA_OPTION_HELP="$("$ARIA_EXECUTABLE" --help=#all 2>/dev/null || true)"
+if grep -Fq -- '--dht-file-path=' <<<"$ARIA_OPTION_HELP"; then
+  printf 'dht-file-path=%s\n' "$PROBE_ROOT/dht.dat" >>"$RPC_CONFIG"
+fi
+if grep -Fq -- '--dht-file-path6=' <<<"$ARIA_OPTION_HELP"; then
+  printf 'dht-file-path6=%s\n' "$PROBE_ROOT/dht6.dat" >>"$RPC_CONFIG"
+fi
+
 : >"$SESSION_FILE"
 mkdir "$PROBE_ROOT/downloads"
 printf '{"jsonrpc":"2.0","id":"runtime-readiness","method":"aria2.getVersion","params":["token:%s"]}' \
@@ -71,8 +82,6 @@ printf '{"jsonrpc":"2.0","id":"runtime-shutdown","method":"aria2.shutdown","para
   --rpc-listen-all=false \
   --rpc-allow-origin-all=false \
   "--rpc-listen-port=$RPC_PORT" \
-  --enable-dht=false \
-  --enable-dht6=false \
   "--stop-with-process=$$" \
   "--input-file=$SESSION_FILE" \
   "--save-session=$SESSION_FILE" \

--- a/script/macos/verify-aria2-runtime-readiness.sh
+++ b/script/macos/verify-aria2-runtime-readiness.sh
@@ -1,0 +1,158 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_PATH="${1:?App bundle path is required.}"
+RUNTIME_IDENTIFIER="${2:?Runtime identifier is required.}"
+ARIA_EXECUTABLE="$APP_PATH/Contents/MacOS/aria2/aria2c"
+PROBE_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/downkyi-aria2-probe.XXXXXX")"
+ARIA_PID=""
+
+cleanup() {
+  if [ -n "$ARIA_PID" ] && kill -0 "$ARIA_PID" 2>/dev/null; then
+    kill -TERM "$ARIA_PID" 2>/dev/null || true
+    for _ in {1..20}; do
+      if ! kill -0 "$ARIA_PID" 2>/dev/null; then
+        break
+      fi
+      sleep 0.1
+    done
+    if kill -0 "$ARIA_PID" 2>/dev/null; then
+      kill -KILL "$ARIA_PID" 2>/dev/null || true
+    fi
+    wait "$ARIA_PID" 2>/dev/null || true
+  fi
+  rm -rf -- "$PROBE_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "::error::aria2 runtime readiness invariant failed: $*" >&2
+  if [ -f "$PROBE_ROOT/aria2.stderr" ]; then
+    sed -E 's/token:[[:xdigit:]]+/token:[redacted]/g' "$PROBE_ROOT/aria2.stderr" >&2
+  fi
+  exit 1
+}
+
+/bin/bash "$SCRIPT_DIR/aria2-runtime-integrity.sh" verify "$APP_PATH" "$RUNTIME_IDENTIFIER"
+
+if ! command -v python3 >/dev/null 2>&1; then
+  fail "python3 is required for the deterministic RPC readiness probe."
+fi
+
+RPC_PORT="$(python3 - <<'PY'
+import socket
+
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as listener:
+    listener.bind(("127.0.0.1", 0))
+    print(listener.getsockname()[1])
+PY
+)"
+RPC_SECRET="$(openssl rand -hex 32)"
+RPC_CONFIG="$PROBE_ROOT/aria2.conf"
+SESSION_FILE="$PROBE_ROOT/aria2.session"
+VERSION_REQUEST="$PROBE_ROOT/version-request.json"
+VERSION_RESPONSE="$PROBE_ROOT/version-response.json"
+SHUTDOWN_REQUEST="$PROBE_ROOT/shutdown-request.json"
+SHUTDOWN_RESPONSE="$PROBE_ROOT/shutdown-response.json"
+
+umask 077
+printf 'rpc-secret=%s\n' "$RPC_SECRET" >"$RPC_CONFIG"
+: >"$SESSION_FILE"
+mkdir "$PROBE_ROOT/downloads"
+printf '{"jsonrpc":"2.0","id":"runtime-readiness","method":"aria2.getVersion","params":["token:%s"]}' \
+  "$RPC_SECRET" >"$VERSION_REQUEST"
+printf '{"jsonrpc":"2.0","id":"runtime-shutdown","method":"aria2.shutdown","params":["token:%s"]}' \
+  "$RPC_SECRET" >"$SHUTDOWN_REQUEST"
+
+"$ARIA_EXECUTABLE" \
+  "--conf-path=$RPC_CONFIG" \
+  --enable-rpc=true \
+  --rpc-listen-all=false \
+  --rpc-allow-origin-all=false \
+  "--rpc-listen-port=$RPC_PORT" \
+  "--stop-with-process=$$" \
+  "--input-file=$SESSION_FILE" \
+  "--save-session=$SESSION_FILE" \
+  "--dir=$PROBE_ROOT/downloads" \
+  --log-level=notice \
+  >"$PROBE_ROOT/aria2.stdout" 2>"$PROBE_ROOT/aria2.stderr" &
+ARIA_PID=$!
+
+READY=false
+for _ in {1..50}; do
+  if ! kill -0 "$ARIA_PID" 2>/dev/null; then
+    wait "$ARIA_PID" || status=$?
+    fail "aria2 exited before RPC became ready (status ${status:-0})."
+  fi
+
+  if curl --fail --silent --show-error \
+      --connect-timeout 1 \
+      --max-time 1 \
+      --header 'Content-Type: application/json' \
+      --data-binary "@$VERSION_REQUEST" \
+      "http://127.0.0.1:$RPC_PORT/jsonrpc" \
+      >"$VERSION_RESPONSE" 2>/dev/null \
+    && python3 - "$VERSION_RESPONSE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as response_file:
+    response = json.load(response_file)
+
+result = response.get("result")
+if not isinstance(result, dict) or not isinstance(result.get("version"), str):
+    raise SystemExit(1)
+if "downkyi-secure-redirect-v2" not in result.get("enabledFeatures", []):
+    raise SystemExit(1)
+PY
+  then
+    READY=true
+    break
+  fi
+
+  sleep 0.1
+done
+
+if [ "$READY" != "true" ]; then
+  fail "aria2 did not return system version and required downkyi-secure-redirect-v2 capability before the bounded deadline."
+fi
+
+if ! curl --fail --silent --show-error \
+    --connect-timeout 1 \
+    --max-time 2 \
+    --header 'Content-Type: application/json' \
+    --data-binary "@$SHUTDOWN_REQUEST" \
+    "http://127.0.0.1:$RPC_PORT/jsonrpc" \
+    >"$SHUTDOWN_RESPONSE"; then
+  fail "aria2 shutdown RPC request failed."
+fi
+
+if ! python3 - "$SHUTDOWN_RESPONSE" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as response_file:
+    response = json.load(response_file)
+
+if response.get("result") != "OK":
+    raise SystemExit(1)
+PY
+then
+  fail "aria2 shutdown RPC did not return OK."
+fi
+
+for _ in {1..50}; do
+  if ! kill -0 "$ARIA_PID" 2>/dev/null; then
+    wait "$ARIA_PID" || status=$?
+    if [ "${status:-0}" -ne 0 ]; then
+      fail "aria2 exited abnormally after shutdown RPC (status $status)."
+    fi
+    ARIA_PID=""
+    echo "[INFO] Packaged aria2 passed integrity, RPC readiness, secure-redirect capability, and graceful shutdown checks."
+    exit 0
+  fi
+  sleep 0.1
+done
+
+fail "aria2 did not exit after successful shutdown RPC."

--- a/script/macos/verify-aria2-runtime-readiness.sh
+++ b/script/macos/verify-aria2-runtime-readiness.sh
@@ -71,6 +71,8 @@ printf '{"jsonrpc":"2.0","id":"runtime-shutdown","method":"aria2.shutdown","para
   --rpc-listen-all=false \
   --rpc-allow-origin-all=false \
   "--rpc-listen-port=$RPC_PORT" \
+  --enable-dht=false \
+  --enable-dht6=false \
   "--stop-with-process=$$" \
   "--input-file=$SESSION_FILE" \
   "--save-session=$SESSION_FILE" \
@@ -103,7 +105,10 @@ with open(sys.argv[1], "r", encoding="utf-8") as response_file:
 result = response.get("result")
 if not isinstance(result, dict) or not isinstance(result.get("version"), str):
     raise SystemExit(1)
-if "downkyi-secure-redirect-v2" not in result.get("enabledFeatures", []):
+features = result.get("enabledFeatures")
+if not isinstance(features, list) or not all(isinstance(feature, str) for feature in features):
+    raise SystemExit(1)
+if "downkyi-secure-redirect-v2" not in features:
     raise SystemExit(1)
 PY
   then

--- a/script/macos/verify-dmg-contents.sh
+++ b/script/macos/verify-dmg-contents.sh
@@ -38,6 +38,8 @@ fi
 "$SCRIPT_DIR/verify-runtime-architecture.sh" "$APP_PATH" "$EXPECTED_RUNTIME_IDENTIFIER"
 
 "$SCRIPT_DIR/verify-app.sh" "$APP_PATH"
+/bin/bash "$SCRIPT_DIR/aria2-runtime-integrity.sh" verify "$APP_PATH" "$EXPECTED_RUNTIME_IDENTIFIER"
+/bin/bash "$SCRIPT_DIR/verify-aria2-runtime-readiness.sh" "$APP_PATH" "$EXPECTED_RUNTIME_IDENTIFIER"
 "$SCRIPT_DIR/verify-app-launch.sh" "$APP_PATH"
 
 COPIED_APP_PATH="$COPY_ROOT/$(basename "$APP_PATH")"
@@ -45,4 +47,6 @@ COPIED_APP_PATH="$COPY_ROOT/$(basename "$APP_PATH")"
 
 "$SCRIPT_DIR/verify-runtime-architecture.sh" "$COPIED_APP_PATH" "$EXPECTED_RUNTIME_IDENTIFIER"
 "$SCRIPT_DIR/verify-app.sh" "$COPIED_APP_PATH"
+/bin/bash "$SCRIPT_DIR/aria2-runtime-integrity.sh" verify "$COPIED_APP_PATH" "$EXPECTED_RUNTIME_IDENTIFIER"
+/bin/bash "$SCRIPT_DIR/verify-aria2-runtime-readiness.sh" "$COPIED_APP_PATH" "$EXPECTED_RUNTIME_IDENTIFIER"
 "$SCRIPT_DIR/verify-app-launch.sh" "$COPIED_APP_PATH"

--- a/src/DownKyi.Desktop/Languages/Default.axaml
+++ b/src/DownKyi.Desktop/Languages/Default.axaml
@@ -211,6 +211,7 @@
     <system:String x:Key="BuiltinDownloader">内建下载器</system:String>
     <system:String x:Key="Aria2cDownloader">Aria2下载器</system:String>
     <system:String x:Key="CustomAria2cDownloader">自定义Aria2下载器</system:String>
+    <system:String x:Key="CustomAriaCompatibilityRequirement">仅支持 aria2.getVersion().enabledFeatures 包含 downkyi-secure-redirect-v2 的 DownKyi 兼容端点；标准 aria2 与 Motrix 不受支持。</system:String>
     <system:String x:Key="HighSpeedDownloadMode">高速下载模式（套用推荐分片/连接参数）</system:String>
     <system:String x:Key="HighSpeedDownloadModeTip">开启时会将内建线程数设为16，Aria最大线程数设为16，同服务器连接数设为16，最小分片设为1MB。</system:String>
     <system:String x:Key="AriaServerHost">Aria服务器地址：</system:String>

--- a/src/DownKyi.Desktop/Services/Download/Aria2RuntimeLifecycle.cs
+++ b/src/DownKyi.Desktop/Services/Download/Aria2RuntimeLifecycle.cs
@@ -170,7 +170,10 @@ internal sealed class Aria2RuntimeLifecycle : IDisposable
         if (!features.Contains(SecureRedirectFeature, StringComparer.Ordinal))
         {
             throw new InvalidOperationException(
-                "The aria2 endpoint does not enforce DownKyi secure redirects.");
+                "The aria2 endpoint is incompatible with DownKyi downloads: " +
+                "aria2.getVersion().enabledFeatures does not include the required " +
+                $"'{SecureRedirectFeature}' capability. Standard aria2 and Motrix do not " +
+                "provide this DownKyi-specific redirect protection.");
         }
     }
 

--- a/src/DownKyi.Desktop/Views/Settings/CustomAriaSettingsView.axaml
+++ b/src/DownKyi.Desktop/Views/Settings/CustomAriaSettingsView.axaml
@@ -4,6 +4,12 @@
              x:Class="DownKyi.Views.Settings.CustomAriaSettingsView"
              x:DataType="vms:ViewNetworkViewModel">
     <StackPanel x:Name="NameCustomAria" IsVisible="{Binding CustomAria2C}">
+        <TextBlock
+            MaxWidth="520"
+            HorizontalAlignment="Left"
+            Foreground="{DynamicResource BrushTextDark}"
+            Text="{DynamicResource CustomAriaCompatibilityRequirement}"
+            TextWrapping="Wrap" />
         <StackPanel
             Margin="0,20,0,0"
             Orientation="Horizontal"

--- a/tests/DownKyi.Architecture.Tests/NetworkSettingsViewArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/NetworkSettingsViewArchitectureTests.cs
@@ -58,7 +58,7 @@ public sealed class NetworkSettingsViewArchitectureTests
 
         Assert.Equal(89, Count(source, @"\{Binding\s+([^},]+)"));
         Assert.Equal(38, Count(source, @"(?:x:Name|Name)=""([^""]+)"""));
-        Assert.Equal(68, Count(source, @"\{DynamicResource\s+([^}]+)\}"));
+        Assert.Equal(70, Count(source, @"\{DynamicResource\s+([^}]+)\}"));
         Assert.Equal(4, Count(source, @"\{StaticResource\s+([^}]+)\}"));
         Assert.Equal(25, Count(source, @"CommandParameter=""([^""]+)"""));
     }

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -462,6 +462,7 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("codesign_app_path \"$file\"", signScript, StringComparison.Ordinal);
         AssertInOrder(
             signScript,
+            "aria2-runtime-integrity.sh\" verify \"$APP_NAME\"",
             "codesign_app_path \"$file\"",
             "aria2-runtime-integrity.sh\" refresh \"$APP_NAME\"",
             "codesign_app_path \"$MAIN_EXECUTABLE\"",
@@ -497,6 +498,9 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("lipo -archs", ariaIntegrityScript, StringComparison.Ordinal);
         Assert.Contains("aria2.getVersion", ariaReadinessScript, StringComparison.Ordinal);
         Assert.Contains("downkyi-secure-redirect-v2", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("isinstance(features, list)", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("--enable-dht=false", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("--enable-dht6=false", ariaReadinessScript, StringComparison.Ordinal);
         Assert.Contains("aria2.shutdown", ariaReadinessScript, StringComparison.Ordinal);
     }
 

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -492,6 +492,7 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("verify-app-launch.sh\" \"$COPIED_APP_PATH\"", verifyDmgContentsScript, StringComparison.Ordinal);
 
         Assert.Contains("runtime checksum path must remain a symlink", ariaIntegrityScript, StringComparison.Ordinal);
+        Assert.Contains("Contents/_CodeSignature/CodeResources", ariaIntegrityScript, StringComparison.Ordinal);
         Assert.Contains("refusing to modify the runtime checksum after the outer app signature is sealed", ariaIntegrityScript, StringComparison.Ordinal);
         Assert.Contains("lipo -archs", ariaIntegrityScript, StringComparison.Ordinal);
         Assert.Contains("aria2.getVersion", ariaReadinessScript, StringComparison.Ordinal);

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -413,6 +413,10 @@ public sealed class ReleaseWorkflowArchitectureTests
             Path.Combine(RepositoryRoot, "script", "macos", "verify-dmg.sh"));
         var verifyDmgContentsScript = File.ReadAllText(
             Path.Combine(RepositoryRoot, "script", "macos", "verify-dmg-contents.sh"));
+        var ariaIntegrityScript = File.ReadAllText(
+            Path.Combine(RepositoryRoot, "script", "macos", "aria2-runtime-integrity.sh"));
+        var ariaReadinessScript = File.ReadAllText(
+            Path.Combine(RepositoryRoot, "script", "macos", "verify-aria2-runtime-readiness.sh"));
 
         Assert.DoesNotContain(
             "MACOS_SIGNING_REQUIRED",
@@ -437,6 +441,7 @@ public sealed class ReleaseWorkflowArchitectureTests
             workflow,
             "Package app",
             "Validate packaged runtime",
+            "Verify pre-sign aria2 supply-chain boundary",
             "Sign app",
             "Verify app signature",
             "Notarize app",
@@ -455,6 +460,12 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("find \"$APP_NAME/Contents\" -type f", signScript, StringComparison.Ordinal);
         Assert.Contains("is_signable_app_file \"$file\"", signScript, StringComparison.Ordinal);
         Assert.Contains("codesign_app_path \"$file\"", signScript, StringComparison.Ordinal);
+        AssertInOrder(
+            signScript,
+            "codesign_app_path \"$file\"",
+            "aria2-runtime-integrity.sh\" refresh \"$APP_NAME\"",
+            "codesign_app_path \"$MAIN_EXECUTABLE\"",
+            "codesign_app_path \"$APP_NAME\"");
         Assert.Contains("Print :CFBundleExecutable", signScript, StringComparison.Ordinal);
         Assert.Contains("codesign_app_path \"$MAIN_EXECUTABLE\"", signScript, StringComparison.Ordinal);
         Assert.Contains("codesign_app_path \"$APP_NAME\"", signScript, StringComparison.Ordinal);
@@ -476,7 +487,16 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("spctl --assess --type open --context context:primary-signature", verifyDmgScript, StringComparison.Ordinal);
         Assert.Contains("/usr/bin/ditto \"$APP_PATH\" \"$COPIED_APP_PATH\"", verifyDmgContentsScript, StringComparison.Ordinal);
         Assert.Contains("verify-app.sh\" \"$COPIED_APP_PATH\"", verifyDmgContentsScript, StringComparison.Ordinal);
+        Assert.Equal(2, CountOccurrences(verifyDmgContentsScript, "aria2-runtime-integrity.sh\" verify"));
+        Assert.Equal(2, CountOccurrences(verifyDmgContentsScript, "verify-aria2-runtime-readiness.sh"));
         Assert.Contains("verify-app-launch.sh\" \"$COPIED_APP_PATH\"", verifyDmgContentsScript, StringComparison.Ordinal);
+
+        Assert.Contains("runtime checksum path must remain a symlink", ariaIntegrityScript, StringComparison.Ordinal);
+        Assert.Contains("refusing to modify the runtime checksum after the outer app signature is sealed", ariaIntegrityScript, StringComparison.Ordinal);
+        Assert.Contains("lipo -archs", ariaIntegrityScript, StringComparison.Ordinal);
+        Assert.Contains("aria2.getVersion", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("downkyi-secure-redirect-v2", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("aria2.shutdown", ariaReadinessScript, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -492,6 +512,7 @@ public sealed class ReleaseWorkflowArchitectureTests
                      "Run macOS packaging regressions",
                      "Build ${{ matrix.cpu }}",
                      "Package app",
+                     "Verify pre-sign aria2 supply-chain boundary",
                      "Sign app",
                      "Verify app signature",
                      "Create DMG",
@@ -518,7 +539,7 @@ public sealed class ReleaseWorkflowArchitectureTests
     }
 
     [Fact]
-    public void MacAdHocPackageWorkflowUsesMacOs26Arm64WithoutAppleCredentials()
+    public void MacAdHocPackageWorkflowCoversBothRidsWithoutAppleCredentials()
     {
         var workflow = File.ReadAllText(
             Path.Combine(RepositoryRoot, ".github", "workflows", "macos-adhoc-package.yml"));
@@ -530,7 +551,11 @@ public sealed class ReleaseWorkflowArchitectureTests
             .Select(line => line.Trim()[2..].Trim('\'', '"'))
             .ToHashSet(StringComparer.Ordinal);
 
-        Assert.Contains("runs-on: macos-26", workflow, StringComparison.Ordinal);
+        Assert.Contains("runs-on: ${{ matrix.os }}", workflow, StringComparison.Ordinal);
+        Assert.Contains("os: macos-26", workflow, StringComparison.Ordinal);
+        Assert.Contains("os: macos-15-intel", workflow, StringComparison.Ordinal);
+        Assert.Contains("runtime: osx-x64", workflow, StringComparison.Ordinal);
+        Assert.Contains("runtime: osx-arm64", workflow, StringComparison.Ordinal);
         Assert.Contains("MACOS_ADHOC_SIGNING: 'true'", workflow, StringComparison.Ordinal);
         foreach (var packageInput in new[]
                  {
@@ -551,6 +576,7 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("dotnet publish", workflow, StringComparison.Ordinal);
         Assert.Contains("./sign.sh", workflow, StringComparison.Ordinal);
         Assert.Contains("./verify-app.sh", workflow, StringComparison.Ordinal);
+        Assert.Contains("./aria2-runtime-integrity.sh verify", workflow, StringComparison.Ordinal);
         Assert.Contains("flags=.*runtime", workflow, StringComparison.Ordinal);
         Assert.Contains("create-dmg", workflow, StringComparison.Ordinal);
         Assert.Contains("./verify-dmg-contents.sh", workflow, StringComparison.Ordinal);

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -499,8 +499,9 @@ public sealed class ReleaseWorkflowArchitectureTests
         Assert.Contains("aria2.getVersion", ariaReadinessScript, StringComparison.Ordinal);
         Assert.Contains("downkyi-secure-redirect-v2", ariaReadinessScript, StringComparison.Ordinal);
         Assert.Contains("isinstance(features, list)", ariaReadinessScript, StringComparison.Ordinal);
-        Assert.Contains("--enable-dht=false", ariaReadinessScript, StringComparison.Ordinal);
-        Assert.Contains("--enable-dht6=false", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("--help=#all", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("\"$PROBE_ROOT/dht.dat\"", ariaReadinessScript, StringComparison.Ordinal);
+        Assert.Contains("\"$PROBE_ROOT/dht6.dat\"", ariaReadinessScript, StringComparison.Ordinal);
         Assert.Contains("aria2.shutdown", ariaReadinessScript, StringComparison.Ordinal);
     }
 

--- a/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/TlsSecurityArchitectureTests.cs
@@ -132,6 +132,7 @@ public sealed class TlsSecurityArchitectureTests
         Assert.Contains("LocalAriaRpcEndpoint.Create", factory, StringComparison.Ordinal);
         Assert.DoesNotContain("\"downkyi\"", factory, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("PasswordChar=\"*\"", customSettings, StringComparison.Ordinal);
+        Assert.Contains("CustomAriaCompatibilityRequirement", customSettings, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/DownKyi.MacOS.Tests/MacAriaRuntimeIntegrityTests.cs
+++ b/tests/DownKyi.MacOS.Tests/MacAriaRuntimeIntegrityTests.cs
@@ -1,0 +1,349 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace DownKyi.MacOS.Tests;
+
+[SupportedOSPlatform("macos")]
+public sealed class MacAriaRuntimeIntegrityTests
+{
+    private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string IntegrityScript = Path.Combine(
+        RepositoryRoot,
+        "script",
+        "macos",
+        "aria2-runtime-integrity.sh");
+
+    [Fact]
+    public void SigningFinalizesRuntimeChecksumBeforeOuterSealAndSurvivesDmgCopy()
+    {
+        var fixtureRoot = CreateTemporaryDirectory();
+        var appPath = Path.Combine(fixtureRoot, "Fixture.app");
+        var runtimeIdentifier = CurrentRuntimeIdentifier();
+
+        try
+        {
+            CreateAppFixture(fixtureRoot, appPath);
+            AssertSuccess(Run("/bin/bash", fixtureRoot, IntegrityScript, "verify", appPath, runtimeIdentifier));
+
+            var ariaExecutable = Path.Combine(appPath, "Contents", "MacOS", "aria2", "aria2c");
+            var originalHash = HashFile(ariaExecutable);
+            AssertSuccess(Run("/usr/bin/codesign", fixtureRoot, "--force", "--sign", "-", ariaExecutable));
+            Assert.NotEqual(originalHash, HashFile(ariaExecutable));
+
+            var staleAfterNestedSigning = Run(
+                "/bin/bash",
+                fixtureRoot,
+                IntegrityScript,
+                "verify",
+                appPath,
+                runtimeIdentifier);
+            AssertFailureContains(staleAfterNestedSigning, "does not match runtime sidecar");
+
+            AssertSuccess(Run("/bin/bash", fixtureRoot, IntegrityScript, "refresh", appPath));
+            AssertSuccess(Run("/bin/bash", fixtureRoot, IntegrityScript, "verify", appPath, runtimeIdentifier));
+
+            AssertSuccess(Run(
+                "/bin/bash",
+                fixtureRoot,
+                new Dictionary<string, string?> { ["MACOS_ADHOC_SIGNING"] = "true" },
+                Path.Combine(RepositoryRoot, "script", "macos", "sign.sh"),
+                appPath));
+            AssertSuccess(Run("/usr/bin/codesign", fixtureRoot, "--verify", "--deep", "--strict", appPath));
+            AssertSuccess(Run("/bin/bash", fixtureRoot, IntegrityScript, "verify", appPath, runtimeIdentifier));
+            AssertFailureContains(
+                Run("/bin/bash", fixtureRoot, IntegrityScript, "refresh", appPath),
+                "refusing to modify the runtime checksum after the outer app signature is sealed");
+
+            var copiedApp = AssertDmgAndInstalledCopyRoundtrip(
+                fixtureRoot,
+                appPath,
+                runtimeIdentifier);
+
+            File.AppendAllText(
+                Path.Combine(copiedApp, "Contents", "MacOS", "aria2", "aria2c"),
+                "tamper",
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            AssertFailureContains(
+                Run("/bin/bash", fixtureRoot, IntegrityScript, "verify", copiedApp, runtimeIdentifier),
+                "does not match runtime sidecar");
+
+            File.WriteAllText(
+                Path.Combine(appPath, "Contents", "Resources", "dotnet", "aria2", "aria2c.sha256"),
+                new string('0', 64),
+                new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            AssertFailureContains(
+                Run("/bin/bash", fixtureRoot, IntegrityScript, "verify", appPath, runtimeIdentifier),
+                "does not match runtime sidecar");
+        }
+        finally
+        {
+            Directory.Delete(fixtureRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IntegrityBoundaryRejectsMalformedOrReplacedChecksumSymlink()
+    {
+        var fixtureRoot = CreateTemporaryDirectory();
+        var appPath = Path.Combine(fixtureRoot, "Fixture.app");
+        var runtimeIdentifier = CurrentRuntimeIdentifier();
+
+        try
+        {
+            CreateAppFixture(fixtureRoot, appPath);
+            var checksumTarget = Path.Combine(
+                appPath,
+                "Contents",
+                "Resources",
+                "dotnet",
+                "aria2",
+                "aria2c.sha256");
+            File.WriteAllText(checksumTarget, "not-a-digest");
+            AssertFailureContains(
+                Run("/bin/bash", fixtureRoot, IntegrityScript, "verify", appPath, runtimeIdentifier),
+                "exactly one 64-character SHA-256 digest");
+
+            var checksumLink = Path.Combine(appPath, "Contents", "MacOS", "aria2", "aria2c.sha256");
+            File.Delete(checksumLink);
+            File.WriteAllText(checksumLink, HashFile(Path.Combine(
+                appPath,
+                "Contents",
+                "MacOS",
+                "aria2",
+                "aria2c")));
+            AssertFailureContains(
+                Run("/bin/bash", fixtureRoot, IntegrityScript, "verify", appPath, runtimeIdentifier),
+                "must remain a symlink");
+        }
+        finally
+        {
+            Directory.Delete(fixtureRoot, recursive: true);
+        }
+    }
+
+    private static string AssertDmgAndInstalledCopyRoundtrip(
+        string fixtureRoot,
+        string appPath,
+        string runtimeIdentifier)
+    {
+        var stagingDirectory = Path.Combine(fixtureRoot, "dmg-staging");
+        var stagedApp = Path.Combine(stagingDirectory, Path.GetFileName(appPath));
+        var dmgPath = Path.Combine(fixtureRoot, "fixture.dmg");
+        var mountPoint = Path.Combine(fixtureRoot, "mounted");
+        var copiedApp = Path.Combine(fixtureRoot, "installed", Path.GetFileName(appPath));
+        Directory.CreateDirectory(stagingDirectory);
+        Directory.CreateDirectory(mountPoint);
+        Directory.CreateDirectory(Path.GetDirectoryName(copiedApp)!);
+
+        AssertSuccess(Run("/usr/bin/ditto", fixtureRoot, appPath, stagedApp));
+        AssertSuccess(Run(
+            "/usr/bin/hdiutil",
+            fixtureRoot,
+            "create",
+            "-quiet",
+            "-fs",
+            "HFS+",
+            "-volname",
+            "DownKyiIntegrityFixture",
+            "-srcfolder",
+            stagingDirectory,
+            dmgPath));
+        AssertSuccess(Run(
+            "/usr/bin/hdiutil",
+            fixtureRoot,
+            "attach",
+            "-readonly",
+            "-nobrowse",
+            "-mountpoint",
+            mountPoint,
+            dmgPath));
+
+        try
+        {
+            var mountedApp = Path.Combine(mountPoint, Path.GetFileName(appPath));
+            AssertSuccess(Run(
+                "/bin/bash",
+                fixtureRoot,
+                IntegrityScript,
+                "verify",
+                mountedApp,
+                runtimeIdentifier));
+            AssertSuccess(Run("/usr/bin/codesign", fixtureRoot, "--verify", "--deep", "--strict", mountedApp));
+            AssertSuccess(Run("/usr/bin/ditto", fixtureRoot, mountedApp, copiedApp));
+        }
+        finally
+        {
+            AssertSuccess(Run("/usr/bin/hdiutil", fixtureRoot, "detach", "-quiet", mountPoint));
+        }
+
+        AssertSuccess(Run(
+            "/bin/bash",
+            fixtureRoot,
+            IntegrityScript,
+            "verify",
+            copiedApp,
+            runtimeIdentifier));
+        AssertSuccess(Run("/usr/bin/codesign", fixtureRoot, "--verify", "--deep", "--strict", copiedApp));
+        return copiedApp;
+    }
+
+    private static void CreateAppFixture(string fixtureRoot, string appPath)
+    {
+        var contentsDirectory = Path.Combine(appPath, "Contents");
+        var macOsDirectory = Path.Combine(contentsDirectory, "MacOS");
+        var ariaDirectory = Path.Combine(macOsDirectory, "aria2");
+        var resourceDirectory = Path.Combine(contentsDirectory, "Resources", "dotnet", "aria2");
+        Directory.CreateDirectory(ariaDirectory);
+        Directory.CreateDirectory(resourceDirectory);
+
+        var sourcePath = Path.Combine(fixtureRoot, "fixture.c");
+        var unsignedMachO = Path.Combine(fixtureRoot, "fixture-macho");
+        File.WriteAllText(sourcePath, "int main(void) { return 0; }\n");
+        AssertSuccess(Run(
+            "/usr/bin/clang",
+            fixtureRoot,
+            "-arch",
+            CurrentArchitecture(),
+            sourcePath,
+            "-o",
+            unsignedMachO));
+        // Apple Silicon linkers commonly add an ad-hoc signature while Intel
+        // linkers may leave the fixture unsigned. Either state is a valid
+        // source baseline; the explicit signing step below remains mandatory.
+        _ = Run("/usr/bin/codesign", fixtureRoot, "--remove-signature", unsignedMachO);
+
+        var mainExecutable = Path.Combine(macOsDirectory, "DownKyi");
+        var ariaExecutable = Path.Combine(ariaDirectory, "aria2c");
+        File.Copy(unsignedMachO, mainExecutable);
+        File.Copy(unsignedMachO, ariaExecutable);
+        AssertSuccess(Run("/bin/chmod", fixtureRoot, "+x", mainExecutable, ariaExecutable));
+
+        var checksumTarget = Path.Combine(resourceDirectory, "aria2c.sha256");
+        File.WriteAllText(checksumTarget, HashFile(ariaExecutable));
+        File.CreateSymbolicLink(
+            Path.Combine(ariaDirectory, "aria2c.sha256"),
+            "../../Resources/dotnet/aria2/aria2c.sha256");
+        File.WriteAllText(
+            Path.Combine(contentsDirectory, "Info.plist"),
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0">
+            <dict>
+              <key>CFBundleExecutable</key>
+              <string>DownKyi</string>
+              <key>CFBundleIdentifier</key>
+              <string>cn.bzdrs.downkyi.integrity-fixture</string>
+              <key>CFBundlePackageType</key>
+              <string>APPL</string>
+            </dict>
+            </plist>
+            """,
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static string CurrentRuntimeIdentifier() => $"osx-{RuntimeInformation.ProcessArchitecture switch
+    {
+        Architecture.X64 => "x64",
+        Architecture.Arm64 => "arm64",
+        _ => throw new PlatformNotSupportedException(
+            $"Unsupported macOS architecture: {RuntimeInformation.ProcessArchitecture}")
+    }}";
+
+    private static string CurrentArchitecture() => RuntimeInformation.ProcessArchitecture switch
+    {
+        Architecture.X64 => "x86_64",
+        Architecture.Arm64 => "arm64",
+        _ => throw new PlatformNotSupportedException(
+            $"Unsupported macOS architecture: {RuntimeInformation.ProcessArchitecture}")
+    };
+
+    private static string HashFile(string path) =>
+        Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(path)));
+
+    private static void AssertFailureContains(ProcessResult result, string expected)
+    {
+        Assert.NotEqual(0, result.ExitCode);
+        Assert.Contains(expected, result.StandardOutput + result.StandardError, StringComparison.Ordinal);
+    }
+
+    private static ProcessResult Run(
+        string fileName,
+        string workingDirectory,
+        params string[] arguments) =>
+        Run(fileName, workingDirectory, environment: null, arguments);
+
+    private static ProcessResult Run(
+        string fileName,
+        string workingDirectory,
+        IReadOnlyDictionary<string, string?>? environment,
+        params string[] arguments)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = fileName,
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+        if (environment != null)
+        {
+            foreach (var item in environment)
+            {
+                startInfo.Environment[item.Key] = item.Value;
+            }
+        }
+
+        using var process = Process.Start(startInfo)
+            ?? throw new InvalidOperationException($"Failed to start {fileName}.");
+        var output = process.StandardOutput.ReadToEndAsync();
+        var error = process.StandardError.ReadToEndAsync();
+        if (!process.WaitForExit(120_000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException($"Process timed out: {fileName}");
+        }
+
+        return new ProcessResult(
+            process.ExitCode,
+            output.GetAwaiter().GetResult(),
+            error.GetAwaiter().GetResult());
+    }
+
+    private static void AssertSuccess(ProcessResult result)
+    {
+        Assert.True(
+            result.ExitCode == 0,
+            $"Process failed with exit code {result.ExitCode}. stdout={result.StandardOutput} stderr={result.StandardError}");
+    }
+
+    private static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"downkyi-aria-integrity-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory != null && !File.Exists(Path.Combine(directory.FullName, "DownKyi.sln")))
+        {
+            directory = directory.Parent;
+        }
+
+        return directory?.FullName
+               ?? throw new DirectoryNotFoundException("Could not locate the DownKyi repository root.");
+    }
+
+    private sealed record ProcessResult(int ExitCode, string StandardOutput, string StandardError);
+}

--- a/tests/DownKyi.MacOS.Tests/MacBundleLayoutTests.cs
+++ b/tests/DownKyi.MacOS.Tests/MacBundleLayoutTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace DownKyi.MacOS.Tests;
@@ -71,7 +72,7 @@ public sealed class MacBundleLayoutTests
             var legacySigning = RunSigningScript(legacyApp);
             Assert.NotEqual(0, legacySigning.ExitCode);
             var legacyOutput = legacySigning.StandardOutput + legacySigning.StandardError;
-            Assert.Contains("code object is not signed at all", legacyOutput, StringComparison.Ordinal);
+            Assert.Contains("runtime checksum path must remain a symlink", legacyOutput, StringComparison.Ordinal);
 
             CreateAppBundle(correctedApp, publishDirectory);
             AssertSuccess(Run(
@@ -243,6 +244,14 @@ public sealed class MacBundleLayoutTests
         Directory.CreateDirectory(Path.Combine(contentsDirectory, "Resources"));
 
         AssertSuccess(Run("/bin/cp", RepositoryRoot, "-a", $"{publishDirectory}/.", macOsDirectory));
+        var ariaDirectory = Path.Combine(macOsDirectory, "aria2");
+        var ariaExecutable = Path.Combine(ariaDirectory, "aria2c");
+        Directory.CreateDirectory(ariaDirectory);
+        File.Copy(Path.Combine(macOsDirectory, "BundleProbe"), ariaExecutable);
+        AssertSuccess(Run("/bin/chmod", RepositoryRoot, "+x", ariaExecutable));
+        File.WriteAllText(
+            $"{ariaExecutable}.sha256",
+            Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(ariaExecutable))));
         File.WriteAllText(
             Path.Combine(contentsDirectory, "Info.plist"),
             """

--- a/tests/DownKyi.MacOS.Tests/MacSigningScriptTests.cs
+++ b/tests/DownKyi.MacOS.Tests/MacSigningScriptTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Runtime.Versioning;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace DownKyi.MacOS.Tests;
@@ -116,8 +117,11 @@ public sealed class MacSigningScriptTests
                 "aria2");
             Directory.CreateDirectory(ariaDirectory);
             Directory.CreateDirectory(ariaResourceDirectory);
-            File.WriteAllText(Path.Combine(ariaDirectory, "aria2c"), "fixture");
-            File.WriteAllText(Path.Combine(ariaResourceDirectory, "aria2c.sha256"), new string('0', 64));
+            var ariaExecutable = Path.Combine(ariaDirectory, "aria2c");
+            File.WriteAllText(ariaExecutable, "fixture");
+            File.WriteAllText(
+                Path.Combine(ariaResourceDirectory, "aria2c.sha256"),
+                Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(ariaExecutable))));
             File.CreateSymbolicLink(
                 Path.Combine(ariaDirectory, "aria2c.sha256"),
                 "../../Resources/dotnet/aria2/aria2c.sha256");

--- a/tests/DownKyi.MacOS.Tests/MacSigningScriptTests.cs
+++ b/tests/DownKyi.MacOS.Tests/MacSigningScriptTests.cs
@@ -55,7 +55,13 @@ public sealed class MacSigningScriptTests
 
         try
         {
-            foreach (var fileName in new[] { "sign.sh", "codesign-common.sh", "DownKyi.entitlements" })
+            foreach (var fileName in new[]
+                     {
+                         "sign.sh",
+                         "codesign-common.sh",
+                         "aria2-runtime-integrity.sh",
+                         "DownKyi.entitlements"
+                     })
             {
                 var source = File.ReadAllText(
                     Path.Combine(RepositoryRoot, "script", "macos", fileName));
@@ -71,7 +77,7 @@ public sealed class MacSigningScriptTests
                 #!/bin/bash
                 set -eu
                 case "$1" in
-                  */DownKyi|*.dylib)
+                  */DownKyi|*/aria2c|*.dylib)
                     printf '%s: Mach-O 64-bit executable\n' "$1"
                     ;;
                   *.dll)
@@ -87,6 +93,9 @@ public sealed class MacSigningScriptTests
                 """
                 #!/bin/bash
                 set -eu
+                if [ "${1:-}" = "--verify" ] || [ "${1:-}" = "-d" ]; then
+                  exit 1
+                fi
                 {
                   printf 'CALL'
                   for argument in "$@"; do
@@ -99,6 +108,19 @@ public sealed class MacSigningScriptTests
             File.WriteAllText(Path.Combine(appBinaryDirectory, "libfixture.dylib"), "fixture");
             File.WriteAllText(Path.Combine(appBinaryDirectory, "ManagedDependency.dll"), "fixture");
             File.WriteAllText(Path.Combine(appBinaryDirectory, "runtimeconfig.json"), "{}");
+            var ariaDirectory = Path.Combine(appBinaryDirectory, "aria2");
+            var ariaResourceDirectory = Path.Combine(
+                appContentsDirectory,
+                "Resources",
+                "dotnet",
+                "aria2");
+            Directory.CreateDirectory(ariaDirectory);
+            Directory.CreateDirectory(ariaResourceDirectory);
+            File.WriteAllText(Path.Combine(ariaDirectory, "aria2c"), "fixture");
+            File.WriteAllText(Path.Combine(ariaResourceDirectory, "aria2c.sha256"), new string('0', 64));
+            File.CreateSymbolicLink(
+                Path.Combine(ariaDirectory, "aria2c.sha256"),
+                "../../Resources/dotnet/aria2/aria2c.sha256");
             File.WriteAllText(
                 Path.Combine(appContentsDirectory, "Info.plist"),
                 """
@@ -125,7 +147,7 @@ public sealed class MacSigningScriptTests
             startInfo.ArgumentList.Add("-c");
             startInfo.ArgumentList.Add(
                 "set -euo pipefail; " +
-                "chmod +x stub-bin/file stub-bin/codesign; " +
+                "chmod +x stub-bin/file stub-bin/codesign Test.app/Contents/MacOS/aria2/aria2c; " +
                 "export PATH=\"$PWD/stub-bin:$PATH\"; " +
                 "export CODESIGN_LOG=\"$PWD/codesign.log\"; " +
                 $"export MACOS_ADHOC_SIGNING={(adHoc ? "true" : "false")}; " +
@@ -163,12 +185,13 @@ public sealed class MacSigningScriptTests
 
     private static void AssertSigningCoverage(string[][] calls)
     {
-        Assert.Equal(4, calls.Length);
+        Assert.Equal(5, calls.Length);
 
         var signedPaths = calls.Select(arguments => arguments[^1]).ToArray();
         Assert.Contains("Test.app/Contents/MacOS/DownKyi", signedPaths);
         Assert.Contains("Test.app/Contents/MacOS/libfixture.dylib", signedPaths);
         Assert.Contains("Test.app/Contents/MacOS/ManagedDependency.dll", signedPaths);
+        Assert.Contains("Test.app/Contents/MacOS/aria2/aria2c", signedPaths);
         Assert.DoesNotContain("Test.app/Contents/MacOS/runtimeconfig.json", signedPaths);
         Assert.Equal("Test.app/Contents/MacOS/DownKyi", signedPaths[^2]);
         Assert.Equal("Test.app", signedPaths[^1]);

--- a/tests/DownKyi.Tests/AriaSecurityTests.cs
+++ b/tests/DownKyi.Tests/AriaSecurityTests.cs
@@ -289,6 +289,85 @@ public sealed class AriaSecurityTests
     }
 
     [Fact]
+    public async Task GenericCustomAriaIsRejectedWithActionableCompatibilityDiagnostic()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-custom-aria-incompatible-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using var settings = new SettingsStore(Path.Combine(directory, "settings.json"));
+            var client = new AriaClient(
+                "https://aria.example",
+                6800,
+                string.Empty,
+                (_, _, _) => Task.FromResult<string?>(
+                    "{\"id\":\"test\",\"jsonrpc\":\"2.0\",\"result\":{\"version\":\"1.37.0\",\"enabledFeatures\":[]}}"));
+            using var lifecycle = new Aria2RuntimeLifecycle(
+                settings.Current.Network,
+                client,
+                new DownloadDiagnosticLogger(
+                    NullLogger<DownloadDiagnosticLogger>.Instance),
+                new AriaServer(NullLoggerFactory.Instance),
+                NullLogger<Aria2RuntimeLifecycle>.Instance,
+                ownsAriaServer: false,
+                localEndpoint: null);
+
+            var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => lifecycle.StartAsync(TestContext.Current.CancellationToken));
+
+            Assert.Contains("aria2.getVersion().enabledFeatures", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("downkyi-secure-redirect-v2", exception.Message, StringComparison.Ordinal);
+            Assert.Contains("Motrix", exception.Message, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task DownKyiCompatibleCustomAriaPassesCapabilityProbe()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            $"downkyi-custom-aria-compatible-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(directory);
+        try
+        {
+            using var settings = new SettingsStore(Path.Combine(directory, "settings.json"));
+            var client = new AriaClient(
+                "https://aria.example",
+                6800,
+                string.Empty,
+                (_, _, _) => Task.FromResult<string?>(
+                    "{\"id\":\"test\",\"jsonrpc\":\"2.0\",\"result\":{\"version\":\"1.37.0\",\"enabledFeatures\":[\"downkyi-secure-redirect-v2\"]}}"));
+            using var lifecycle = new Aria2RuntimeLifecycle(
+                settings.Current.Network,
+                client,
+                new DownloadDiagnosticLogger(
+                    NullLogger<DownloadDiagnosticLogger>.Instance),
+                new AriaServer(NullLoggerFactory.Instance),
+                NullLogger<Aria2RuntimeLifecycle>.Instance,
+                ownsAriaServer: false,
+                localEndpoint: null);
+
+            await lifecycle.StartAsync(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            if (Directory.Exists(directory))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
     public async Task PausedGidRefreshesCurrentCredentialsBeforeUnpause()
     {
         var requests = new List<JObject>();


### PR DESCRIPTION
## Root cause

macOS `codesign` mutates the bundled `aria2c` Mach-O after the upstream digest has already been written to `aria2c.sha256`. The released app therefore carried stale runtime integrity metadata and `AriaBinaryIntegrityVerifier` correctly failed closed.

## Changes

- Preserve `script/assets/external-assets.json` and `aria2.sh` as the upstream supply-chain integrity boundary.
- Add a reusable macOS final-runtime verifier that validates the executable, permissions, checksum format, canonical checksum symlink, final SHA-256, and RID architecture.
- Refresh the runtime sidecar after nested signing and before signing the main executable and outer app; refuse refresh once an outer signature exists.
- Re-verify runtime integrity after app signing, after app notarization/stapling, from the mounted DMG, and after the real `/usr/bin/ditto` installed-copy simulation.
- Add deterministic packaged aria2 readiness probing through `aria2.getVersion`, `downkyi-secure-redirect-v2`, `aria2.shutdown`, and bounded cleanup.
- Exercise the same contract for `osx-x64` and `osx-arm64`, including the credential-free ad-hoc workflow matrix.
- Add native macOS behavioral regressions for stale sidecars, signing mutation, refresh, outer sealing, DMG/copy roundtrips, binary tampering, checksum tampering, and symlink invariants.
- Keep the secure-redirect gate for Custom Aria. Standard aria2/Motrix remains unsupported; the settings UI, runtime diagnostic, documentation, and tests now state the required capability explicitly.

## Integrity transaction

trusted upstream asset -> publish -> app layout -> nested signing -> runtime digest finalization -> main/outer signing -> notarization/stapling -> DMG -> mounted verification -> installed-copy verification

No stage that can mutate the delivered aria2 bytes is followed by stale, unchecked runtime metadata.

## Local verification

- Strict Release solution build: passed, 0 warnings / 0 errors.
- Focused architecture suite: 318/318 passed.
- Aria security suite: 28/28 passed.
- Windows-selected solution suite before the final macOS-fixture-only audit edits: 1134 passed, 1 expected packaged-aria skip.
- macOS test project strict compilation on Windows: passed.
- `bash -n`, actionlint, format verification, module-boundary audit, release-version contract, dependency audits, Gitleaks, `git diff --check`, and `git fsck`: passed.

The final formal Windows run was stopped at the first unrelated failure in unchanged test infrastructure: `AriaClientSecurityTests.RemoteHttpsRpcRejectsAnUntrustedCertificate` failed while `TestCertificateAuthority` imported a PFX (`CryptographicException: system cannot find the specified file`). It had 26 Application passes, 317 Architecture passes, then 230 Core passes / 2 skips / 1 failure. The failure recorder was preserved and the run was not repeated merely to obtain green output.

## CI evidence required

This PR intentionally relies on native macOS runners for real `codesign`, `lipo`, `hdiutil`, DMG mount, `/usr/bin/ditto`, and aria2 RPC readiness on both RIDs. PR CI validates the ad-hoc path. The release workflow retains the real Developer ID and post-notarization/stapling gates when Apple credentials are available; this PR does not claim those secrets are available in PR CI.

Closes #254