### PR TITLE
Fix #177 F: enforce one production instance across installs

### DIFF
--- a/src/DownKyi.Desktop/App.axaml.cs
+++ b/src/DownKyi.Desktop/App.axaml.cs
@@ -31,7 +31,8 @@ internal partial class App : Avalonia.Application, IAsyncDisposable
     private Task? _disposeTask;
 
 #if !DEBUG
-    private SingleInstanceGuard? _singleInstanceGuard;
+    // Keep the admission identity alive until the process exits. Host shutdown can time out.
+    private static SingleInstanceGuard? _processInstanceGuard;
 #endif
 
     private IHost? _host;
@@ -47,7 +48,7 @@ internal partial class App : Avalonia.Application, IAsyncDisposable
         if (!SingleInstanceGuard.TryAcquire(
                 AppConstant.RepoOwner,
                 AppConstant.RepoName,
-                out _singleInstanceGuard))
+                out _processInstanceGuard))
         {
             Environment.Exit(0);
         }
@@ -147,11 +148,6 @@ internal partial class App : Avalonia.Application, IAsyncDisposable
                     {
                         _logProvider = null;
                         _logger = null;
-
-#if !DEBUG
-                        _singleInstanceGuard?.Dispose();
-                        _singleInstanceGuard = null;
-#endif
                     }
                 }
             }

--- a/src/DownKyi.Desktop/App.axaml.cs
+++ b/src/DownKyi.Desktop/App.axaml.cs
@@ -47,7 +47,6 @@ internal partial class App : Avalonia.Application, IAsyncDisposable
         if (!SingleInstanceGuard.TryAcquire(
                 AppConstant.RepoOwner,
                 AppConstant.RepoName,
-                AppContext.BaseDirectory,
                 out _singleInstanceGuard))
         {
             Environment.Exit(0);

--- a/src/DownKyi.Desktop/Platform/SingleInstanceGuard.cs
+++ b/src/DownKyi.Desktop/Platform/SingleInstanceGuard.cs
@@ -18,20 +18,29 @@ internal sealed class SingleInstanceGuard : IDisposable
         string repository,
         out SingleInstanceGuard? guard)
     {
-        var mutex = new Mutex(
-            initiallyOwned: true,
-            BuildMutexName(owner, repository),
-            new NamedWaitHandleOptions { CurrentUserOnly = false, CurrentSessionOnly = false },
-            out var createdNew);
-        if (!createdNew)
+        try
         {
-            mutex.Dispose();
+            var mutex = new Mutex(
+                initiallyOwned: false,
+                BuildMutexName(owner, repository),
+                new NamedWaitHandleOptions { CurrentUserOnly = false, CurrentSessionOnly = false },
+                out var createdNew);
+            if (!createdNew)
+            {
+                mutex.Dispose();
+                guard = null;
+                return false;
+            }
+
+            guard = new SingleInstanceGuard(mutex);
+            return true;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // An existing global mutex may deny access to another Windows user.
             guard = null;
             return false;
         }
-
-        guard = new SingleInstanceGuard(mutex);
-        return true;
     }
 
     internal static string BuildMutexName(string owner, string repository)
@@ -50,19 +59,6 @@ internal sealed class SingleInstanceGuard : IDisposable
         }
 
         _disposed = true;
-        ReleaseMutexBestEffort();
         _mutex.Dispose();
-    }
-
-    private void ReleaseMutexBestEffort()
-    {
-        try
-        {
-            _mutex.ReleaseMutex();
-        }
-        catch (ApplicationException)
-        {
-            return;
-        }
     }
 }

--- a/src/DownKyi.Desktop/Platform/SingleInstanceGuard.cs
+++ b/src/DownKyi.Desktop/Platform/SingleInstanceGuard.cs
@@ -1,7 +1,4 @@
 using System;
-using System.IO;
-using System.Security.Cryptography;
-using System.Text;
 using System.Threading;
 
 namespace DownKyi.Platform;
@@ -19,12 +16,12 @@ internal sealed class SingleInstanceGuard : IDisposable
     public static bool TryAcquire(
         string owner,
         string repository,
-        string installDirectory,
         out SingleInstanceGuard? guard)
     {
         var mutex = new Mutex(
             initiallyOwned: true,
-            BuildMutexName(owner, repository, installDirectory),
+            BuildMutexName(owner, repository),
+            new NamedWaitHandleOptions { CurrentUserOnly = false, CurrentSessionOnly = false },
             out var createdNew);
         if (!createdNew)
         {
@@ -37,18 +34,12 @@ internal sealed class SingleInstanceGuard : IDisposable
         return true;
     }
 
-    internal static string BuildMutexName(string owner, string repository, string installDirectory)
+    internal static string BuildMutexName(string owner, string repository)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(owner);
         ArgumentException.ThrowIfNullOrWhiteSpace(repository);
-        ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
 
-        var installPath = Path.GetFullPath(installDirectory)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            .ToUpperInvariant();
-        var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(installPath)).AsSpan(0, 8));
-        var prefix = OperatingSystem.IsWindows() ? @"Global\" : string.Empty;
-        return $"{prefix}DownKyi-{owner}-{repository}-{hash}";
+        return $"DownKyi-{owner}-{repository}";
     }
 
     public void Dispose()

