### PR TITLE
refactor(release): derive safety gates from version source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -163,16 +163,22 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - name: Validate exact v1.1.6 release subject
+      - name: Validate exact release subject
         if: startsWith(github.ref, 'refs/tags/')
         shell: pwsh
-        run: ./script/validate-v116-release-subject.ps1 -SubjectDirectory . -ReleaseVersion '${{ github.ref_name }}' -SubjectSha '${{ github.sha }}'
+        run: ./script/validate-release-subject.ps1 -SubjectDirectory . -ReleaseVersion '${{ github.ref_name }}' -SubjectSha '${{ github.sha }}'
+      - name: Resolve previous release tag
+        id: previous-release
+        shell: pwsh
+        run: |
+          $tag = ./script/resolve-previous-release-tag.ps1
+          "tag=$tag" | Add-Content -LiteralPath $env:GITHUB_OUTPUT -Encoding utf8
       - name: Generate a changelog
         uses: orhun/git-cliff-action@v4
         id: git-cliff
         with:
           config: cliff.toml
-          args: -vv v1.1.5..HEAD --strip header
+          args: -vv ${{ steps.previous-release.outputs.tag }}..HEAD --strip header
         env:
           OUTPUT: CHANGELOG.md
       - name: Print the changelog
@@ -239,7 +245,7 @@ jobs:
         shell: pwsh
         run: |
           $package = "script/pupnet/output/DownKyi-${{ steps.version.outputs.content }}-1.win-${{ matrix.cpu }}.${{ matrix.kind }}"
-          ./script/validate-v116-release-package.ps1 `
+          ./script/validate-release-package.ps1 `
             -PackagePath $package `
             -PackageKind "${{ matrix.kind }}" `
             -RuntimeIdentifier "win-${{ matrix.cpu }}" `
@@ -408,7 +414,7 @@ jobs:
           $package = Get-ChildItem "script/pupnet/output" -File -Filter "*${{ matrix.package-tail }}.${{ matrix.kind }}" |
             Select-Object -First 1
           if ($null -eq $package) { throw "Expected Linux package was not produced." }
-          ./script/validate-v116-release-package.ps1 `
+          ./script/validate-release-package.ps1 `
             -PackagePath $package.FullName `
             -PackageKind "${{ matrix.kind }}" `
             -RuntimeIdentifier "linux-${{ matrix.cpu }}" `
@@ -490,7 +496,7 @@ jobs:
           if ($packages.Count -ne 1) { throw "Expected exactly one ARM64 ${{ matrix.kind }} package, found $($packages.Count)." }
           $expectedManifest = "candidate/expected-publish-manifest-linux-arm64.json"
           $approvedManifest = "candidate/publish-manifest-linux-arm64-${{ matrix.kind }}.json"
