### PR TITLE
ci: enable GitHub auto-merge for FFmpeg updater PRs

### DIFF
--- a/.github/workflows/update-ffmpeg-assets.yml
+++ b/.github/workflows/update-ffmpeg-assets.yml
@@ -206,6 +206,7 @@ jobs:
             --previous-version "$previous_version" \
             --output .ffmpeg-update/pr-body.md
       - name: Create manifest pull request
+        id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.DOWNKYI_AUTOMATION_TOKEN }}
@@ -216,3 +217,9 @@ jobs:
           delete-branch: true
           title: "build(deps): update mirrored FFmpeg to ${{ needs.discover.outputs.mirror_tag }}"
           body-path: .ffmpeg-update/pr-body.md
+      - name: Enable auto-merge
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        env:
+          GH_TOKEN: ${{ secrets.DOWNKYI_AUTOMATION_TOKEN }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+        run: gh pr merge "$PR_NUMBER" --auto --merge --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Change

The FFmpeg updater already creates or updates a manifest PR after its existing validation. When `create-pull-request@v7` returns a PR number, enable GitHub native auto-merge for that exact PR with the existing automation token and merge-commit method. GitHub will wait for the repository's required checks and branch protection; the workflow does not use an administrative bypass.

The change is limited to `.github/workflows/update-ffmpeg-assets.yml` (7 added lines). No FFmpeg verification or production C# code changed.

## Validation

- YAML parsed and `actionlint@v1.7.12` passed for all workflows.
- Strict Release solution build passed with no warnings or errors.
- `script/test-solution.ps1 -Configuration Release -NoRestore -NoBuild` passed all 8 Windows-applicable projects.
- `dotnet format --verify-no-changes`, module boundary audit, vulnerable/deprecated package audits, Gitleaks 8.30.1, and `git diff --check` passed.

Runtime auto-merge activation cannot be exercised without a real updater-created PR and its automation token; this PR verifies the workflow configuration and repository prerequisites.