--- a/tests/DownKyi.Architecture.Tests/AppLifecycleArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/AppLifecycleArchitectureTests.cs
@@ -96,6 +96,27 @@ public sealed class AppLifecycleArchitectureTests
     }
 
     [Fact]
+    public void ProductionSingleInstanceGuardPrecedesHostAndStorageInitialization()
+    {
+        var appSource = ReadSource("src", "DownKyi.Desktop", "App.axaml.cs");
+        var initializeStart = appSource.IndexOf("public override void Initialize()", StringComparison.Ordinal);
+        var initializeEnd = appSource.IndexOf(
+            "public override void OnFrameworkInitializationCompleted()", StringComparison.Ordinal);
+        Assert.True(initializeStart >= 0 && initializeEnd > initializeStart);
+
+        var initialize = appSource[initializeStart..initializeEnd];
+        var productionGuard = initialize.IndexOf("#if !DEBUG", StringComparison.Ordinal);
+        var acquire = initialize.IndexOf("SingleInstanceGuard.TryAcquire", StringComparison.Ordinal);
+        var exit = initialize.IndexOf("Environment.Exit(0)", StringComparison.Ordinal);
+        var loadXaml = initialize.IndexOf("AvaloniaXamlLoader.Load", StringComparison.Ordinal);
+        var createHost = initialize.IndexOf("CreateHost()", StringComparison.Ordinal);
+
+        Assert.True(productionGuard >= 0 && productionGuard < acquire);
+        Assert.True(acquire < exit && exit < loadXaml && loadXaml < createHost);
+        Assert.DoesNotContain("AppContext.BaseDirectory", initialize, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AppDoesNotOwnGlobalDownloadCollections()
     {
         var source = ReadSource("src", "DownKyi.Desktop", "App.axaml.cs");

--- a/tests/DownKyi.Tests/SingleInstanceGuardTests.cs
+++ b/tests/DownKyi.Tests/SingleInstanceGuardTests.cs
@@ -64,14 +64,18 @@ public sealed class SingleInstanceGuardTests
     {
         var owner = Environment.GetEnvironmentVariable("DOWNKYI_SINGLE_INSTANCE_PROBE_OWNER");
         var expected = Environment.GetEnvironmentVariable("DOWNKYI_SINGLE_INSTANCE_PROBE_EXPECTED");
+        var marker = Environment.GetEnvironmentVariable("DOWNKYI_SINGLE_INSTANCE_PROBE_MARKER");
         Assert.False(string.IsNullOrWhiteSpace(owner));
         Assert.True(expected is "true" or "false");
+        Assert.False(string.IsNullOrWhiteSpace(marker));
 
         var acquired = SingleInstanceGuard.TryAcquire(owner, "repo", out var guard);
         using (guard)
         {
             Assert.Equal(expected == "true", acquired);
         }
+
+        File.WriteAllText(marker, "executed");
     }
 
     [Fact]
@@ -88,6 +92,7 @@ public sealed class SingleInstanceGuardTests
 
     private static async Task AssertProbeResultAsync(string directory, string owner, bool expectedAcquired)
     {
+        var marker = Path.Combine(directory, $"probe-{Guid.NewGuid():N}.marker");
         var startInfo = new ProcessStartInfo("dotnet")
         {
             WorkingDirectory = directory,
@@ -105,6 +110,7 @@ public sealed class SingleInstanceGuardTests
         startInfo.Environment["DOWNKYI_SINGLE_INSTANCE_PROBE_OWNER"] = owner;
         startInfo.Environment["DOWNKYI_SINGLE_INSTANCE_PROBE_EXPECTED"] =
             expectedAcquired ? "true" : "false";
+        startInfo.Environment["DOWNKYI_SINGLE_INSTANCE_PROBE_MARKER"] = marker;
 
         using var process = Process.Start(startInfo)!;
         var output = process.StandardOutput.ReadToEndAsync();
@@ -129,5 +135,6 @@ public sealed class SingleInstanceGuardTests
         Assert.True(process.ExitCode == 0,
             $"Second installation probe exited {process.ExitCode}. " +
             $"{await output.ConfigureAwait(true)} {await error.ConfigureAwait(true)}");
+        Assert.Equal("executed", await File.ReadAllTextAsync(marker).ConfigureAwait(true));
     }
 }

--- a/tests/DownKyi.Tests/SingleInstanceGuardTests.cs
+++ b/tests/DownKyi.Tests/SingleInstanceGuardTests.cs
@@ -1,5 +1,4 @@
-using System.Reflection;
-using System.Runtime.Loader;
+using System.Diagnostics;
 using DownKyi.Platform;
 
 namespace DownKyi.Tests;
@@ -33,40 +32,45 @@ public sealed class SingleInstanceGuardTests
     }
 
     [Fact]
-    public void DifferentInstallCopiesCannotOwnTheApplicationIdentityTogether()
+    public async Task DifferentInstallCopiesCannotOwnTheApplicationIdentityTogether()
     {
         var root = Path.Combine(Path.GetTempPath(), $"downkyi-guard-{Guid.NewGuid():N}");
-        var firstDirectory = Path.Combine(root, "first-install");
-        var secondDirectory = Path.Combine(root, "second-install");
-        Directory.CreateDirectory(firstDirectory);
-        Directory.CreateDirectory(secondDirectory);
-
-        var assemblyName = Path.GetFileName(typeof(SingleInstanceGuard).Assembly.Location);
-        var firstCopy = Path.Combine(firstDirectory, assemblyName);
-        var secondCopy = Path.Combine(secondDirectory, assemblyName);
-        File.Copy(typeof(SingleInstanceGuard).Assembly.Location, firstCopy);
-        File.Copy(typeof(SingleInstanceGuard).Assembly.Location, secondCopy);
-
-        var firstContext = new AssemblyLoadContext($"first-{Guid.NewGuid():N}", isCollectible: true);
-        var secondContext = new AssemblyLoadContext($"second-{Guid.NewGuid():N}", isCollectible: true);
+        Directory.CreateDirectory(root);
         try
         {
-            var owner = $"owner-{Guid.NewGuid():N}";
-            var first = TryAcquireFromCopy(firstContext, firstCopy, owner);
-            Assert.True(first.Acquired);
-            using (first.Guard)
+            var sourceDirectory = AppContext.BaseDirectory;
+            foreach (var source in Directory.EnumerateFiles(sourceDirectory))
             {
-                var second = TryAcquireFromCopy(secondContext, secondCopy, owner);
-                second.Guard?.Dispose();
-                Assert.False(second.Acquired);
-                Assert.Null(second.Guard);
+                File.Copy(source, Path.Combine(root, Path.GetFileName(source)));
             }
+
+            var owner = $"owner-{Guid.NewGuid():N}";
+            Assert.True(SingleInstanceGuard.TryAcquire(owner, "repo", out var first));
+            using (first)
+            {
+                await AssertProbeResultAsync(root, owner, expectedAcquired: false);
+            }
+
+            await AssertProbeResultAsync(root, owner, expectedAcquired: true);
         }
         finally
         {
-            firstContext.Unload();
-            secondContext.Unload();
             Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact(Explicit = true)]
+    public void ProbeApplicationIdentityInSeparateProcess()
+    {
+        var owner = Environment.GetEnvironmentVariable("DOWNKYI_SINGLE_INSTANCE_PROBE_OWNER");
+        var expected = Environment.GetEnvironmentVariable("DOWNKYI_SINGLE_INSTANCE_PROBE_EXPECTED");
+        Assert.False(string.IsNullOrWhiteSpace(owner));
+        Assert.True(expected is "true" or "false");
+
+        var acquired = SingleInstanceGuard.TryAcquire(owner, "repo", out var guard);
+        using (guard)
+        {
+            Assert.Equal(expected == "true", acquired);
         }
     }
 
@@ -82,17 +86,48 @@ public sealed class SingleInstanceGuardTests
         second?.Dispose();
     }
 
-    private static (bool Acquired, IDisposable? Guard) TryAcquireFromCopy(
-        AssemblyLoadContext context,
-        string assemblyPath,
-        string owner)
+    private static async Task AssertProbeResultAsync(string directory, string owner, bool expectedAcquired)
     {
-        using var assemblyStream = File.OpenRead(assemblyPath);
-        var assembly = context.LoadFromStream(assemblyStream);
-        var guardType = assembly.GetType("DownKyi.Platform.SingleInstanceGuard", throwOnError: true)!;
-        var tryAcquire = guardType.GetMethod("TryAcquire", BindingFlags.Public | BindingFlags.Static)!;
-        object?[] arguments = [owner, "repo", null];
-        var acquired = (bool)tryAcquire.Invoke(null, arguments)!;
-        return (acquired, (IDisposable?)arguments[2]);
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = directory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        };
+        startInfo.ArgumentList.Add(Path.Combine(
+            directory, Path.GetFileName(typeof(SingleInstanceGuardTests).Assembly.Location)));
+        startInfo.ArgumentList.Add("-explicit");
+        startInfo.ArgumentList.Add("only");
+        startInfo.ArgumentList.Add("-method");
+        startInfo.ArgumentList.Add(
+            $"{typeof(SingleInstanceGuardTests).FullName}.{nameof(ProbeApplicationIdentityInSeparateProcess)}");
+        startInfo.Environment["DOWNKYI_SINGLE_INSTANCE_PROBE_OWNER"] = owner;
+        startInfo.Environment["DOWNKYI_SINGLE_INSTANCE_PROBE_EXPECTED"] =
+            expectedAcquired ? "true" : "false";
+
+        using var process = Process.Start(startInfo)!;
+        var output = process.StandardOutput.ReadToEndAsync();
+        var error = process.StandardError.ReadToEndAsync();
+        try
+        {
+            await process.WaitForExitAsync(TestContext.Current.CancellationToken)
+                .WaitAsync(TimeSpan.FromSeconds(20), TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+        }
+        catch
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+                await process.WaitForExitAsync().WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(true);
+            }
+
+            throw;
+        }
+
+        Assert.True(process.ExitCode == 0,
+            $"Second installation probe exited {process.ExitCode}. " +
+            $"{await output.ConfigureAwait(true)} {await error.ConfigureAwait(true)}");
     }
 }