-          ./script/validate-v116-release-package.ps1 `
+          ./script/validate-release-package.ps1 `
             -PackagePath $packages[0].FullName `
             -PackageKind "${{ matrix.kind }}" `
             -RuntimeIdentifier linux-arm64 `

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 </div>
 
-DownKyi Core 是基于哔哩下载姬 Windows 版与 Avalonia 的跨平台 B 站视频下载工具。v1.1.6 使用 .NET 10、Avalonia 12、Microsoft Generic Host、Microsoft DI 与 CommunityToolkit MVVM，并重构了导航、下载状态、SQLite、HTTP、日志、aria2、FFmpeg 和应用生命周期。
+DownKyi Core 是基于哔哩下载姬 Windows 版与 Avalonia 的跨平台 B 站视频下载工具。项目使用 .NET 10、Avalonia 12、Microsoft Generic Host、Microsoft DI 与 CommunityToolkit MVVM，并重构了导航、下载状态、SQLite、HTTP、日志、aria2、FFmpeg 和应用生命周期。
 
 ## 下载
 

--- a/docs/ai-knowledge-graph.md
+++ b/docs/ai-knowledge-graph.md
@@ -2680,6 +2680,9 @@ paths:
   - DownKyi.Core/DownKyi.Core.csproj
   - version.txt
   - script/validate-release-version.ps1
+  - script/validate-release-subject.ps1
+  - script/resolve-previous-release-tag.ps1
+  - script/validate-release-package.ps1
   - script/validate-publish-output.ps1
   - script/assets/external-assets.json
   - script/aria2.ps1
@@ -2704,6 +2707,8 @@ contracts:
   - Windows, Linux, and macOS run strict Release build and all tests before changelog or package jobs can start.
   - Manual dispatch builds and uploads the same packages without publishing a GitHub Release; tag execution alone may create the Release.
   - `script/validate-release-version.ps1` requires stable `major.minor.patch` text and blocks a tag whose `refs/tags/v<version>` value differs from `version.txt`.
+  - Release-subject and package validators derive their expected release identity from `version.txt`; validator and regression-test names remain version-neutral.
+  - Changelog generation resolves the nearest annotated stable SemVer release tag before HEAD on first-parent history, then passes that explicit tag range to git-cliff; lightweight, non-SemVer and merged-branch tags are not release-range owners.
   - Each Windows and Linux RID performs one dotnet publish into a fixed canonical directory containing non-empty DownKyi, aria2, FFmpeg, ffprobe, dependency-manifest, and LICENSE files; every Linux package kind restores the same immutable RID transport, and PupNet standalone packaging copies that validated payload into its package staging directory.
   - Publish validation checks the expected assembly version, requires Fluent, rejects Simple, and emits path, byte-count, and SHA-256 evidence for every canonical runtime file; extracted final runtime payload must match it exactly.
   - Package wrapper metadata is classified separately rather than treated as canonical runtime: release-critical AppImage entrypoint and deb/rpm control semantics are validated through package-kind identity, architecture, symlink, permission, and launch contracts outside the runtime-payload manifest.

--- a/script/resolve-previous-release-tag.ps1
+++ b/script/resolve-previous-release-tag.ps1
@@ -1,0 +1,56 @@
+[CmdletBinding()]
+param(
+    [string]$RepositoryRoot = (Split-Path -Parent $PSScriptRoot)
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repository = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+& (Join-Path $PSScriptRoot 'validate-release-version.ps1') -RepositoryRoot $repository | Out-Null
+
+function Invoke-RepositoryGit {
+    param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
+
+    $output = @(& git -C $repository @Arguments 2>&1)
+    if ($LASTEXITCODE -ne 0) {
+        throw "git -C $repository $($Arguments -join ' ') failed: $($output -join [Environment]::NewLine)"
+    }
+    return $output
+}
+
+$releaseTagsByCommit = @{}
+$tagLines = @(Invoke-RepositoryGit for-each-ref '--format=%(refname:short) %(objecttype) %(*objectname)' refs/tags)
+foreach ($tagLine in $tagLines) {
+    if ($tagLine -notmatch '^(?<name>\S+) tag (?<commit>[0-9a-fA-F]+)$') {
+        continue
+    }
+
+    $tagName = $Matches.name
+    $commit = $Matches.commit.ToLowerInvariant()
+    if ($tagName -notmatch '^v(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$') {
+        continue
+    }
+
+    if (-not $releaseTagsByCommit.ContainsKey($commit)) {
+        $releaseTagsByCommit[$commit] = [System.Collections.Generic.List[string]]::new()
+    }
+    $releaseTagsByCommit[$commit].Add($tagName)
+}
+
+$history = @(Invoke-RepositoryGit rev-list --first-parent HEAD)
+foreach ($commit in ($history | Select-Object -Skip 1)) {
+    $normalizedCommit = $commit.Trim().ToLowerInvariant()
+    if (-not $releaseTagsByCommit.ContainsKey($normalizedCommit)) {
+        continue
+    }
+
+    $releaseTags = @($releaseTagsByCommit[$normalizedCommit])
+    if ($releaseTags.Count -ne 1) {
+        throw "Release history is ambiguous at $commit; found annotated SemVer tags: $($releaseTags -join ', ')."
+    }
+
+    Write-Output $releaseTags[0]
+    return
+}
+
+throw 'No previous annotated stable SemVer release tag exists on the first-parent history before HEAD.'

--- a/script/validate-release-package.ps1
+++ b/script/validate-release-package.ps1
@@ -18,11 +18,9 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$expectedVersion = '1.1.6'
-$repositoryVersion = (Get-Content -LiteralPath (Join-Path $PSScriptRoot '../version.txt') -Raw).Trim()
-if ($repositoryVersion -cne $expectedVersion) {
-    throw "v1.1.6 package validation requires version.txt to remain exactly $expectedVersion."
-}
+$repositoryRoot = (Resolve-Path -LiteralPath (Join-Path $PSScriptRoot '..')).Path
+& (Join-Path $PSScriptRoot 'validate-release-version.ps1') -RepositoryRoot $repositoryRoot | Out-Null
+$expectedVersion = (Get-Content -LiteralPath (Join-Path $repositoryRoot 'version.txt') -Raw).Trim()
 $package = (Resolve-Path -LiteralPath $PackagePath).Path
 $expectedManifestPath = (Resolve-Path -LiteralPath $ExpectedManifestPath).Path
 $approvedManifestPath = [IO.Path]::GetFullPath($OutputPath)
@@ -167,7 +165,7 @@ function Assert-WindowsBinaryArchitecture {
         0x8664
     }
     else {
-        throw "Unsupported v1.1.6 Windows runtime identifier: $ExpectedRuntimeIdentifier"
+        throw "Unsupported Windows release runtime identifier: $ExpectedRuntimeIdentifier"
     }
 
     $stream = [IO.File]::OpenRead($Path)
@@ -332,7 +330,7 @@ try {
     }
     else {
         if ($RuntimeIdentifier -notin @('linux-x64', 'linux-arm64')) {
-            throw "Unsupported v1.1.6 Linux runtime identifier: $RuntimeIdentifier"
+            throw "Unsupported Linux release runtime identifier: $RuntimeIdentifier"
         }
 
         $expectedPackageArchitecture = if ($RuntimeIdentifier -ceq 'linux-x64') {

--- a/script/validate-release-subject.ps1
+++ b/script/validate-release-subject.ps1
@@ -9,14 +9,11 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
-$expectedReleaseVersion = 'v1.1.6'
-$expectedApplicationVersion = '1.1.6'
-
-if ($ReleaseVersion -cne $expectedReleaseVersion) {
-    throw "v1.1.6 release validation requires exactly $expectedReleaseVersion."
-}
-
 $subject = (Resolve-Path -LiteralPath $SubjectDirectory).Path
+$versionValidator = Join-Path $PSScriptRoot 'validate-release-version.ps1'
+& $versionValidator -RepositoryRoot $subject -GitRef "refs/tags/$ReleaseVersion" | Out-Null
+$expectedApplicationVersion = (Get-Content -LiteralPath (Join-Path $subject 'version.txt') -Raw).Trim()
+$expectedReleaseVersion = "v$expectedApplicationVersion"
 
 function Invoke-SubjectGit {
     param([Parameter(ValueFromRemainingArguments = $true)][string[]]$Arguments)
@@ -29,7 +26,7 @@ function Invoke-SubjectGit {
 
 $head = Invoke-SubjectGit rev-parse HEAD
 if (-not [string]::Equals($head, $SubjectSha, [StringComparison]::OrdinalIgnoreCase)) {
-    throw "v1.1.6 release subject HEAD is $head; expected $SubjectSha."
+    throw "Release subject HEAD is $head; expected $SubjectSha."
 }
 
 $tagType = Invoke-SubjectGit cat-file -t $expectedReleaseVersion
@@ -42,20 +39,15 @@ if (-not [string]::Equals($tagCommit, $SubjectSha, [StringComparison]::OrdinalIg
     throw "$expectedReleaseVersion resolves to $tagCommit; expected $SubjectSha."
 }
 
-$applicationVersion = (Get-Content -LiteralPath (Join-Path $subject 'version.txt') -Raw).Trim()
-if ($applicationVersion -cne $expectedApplicationVersion) {
-    throw "v1.1.6 release subject version.txt is $applicationVersion; expected $expectedApplicationVersion."
-}
-
 $trackedChanges = Invoke-SubjectGit status --porcelain --untracked-files=no
 if ($trackedChanges) {
-    throw "v1.1.6 release subject contains tracked changes:`n$trackedChanges"
+    throw "Release subject contains tracked changes:`n$trackedChanges"
 }
 
 Invoke-SubjectGit fetch --no-tags origin '+refs/heads/main:refs/remotes/origin/main' | Out-Null
 $mainCommit = Invoke-SubjectGit rev-parse 'refs/remotes/origin/main^{commit}'
 if (-not [string]::Equals($SubjectSha, $mainCommit, [StringComparison]::OrdinalIgnoreCase)) {
-    throw "v1.1.6 release subject $SubjectSha does not equal current main $mainCommit."
+    throw "Release subject $SubjectSha does not equal current main $mainCommit."
 }
 
