### PR TITLE
ci: auto-merge verified FFmpeg manifest updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ on:
     branches:
       - main
       - release/v1.1.1-integration
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
   workflow_dispatch:
     inputs:
       update_ffmpeg_assets:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,6 @@ on:
     branches:
       - main
       - release/v1.1.1-integration
-    paths:
-      - 'script/assets/external-assets.json'
-      - 'script/ffmpeg-assets.py'
-      - 'script/ffmpeg.ps1'
-      - 'script/ffmpeg.sh'
-      - 'script/tests/test_ffmpeg_assets.py'
-      - '.github/workflows/build.yml'
-      - '.github/workflows/update-ffmpeg-assets.yml'
   workflow_dispatch:
     inputs:
       update_ffmpeg_assets:
@@ -47,7 +39,7 @@ jobs:
       - name: Validate GitHub Actions workflow syntax
         uses: raven-actions/actionlint@v2
         with:
-          files: .github/workflows/build.yml,.github/workflows/update-ffmpeg-assets.yml
+          files: .github/workflows/build.yml,.github/workflows/ffmpeg-manifest-auto-merge.yml,.github/workflows/update-ffmpeg-assets.yml
           fail-on-error: true
           pyflakes: true
           shellcheck: true
@@ -95,8 +87,36 @@ jobs:
           python-version: '3.12'
       - name: Validate immutable FFmpeg manifest
         run: python script/ffmpeg-assets.py validate-manifest --manifest script/assets/external-assets.json
+      - name: Read back immutable mirror release evidence
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: python script/ffmpeg-assets.py validate-mirror-releases --manifest script/assets/external-assets.json
       - name: Check external asset availability
         run: python script/ffmpeg-assets.py preflight --manifest script/assets/external-assets.json --timeout 30
+
+  ffmpeg-linux-arm64-smoke:
+    name: FFmpeg runtime smoke (linux-arm64)
+    needs: external-assets-preflight
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Install Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+      - name: Install verified FFmpeg runtime
+        working-directory: ./script
+        run: |
+          chmod +x ffmpeg.sh
+          ./ffmpeg.sh linux arm64
+      - name: Transcode and probe a real stream
+        run: >
+          python script/ffmpeg-assets.py smoke-binaries
+          --ffmpeg DownKyi.Core/Binary/linux-arm64/ffmpeg/ffmpeg
+          --ffprobe DownKyi.Core/Binary/linux-arm64/ffmpeg/ffprobe
+          --rid linux-arm64
+          --required-encoder h264_nvenc
 
   release-gate:
     name: Release gate (${{ matrix.os }})
@@ -216,6 +236,14 @@ jobs:
           .\ffmpeg.ps1 ${{ matrix.cpu }}
           .\aria2.ps1 ${{ matrix.cpu }}
         working-directory: ./script
+      - name: Transcode and probe the installed FFmpeg runtime
+        if: ${{ matrix.cpu == 'x64' }}
+        run: >
+          python script/ffmpeg-assets.py smoke-binaries
+          --ffmpeg DownKyi.Core/Binary/win-x64/ffmpeg/ffmpeg.exe
+          --ffprobe DownKyi.Core/Binary/win-x64/ffmpeg/ffprobe.exe
+          --rid win-x64
+          --required-encoder h264_nvenc
       - name: Build canonical publish
         run: >
           dotnet publish ./DownKyi/DownKyi.csproj
@@ -290,6 +318,14 @@ jobs:
           ./ffmpeg.sh linux ${{ matrix.cpu }}
           ./aria2.sh linux-${{ matrix.cpu }}
         working-directory: ./script
+      - name: Transcode and probe the installed FFmpeg runtime
+        if: ${{ matrix.cpu == 'x64' }}
+        run: >
+          python script/ffmpeg-assets.py smoke-binaries
+          --ffmpeg DownKyi.Core/Binary/linux-x64/ffmpeg/ffmpeg
+          --ffprobe DownKyi.Core/Binary/linux-x64/ffmpeg/ffprobe
+          --rid linux-x64
+          --required-encoder h264_nvenc
       - name: Build canonical publish
         run: >
           dotnet publish ./DownKyi/DownKyi.csproj