--- a/tests/DownKyi.Tests/SingleInstanceGuardTests.cs
+++ b/tests/DownKyi.Tests/SingleInstanceGuardTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Runtime.Loader;
 using DownKyi.Platform;
 
 namespace DownKyi.Tests;
@@ -5,36 +7,92 @@ namespace DownKyi.Tests;
 public sealed class SingleInstanceGuardTests
 {
     [Fact]
-    public void MutexNameIsStablePerInstallWithoutLeakingThePath()
+    public void MutexNameUsesStableApplicationIdentityWithoutAnInstallPath()
     {
-        var firstPath = Path.Combine(Path.GetTempPath(), "DownKyi", "first-install");
-        var secondPath = Path.Combine(Path.GetTempPath(), "DownKyi", "second-install");
+        var first = SingleInstanceGuard.BuildMutexName("owner", "repo");
+        var repeated = SingleInstanceGuard.BuildMutexName("owner", "repo");
 
-        var first = SingleInstanceGuard.BuildMutexName("owner", "repo", firstPath);
-        var repeated = SingleInstanceGuard.BuildMutexName("owner", "repo", firstPath);
-        var second = SingleInstanceGuard.BuildMutexName("owner", "repo", secondPath);
-
+        Assert.Equal("DownKyi-owner-repo", first);
         Assert.Equal(first, repeated);
-        Assert.NotEqual(first, second);
-        Assert.DoesNotContain("first-install", first, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("DownKyi-owner-repo-", first, StringComparison.Ordinal);
+        Assert.DoesNotContain(Path.GetTempPath(), first, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
-    public void OnlyOneGuardCanOwnTheSameInstallIdentity()
+    public void OnlyOneGuardCanOwnTheSameApplicationIdentity()
     {
-        var installPath = Path.Combine(Path.GetTempPath(), $"downkyi-guard-{Guid.NewGuid():N}");
+        var owner = $"owner-{Guid.NewGuid():N}";
 
-        Assert.True(SingleInstanceGuard.TryAcquire("owner", "repo", installPath, out var first));
+        Assert.True(SingleInstanceGuard.TryAcquire(owner, "repo", out var first));
         using (first)
         {
-            var secondAcquired = SingleInstanceGuard.TryAcquire("owner", "repo", installPath, out var second);
+            var secondAcquired = SingleInstanceGuard.TryAcquire(owner, "repo", out var second);
             second?.Dispose();
             Assert.False(secondAcquired);
             Assert.Null(second);
         }
+    }
 
-        Assert.True(SingleInstanceGuard.TryAcquire("owner", "repo", installPath, out var reacquired));
-        reacquired?.Dispose();
+    [Fact]
+    public void DifferentInstallCopiesCannotOwnTheApplicationIdentityTogether()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"downkyi-guard-{Guid.NewGuid():N}");
+        var firstDirectory = Path.Combine(root, "first-install");
+        var secondDirectory = Path.Combine(root, "second-install");
+        Directory.CreateDirectory(firstDirectory);
+        Directory.CreateDirectory(secondDirectory);
+
+        var assemblyName = Path.GetFileName(typeof(SingleInstanceGuard).Assembly.Location);
+        var firstCopy = Path.Combine(firstDirectory, assemblyName);
+        var secondCopy = Path.Combine(secondDirectory, assemblyName);
+        File.Copy(typeof(SingleInstanceGuard).Assembly.Location, firstCopy);
+        File.Copy(typeof(SingleInstanceGuard).Assembly.Location, secondCopy);
+
+        var firstContext = new AssemblyLoadContext($"first-{Guid.NewGuid():N}", isCollectible: true);
+        var secondContext = new AssemblyLoadContext($"second-{Guid.NewGuid():N}", isCollectible: true);
+        try
+        {
+            var owner = $"owner-{Guid.NewGuid():N}";
+            var first = TryAcquireFromCopy(firstContext, firstCopy, owner);
+            Assert.True(first.Acquired);
+            using (first.Guard)
+            {
+                var second = TryAcquireFromCopy(secondContext, secondCopy, owner);
+                second.Guard?.Dispose();
+                Assert.False(second.Acquired);
+                Assert.Null(second.Guard);
+            }
+        }
+        finally
+        {
+            firstContext.Unload();
+            secondContext.Unload();
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReleasedApplicationIdentityCanBeAcquiredAgain()
+    {
+        var owner = $"owner-{Guid.NewGuid():N}";
+
+        Assert.True(SingleInstanceGuard.TryAcquire(owner, "repo", out var first));
+        first?.Dispose();
+
+        Assert.True(SingleInstanceGuard.TryAcquire(owner, "repo", out var second));
+        second?.Dispose();
+    }
+
+    private static (bool Acquired, IDisposable? Guard) TryAcquireFromCopy(
+        AssemblyLoadContext context,
+        string assemblyPath,
+        string owner)
+    {
+        using var assemblyStream = File.OpenRead(assemblyPath);
+        var assembly = context.LoadFromStream(assemblyStream);
+        var guardType = assembly.GetType("DownKyi.Platform.SingleInstanceGuard", throwOnError: true)!;
+        var tryAcquire = guardType.GetMethod("TryAcquire", BindingFlags.Public | BindingFlags.Static)!;
+        object?[] arguments = [owner, "repo", null];
+        var acquired = (bool)tryAcquire.Invoke(null, arguments)!;
+        return (acquired, (IDisposable?)arguments[2]);
     }
 }


### PR DESCRIPTION
Two production copies installed in different directories previously used different named mutexes because the identity included an install-directory hash. Both could start and reach output admission. This PR gives every production DownKyi copy the same application identity, so a second copy exits in `App.Initialize()` before XAML, Host, SQLite, or download runtime initialization.

The guard uses `DownKyi-{owner}-{repository}` with a named mutex shared across users and sessions. Its handle stays rooted until the process exits: an abnormal Host shutdown can time out while services are still active, so disposing the App must not reopen admission. An access-denied response to an existing global mutex fails closed before Host creation. The existing `#if !DEBUG` policy, download allocator, collision retry, and SQLite `output_reservation_key` UNIQUE invariant remain unchanged. This addresses **F only** in #177; the issue remains open for other work.

Verification on exact head `d102e423d640ed1dd04a3ddae5c15abac9ee5858` (base `96a00770e423c0fc2de4a7c069c1dd22403a8777`):

- Strict Release solution build: 0 warnings, 0 errors. Windows CentralTestRunner full solution passed 8 selected projects; the final test-only marker change also passed its focused class through CentralTestRunner.
- The different-install regression launches a separate test process from a copied output directory and observes `ACQUIRED → DENIED → ACQUIRED after release`. A unique marker proves the selected child test actually ran, even if xUnit would otherwise return exit code 0 for zero selected tests.
- Exact-head PR checks: 17 successful, 11 expected skipped, 0 failures. Windows, Ubuntu, and macOS build-and-test, CodeQL, format, and both macOS ad-hoc package-and-launch jobs succeeded.
- Local release-version, module-boundary, actionlint, NuGet vulnerable/deprecated, secret-scan, and diff checks passed. Independent same-head read-only review found no new actionable finding.

Limits: different OS users and sessions have not been tested with native dual-account launches. Older DownKyi binaries still use their former mutex identity, so they cannot participate in this new admission contract. No merge, tag, or release is part of this PR.
