### PR TITLE
fix(ci): report required FFmpeg gate on every PR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,14 +12,6 @@ on:
     branches:
       - main
       - release/v1.1.1-integration
-    paths:
-      - 'script/assets/external-assets.json'
-      - 'script/ffmpeg-assets.py'
-      - 'script/ffmpeg.ps1'
-      - 'script/ffmpeg.sh'
-      - 'script/tests/test_ffmpeg_assets.py'
-      - '.github/workflows/build.yml'
-      - '.github/workflows/update-ffmpeg-assets.yml'
   workflow_dispatch:
     inputs:
       update_ffmpeg_assets:
@@ -36,6 +28,8 @@ on:
 jobs:
   ffmpeg-tooling:
     name: FFmpeg tooling / implementation gate
+    needs: detect-production-manifest-change
+    if: ${{ github.event_name != 'pull_request' || needs.detect-production-manifest-change.outputs.ffmpeg_related == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -69,8 +63,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       external_assets: ${{ steps.filter.outputs.external_assets }}
+      ffmpeg_related: ${{ steps.filter.outputs.ffmpeg_related }}
     steps:
-      - name: Detect external asset manifest changes in the PR diff
+      - name: Detect FFmpeg changes in the PR diff
         id: filter
         if: github.event_name == 'pull_request'
         uses: dorny/paths-filter@v3
@@ -78,6 +73,14 @@ jobs:
           filters: |
             external_assets:
               - 'script/assets/external-assets.json'
+            ffmpeg_related:
+              - 'script/assets/external-assets.json'
+              - 'script/ffmpeg-assets.py'
+              - 'script/ffmpeg.ps1'
+              - 'script/ffmpeg.sh'
+              - 'script/tests/test_ffmpeg_assets.py'
+              - '.github/workflows/build.yml'
+              - '.github/workflows/update-ffmpeg-assets.yml'
 
   external-assets-preflight:
     name: Production manifest preflight
@@ -97,6 +100,36 @@ jobs:
         run: python script/ffmpeg-assets.py validate-manifest --manifest script/assets/external-assets.json
       - name: Check external asset availability
         run: python script/ffmpeg-assets.py preflight --manifest script/assets/external-assets.json --timeout 30
+
+  ffmpeg-required-gate:
+    name: FFmpeg manifest gate
+    needs:
+      - detect-production-manifest-change
+      - ffmpeg-tooling
+      - external-assets-preflight
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report the FFmpeg validation result
+        env:
+          DETECTION_RESULT: ${{ needs.detect-production-manifest-change.result }}
+          TOOLING_RESULT: ${{ needs.ffmpeg-tooling.result }}
+          PREFLIGHT_RESULT: ${{ needs.external-assets-preflight.result }}
+          FFMPEG_RELATED: ${{ needs.detect-production-manifest-change.outputs.ffmpeg_related }}
+          EXTERNAL_ASSETS: ${{ needs.detect-production-manifest-change.outputs.external_assets }}
+        run: |
+          set -e
+          test "$DETECTION_RESULT" = success
+          if [ "$FFMPEG_RELATED" = true ]; then
+            test "$TOOLING_RESULT" = success
+          else
+            test "$TOOLING_RESULT" = skipped
+          fi
+          if [ "$EXTERNAL_ASSETS" = true ]; then
+            test "$PREFLIGHT_RESULT" = success
+          else
+            test "$PREFLIGHT_RESULT" = skipped
+          fi
 
   release-gate:
     name: Release gate (${{ matrix.os }})

--- a/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/ReleaseWorkflowArchitectureTests.cs
@@ -62,6 +62,76 @@ public sealed class ReleaseWorkflowArchitectureTests
     }
 
     [Fact]
+    public void OrdinaryPullRequestProducesSuccessfulFfmpegRequiredCheckWithoutReleaseWork()
+    {
+        var workflow = File.ReadAllText(
+            Path.Combine(RepositoryRoot, ".github", "workflows", "build.yml"));
+        var lines = workflow.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var pullRequest = GetYamlBlock(lines, "  pull_request:", 2);
+        var detector = GetYamlBlock(lines, "  detect-production-manifest-change:", 2);
+        var tooling = GetYamlBlock(lines, "  ffmpeg-tooling:", 2);
+        var preflight = GetYamlBlock(lines, "  external-assets-preflight:", 2);
+        var gate = GetYamlBlock(lines, "  ffmpeg-required-gate:", 2);
+        var release = GetYamlBlock(lines, "  release-gate:", 2);
+
+        Assert.DoesNotContain(pullRequest, line =>
+            GetIndent(line) == 4 && line.Trim() == "paths:");
+        Assert.Contains("    if: ${{ github.event_name != 'pull_request' || needs.detect-production-manifest-change.outputs.ffmpeg_related == 'true' }}", tooling);
+        Assert.Contains("    if: ${{ always() && !inputs.update_ffmpeg_assets && needs.ffmpeg-tooling.result == 'success' && (github.event_name != 'pull_request' || needs.detect-production-manifest-change.outputs.external_assets == 'true') }}", preflight);
+        Assert.Contains("    needs: external-assets-preflight", release);
+        Assert.Contains("    name: FFmpeg manifest gate", gate);
+        Assert.Contains("    if: ${{ always() && github.event_name == 'pull_request' }}", gate);
+        Assert.Contains("      - detect-production-manifest-change", gate);
+        Assert.Contains("      - ffmpeg-tooling", gate);
+        Assert.Contains("      - external-assets-preflight", gate);
+        Assert.Contains("          test \"$DETECTION_RESULT\" = success", gate);
+        Assert.Contains("          if [ \"$FFMPEG_RELATED\" = true ]; then", gate);
+        Assert.Contains("          if [ \"$EXTERNAL_ASSETS\" = true ]; then", gate);
+        Assert.Contains("            test \"$TOOLING_RESULT\" = skipped", gate);
+        Assert.Contains("            test \"$PREFLIGHT_RESULT\" = skipped", gate);
+        Assert.DoesNotContain("              - 'src/DownKyi.Desktop/**'", detector);
+    }
+
+    [Fact]
+    public void FfmpegPullRequestValidationFailuresReachTheRequiredCheck()
+    {
+        var workflow = File.ReadAllText(
+            Path.Combine(RepositoryRoot, ".github", "workflows", "build.yml"));
+        var lines = workflow.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        var detector = GetYamlBlock(lines, "  detect-production-manifest-change:", 2);
+        var tooling = GetYamlBlock(lines, "  ffmpeg-tooling:", 2);
+        var preflight = GetYamlBlock(lines, "  external-assets-preflight:", 2);
+        var gate = GetYamlBlock(lines, "  ffmpeg-required-gate:", 2);
+        var ffmpegPaths = GetYamlBlock(detector.ToArray(), "            ffmpeg_related:", 12)
+            .Where(line => GetIndent(line) == 14 && line.TrimStart().StartsWith("- ", StringComparison.Ordinal))
+            .Select(line => line.Trim()[2..].Trim('\'', '"'))
+            .ToArray();
+
+        Assert.Equal(
+            [
+                "script/assets/external-assets.json",
+                "script/ffmpeg-assets.py",
+                "script/ffmpeg.ps1",
+                "script/ffmpeg.sh",
+                "script/tests/test_ffmpeg_assets.py",
+                ".github/workflows/build.yml",
+                ".github/workflows/update-ffmpeg-assets.yml"
+            ], ffmpegPaths);
+        Assert.Contains("    needs: detect-production-manifest-change", tooling);
+        Assert.Contains("      - name: Run FFmpeg asset guards", tooling);
+        Assert.Contains("        run: python -m unittest script/tests/test_ffmpeg_assets.py -v", tooling);
+        Assert.DoesNotContain("continue-on-error: true", tooling);
+        Assert.Contains("        run: python script/ffmpeg-assets.py validate-manifest --manifest script/assets/external-assets.json", preflight);
+        Assert.Contains("        run: python script/ffmpeg-assets.py preflight --manifest script/assets/external-assets.json --timeout 30", preflight);
+        Assert.Contains("          set -e", gate);
+        Assert.Contains("          FFMPEG_RELATED: ${{ needs.detect-production-manifest-change.outputs.ffmpeg_related }}", gate);
+        Assert.Contains("          EXTERNAL_ASSETS: ${{ needs.detect-production-manifest-change.outputs.external_assets }}", gate);
+        Assert.Contains("            test \"$TOOLING_RESULT\" = success", gate);
+        Assert.Contains("            test \"$PREFLIGHT_RESULT\" = success", gate);
+        Assert.DoesNotContain("continue-on-error: true", gate);
+    }
+
+    [Fact]
     public void TagReleaseDependencyGuardRejectsJobLevelSkipsAndNonExecutableLookalikes()
     {
         const string validWorkflow = """


### PR DESCRIPTION
## Why

`main` requires the exact GitHub Actions check context `FFmpeg manifest gate`, but the Build workflow's workflow-level PR path filter prevented that context from being created on ordinary PRs (including #261). This is a required-check contract failure, not a runner timeout.

## Change

- Start Build for every target PR, while keeping the existing tag and manual triggers.
- Detect FFmpeg-related paths inside the workflow. Skip the existing tooling job for ordinary PRs; run its real actionlint and Python validation for FFmpeg-related PRs.
- Keep production manifest network preflight conditional on manifest changes, and retain the existing release chain dependency.
- Always create the exact required `FFmpeg manifest gate` PR job. It reports success for an ordinary PR only when detection succeeded and tooling/preflight were correctly skipped. FFmpeg PR failures in detection, tooling or applicable preflight fail the required gate.

## Verification

On a clean worktree based on current `main` (`d9c5162`): strict Release build (0 warnings/errors), CentralTestRunner solution run (all 8 Windows-applicable projects), Architecture 326/326, FFmpeg Python unit tests (18 passed, 1 Windows skip), `dotnet format --verify-no-changes`, module-boundary audit, actionlint, YAML syntax, NuGet vulnerable/deprecated audits, Gitleaks 8.30.1 (0 findings), and staged `git diff --check` passed.

This PR contains no #177 product code. Merge only after exact-head required CI and same-head review are clear; then #261 can update from `main`.