-Write-Output "Validated exact v1.1.6 release subject at $SubjectSha."
+Write-Output "Validated exact $expectedReleaseVersion release subject at $SubjectSha."

--- a/tests/DownKyi.Architecture.Tests/ReleaseSafetyRegressionTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseSafetyRegressionTests.cs
@@ -4,23 +4,31 @@ using System.IO.Compression;
 
 namespace DownKyi.Architecture.Tests;
 
-public sealed class V116ReleaseSafetyRegressionTests
+public sealed class ReleaseSafetyRegressionTests
 {
     private static readonly string RepositoryRoot = FindRepositoryRoot();
+    private static readonly string RepositoryVersion =
+        File.ReadAllText(Path.Combine(RepositoryRoot, "version.txt")).Trim();
 
     [Fact]
     public void GenericReleaseWorkflowInvokesFailClosedReleaseGates()
     {
         var workflow = File.ReadAllText(Path.Combine(RepositoryRoot, ".github", "workflows", "build.yml"));
         var packageValidator = File.ReadAllText(
-            Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1"));
+            Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1"));
 
-        Assert.Contains("validate-v116-release-subject.ps1", workflow, StringComparison.Ordinal);
-        Assert.Contains("args: -vv v1.1.5..HEAD --strip header", workflow, StringComparison.Ordinal);
+        Assert.Contains("validate-release-subject.ps1", workflow, StringComparison.Ordinal);
+        Assert.Contains("resolve-previous-release-tag.ps1", workflow, StringComparison.Ordinal);
+        Assert.Contains(
+            "args: -vv ${{ steps.previous-release.outputs.tag }}..HEAD --strip header",
+            workflow,
+            StringComparison.Ordinal);
         Assert.DoesNotContain("args: -vv --latest --strip header", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain($"v{RepositoryVersion}", workflow, StringComparison.Ordinal);
+        Assert.DoesNotContain($"'{RepositoryVersion}'", packageValidator, StringComparison.Ordinal);
         Assert.Contains("resolve-v112-macos-trust.ps1", workflow, StringComparison.Ordinal);
         Assert.DoesNotContain("HAS_MACOS_SIGNING: ${{ secrets.", workflow, StringComparison.Ordinal);
-        Assert.Equal(3, CountOccurrences(workflow, "validate-v116-release-package.ps1"));
+        Assert.Equal(3, CountOccurrences(workflow, "validate-release-package.ps1"));
         Assert.Equal(3, CountOccurrences(workflow, "-ExpectedManifestPath"));
         Assert.Contains("verify-dmg-contents.sh DownKyi-", workflow, StringComparison.Ordinal);
         Assert.Contains("ubuntu-24.04-arm", workflow, StringComparison.Ordinal);
@@ -37,6 +45,54 @@ public sealed class V116ReleaseSafetyRegressionTests
             packageValidator,
             StringComparison.Ordinal);
         Assert.DoesNotContain("& 7z", packageValidator, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PreviousReleaseTagResolutionUsesAnnotatedFirstParentSemVerHistory()
+    {
+        var root = CreateTemporaryDirectory();
+        var repository = Path.Combine(root, "repository");
+        var resolver = Path.Combine(RepositoryRoot, "script", "resolve-previous-release-tag.ps1");
+
+        try
+        {
+            RunRequired("git", ["init", "-b", "main", repository], root);
+            RunRequired("git", ["config", "user.name", "Release Fixture"], repository);
+            RunRequired("git", ["config", "user.email", "release-fixture@example.invalid"], repository);
+            File.WriteAllText(Path.Combine(repository, "version.txt"), "2.0.0");
+            File.WriteAllText(Path.Combine(repository, "fixture.txt"), "previous release");
+            RunRequired("git", ["add", "version.txt", "fixture.txt"], repository);
+            RunRequired("git", ["commit", "-m", "previous release fixture"], repository);
+            RunRequired("git", ["tag", "-a", "v1.8.0", "-m", "v1.8.0"], repository);
+
+            RunRequired("git", ["checkout", "-b", "tagged-side-branch"], repository);
+            File.WriteAllText(Path.Combine(repository, "side.txt"), "merged branch tag");
+            RunRequired("git", ["add", "side.txt"], repository);
+            RunRequired("git", ["commit", "-m", "tagged side branch fixture"], repository);
+            RunRequired("git", ["tag", "-a", "v1.9.5", "-m", "v1.9.5"], repository);
+            RunRequired("git", ["checkout", "main"], repository);
+
+            File.AppendAllText(Path.Combine(repository, "fixture.txt"), "\nintermediate");
+            RunRequired("git", ["add", "fixture.txt"], repository);
+            RunRequired("git", ["commit", "-m", "intermediate fixture"], repository);
+            RunRequired("git", ["tag", "v1.9.0"], repository);
+            RunRequired("git", ["tag", "-a", "release-candidate", "-m", "release-candidate"], repository);
+            RunRequired("git", ["merge", "--no-ff", "tagged-side-branch", "-m", "merge tagged side branch fixture"], repository);
+
+            File.AppendAllText(Path.Combine(repository, "fixture.txt"), "\ncurrent release");
+            RunRequired("git", ["add", "fixture.txt"], repository);
+            RunRequired("git", ["commit", "-m", "current release fixture"], repository);
+            RunRequired("git", ["tag", "-a", "v2.0.0", "-m", "v2.0.0"], repository);
+
+            var result = RunPowerShell(resolver, ["-RepositoryRoot", repository], repository);
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal("v1.8.0", result.StandardOutput.Trim());
+        }
+        finally
+        {
+            DeleteTemporaryDirectory(root);
+        }
     }
 
     [Fact]
@@ -163,7 +219,8 @@ public sealed class V116ReleaseSafetyRegressionTests
         var root = CreateTemporaryDirectory();
         var remote = Path.Combine(root, "remote.git");
         var repository = Path.Combine(root, "repository");
-        var validator = Path.Combine(RepositoryRoot, "script", "validate-v116-release-subject.ps1");
+        var validator = Path.Combine(RepositoryRoot, "script", "validate-release-subject.ps1");
+        var releaseTag = $"v{RepositoryVersion}";
 
         try
         {
@@ -172,44 +229,44 @@ public sealed class V116ReleaseSafetyRegressionTests
             RunRequired("git", ["config", "user.name", "Release Fixture"], repository);
             RunRequired("git", ["config", "user.email", "release-fixture@example.invalid"], repository);
             File.WriteAllText(Path.Combine(repository, "fixture.txt"), "main");
-            File.WriteAllText(Path.Combine(repository, "version.txt"), "1.1.6");
+            File.WriteAllText(Path.Combine(repository, "version.txt"), RepositoryVersion);
             RunRequired("git", ["add", "fixture.txt", "version.txt"], repository);
             RunRequired("git", ["commit", "-m", "main fixture"], repository);
             RunRequired("git", ["remote", "add", "origin", remote], repository);
             RunRequired("git", ["push", "-u", "origin", "main"], repository);
             var mainCommit = RunRequired("git", ["rev-parse", "HEAD"], repository).StandardOutput.Trim();
 
-            RunRequired("git", ["tag", "-a", "v1.1.6", "-m", "v1.1.6"], repository);
+            RunRequired("git", ["tag", "-a", releaseTag, "-m", releaseTag], repository);
             var valid = RunPowerShell(
                 validator,
-                ["-SubjectDirectory", repository, "-ReleaseVersion", "v1.1.6", "-SubjectSha", mainCommit],
+                ["-SubjectDirectory", repository, "-ReleaseVersion", releaseTag, "-SubjectSha", mainCommit],
                 repository);
             Assert.Equal(0, valid.ExitCode);
 
-            RunRequired("git", ["tag", "-d", "v1.1.6"], repository);
-            RunRequired("git", ["tag", "v1.1.6"], repository);
+            RunRequired("git", ["tag", "-d", releaseTag], repository);
+            RunRequired("git", ["tag", releaseTag], repository);
             var lightweight = RunPowerShell(
                 validator,
-                ["-SubjectDirectory", repository, "-ReleaseVersion", "v1.1.6", "-SubjectSha", mainCommit],
+                ["-SubjectDirectory", repository, "-ReleaseVersion", releaseTag, "-SubjectSha", mainCommit],
                 repository);
             Assert.NotEqual(0, lightweight.ExitCode);
             Assert.Contains("annotated tag", NormalizeDiagnostic(lightweight), StringComparison.OrdinalIgnoreCase);
 
-            RunRequired("git", ["tag", "-d", "v1.1.6"], repository);
-            File.WriteAllText(Path.Combine(repository, "version.txt"), "1.1.3");
+            RunRequired("git", ["tag", "-d", releaseTag], repository);
+            File.WriteAllText(Path.Combine(repository, "version.txt"), "0.0.0");
             RunRequired("git", ["add", "version.txt"], repository);
             RunRequired("git", ["commit", "-m", "mismatched version fixture"], repository);
             RunRequired("git", ["push", "origin", "main"], repository);
             var mismatchedMainCommit = RunRequired("git", ["rev-parse", "HEAD"], repository).StandardOutput.Trim();
-            RunRequired("git", ["tag", "-a", "v1.1.6", "-m", "v1.1.6"], repository);
+            RunRequired("git", ["tag", "-a", releaseTag, "-m", releaseTag], repository);
             var mismatchedVersion = RunPowerShell(
                 validator,
-                ["-SubjectDirectory", repository, "-ReleaseVersion", "v1.1.6", "-SubjectSha", mismatchedMainCommit],
+                ["-SubjectDirectory", repository, "-ReleaseVersion", releaseTag, "-SubjectSha", mismatchedMainCommit],
                 repository);
             Assert.NotEqual(0, mismatchedVersion.ExitCode);
-            Assert.Contains("version.txt is 1.1.3", NormalizeDiagnostic(mismatchedVersion), StringComparison.Ordinal);
+            Assert.Contains("does not match version.txt", NormalizeDiagnostic(mismatchedVersion), StringComparison.Ordinal);
 
-            File.WriteAllText(Path.Combine(repository, "version.txt"), "1.1.6");
+            File.WriteAllText(Path.Combine(repository, "version.txt"), RepositoryVersion);
             RunRequired("git", ["add", "version.txt"], repository);
             RunRequired("git", ["commit", "-m", "restore release version fixture"], repository);
             RunRequired("git", ["push", "origin", "main"], repository);
@@ -219,15 +276,15 @@ public sealed class V116ReleaseSafetyRegressionTests
             RunRequired("git", ["add", "fixture.txt"], repository);
             RunRequired("git", ["commit", "-m", "release-only fixture"], repository);
             var releaseOnlyCommit = RunRequired("git", ["rev-parse", "HEAD"], repository).StandardOutput.Trim();
-            RunRequired("git", ["tag", "-f", "-a", "v1.1.6", "-m", "v1.1.6"], repository);
+            RunRequired("git", ["tag", "-f", "-a", releaseTag, "-m", releaseTag], repository);
             var remoteMain = RunRequired("git", ["rev-parse", "refs/remotes/origin/main"], repository).StandardOutput.Trim();
             Assert.NotEqual(remoteMain, releaseOnlyCommit);
-            Assert.Equal("tag", RunRequired("git", ["cat-file", "-t", "v1.1.6"], repository).StandardOutput.Trim());
-            Assert.Equal(releaseOnlyCommit, RunRequired("git", ["rev-list", "-n", "1", "v1.1.6"], repository).StandardOutput.Trim());
-            Assert.Equal("1.1.6", File.ReadAllText(Path.Combine(repository, "version.txt")));
+            Assert.Equal("tag", RunRequired("git", ["cat-file", "-t", releaseTag], repository).StandardOutput.Trim());
+            Assert.Equal(releaseOnlyCommit, RunRequired("git", ["rev-list", "-n", "1", releaseTag], repository).StandardOutput.Trim());
+            Assert.Equal(RepositoryVersion, File.ReadAllText(Path.Combine(repository, "version.txt")));
             var nonMain = RunPowerShell(
                 validator,
-                ["-SubjectDirectory", repository, "-ReleaseVersion", "v1.1.6", "-SubjectSha", releaseOnlyCommit],
+                ["-SubjectDirectory", repository, "-ReleaseVersion", releaseTag, "-SubjectSha", releaseOnlyCommit],
                 repository);
             Assert.NotEqual(0, nonMain.ExitCode);
         }
@@ -271,11 +328,11 @@ public sealed class V116ReleaseSafetyRegressionTests
         var runtime = Path.Combine(root, "runtime");
         Directory.CreateDirectory(Path.Combine(runtime, "aria2"));
         Directory.CreateDirectory(Path.Combine(runtime, "ffmpeg"));
-        var validator = Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1");
+        var validator = Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1");
 
         try
         {
-            File.Copy(typeof(V116ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
+            File.Copy(typeof(ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
             WritePeFile(Path.Combine(runtime, "DownKyi.exe"), 0x8664);
             var aria = Path.Combine(runtime, "aria2", "aria2c.exe");
             WritePeFile(aria, 0x8664);
@@ -294,7 +351,7 @@ public sealed class V116ReleaseSafetyRegressionTests
                 [
                     "-PublishDirectory", runtime,
                     "-RuntimeIdentifier", "win-x64",
-                    "-ExpectedVersion", "1.1.6",
+                    "-ExpectedVersion", RepositoryVersion,
                     "-OutputPath", expectedManifest
                 ],
                 root);
@@ -434,7 +491,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         {
             var package = CreateLinuxDebPackage(root, "amd64", includeExecuteBits: false);
             var result = RunPowerShell(
-                Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1"),
+                Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1"),
                 [
                     "-PackagePath", package,
                     "-PackageKind", "deb",
@@ -464,7 +521,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         {
             var package = CreateLinuxDebPackage(root, "amd64", includeExecuteBits: true);
             var result = RunPowerShell(
-                Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1"),
+                Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1"),
                 [
                     "-PackagePath", package,
                     "-PackageKind", "deb",
@@ -498,7 +555,7 @@ public sealed class V116ReleaseSafetyRegressionTests
                 includeExecuteBits: true,
                 ownerOnlyExecute: true);
             var result = RunPowerShell(
-                Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1"),
+                Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1"),
                 [
                     "-PackagePath", package,
                     "-PackageKind", "deb",
@@ -532,7 +589,7 @@ public sealed class V116ReleaseSafetyRegressionTests
                 includeExecuteBits: true,
                 crossFormatExecutable: true);
             var result = RunPowerShell(
-                Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1"),
+                Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1"),
                 [
                     "-PackagePath", package,
                     "-PackageKind", "deb",
@@ -566,7 +623,7 @@ public sealed class V116ReleaseSafetyRegressionTests
                 includeExecuteBits: true,
                 mixedArchitectureLibrary: true);
             var result = RunPowerShell(
-                Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1"),
+                Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1"),
                 [
                     "-PackagePath", package,
                     "-PackageKind", "deb",
@@ -595,7 +652,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         var root = CreateTemporaryDirectory();
         try
         {
-            var validator = Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1");
+            var validator = Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1");
             var brokenAppRunFixture = CreateLinuxAppImageFixture(
                 Path.Combine(root, "broken-app-run"),
                 AppRunFixtureKind.RegularExitsImmediately);
@@ -723,7 +780,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         var root = CreateTemporaryDirectory();
         try
         {
-            var validator = Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1");
+            var validator = Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1");
             var debPackage = CreateLinuxDebPackage(
                 root,
                 "amd64",
@@ -740,7 +797,7 @@ public sealed class V116ReleaseSafetyRegressionTests
                 ],
                 root);
             Assert.NotEqual(0, debResult.ExitCode);
-            Assert.Contains("package version 1.1.2-1 does not match 1.1.6-1", NormalizeDiagnostic(debResult), StringComparison.Ordinal);
+            Assert.Contains($"package version 1.1.2-1 does not match {RepositoryVersion}-1", NormalizeDiagnostic(debResult), StringComparison.Ordinal);
 
             var rpmPackage = CreateLinuxRpmPackage(root, "x86_64", "1.1.2");
             var rpmResult = RunPowerShell(
@@ -754,7 +811,7 @@ public sealed class V116ReleaseSafetyRegressionTests
                 ],
                 root);
             Assert.NotEqual(0, rpmResult.ExitCode);
-            Assert.Contains("package EVR 0:1.1.2-1 does not match 0:1.1.6-1", NormalizeDiagnostic(rpmResult), StringComparison.Ordinal);
+            Assert.Contains($"package EVR 0:1.1.2-1 does not match 0:{RepositoryVersion}-1", NormalizeDiagnostic(rpmResult), StringComparison.Ordinal);
         }
         finally
         {
@@ -771,8 +828,8 @@ public sealed class V116ReleaseSafetyRegressionTests
         var root = CreateTemporaryDirectory();
         try
         {
-            var validator = Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1");
-            var releasePackage = CreateLinuxRpmPackage(root, "x86_64", "1.1.6", release: "2");
+            var validator = Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1");
+            var releasePackage = CreateLinuxRpmPackage(root, "x86_64", RepositoryVersion, release: "2");
             var releaseResult = RunPowerShell(
                 validator,
                 [
@@ -784,9 +841,9 @@ public sealed class V116ReleaseSafetyRegressionTests
                 ],
                 root);
             Assert.NotEqual(0, releaseResult.ExitCode);
-            Assert.Contains("package EVR 0:1.1.6-2 does not match 0:1.1.6-1", NormalizeDiagnostic(releaseResult), StringComparison.Ordinal);
+            Assert.Contains($"package EVR 0:{RepositoryVersion}-2 does not match 0:{RepositoryVersion}-1", NormalizeDiagnostic(releaseResult), StringComparison.Ordinal);
 
-            var epochPackage = CreateLinuxRpmPackage(root, "x86_64", "1.1.6", epoch: 1);
+            var epochPackage = CreateLinuxRpmPackage(root, "x86_64", RepositoryVersion, epoch: 1);
             var epochResult = RunPowerShell(
                 validator,
                 [
@@ -798,7 +855,7 @@ public sealed class V116ReleaseSafetyRegressionTests
                 ],
                 root);
             Assert.NotEqual(0, epochResult.ExitCode);
-            Assert.Contains("package EVR 1:1.1.6-1 does not match 0:1.1.6-1", NormalizeDiagnostic(epochResult), StringComparison.Ordinal);
+            Assert.Contains($"package EVR 1:{RepositoryVersion}-1 does not match 0:{RepositoryVersion}-1", NormalizeDiagnostic(epochResult), StringComparison.Ordinal);
         }
         finally
         {
@@ -815,7 +872,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         var root = CreateTemporaryDirectory();
         try
         {
-            var validator = Path.Combine(RepositoryRoot, "script", "validate-v116-release-package.ps1");
+            var validator = Path.Combine(RepositoryRoot, "script", "validate-release-package.ps1");
             var debPackage = CreateLinuxDebPackage(
                 root,
                 "amd64",
@@ -834,7 +891,7 @@ public sealed class V116ReleaseSafetyRegressionTests
             Assert.NotEqual(0, debResult.ExitCode);
             Assert.Contains("package identity downkyi-fixture does not match downkyi", NormalizeDiagnostic(debResult), StringComparison.Ordinal);
 
-            var rpmPackage = CreateLinuxRpmPackage(root, "x86_64", "1.1.6", "downkyi-fixture");
+            var rpmPackage = CreateLinuxRpmPackage(root, "x86_64", RepositoryVersion, "downkyi-fixture");
             var rpmResult = RunPowerShell(
                 validator,
                 [
@@ -895,11 +952,12 @@ public sealed class V116ReleaseSafetyRegressionTests
         string architecture,
         bool includeExecuteBits,
         bool ownerOnlyExecute = false,
-        string version = "1.1.6",
+        string? version = null,
         string packageName = "downkyi",
         bool crossFormatExecutable = false,
         bool mixedArchitectureLibrary = false)
     {
+        version ??= RepositoryVersion;
         var packageRoot = Path.Combine(root, $"deb-{architecture}-{includeExecuteBits}-{ownerOnlyExecute}-{version}-{packageName}");
         var controlDirectory = Path.Combine(packageRoot, "DEBIAN");
         var runtime = Path.Combine(packageRoot, "usr", "lib", "downkyi");
@@ -907,7 +965,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         Directory.CreateDirectory(Path.Combine(runtime, "aria2"));
         Directory.CreateDirectory(Path.Combine(runtime, "ffmpeg"));
 
-        File.Copy(typeof(V116ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
+        File.Copy(typeof(ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
         var executables = new[]
         {
             Path.Combine(runtime, "DownKyi"),
@@ -980,7 +1038,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         Directory.CreateDirectory(Path.Combine(runtime, "aria2"));
         Directory.CreateDirectory(Path.Combine(runtime, "ffmpeg"));
 
-        File.Copy(typeof(V116ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
+        File.Copy(typeof(ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
         var executables = new[]
         {
             Path.Combine(runtime, "DownKyi"),
@@ -1055,7 +1113,7 @@ public sealed class V116ReleaseSafetyRegressionTests
         Directory.CreateDirectory(Path.Combine(runtime, "aria2"));
         Directory.CreateDirectory(Path.Combine(runtime, "ffmpeg"));
 
-        File.Copy(typeof(V116ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
+        File.Copy(typeof(ReleaseSafetyRegressionTests).Assembly.Location, Path.Combine(runtime, "DownKyi.dll"));
         var downKyiSource = Path.Combine(root, "downkyi-fixture.c");
         File.WriteAllText(
             downKyiSource,
@@ -1160,7 +1218,7 @@ public sealed class V116ReleaseSafetyRegressionTests
             [
                 "-PublishDirectory", runtime,
                 "-RuntimeIdentifier", runtimeIdentifier,
-                "-ExpectedVersion", "1.1.6",
+                "-ExpectedVersion", RepositoryVersion,
                 "-OutputPath", outputPath
             ],
             workingDirectory);

--- a/tests/DownKyi.Linux.Tests/ReleasePackageTests.cs
+++ b/tests/DownKyi.Linux.Tests/ReleasePackageTests.cs
@@ -4,68 +4,68 @@ using DownKyi.Architecture.Tests;
 namespace DownKyi.Linux.Tests;
 
 [SupportedOSPlatform("linux")]
-public sealed class V116ReleasePackageTests
+public sealed class ReleasePackageTests
 {
     [Fact]
     public void FinalPackageValidationRejectsMissingExecuteBits()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsMissingExecuteBits();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsArchitectureMismatch()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsArchitectureMismatch();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsOwnerOnlyExecuteBits()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsOwnerOnlyExecuteBits();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsCrossFormatBinary()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsCrossFormatBinary();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsMixedElfArchitectures()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsMixedElfArchitectures();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsMissingAppImageEntrypoint()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsMissingAppImageEntrypoint();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsPackageManagerVersionMismatch()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsPackageManagerVersionMismatch();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsPackageManagerIdentityMismatch()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsPackageManagerIdentityMismatch();
     }
 
     [Fact]
     public void FinalPackageValidationRejectsRpmEvrMismatch()
     {
-        V116ReleaseSafetyRegressionTests
+        ReleaseSafetyRegressionTests
             .LinuxReleasePackageValidationRejectsRpmEvrMismatch();
     }
 }


### PR DESCRIPTION
## Summary
- make release subject and package validators version-neutral and derive their expected identity from version.txt
- resolve an explicit previous annotated stable SemVer tag from first-parent history for git-cliff
- rename release regression tests and remove the release number from the README architecture description

## Validation
- dotnet restore ./DownKyi.sln
- release version contract
- strict full-solution Release build (0 warnings, 0 errors)
- CentralTestRunner solution gate (8 Windows projects passed)
- dotnet format verification
- module-boundary audit
- actionlint v1.7.12
- vulnerable and deprecated package audits
- Gitleaks 8.30.1 (1156 candidate files, 0 findings)
- git diff --check