@@ -715,7 +751,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [changelog, build-windows, build-linux, validate-linux-arm64, build-macos]
+    needs: [changelog, ffmpeg-linux-arm64-smoke, build-windows, build-linux, validate-linux-arm64, build-macos]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: Checkout release validators
@@ -766,3 +802,93 @@ jobs:
           replacesArtifacts: true
           artifacts: artifacts/*
           body: ${{ needs.changelog.outputs.release_body }}
+
+  ffmpeg-manifest-gate:
+    name: FFmpeg manifest gate
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs:
+      - ffmpeg-tooling
+      - ffmpeg-asset-updater
+      - detect-production-manifest-change
+      - external-assets-preflight
+      - ffmpeg-linux-arm64-smoke
+      - release-gate
+      - changelog
+      - build-windows
+      - build-linux-publish
+      - build-linux
+      - validate-linux-arm64
+      - build-macos
+      - release
+    env:
+      HEAD_REF: ${{ github.head_ref }}
+      EXTERNAL_ASSETS_CHANGED: ${{ needs.detect-production-manifest-change.outputs.external_assets }}
+      FFMPEG_TOOLING_RESULT: ${{ needs.ffmpeg-tooling.result }}
+      UPDATER_RESULT: ${{ needs.ffmpeg-asset-updater.result }}
+      DETECT_RESULT: ${{ needs.detect-production-manifest-change.result }}
+      PREFLIGHT_RESULT: ${{ needs.external-assets-preflight.result }}
+      LINUX_ARM64_SMOKE_RESULT: ${{ needs.ffmpeg-linux-arm64-smoke.result }}
+      RELEASE_GATE_RESULT: ${{ needs.release-gate.result }}
+      CHANGELOG_RESULT: ${{ needs.changelog.result }}
+      WINDOWS_RESULT: ${{ needs.build-windows.result }}
+      LINUX_PUBLISH_RESULT: ${{ needs.build-linux-publish.result }}
+      LINUX_RESULT: ${{ needs.build-linux.result }}
+      LINUX_ARM64_RESULT: ${{ needs.validate-linux-arm64.result }}
+      MACOS_RESULT: ${{ needs.build-macos.result }}
+      PUBLISH_RESULT: ${{ needs.release.result }}
+    steps:
+      - name: Require the complete applicable Build result
+        shell: bash
+        run: |
+          test "$FFMPEG_TOOLING_RESULT" = success
+          test "$DETECT_RESULT" = success
+          test "$UPDATER_RESULT" = skipped
+
+          if [[ "$EXTERNAL_ASSETS_CHANGED" != true ]]; then
+            if [[ "$HEAD_REF" == automation/ffmpeg-* ]]; then
+              echo 'An FFmpeg automation branch must change the production manifest.' >&2
+              exit 1
+            fi
+            exit 0
+          fi
+
+          test "$PREFLIGHT_RESULT" = success
+          test "$LINUX_ARM64_SMOKE_RESULT" = success
+          test "$RELEASE_GATE_RESULT" = success
+          test "$CHANGELOG_RESULT" = success
+          test "$WINDOWS_RESULT" = success
+          test "$LINUX_PUBLISH_RESULT" = success
+          test "$LINUX_RESULT" = success
+          test "$LINUX_ARM64_RESULT" = success
+          test "$MACOS_RESULT" = success
+          test "$PUBLISH_RESULT" = skipped
+
+      - name: Checkout the tested merge
+        if: ${{ startsWith(github.head_ref, 'automation/ffmpeg-') }}
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Validate the exact updater-owned manifest delta
+        if: ${{ startsWith(github.head_ref, 'automation/ffmpeg-') }}
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          mapfile -t changed_paths < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+          if [[ "${#changed_paths[@]}" -ne 1 || "${changed_paths[0]}" != 'script/assets/external-assets.json' ]]; then
+            echo 'FFmpeg auto-merge accepts only script/assets/external-assets.json.' >&2
+            printf 'changed=%s\n' "${changed_paths[@]}" >&2
+            exit 1
+          fi
+
+          mkdir -p .ffmpeg-update
+          git show "$BASE_SHA:script/assets/external-assets.json" > .ffmpeg-update/base-external-assets.json
+          python script/ffmpeg-assets.py validate-auto-merge-change \
+            --base-manifest .ffmpeg-update/base-external-assets.json \
+            --updated-manifest script/assets/external-assets.json \
+            --head-ref "$HEAD_REF" \
+            --title "$PR_TITLE"

--- a/.github/workflows/ffmpeg-manifest-auto-merge.yml
+++ b/.github/workflows/ffmpeg-manifest-auto-merge.yml
@@ -8,6 +8,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - edited
       - ready_for_review
   push:
     branches:

--- a/.github/workflows/ffmpeg-manifest-auto-merge.yml
+++ b/.github/workflows/ffmpeg-manifest-auto-merge.yml
@@ -1,0 +1,158 @@
+name: FFmpeg manifest auto-merge
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ffmpeg-manifest-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  reconcile:
+    name: Reconcile trusted updater PRs
+    runs-on: ubuntu-latest
+    steps:
+      # This privileged workflow must never check out or execute pull-request content.
+      - name: Update and enable auto-merge for exact updater PRs
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.DOWNKYI_AUTOMATION_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const requiredChecks = new Set([
+              'FFmpeg manifest gate',
+              'Format check',
+              'Build and test (windows-latest)',
+              'Build and test (ubuntu-latest)',
+              'Build and test (macos-latest)',
+              'aria2 TLS security (win-x86)',
+              'aria2 TLS security (win-x64)',
+              'aria2 TLS security (linux-x64)',
+              'aria2 TLS security (linux-arm64)',
+              'aria2 TLS security (osx-x64)',
+              'aria2 TLS security (osx-arm64)',
+              'Package audit',
+              'Analyze C#',
+              'CodeQL',
+            ]);
+
+            const { data: protection } = await github.rest.repos.getBranchProtection({
+              owner,
+              repo,
+              branch: 'main',
+            });
+            const statusChecks = protection.required_status_checks;
+            const configuredChecks = new Set(statusChecks?.contexts ?? []);
+            const missingChecks = [...requiredChecks].filter(check => !configuredChecks.has(check));
+            if (!statusChecks?.strict || missingChecks.length > 0) {
+              core.setFailed(`FFmpeg auto-merge requires strict main checks; missing=${missingChecks.join(',')}`);
+              return;
+            }
+
+            let pullRequests;
+            if (context.eventName === 'pull_request_target') {
+              pullRequests = [context.payload.pull_request];
+            } else {
+              pullRequests = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                base: 'main',
+                per_page: 100,
+              });
+            }
+
+            for (const summary of pullRequests) {
+              const { data: pull } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: summary.number,
+              });
+              if (!pull.head.ref.startsWith('automation/ffmpeg-')) {
+                continue;
+              }
+
+              const titleMatch = /^build\(deps\): update mirrored FFmpeg to (ffmpeg-btbn-autobuild-\d{4}-\d{2}-\d{2}-\d{2}-\d{2})$/.exec(pull.title);
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pull.number,
+                per_page: 100,
+              });
+              const eligible = !pull.draft
+                && pull.state === 'open'
+                && pull.base.ref === 'main'
+                && pull.head.repo?.full_name.toLowerCase() === `${owner}/${repo}`.toLowerCase()
+                && pull.user?.login.toLowerCase() === owner.toLowerCase()
+                && titleMatch !== null
+                && pull.head.ref === `automation/ffmpeg-${titleMatch?.[1]}`
+                && files.length === 1
+                && files[0].filename === 'script/assets/external-assets.json'
+                && files[0].status === 'modified';
+
+              if (!eligible) {
+                if (pull.auto_merge) {
+                  await github.graphql(
+                    `mutation($pullRequestId: ID!) {
+                      disablePullRequestAutoMerge(input: {pullRequestId: $pullRequestId}) {
+                        pullRequest { number }
+                      }
+                    }`,
+                    { pullRequestId: pull.node_id },
+                  );
+                }
+                core.warning(`PR #${pull.number} is not an exact FFmpeg updater PR; auto-merge is disabled.`);
+                continue;
+              }
+
+              const { data: main } = await github.rest.git.getRef({
+                owner,
+                repo,
+                ref: 'heads/main',
+              });
+              const comparison = await github.rest.repos.compareCommitsWithBasehead({
+                owner,
+                repo,
+                basehead: `${main.object.sha}...${pull.head.sha}`,
+              });
+              if (!['ahead', 'identical'].includes(comparison.data.status)) {
+                await github.rest.pulls.updateBranch({
+                  owner,
+                  repo,
+                  pull_number: pull.number,
+                  expected_head_sha: pull.head.sha,
+                });
+                core.info(`PR #${pull.number} was updated with the current main branch.`);
+              }
+
+              if (!pull.auto_merge) {
+                await github.graphql(
+                  `mutation($pullRequestId: ID!) {
+                    enablePullRequestAutoMerge(input: {
+                      pullRequestId: $pullRequestId,
+                      mergeMethod: MERGE
+                    }) {
+                      pullRequest { number }
+                    }
+                  }`,
+                  { pullRequestId: pull.node_id },
+                );
+                core.info(`Auto-merge enabled for FFmpeg updater PR #${pull.number}.`);
+              }
+            }

--- a/docs/operations/ffmpeg-asset-mirroring.md
+++ b/docs/operations/ffmpeg-asset-mirroring.md
@@ -141,12 +141,14 @@ The workflow uses two narrowly scoped credentials:
   with **Contents: read/write** only on
   `crazysmile-PhD/downkyi-runtime-assets`. It creates releases and uploads
   assets, but has no DownKyi source-repository permission.
-- `DOWNKYI_AUTOMATION_TOKEN`: fine-grained token or GitHub App installation
-  token with **Contents: read/write** and **Pull requests: read/write** only on
-  `crazysmile-PhD/downkyicore`. It creates the manifest PR, updates an eligible
-  branch with current `main`, and enables GitHub auto-merge. A separate token
-  is required because a PR opened or updated by `GITHUB_TOKEN` does not
-  reliably trigger the repository's package CI without approval.
+- `DOWNKYI_AUTOMATION_TOKEN`: a fine-grained personal access token owned by the
+  repository owner, with **Contents: read/write**, **Pull requests: read/write**,
+  and **Administration: read** only on `crazysmile-PhD/downkyicore`. It creates
+  the manifest PR as the repository owner, reads the required branch-protection
+  policy, updates an eligible branch with current `main`, and enables GitHub
+  auto-merge. A separate token is required because a PR opened or updated by
+  `GITHUB_TOKEN` does not reliably trigger the repository's package CI without
+  approval.
 
 No token is needed by normal builds or package downloaders.
 

--- a/docs/operations/ffmpeg-asset-mirroring.md
+++ b/docs/operations/ffmpeg-asset-mirroring.md
@@ -60,7 +60,8 @@ The updater then:
    publisher API and its per-asset SHA-256 digest.
 2. Download the selected archives, verify size and SHA-256, extract them, and
    require non-empty `ffmpeg` and `ffprobe` files.
-3. On native runners run `ffmpeg -version`, `ffprobe -version`, and where
+3. On native runners run `ffmpeg -version`, `ffprobe -version`, perform a real
+   one-frame MPEG-4 transcode and probe its stream metadata, and where
    applicable verify the required `h264_nvenc` encoder is compiled in.
 4. Only after every matrix validation job succeeds and repository release
    immutability is confirmed, create a draft mirror release, upload the exact
@@ -69,6 +70,9 @@ The updater then:
    the preflight, require immutable release read-back, then create a manifest
    PR against the same branch that supplied the manifest. The workflow cannot
    push `main`.
+6. For `main`, the separate base-branch auto-merge workflow opts in only the
+   exact scheduled BtbN manifest PR. GitHub merges it after the strict current-
+   base checks and the complete package gate pass.
 
 A validation, download, checksum, extraction, capability, upload, or preflight
 failure stops before manifest mutation. A failed upload may leave an
@@ -76,6 +80,32 @@ unreferenced incomplete release for an operator to inspect, but it cannot
 update the production manifest or replace a historical asset. Manifest PR
 creation is path-scoped to `script/assets/external-assets.json`; downloaded
 archives and updater evidence remain ignored workspace data.
+
+## Automatic merge policy
+
+`.github/workflows/ffmpeg-manifest-auto-merge.yml` is the only component that
+may opt a generated manifest PR into GitHub auto-merge. It runs from the base
+branch with a narrowly scoped token and never checks out or executes pull-
+request content. It accepts only a non-draft PR owned by this repository and
+repository owner, targeting `main`, whose branch and title exactly encode a
+fixed `ffmpeg-btbn-autobuild-*` release and whose only changed file is
+`script/assets/external-assets.json`. If a previously opted-in updater PR stops
+matching those conditions, the workflow disables auto-merge.
+
+The required `FFmpeg manifest gate` is emitted for every PR. On an updater
+branch it fails closed unless the diff changes only the scheduled BtbN RIDs,
+moves to a newer fixed release, preserves every other manifest field, reads
+the project mirror back as immutable with exact asset names, sizes and SHA-256,
+and all release-gate and package jobs succeed. Other PRs are not opted into
+auto-merge by this policy.
+
+Repository auto-merge must be enabled, and `main` branch protection must use
+strict status checks so a PR is tested with the latest `main`. The required
+contexts are `FFmpeg manifest gate`, every unconditional Strict PR CI job,
+`Analyze C#`, and `CodeQL`; the privileged workflow verifies this protection
+before it enables auto-merge. When `main` advances, the same workflow updates
+eligible updater branches with `DOWNKYI_AUTOMATION_TOKEN`, which preserves the
+automatic CI trigger and causes the exact-head checks to run again.
 
 ## Bootstrap and recovery
 
@@ -96,8 +126,8 @@ If the bootstrap fails:
    not overwrite the partial mirror release/tag. If the release was fully
    published before a later step failed, a re-run may reuse it only as immutable
    read-back evidence after every expected asset matches exactly.
-4. Re-run the dispatch. Review the generated PR and require the release/package
-   workflow before merging.
+4. Re-run the dispatch. A normal `main` BtbN update is merged only by the
+   automatic policy above; bootstrap or non-`main` updates remain manual.
 
 To force a normal BtbN refresh, run the same workflow with `bootstrap=false`.
 If the selected fixed release is already represented in the manifest, it exits
@@ -113,9 +143,10 @@ The workflow uses two narrowly scoped credentials:
   assets, but has no DownKyi source-repository permission.
 - `DOWNKYI_AUTOMATION_TOKEN`: fine-grained token or GitHub App installation
   token with **Contents: read/write** and **Pull requests: read/write** only on
-  `crazysmile-PhD/downkyicore`. It creates the manifest PR. A separate token is
-  required because a PR opened by `GITHUB_TOKEN` does not reliably trigger the
-  repository's package CI.
+  `crazysmile-PhD/downkyicore`. It creates the manifest PR, updates an eligible
+  branch with current `main`, and enables GitHub auto-merge. A separate token
+  is required because a PR opened or updated by `GITHUB_TOKEN` does not
+  reliably trigger the repository's package CI without approval.
 
 No token is needed by normal builds or package downloaders.
 
@@ -128,6 +159,7 @@ same fail-closed checksum verifier.
 ```powershell
 python -m unittest script/tests/test_ffmpeg_assets.py -v
 python script/ffmpeg-assets.py validate-manifest --manifest script/assets/external-assets.json
+python script/ffmpeg-assets.py validate-mirror-releases --manifest script/assets/external-assets.json
 python script/ffmpeg-assets.py preflight --manifest script/assets/external-assets.json --timeout 30
 ```
 

--- a/script/ffmpeg-assets.py
+++ b/script/ffmpeg-assets.py
@@ -31,11 +31,13 @@ from typing import Any, Iterable
 
 
 EXPECTED_RIDS = ("win-x86", "win-x64", "linux-x64", "linux-arm64", "osx-x64", "osx-arm64")
+AUTOMATED_RIDS = ("win-x64", "linux-x64", "linux-arm64")
 MIRROR_OWNER = "crazysmile-PhD"
 BTBN_REPOSITORY = "BtbN/FFmpeg-Builds"
 YTDLP_REPOSITORY = "yt-dlp/FFmpeg-Builds"
 GITHUB_API = "https://api.github.com"
 SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+BTBN_TAG_RE = re.compile(r"^autobuild-(\d{4})-(\d{2})-(\d{2})-(\d{2})-(\d{2})$")
 NATIVE_RUNNERS_BY_RID = {
     "win-x86": {"runner": "windows-latest", "architecture": "x64"},
     "win-x64": {"runner": "windows-latest", "architecture": "x64"},
@@ -396,18 +398,99 @@ def validate_candidate_archive(candidate: dict[str, Any], rid: str, directory: P
         if ffprobe is None:
             raise AssetError(f"Archive layout validation failed for {rid}: ffprobe is missing or empty.")
         if execute:
-            for binary in (ffmpeg, ffprobe):
-                ensure_executable(binary)
-                try:
-                    result = subprocess.run([str(binary), "-version"], capture_output=True, text=True, timeout=30, check=False)
-                except (OSError, subprocess.TimeoutExpired) as error:
-                    raise AssetError(f"Executable validation failed for {rid} {binary.name}: {error}.") from error
-                if result.returncode != 0 or not (result.stdout or result.stderr).strip():
-                    raise AssetError(f"Executable validation failed for {rid} {binary.name}: exit code {result.returncode}.")
-            if required_encoder:
-                result = subprocess.run([str(ffmpeg), "-hide_banner", "-encoders"], capture_output=True, text=True, timeout=30, check=False)
-                if result.returncode != 0 or required_encoder not in f"{result.stdout}\n{result.stderr}":
-                    raise AssetError(f"Capability validation failed for {rid}: encoder {required_encoder} is absent.")
+            validate_installed_binaries(ffmpeg, ffprobe, rid, required_encoder)
+
+
+def validate_smoke_probe_output(rid: str, output: str) -> None:
+    try:
+        value = json.loads(output)
+    except json.JSONDecodeError as error:
+        raise AssetError(f"Transcode probe failed for {rid}: invalid JSON output.") from error
+    streams = value.get("streams") if isinstance(value, dict) else None
+    if not isinstance(streams, list) or len(streams) != 1:
+        raise AssetError(f"Transcode probe failed for {rid}: expected exactly one video stream.")
+    stream = streams[0]
+    if not isinstance(stream, dict) or (
+        stream.get("codec_name") != "mpeg4"
+        or stream.get("width") != 16
+        or stream.get("height") != 16
+    ):
+        raise AssetError(f"Transcode probe failed for {rid}: unexpected stream metadata.")
+
+
+def validate_installed_binaries(ffmpeg: Path, ffprobe: Path, rid: str, required_encoder: str | None) -> None:
+    for binary in (ffmpeg, ffprobe):
+        if not binary.is_file() or binary.stat().st_size == 0:
+            raise AssetError(f"Executable validation failed for {rid}: {binary} is missing or empty.")
+        ensure_executable(binary)
+        try:
+            result = subprocess.run([str(binary), "-version"], capture_output=True, text=True, timeout=30, check=False)
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise AssetError(f"Executable validation failed for {rid} {binary.name}: {error}.") from error
+        if result.returncode != 0 or not (result.stdout or result.stderr).strip():
+            raise AssetError(f"Executable validation failed for {rid} {binary.name}: exit code {result.returncode}.")
+
+    if required_encoder:
+        result = subprocess.run([str(ffmpeg), "-hide_banner", "-encoders"], capture_output=True, text=True, timeout=30, check=False)
+        if result.returncode != 0 or required_encoder not in f"{result.stdout}\n{result.stderr}":
+            raise AssetError(f"Capability validation failed for {rid}: encoder {required_encoder} is absent.")
+
+    with tempfile.TemporaryDirectory(prefix=f"downkyi-ffmpeg-smoke-{rid}-") as temp:
+        smoke_output = Path(temp) / "smoke.mp4"
+        try:
+            result = subprocess.run(
+                [
+                    str(ffmpeg),
+                    "-hide_banner",
+                    "-loglevel",
+                    "error",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "color=c=black:s=16x16:r=1",
+                    "-frames:v",
+                    "1",
+                    "-c:v",
+                    "mpeg4",
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-y",
+                    str(smoke_output),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise AssetError(f"Transcode smoke test failed for {rid}: {error}.") from error
+        if result.returncode != 0 or not smoke_output.is_file() or smoke_output.stat().st_size == 0:
+            raise AssetError(f"Transcode smoke test failed for {rid}: exit code {result.returncode}.")
+
+        try:
+            result = subprocess.run(
+                [
+                    str(ffprobe),
+                    "-v",
+                    "error",
+                    "-select_streams",
+                    "v:0",
+                    "-show_entries",
+                    "stream=codec_name,width,height",
+                    "-of",
+                    "json",
+                    str(smoke_output),
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise AssetError(f"Transcode probe failed for {rid}: {error}.") from error
+        if result.returncode != 0:
+            raise AssetError(f"Transcode probe failed for {rid}: exit code {result.returncode}.")
+        validate_smoke_probe_output(rid, result.stdout)
 
 
 def is_project_owned_url(url: str, owner: str) -> bool:
@@ -484,6 +567,125 @@ def validate_manifest(manifest: dict[str, Any], owner: str = MIRROR_OWNER) -> No
         for field in ("upstreamRepository", "upstreamRelease", "originalAssetName", "upstreamUrl", "mirroredAt", "ffmpegVersion"):
             if not isinstance(provenance.get(field), str) or not provenance[field]:
                 raise AssetError(f"ffmpeg asset {rid} provenance is missing {field}.")
+
+
+def release_tag_and_name(url: str) -> tuple[str, str]:
+    pieces = [piece for piece in urllib.parse.urlparse(url).path.split("/") if piece]
+    if len(pieces) != 6 or pieces[2:4] != ["releases", "download"]:
+        raise AssetError(f"Malformed fixed mirror URL: {url}.")
+    return urllib.parse.unquote(pieces[4]), urllib.parse.unquote(pieces[5])
+
+
+def validate_manifest_mirror_releases(manifest: dict[str, Any]) -> None:
+    validate_manifest(manifest)
+    ffmpeg = manifest["ffmpeg"]
+    repository = ffmpeg["mirror"]["repository"]
+    expected_by_tag: dict[str, dict[str, str]] = {}
+    for rid in ffmpeg["requiredRids"]:
+        asset = ffmpeg["assets"][rid]
+        for url_field, digest_field in (("url", "sha256"), ("ffprobeUrl", "ffprobeSha256")):
+            if url_field not in asset:
+                continue
+            tag, name = release_tag_and_name(asset[url_field])
+            expected_by_tag.setdefault(tag, {})[name] = asset[digest_field].lower()
+
+    for tag, expected_assets in expected_by_tag.items():
+        encoded_tag = urllib.parse.quote(tag, safe="")
+        release = github_api(f"/repos/{repository}/releases/tags/{encoded_tag}")
+        if not isinstance(release, dict) or release.get("tag_name") != tag:
+            raise AssetError(f"Mirror release read-back failed for {repository}@{tag}.")
+        if release.get("immutable") is not True or release.get("draft") or release.get("prerelease"):
+            raise AssetError(f"Mirror release {repository}@{tag} is not an immutable published release.")
+        release_assets = release.get("assets")
+        if not isinstance(release_assets, list):
+            raise AssetError(f"Mirror release {repository}@{tag} has malformed assets.")
+        actual_assets = {
+            asset.get("name"): asset
+            for asset in release_assets
+            if isinstance(asset, dict) and isinstance(asset.get("name"), str)
+        }
+        for name, expected_digest in expected_assets.items():
+            actual = actual_assets.get(name)
+            if (
+                not isinstance(actual, dict)
+                or actual.get("state") != "uploaded"
+                or not isinstance(actual.get("size"), int)
+                or actual["size"] <= 0
+                or actual.get("digest") != f"sha256:{expected_digest}"
+                or actual.get("browser_download_url") != mirror_url(repository, tag, name)
+            ):
+                raise AssetError(f"Mirror release read-back mismatch for {repository}@{tag}/{name}.")
+
+
+def parse_btbn_tag(value: str) -> tuple[int, int, int, int, int]:
+    match = BTBN_TAG_RE.fullmatch(value)
+    if match is None:
+        raise AssetError(f"Invalid fixed BtbN release tag: {value!r}.")
+    return tuple(int(part) for part in match.groups())
+
+
+def validate_automated_manifest_change(
+    base: dict[str, Any],
+    updated: dict[str, Any],
+    head_ref: str,
+    title: str,
+) -> None:
+    """Accept only the deterministic manifest delta produced by the scheduled BtbN updater."""
+    validate_manifest(base)
+    validate_manifest(updated)
+    base_ffmpeg = base["ffmpeg"]
+    updated_ffmpeg = updated["ffmpeg"]
+    version = updated_ffmpeg.get("version")
+    if not isinstance(version, str) or not version.startswith("btbn-"):
+        raise AssetError("Automated FFmpeg update has an invalid version.")
+    upstream_tag = version.removeprefix("btbn-")
+    previous = base_ffmpeg.get("version")
+    if not isinstance(previous, str) or not previous.startswith("btbn-"):
+        raise AssetError("Automated FFmpeg update requires a BtbN base version.")
+    if parse_btbn_tag(upstream_tag) <= parse_btbn_tag(previous.removeprefix("btbn-")):
+        raise AssetError("Automated FFmpeg update must move to a newer fixed release.")
+
+    mirror_tag = f"ffmpeg-{version}"
+    if head_ref != f"automation/ffmpeg-{mirror_tag}":
+        raise AssetError("Automated FFmpeg update branch does not match the fixed release.")
+    if title != f"build(deps): update mirrored FFmpeg to {mirror_tag}":
+        raise AssetError("Automated FFmpeg update title does not match the fixed release.")
+
+    expected = copy.deepcopy(base)
+    expected["ffmpeg"]["version"] = version
+    for rid in AUTOMATED_RIDS:
+        asset = updated_ffmpeg["assets"][rid]
+        if asset == base_ffmpeg["assets"][rid]:
+            raise AssetError(f"Automated FFmpeg update did not replace {rid}.")
+        if set(asset) != {"url", "sha256", "fileName", "provenance"}:
+            raise AssetError(f"Automated FFmpeg update contains unexpected {rid} fields.")
+        provenance = asset["provenance"]
+        if set(provenance) != {
+            "upstreamRepository",
+            "upstreamRelease",
+            "originalAssetName",
+            "upstreamUrl",
+            "mirroredAt",
+            "ffmpegVersion",
+        }:
+            raise AssetError(f"Automated FFmpeg update contains unexpected {rid} provenance fields.")
+        original_name = provenance["originalAssetName"]
+        digest = asset["sha256"].lower()
+        expected_name = mirrored_file_name(rid, upstream_tag, original_name, digest)
+        if (
+            provenance["upstreamRepository"] != f"https://github.com/{BTBN_REPOSITORY}"
+            or provenance["upstreamRelease"] != upstream_tag
+            or provenance["upstreamUrl"]
+            != f"https://github.com/{BTBN_REPOSITORY}/releases/download/{upstream_tag}/{original_name}"
+            or provenance["ffmpegVersion"] != original_name
+            or asset["fileName"] != expected_name
+            or asset["url"] != mirror_url(updated_ffmpeg["mirror"]["repository"], mirror_tag, expected_name)
+        ):
+            raise AssetError(f"Automated FFmpeg update provenance mismatch for {rid}.")
+        expected["ffmpeg"]["assets"][rid] = copy.deepcopy(asset)
+
+    if expected != updated:
+        raise AssetError("Automated FFmpeg update changed content outside the scheduled BtbN manifest fields.")
 
 
 def expected_file_size(file: dict[str, Any]) -> int:
@@ -809,6 +1011,20 @@ def parse_args() -> argparse.Namespace:
     preflight_parser = subparsers.add_parser("preflight")
     preflight_parser.add_argument("--manifest", required=True)
     preflight_parser.add_argument("--timeout", type=int, default=30)
+    mirror_releases = subparsers.add_parser("validate-mirror-releases")
+    mirror_releases.add_argument("--manifest", required=True)
+
+    binary_smoke = subparsers.add_parser("smoke-binaries")
+    binary_smoke.add_argument("--ffmpeg", required=True)
+    binary_smoke.add_argument("--ffprobe", required=True)
+    binary_smoke.add_argument("--rid", required=True)
+    binary_smoke.add_argument("--required-encoder")
+
+    auto_merge = subparsers.add_parser("validate-auto-merge-change")
+    auto_merge.add_argument("--base-manifest", required=True)
+    auto_merge.add_argument("--updated-manifest", required=True)
+    auto_merge.add_argument("--head-ref", required=True)
+    auto_merge.add_argument("--title", required=True)
 
     authority = subparsers.add_parser("validate-workflow-authority")
     authority.add_argument("--ref-type", required=True)
@@ -862,6 +1078,22 @@ def main() -> int:
             validate_manifest(load_json(Path(args.manifest)))
         elif args.command == "preflight":
             preflight(load_json(Path(args.manifest)), args.timeout)
+        elif args.command == "validate-mirror-releases":
+            validate_manifest_mirror_releases(load_json(Path(args.manifest)))
+        elif args.command == "smoke-binaries":
+            validate_installed_binaries(
+                Path(args.ffmpeg),
+                Path(args.ffprobe),
+                args.rid,
+                args.required_encoder or None,
+            )
+        elif args.command == "validate-auto-merge-change":
+            validate_automated_manifest_change(
+                load_json(Path(args.base_manifest)),
+                load_json(Path(args.updated_manifest)),
+                args.head_ref,
+                args.title,
+            )
         elif args.command == "validate-workflow-authority":
             validate_workflow_authority(args.ref_type, args.ref_name, args.manifest_base)
         elif args.command == "discover":

--- a/script/tests/test_ffmpeg_assets.py
+++ b/script/tests/test_ffmpeg_assets.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import threading
 import unittest
+import urllib.parse
 import zipfile
 from pathlib import Path
 from unittest import mock
@@ -106,6 +107,35 @@ def release_readback_for(candidate: dict, repository: str, tag: str) -> dict:
             })
             asset_id += 1
     return {"id": 99, "tag_name": tag, "immutable": True, "assets": assets}
+
+
+def automated_manifest_update(base: dict, tag: str = "autobuild-2099-01-02-03-04") -> dict:
+    updated = copy.deepcopy(base)
+    version = f"btbn-{tag}"
+    updated["ffmpeg"]["version"] = version
+    repository = updated["ffmpeg"]["mirror"]["repository"]
+    platform_names = {
+        "win-x64": "ffmpeg-N-999999-gdeadbeef-win64-gpl.zip",
+        "linux-x64": "ffmpeg-N-999999-gdeadbeef-linux64-gpl.tar.xz",
+        "linux-arm64": "ffmpeg-N-999999-gdeadbeef-linuxarm64-gpl.tar.xz",
+    }
+    for rid, original_name in platform_names.items():
+        sha256 = digest(f"{rid}-{tag}")
+        file_name = ffmpeg_assets.mirrored_file_name(rid, tag, original_name, sha256)
+        updated["ffmpeg"]["assets"][rid] = {
+            "url": ffmpeg_assets.mirror_url(repository, f"ffmpeg-{version}", file_name),
+            "sha256": sha256,
+            "fileName": file_name,
+            "provenance": {
+                "upstreamRepository": "https://github.com/BtbN/FFmpeg-Builds",
+                "upstreamRelease": tag,
+                "originalAssetName": original_name,
+                "upstreamUrl": f"https://github.com/BtbN/FFmpeg-Builds/releases/download/{tag}/{original_name}",
+                "mirroredAt": "2099-01-02T03:05:00Z",
+                "ffmpegVersion": original_name,
+            },
+        }
+    return updated
 
 
 class AssetRequestHandler(http.server.BaseHTTPRequestHandler):
@@ -226,6 +256,41 @@ class FfmpegAssetsTests(unittest.TestCase):
             with self.assertRaisesRegex(ffmpeg_assets.AssetError, "ffprobe"):
                 ffmpeg_assets.validate_candidate_archive(candidate, "linux-x64", directory, False, None)
 
+    def test_candidate_execution_transcodes_and_probes_a_real_stream(self) -> None:
+        candidate = candidate_for("linux-x64")
+        file = candidate["assets"]["linux-x64"]["files"][0]
+        calls: list[list[str]] = []
+
+        def run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append(command)
+            if "-encoders" in command:
+                return subprocess.CompletedProcess(command, 0, "V..... h264_nvenc", "")
+            if "-frames:v" in command:
+                Path(command[-1]).write_bytes(b"smoke")
+                return subprocess.CompletedProcess(command, 0, "", "")
+            if "-show_entries" in command:
+                output = json.dumps({"streams": [{"codec_name": "mpeg4", "width": 16, "height": 16}]})
+                return subprocess.CompletedProcess(command, 0, output, "")
+            return subprocess.CompletedProcess(command, 0, "version", "")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            directory = Path(temporary)
+            archive = directory / file["mirroredFileName"]
+            with zipfile.ZipFile(archive, "w") as source:
+                source.writestr("bin/ffmpeg", b"binary")
+                source.writestr("bin/ffprobe", b"binary")
+            with mock.patch.object(ffmpeg_assets.subprocess, "run", side_effect=run):
+                ffmpeg_assets.validate_candidate_archive(candidate, "linux-x64", directory, True, "h264_nvenc")
+
+        self.assertEqual(5, len(calls))
+        self.assertIn("-frames:v", calls[3])
+        self.assertIn("-show_entries", calls[4])
+
+    def test_transcode_probe_rejects_unexpected_stream_metadata(self) -> None:
+        output = json.dumps({"streams": [{"codec_name": "h264", "width": 16, "height": 16}]})
+        with self.assertRaisesRegex(ffmpeg_assets.AssetError, "unexpected stream metadata"):
+            ffmpeg_assets.validate_smoke_probe_output("linux-x64", output)
+
     def test_workflow_authority_requires_same_branch_checkout_and_manifest_base(self) -> None:
         ffmpeg_assets.validate_workflow_authority(
             "branch",
@@ -295,6 +360,91 @@ class FfmpegAssetsTests(unittest.TestCase):
         with self.assertRaisesRegex(ffmpeg_assets.AssetError, "not immutable"):
             ffmpeg_assets.apply_update(manifest, candidate, mirror)
         self.assertEqual(before, manifest)
+
+    def test_manifest_release_readback_requires_immutable_exact_assets(self) -> None:
+        manifest = valid_manifest()
+        releases: dict[str, dict] = {}
+        for asset in manifest["ffmpeg"]["assets"].values():
+            for url_field, digest_field in (("url", "sha256"), ("ffprobeUrl", "ffprobeSha256")):
+                if url_field not in asset:
+                    continue
+                tag, name = ffmpeg_assets.release_tag_and_name(asset[url_field])
+                release = releases.setdefault(tag, {
+                    "tag_name": tag,
+                    "immutable": True,
+                    "draft": False,
+                    "prerelease": False,
+                    "assets": [],
+                })
+                release["assets"].append({
+                    "name": name,
+                    "state": "uploaded",
+                    "size": 123,
+                    "digest": f"sha256:{asset[digest_field]}",
+                    "browser_download_url": asset[url_field],
+                })
+
+        def github_api(path: str) -> dict:
+            tag = urllib.parse.unquote(path.rsplit("/", 1)[-1])
+            return releases[tag]
+
+        with mock.patch.object(ffmpeg_assets, "github_api", side_effect=github_api):
+            ffmpeg_assets.validate_manifest_mirror_releases(manifest)
+            next(iter(releases.values()))["immutable"] = False
+            with self.assertRaisesRegex(ffmpeg_assets.AssetError, "not an immutable"):
+                ffmpeg_assets.validate_manifest_mirror_releases(manifest)
+
+    def test_automated_manifest_change_accepts_only_the_updater_delta(self) -> None:
+        base = json.loads((SCRIPT.parent / "assets" / "external-assets.json").read_text(encoding="utf-8"))
+        updated = automated_manifest_update(base)
+        version = updated["ffmpeg"]["version"]
+        mirror_tag = f"ffmpeg-{version}"
+
+        ffmpeg_assets.validate_automated_manifest_change(
+            base,
+            updated,
+            f"automation/ffmpeg-{mirror_tag}",
+            f"build(deps): update mirrored FFmpeg to {mirror_tag}",
+        )
+
+        updated["aria2"]["version"] = "unexpected"
+        with self.assertRaisesRegex(ffmpeg_assets.AssetError, "outside the scheduled"):
+            ffmpeg_assets.validate_automated_manifest_change(
+                base,
+                updated,
+                f"automation/ffmpeg-{mirror_tag}",
+                f"build(deps): update mirrored FFmpeg to {mirror_tag}",
+            )
+
+    def test_automated_manifest_change_rejects_spoofed_branch(self) -> None:
+        base = json.loads((SCRIPT.parent / "assets" / "external-assets.json").read_text(encoding="utf-8"))
+        updated = automated_manifest_update(base)
+        mirror_tag = f"ffmpeg-{updated['ffmpeg']['version']}"
+        with self.assertRaisesRegex(ffmpeg_assets.AssetError, "branch"):
+            ffmpeg_assets.validate_automated_manifest_change(
+                base,
+                updated,
+                "automation/ffmpeg-spoofed",
+                f"build(deps): update mirrored FFmpeg to {mirror_tag}",
+            )
+
+    def test_auto_merge_workflow_never_executes_pull_request_content(self) -> None:
+        workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "ffmpeg-manifest-auto-merge.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("pull_request_target:", workflow)
+        self.assertIn("enablePullRequestAutoMerge", workflow)
+        self.assertIn("disablePullRequestAutoMerge", workflow)
+        self.assertIn("getBranchProtection", workflow)
+        self.assertNotIn("actions/checkout", workflow)
+
+    def test_build_exposes_an_always_present_ffmpeg_manifest_gate(self) -> None:
+        workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8")
+        pull_request_section = workflow.split("  pull_request:\n", 1)[1].split("  workflow_dispatch:\n", 1)[0]
+        self.assertNotIn("paths:", pull_request_section)
+        self.assertIn("name: FFmpeg manifest gate", workflow)
+        self.assertIn("validate-auto-merge-change", workflow)
+        self.assertIn("validate-mirror-releases", workflow)
 
     def test_readback_evidence_updates_only_the_selected_rid(self) -> None:
         manifest = valid_manifest()

--- a/script/tests/test_ffmpeg_assets.py
+++ b/script/tests/test_ffmpeg_assets.py
@@ -436,12 +436,14 @@ class FfmpegAssetsTests(unittest.TestCase):
         self.assertIn("enablePullRequestAutoMerge", workflow)
         self.assertIn("disablePullRequestAutoMerge", workflow)
         self.assertIn("getBranchProtection", workflow)
+        self.assertIn("      - edited", workflow)
         self.assertNotIn("actions/checkout", workflow)
 
     def test_build_exposes_an_always_present_ffmpeg_manifest_gate(self) -> None:
         workflow = (SCRIPT.parents[1] / ".github" / "workflows" / "build.yml").read_text(encoding="utf-8")
         pull_request_section = workflow.split("  pull_request:\n", 1)[1].split("  workflow_dispatch:\n", 1)[0]
         self.assertNotIn("paths:", pull_request_section)
+        self.assertIn("      - edited", pull_request_section)
         self.assertIn("name: FFmpeg manifest gate", workflow)
         self.assertIn("validate-auto-merge-change", workflow)
         self.assertIn("validate-mirror-releases", workflow)

--- a/tests/DownKyi.Architecture.Tests/ReleaseSafetyRegressionTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseSafetyRegressionTests.cs
@@ -103,8 +103,8 @@ public sealed class ReleaseSafetyRegressionTests
         AssertArm64PromotionContract(workflow);
         Assert.ThrowsAny<Exception>(() => AssertArm64PromotionContract(
             workflow.Replace(
-                "needs: [changelog, build-windows, build-linux, validate-linux-arm64, build-macos]",
-                "needs: [changelog, build-windows, build-linux, build-macos]",
+                "needs: [changelog, ffmpeg-linux-arm64-smoke, build-windows, build-linux, validate-linux-arm64, build-macos]",
+                "needs: [changelog, ffmpeg-linux-arm64-smoke, build-windows, build-linux, build-macos]",
                 StringComparison.Ordinal)));
         Assert.ThrowsAny<Exception>(() => AssertArm64PromotionContract(
             workflow.Replace(
@@ -1257,7 +1257,7 @@ public sealed class ReleaseSafetyRegressionTests
             StringComparison.Ordinal);
 
         Assert.Contains(
-            "needs: [changelog, build-windows, build-linux, validate-linux-arm64, build-macos]",
+            "needs: [changelog, ffmpeg-linux-arm64-smoke, build-windows, build-linux, validate-linux-arm64, build-macos]",
             release,
             StringComparison.Ordinal);
         Assert.Contains(


### PR DESCRIPTION
## Outcome

Allow only the scheduled, owner-created BtbN FFmpeg manifest PR to enter GitHub native auto-merge. Other PRs remain manual.

## Safety boundary

- Keep the updater unable to push `main`; a base-branch workflow only enables/disables native auto-merge and updates eligible stale branches.
- Require the exact repository/owner, `main` base, fixed branch/title pattern, non-draft state, and exactly one modified path: `script/assets/external-assets.json`.
- Fail closed unless only the three scheduled BtbN RIDs change to a newer fixed tag and every other manifest field remains byte-equivalent as JSON data.
- Re-read GitHub Immutable Release evidence (published state, names, sizes, SHA-256, URLs) in PR CI.
- Exercise a real one-frame MPEG-4 transcode and `ffprobe` on Windows x64, Linux x64, and native Linux arm64.
- Emit an always-present `FFmpeg manifest gate`; the auto-merge controller refuses to opt in unless `main` has strict required status checks including this gate, Strict PR CI, and CodeQL.

## Verification

- `python -m unittest script/tests/test_ffmpeg_assets.py -v` — 26 passed, 1 platform skip
- current and PR #234 immutable mirror read-back — passed
- current Windows x64 mirrored FFmpeg download/SHA/capability/transcode/probe — passed
- strict Release solution build — 0 warnings, 0 errors
- CentralTestRunner full Windows selection — 8/8 projects passed
- focused release-safety regression — passed
- `dotnet format --verify-no-changes` — passed
- actionlint v1.7.12 — passed
- JavaScript syntax check and `git diff --check` — passed

This PR intentionally does not auto-merge itself. After it is integrated, the base-branch push reconciliation will update and opt in #234; GitHub can merge #234 only after the new exact-head gates pass.