### PR TITLE
perf(download): bound reservation reads and reconcile persisted keys (#177)

### DIFF
--- a/benchmarks/DownKyi.SystemBenchmarks/SqliteProgressScenario.cs
+++ b/benchmarks/DownKyi.SystemBenchmarks/SqliteProgressScenario.cs
@@ -207,6 +207,11 @@ internal static class SqliteProgressScenario
             CancellationToken cancellationToken) =>
             _inner.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            _inner.GetActiveOutputReservationKeysAsync(ignoreCase, cancellationToken);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.OutputReservations.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.OutputReservations.cs
@@ -1,0 +1,22 @@
+namespace DownKyi.Application.Downloads;
+
+public sealed partial class DownloadTaskApplicationService
+{
+    public Task<bool> IsOutputPathReservedAsync(
+        string basePath,
+        bool ignoreCase,
+        CancellationToken cancellationToken)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+        bool ignoreCase,
+        CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _store.GetActiveOutputReservationKeysAsync(ignoreCase, cancellationToken);
+    }
+}

--- a/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/DownloadTaskApplicationService.cs
@@ -74,16 +74,6 @@ public sealed partial class DownloadTaskApplicationService : IDownloadTaskApplic
         return _store.GetUnfinishedAsync(cancellationToken);
     }
 
-    public Task<bool> IsOutputPathReservedAsync(
-        string basePath,
-        bool ignoreCase,
-        CancellationToken cancellationToken)
-    {
-        ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
-        ObjectDisposedException.ThrowIf(_disposed, this);
-        return _store.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
-    }
-
     public Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);

--- a/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskApplicationService.cs
@@ -25,6 +25,10 @@ public interface IDownloadTaskApplicationService
         bool ignoreCase,
         CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+        bool ignoreCase,
+        CancellationToken cancellationToken);
+
     Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken);
 
     Task<OperationResult> ConfirmLegacyRemoteTasksStoppedAsync(

--- a/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
+++ b/src/DownKyi.Application/Downloads/IDownloadTaskStore.cs
@@ -27,6 +27,10 @@ public interface IDownloadTaskStore
         bool ignoreCase,
         CancellationToken cancellationToken);
 
+    Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+        bool ignoreCase,
+        CancellationToken cancellationToken);
+
     Task<bool> IsLegacyUpgradeAdmissionBlockedAsync(CancellationToken cancellationToken) =>
         Task.FromResult(false);
 

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
@@ -13,23 +13,23 @@ internal static class DownloadOutputPathResolver
     public static async Task<string> ResolveAdmissionCollisionAsync(
         string basePath,
         bool autoAddNumberSuffix,
-        Func<string, CancellationToken, Task<bool>> isReservedAsync,
+        Func<CancellationToken, Task<IReadOnlyList<string>>> getReservationKeysAsync,
         CancellationToken cancellationToken,
         StringComparer? comparer = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
-        ArgumentNullException.ThrowIfNull(isReservedAsync);
+        ArgumentNullException.ThrowIfNull(getReservationKeysAsync);
         comparer ??= PlatformComparer;
         var occupiedPaths = GetExistingBasePaths(basePath)
             .Select(CreateComparisonKey)
             .ToHashSet(comparer);
+        occupiedPaths.UnionWith(await getReservationKeysAsync(cancellationToken).ConfigureAwait(false));
         for (var suffix = 0; ; suffix++)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var candidate = suffix == 0 ? basePath : $"{basePath}({suffix})";
             var comparisonKey = CreateComparisonKey(candidate);
-            if (!occupiedPaths.Contains(comparisonKey) &&
-                !await isReservedAsync(candidate, cancellationToken).ConfigureAwait(false))
+            if (!occupiedPaths.Contains(comparisonKey))
             {
                 return candidate;
             }

--- a/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadOutputPathResolver.cs
@@ -13,16 +13,33 @@ internal static class DownloadOutputPathResolver
     public static async Task<string> ResolveAdmissionCollisionAsync(
         string basePath,
         bool autoAddNumberSuffix,
+        Func<string, CancellationToken, Task<bool>> isReservedAsync,
         Func<CancellationToken, Task<IReadOnlyList<string>>> getReservationKeysAsync,
         CancellationToken cancellationToken,
         StringComparer? comparer = null)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
+        ArgumentNullException.ThrowIfNull(isReservedAsync);
         ArgumentNullException.ThrowIfNull(getReservationKeysAsync);
+        cancellationToken.ThrowIfCancellationRequested();
         comparer ??= PlatformComparer;
         var occupiedPaths = GetExistingBasePaths(basePath)
             .Select(CreateComparisonKey)
             .ToHashSet(comparer);
+        var baseKey = CreateComparisonKey(basePath);
+        if (!occupiedPaths.Contains(baseKey) &&
+            !await isReservedAsync(basePath, cancellationToken).ConfigureAwait(false))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return basePath;
+        }
+
+        if (!autoAddNumberSuffix)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            throw new IOException("The selected output path is already in use.");
+        }
+
         occupiedPaths.UnionWith(await getReservationKeysAsync(cancellationToken).ConfigureAwait(false));
         for (var suffix = 0; ; suffix++)
         {

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
@@ -55,6 +55,10 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
             var admittedBasePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
                 physicalBasePath,
                 autoAddNumberSuffix,
+                (path, token) => _tasks.IsOutputPathReservedAsync(
+                    path,
+                    DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                    token),
                 token => _tasks.GetActiveOutputReservationKeysAsync(
                     DownloadOutputPathKey.UsesCaseInsensitiveComparison,
                     token),

--- a/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
+++ b/src/DownKyi.Desktop/Services/Download/DownloadTaskAdmissionService.cs
@@ -55,8 +55,7 @@ internal sealed class DownloadTaskAdmissionService : IDisposable
             var admittedBasePath = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
                 physicalBasePath,
                 autoAddNumberSuffix,
-                (candidate, token) => _tasks.IsOutputPathReservedAsync(
-                    candidate,
+                token => _tasks.GetActiveOutputReservationKeysAsync(
                     DownloadOutputPathKey.UsesCaseInsensitiveComparison,
                     token),
                 cancellationToken).ConfigureAwait(true);

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreReservationKeyCompatibility.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreReservationKeyCompatibility.cs
@@ -1,0 +1,187 @@
+using DownKyi.Application.Downloads;
+using DownKyi.Application.Time;
+using Microsoft.Data.Sqlite;
+
+namespace DownKyi.Infrastructure.Downloads;
+
+// A store-open invariant, not a schema-version migration: the same schema can
+// contain keys written under a different platform's comparison policy.
+internal static class DownloadStoreReservationKeyCompatibility
+{
+    private const string BlockedMessage =
+        "Download reservation keys cannot be reconciled; downloads are blocked to protect existing tasks.";
+
+    public static async Task EnsureAsync(
+        SqliteConnection connection,
+        string databasePath,
+        IClock clock,
+        CancellationToken cancellationToken)
+    {
+        // IMMEDIATE excludes other writers through read, backup and commit. A
+        // separate backup connection sees the committed pre-update WAL snapshot.
+        using var transaction = SqliteDownloadStoreDatabase.BeginImmediateTransaction(connection);
+        try
+        {
+            var rows = await ReadRowsAsync(connection, transaction, cancellationToken)
+                .ConfigureAwait(false);
+            var occupied = new Dictionary<string, string>(StringComparer.Ordinal);
+            var targets = new Dictionary<string, string>(StringComparer.Ordinal);
+            var activeIds = new HashSet<string>(StringComparer.Ordinal);
+            var changes = new List<(string Id, string Target)>();
+            foreach (var row in rows)
+            {
+                if (row.StoredKey is not null)
+                {
+                    occupied.Add(row.StoredKey, row.Id);
+                }
+
+                if (!row.IsActive)
+                {
+                    continue;
+                }
+
+                activeIds.Add(row.Id);
+                var target = CreateCurrentKey(row.Path);
+                if (!targets.TryAdd(target, row.Id))
+                {
+                    throw new InvalidOperationException(BlockedMessage);
+                }
+
+                if (!StringComparer.Ordinal.Equals(row.StoredKey, target))
+                {
+                    changes.Add((row.Id, target));
+                }
+            }
+
+            // The UNIQUE index covers quarantine and any completed row retaining
+            // a non-NULL key, even when snapshots exclude those rows.
+            foreach (var (target, id) in targets)
+            {
+                if (occupied.TryGetValue(target, out var holder)
+                    && !StringComparer.Ordinal.Equals(holder, id)
+                    && !activeIds.Contains(holder))
+                {
+                    throw new InvalidOperationException(BlockedMessage);
+                }
+            }
+
+            if (changes.Count > 0)
+            {
+                var backupConnectionString = new SqliteConnectionStringBuilder
+                {
+                    DataSource = databasePath,
+                    Mode = SqliteOpenMode.ReadOnly,
+                    Pooling = false
+                }.ToString();
+                using (var backupSource = new SqliteConnection(backupConnectionString))
+                {
+                    await backupSource.OpenAsync(cancellationToken).ConfigureAwait(false);
+                    await DownloadStoreSchemaLifecycle.BackupReservationKeysAsync(
+                        backupSource, databasePath, clock, cancellationToken).ConfigureAwait(false);
+                }
+
+                // These intermediate NULLs are private to this transaction. The
+                // retained UNIQUE index guards the final state; legal writers
+                // cannot acquire a write transaction until after this commit.
+                foreach (var (id, _) in changes)
+                {
+                    await SetKeyAsync(connection, transaction, id, null, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                foreach (var (id, target) in changes)
+                {
+                    await SetKeyAsync(connection, transaction, id, target, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+
+            await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            await transaction.RollbackAsync(CancellationToken.None).ConfigureAwait(false);
+            throw;
+        }
+    }
+
+    private static async Task<IReadOnlyList<ReservationRow>> ReadRowsAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            SELECT db.id, db.file_path, db.output_reservation_key,
+                   CASE WHEN dl.id IS NOT NULL AND q.record_id IS NULL THEN 1 ELSE 0 END
+            FROM download_base db
+            LEFT JOIN downloading dl ON dl.id = db.id
+            LEFT JOIN download_quarantine q
+                   ON q.source_table = 'downloading' AND q.record_id = db.id
+            WHERE db.output_reservation_key IS NOT NULL
+               OR (dl.id IS NOT NULL AND q.record_id IS NULL)
+            ORDER BY db.id
+            """;
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var rows = new List<ReservationRow>();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            rows.Add(new ReservationRow(
+                reader.GetString(0),
+                reader.GetString(1),
+                await reader.IsDBNullAsync(2, cancellationToken).ConfigureAwait(false)
+                    ? null : reader.GetString(2),
+                reader.GetInt32(3) != 0));
+        }
+
+        return rows;
+    }
+
+    internal static string CreateCurrentKey(string path)
+    {
+        // GetFullPath would reinterpret a foreign absolute path as a local
+        // relative/root-relative path. Such data needs explicit user repair.
+        if ((OperatingSystem.IsWindows()
+                && path.StartsWith('/') && !Path.IsPathFullyQualified(path))
+            || (!OperatingSystem.IsWindows()
+                && (path.StartsWith("//", StringComparison.Ordinal)
+                    || path.StartsWith('\\')
+                    || (path.Length >= 2 && char.IsLetter(path[0]) && path[1] == ':'))))
+        {
+            throw new InvalidOperationException(BlockedMessage);
+        }
+
+        try
+        {
+            return DownloadOutputPathKey.Create(
+                path, DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+        }
+        catch (Exception exception) when (exception is ArgumentException or IOException or NotSupportedException)
+        {
+            throw new InvalidOperationException(BlockedMessage);
+        }
+    }
+
+    private static async Task SetKeyAsync(
+        SqliteConnection connection,
+        SqliteTransaction transaction,
+        string id,
+        string? key,
+        CancellationToken cancellationToken)
+    {
+        using var command = connection.CreateCommand();
+        command.Transaction = transaction;
+        command.CommandText = """
+            UPDATE download_base SET output_reservation_key = @key WHERE id = @id
+            """;
+        command.Parameters.AddWithValue("@key", key ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@id", id);
+        if (await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false) != 1)
+        {
+            throw new InvalidOperationException(BlockedMessage);
+        }
+    }
+
+    private sealed record ReservationRow(string Id, string Path, string? StoredKey, bool IsActive);
+}

--- a/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadStoreSchemaLifecycle.cs
@@ -73,4 +73,42 @@ internal static class DownloadStoreSchemaLifecycle
         await backup.OpenAsync(cancellationToken).ConfigureAwait(false);
         source.BackupDatabase(backup);
     }
+
+    public static async Task BackupReservationKeysAsync(
+        SqliteConnection source,
+        string databasePath,
+        IClock clock,
+        CancellationToken cancellationToken)
+    {
+        var backupDirectory = Path.Combine(Path.GetDirectoryName(databasePath) ?? ".", "Backup");
+        Directory.CreateDirectory(backupDirectory);
+        var timestamp = clock.UtcNow.ToString("yyyyMMdd'T'HHmmssfff'Z'", CultureInfo.InvariantCulture);
+        var backupPath = Path.Combine(
+            backupDirectory,
+            $"{Path.GetFileName(databasePath)}.reservation-keys-{timestamp}-{Guid.NewGuid():N}.bak");
+        var connectionString = new SqliteConnectionStringBuilder
+        {
+            DataSource = backupPath,
+            Mode = SqliteOpenMode.ReadWriteCreate,
+            Pooling = false
+        }.ToString();
+
+        try
+        {
+            using var backup = new SqliteConnection(connectionString);
+            await backup.OpenAsync(cancellationToken).ConfigureAwait(false);
+            cancellationToken.ThrowIfCancellationRequested();
+            source.BackupDatabase(backup);
+            cancellationToken.ThrowIfCancellationRequested();
+        }
+        catch
+        {
+            if (File.Exists(backupPath))
+            {
+                File.Delete(backupPath);
+            }
+
+            throw;
+        }
+    }
 }

--- a/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlWriter.cs
+++ b/src/DownKyi.Infrastructure/Downloads/DownloadTaskSqlWriter.cs
@@ -1,4 +1,3 @@
-using DownKyi.Application.Downloads;
 using DownKyi.Domain.Downloads;
 using Microsoft.Data.Sqlite;
 
@@ -49,11 +48,7 @@ internal static class DownloadTaskSqlWriter
                 zone_id = @zone_id, [order] = @order, main_title = @main_title, name = @name,
                 duration = @duration, video_codec_name = @video_codec_name, resolution = @resolution,
                 audio_codec = @audio_codec, file_path = @file_path,
-                output_reservation_key = CASE
-                    WHEN @output_reservation_key IS NULL THEN NULL
-                    WHEN output_reservation_key IS NULL THEN NULL
-                    ELSE @output_reservation_key
-                END,
+                output_reservation_key = @output_reservation_key,
                  file_size = @file_size, published_artifacts = @published_artifacts,
                  staging_token = @staging_token,
                  publishing_key = @publishing_key, publishing_file_name = @publishing_file_name,
@@ -136,9 +131,7 @@ internal static class DownloadTaskSqlWriter
             "@output_reservation_key",
             task.Phase is DownloadPhase.Completed or DownloadPhase.Deleted
                 ? DBNull.Value
-                : DownloadOutputPathKey.Create(
-                    task.Output.BasePath,
-                    DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+                : DownloadStoreReservationKeyCompatibility.CreateCurrentKey(task.Output.BasePath));
         command.Parameters.AddWithValue("@file_size", task.Output.FileSizeText ?? (object)DBNull.Value);
         command.Parameters.AddWithValue(
             "@published_artifacts",

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreDatabase.cs
@@ -132,6 +132,11 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
                 _clock,
                 _physicalOutputPathResolver,
                 cancellationToken).ConfigureAwait(false);
+            await DownloadStoreReservationKeyCompatibility.EnsureAsync(
+                connection,
+                _options.DatabasePath,
+                _clock,
+                cancellationToken).ConfigureAwait(false);
             await RemoveOrphanedDownloadingRecordsAsync(connection, cancellationToken).ConfigureAwait(false);
             _initialized = true;
         }
@@ -196,6 +201,6 @@ internal sealed class SqliteDownloadStoreDatabase : IDisposable
         }
     }
 
-    private static SqliteTransaction BeginImmediateTransaction(SqliteConnection connection) =>
+    internal static SqliteTransaction BeginImmediateTransaction(SqliteConnection connection) =>
         connection.BeginTransaction(deferred: false);
 }

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
@@ -62,12 +62,63 @@ internal sealed class SqliteDownloadStoreOutputReservations(SqliteDownloadStoreD
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
         using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
-        return await IsOutputPathReservedCoreAsync(
-            connection,
-            transaction: null,
-            basePath,
-            ignoreCase,
-            cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        if (ignoreCase)
+        {
+            command.CommandText = """
+                SELECT 1, NULL
+                FROM download_base db
+                INNER JOIN downloading dl ON dl.id = db.id
+                WHERE (db.output_reservation_key = @key
+                       OR db.file_path = @file_path COLLATE NOCASE)
+                  AND NOT EXISTS (
+                      SELECT 1 FROM download_quarantine q
+                      WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+                UNION ALL
+                SELECT 0, db.file_path
+                FROM download_base db
+                INNER JOIN downloading dl ON dl.id = db.id
+                WHERE db.output_reservation_key IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM download_quarantine q
+                      WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+                """;
+        }
+        else
+        {
+            command.CommandText = """
+                SELECT 1, NULL
+                FROM download_base db
+                INNER JOIN downloading dl ON dl.id = db.id
+                WHERE (db.output_reservation_key = @key OR db.file_path = @file_path)
+                  AND NOT EXISTS (
+                      SELECT 1 FROM download_quarantine q
+                      WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+                UNION ALL
+                SELECT 0, db.file_path
+                FROM download_base db
+                INNER JOIN downloading dl ON dl.id = db.id
+                WHERE db.output_reservation_key IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM download_quarantine q
+                      WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+                """;
+        }
+        var key = DownloadOutputPathKey.Create(basePath, ignoreCase);
+        command.Parameters.AddWithValue("@key", key);
+        command.Parameters.AddWithValue("@file_path", basePath);
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (reader.GetInt32(0) == 1 ||
+                StringComparer.Ordinal.Equals(
+                    DownloadOutputPathKey.Create(reader.GetString(1), ignoreCase), key))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public async Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
@@ -70,6 +70,36 @@ internal sealed class SqliteDownloadStoreOutputReservations(SqliteDownloadStoreD
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+        bool ignoreCase,
+        CancellationToken cancellationToken)
+    {
+        using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT db.output_reservation_key, db.file_path
+            FROM download_base db
+            INNER JOIN downloading dl ON dl.id = db.id
+            WHERE NOT EXISTS (
+                SELECT 1 FROM download_quarantine q
+                WHERE q.source_table = 'downloading' AND q.record_id = db.id)
+            """;
+        using var reader = await command.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        var keys = new HashSet<string>(StringComparer.Ordinal);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (!await reader.IsDBNullAsync(0, cancellationToken).ConfigureAwait(false))
+            {
+                keys.Add(reader.GetString(0));
+            }
+
+            // The file path also covers legacy rows with a null reservation key.
+            keys.Add(DownloadOutputPathKey.Create(reader.GetString(1), ignoreCase));
+        }
+
+        return [.. keys];
+    }
+
     private static async Task<bool> IsOutputPathReservedCoreAsync(
         SqliteConnection connection,
         SqliteTransaction? transaction,

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadStoreOutputReservations.cs
@@ -61,6 +61,16 @@ internal sealed class SqliteDownloadStoreOutputReservations(SqliteDownloadStoreD
         CancellationToken cancellationToken)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(basePath);
+        if (ignoreCase != DownloadOutputPathKey.UsesCaseInsensitiveComparison)
+        {
+            // Persisted keys only index the policy of this store's platform.
+            // An explicit alternate-policy query must derive identities from paths.
+            var requestedKey = DownloadOutputPathKey.Create(basePath, ignoreCase);
+            var keys = await GetActiveOutputReservationKeysAsync(ignoreCase, cancellationToken)
+                .ConfigureAwait(false);
+            return keys.Contains(requestedKey, StringComparer.Ordinal);
+        }
+
         using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         using var command = connection.CreateCommand();
         if (ignoreCase)
@@ -128,7 +138,7 @@ internal sealed class SqliteDownloadStoreOutputReservations(SqliteDownloadStoreD
         using var connection = await _database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
         using var command = connection.CreateCommand();
         command.CommandText = """
-            SELECT db.output_reservation_key, db.file_path
+            SELECT db.file_path
             FROM download_base db
             INNER JOIN downloading dl ON dl.id = db.id
             WHERE NOT EXISTS (
@@ -139,13 +149,7 @@ internal sealed class SqliteDownloadStoreOutputReservations(SqliteDownloadStoreD
         var keys = new HashSet<string>(StringComparer.Ordinal);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            if (!await reader.IsDBNullAsync(0, cancellationToken).ConfigureAwait(false))
-            {
-                keys.Add(reader.GetString(0));
-            }
-
-            // The file path also covers legacy rows with a null reservation key.
-            keys.Add(DownloadOutputPathKey.Create(reader.GetString(1), ignoreCase));
+            keys.Add(DownloadOutputPathKey.Create(reader.GetString(0), ignoreCase));
         }
 
         return [.. keys];

--- a/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
+++ b/src/DownKyi.Infrastructure/Downloads/SqliteDownloadTaskStore.cs
@@ -100,6 +100,13 @@ public sealed class SqliteDownloadTaskStore : IDownloadTaskStore, IDisposable
             .IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken)
             .ConfigureAwait(false);
 
+    public async Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+        bool ignoreCase,
+        CancellationToken cancellationToken) =>
+        await _outputReservations
+            .GetActiveOutputReservationKeysAsync(ignoreCase, cancellationToken)
+            .ConfigureAwait(false);
+
     public async Task<DownloadHistoryPage> GetHistoryPageAsync(
         DownloadHistoryCursor? cursor,
         int pageSize,

--- a/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
+++ b/tests/DownKyi.Application.Tests/DownloadTaskApplicationServiceTests.cs
@@ -438,6 +438,11 @@ public sealed class DownloadTaskApplicationServiceTests
             return Task.FromResult(OperationResult.Success());
         }
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>(Current == null ? [] : [DownloadOutputPathKey.Create(Current.Output.BasePath, ignoreCase)]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
+++ b/tests/DownKyi.Architecture.Tests/SqliteDownloadTaskStoreArchitectureTests.cs
@@ -58,6 +58,9 @@ public sealed class SqliteDownloadTaskStoreArchitectureTests
         ["IsOutputPathReservedAsync"] =
             "await _outputReservations.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken)" +
             ".ConfigureAwait(false)",
+        ["GetActiveOutputReservationKeysAsync"] =
+            "await _outputReservations.GetActiveOutputReservationKeysAsync(ignoreCase, cancellationToken)" +
+            ".ConfigureAwait(false)",
         ["GetHistoryPageAsync"] =
             "await _queries.GetHistoryPageAsync(cursor, pageSize, cancellationToken).ConfigureAwait(false)",
         ["DeleteAsync"] = "await _commands.DeleteAsync(taskId, cancellationToken).ConfigureAwait(false)",

--- a/tests/DownKyi.Infrastructure.Tests/DownloadProgressWriteBehindTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/DownloadProgressWriteBehindTests.cs
@@ -178,6 +178,11 @@ public sealed class DownloadProgressWriteBehindTests
             bool ignoreCase,
             CancellationToken cancellationToken) => throw new NotSupportedException();
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            throw new NotSupportedException();
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -899,6 +899,477 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
     }
 
     [Fact]
+    public async Task ReopenedForeignPolicyReservationAgreesAcrossPointSnapshotAndAdd()
+    {
+        var ignoreCase = DownloadOutputPathKey.UsesCaseInsensitiveComparison;
+        var original = Path.Combine(_directory, "cafe\u0301-foreign");
+        var equivalent = Path.Combine(
+            _directory,
+            ignoreCase ? "CAF\u00c9-FOREIGN" : "caf\u00e9-foreign");
+        using (var first = CreateStore())
+        {
+            Assert.True((await first.AddAsync(
+                CreateQueuedTask("foreign-policy-original", original),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+
+        using (var connection = await OpenConnectionAsync(readOnly: false))
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                UPDATE download_base SET output_reservation_key = @foreign_key
+                WHERE id = 'foreign-policy-original'
+                """;
+            command.Parameters.AddWithValue(
+                "@foreign_key",
+                DownloadOutputPathKey.Create(original, !ignoreCase));
+            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        using var reopened = CreateStore();
+        await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+        var key = DownloadOutputPathKey.Create(equivalent, ignoreCase);
+        Assert.Contains(key, await reopened.GetActiveOutputReservationKeysAsync(
+            ignoreCase, TestContext.Current.CancellationToken));
+        Assert.True(await reopened.IsOutputPathReservedAsync(
+            equivalent, ignoreCase, TestContext.Current.CancellationToken));
+        Assert.False((await reopened.AddAsync(
+            CreateQueuedTask("foreign-policy-second", equivalent),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        var alternatePolicy = !ignoreCase;
+        var alternateEquivalent = Path.Combine(_directory,
+            ignoreCase ? "caf\u00e9-foreign" : "CAF\u00c9-FOREIGN");
+        var alternateKey = DownloadOutputPathKey.Create(alternateEquivalent, alternatePolicy);
+        Assert.Contains(alternateKey, await reopened.GetActiveOutputReservationKeysAsync(
+            alternatePolicy, TestContext.Current.CancellationToken));
+        Assert.True(await reopened.IsOutputPathReservedAsync(alternateEquivalent,
+            alternatePolicy, TestContext.Current.CancellationToken));
+        if (ignoreCase)
+        {
+            var distinctUnderAlternatePolicy = Path.Combine(_directory, "CAF\u00c9-FOREIGN");
+            Assert.False(await reopened.IsOutputPathReservedAsync(distinctUnderAlternatePolicy,
+                alternatePolicy, TestContext.Current.CancellationToken));
+        }
+        Assert.Equal(DownloadOutputPathKey.Create(original, ignoreCase),
+            await ReadReservationKeyAsync("foreign-policy-original"));
+        var backupPath = Assert.Single(Directory.GetFiles(Path.Combine(_directory, "Backup"),
+            "download.db.reservation-keys-*.bak"));
+        using var backup = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = backupPath,
+            Mode = SqliteOpenMode.ReadOnly,
+            Pooling = false
+        }.ToString());
+        await backup.OpenAsync(TestContext.Current.CancellationToken);
+        using var backupKey = backup.CreateCommand();
+        backupKey.CommandText = """
+            SELECT output_reservation_key FROM download_base
+            WHERE id = 'foreign-policy-original'
+            """;
+        Assert.Equal(DownloadOutputPathKey.Create(original, !ignoreCase),
+            await backupKey.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ReservationRekeyRepairsLegacyNullAndIsIdempotentAcrossReopenAndPolicyChanges()
+    {
+        var ignoreCase = DownloadOutputPathKey.UsesCaseInsensitiveComparison;
+        var original = Path.Combine(_directory, "foreign-cafe\u0301");
+        var legacy = Path.Combine(_directory, "legacy");
+        using (var first = CreateStore())
+        {
+            var pending = CreatePausedTask("rekey-original", original);
+            pending = pending.UpdateOutput(new DownloadOutput(original, "1 GB",
+                new Dictionary<string, string> { ["cover"] = "cover.jpg" },
+                pending.Output.StagingToken,
+                new DownloadPublishingArtifact("media", "video.mp4", 3,
+                    new string('A', 64))), _clock.UtcNow.AddSeconds(6)).RequireValue();
+            Assert.True((await first.AddAsync(pending,
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await first.AddAsync(CreatePausedTask("rekey-legacy", legacy),
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await first.AddAsync(CreateCompletedTask("rekey-history", 123),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+
+        var originalBefore = await ReadStoredStateAsync("rekey-original");
+        var legacyBefore = await ReadStoredStateAsync("rekey-legacy");
+        var historyBefore = await ReadStoredStateAsync("rekey-history");
+        var publicationBefore = await ReadPublicationPayloadAsync("rekey-original");
+        await SetReservationKeyAsync("rekey-original",
+            DownloadOutputPathKey.Create(original, !ignoreCase));
+        await SetReservationKeyAsync("rekey-legacy", null);
+        using (var reopened = CreateStore())
+        {
+            await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+        }
+
+        Assert.Equal(DownloadOutputPathKey.Create(original, ignoreCase),
+            await ReadReservationKeyAsync("rekey-original"));
+        Assert.Equal(DownloadOutputPathKey.Create(legacy, ignoreCase),
+            await ReadReservationKeyAsync("rekey-legacy"));
+        Assert.Null(await ReadReservationKeyAsync("rekey-history"));
+        Assert.Equal(originalBefore, await ReadStoredStateAsync("rekey-original"));
+        Assert.Equal(legacyBefore, await ReadStoredStateAsync("rekey-legacy"));
+        Assert.Equal(historyBefore, await ReadStoredStateAsync("rekey-history"));
+        Assert.Equal(publicationBefore, await ReadPublicationPayloadAsync("rekey-original"));
+        using (var repeated = CreateStore())
+        {
+            await repeated.InitializeAsync(TestContext.Current.CancellationToken);
+        }
+        Assert.Single(Directory.GetFiles(Path.Combine(_directory, "Backup"),
+            "download.db.reservation-keys-*.bak"));
+
+        await SetReservationKeyAsync("rekey-original",
+            DownloadOutputPathKey.Create(original, !ignoreCase));
+        using (var switched = CreateStore())
+        {
+            await switched.InitializeAsync(TestContext.Current.CancellationToken);
+        }
+        Assert.Equal(2, Directory.GetFiles(Path.Combine(_directory, "Backup"),
+            "download.db.reservation-keys-*.bak").Length);
+    }
+
+    [Fact]
+    public async Task CanonicalCollisionBlocksStoreAndDirectAddWithoutChangingAnyTask()
+    {
+        var composed = Path.Combine(_directory, "caf\u00e9-conflict");
+        var decomposed = Path.Combine(_directory, "cafe\u0301-conflict");
+        using (var first = CreateStore())
+        {
+            Assert.True((await first.AddAsync(CreatePausedTask("collision-a", composed),
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await first.AddAsync(CreatePausedTask("collision-b"),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+
+        await SetPathAndReservationKeyAsync("collision-b", decomposed,
+            DownloadOutputPathKey.Create(decomposed,
+                !DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+        var firstBefore = await ReadStoredStateAsync("collision-a");
+        var secondBefore = await ReadStoredStateAsync("collision-b");
+        var firstKey = await ReadReservationKeyAsync("collision-a");
+        var secondKey = await ReadReservationKeyAsync("collision-b");
+        using var reopened = CreateStore();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            reopened.InitializeAsync(TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            reopened.AddAsync(CreateQueuedTask("collision-third",
+                Path.Combine(_directory, "unrelated")), TestContext.Current.CancellationToken));
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            reopened.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(firstBefore, await ReadStoredStateAsync("collision-a"));
+        Assert.Equal(secondBefore, await ReadStoredStateAsync("collision-b"));
+        Assert.Equal(firstKey, await ReadReservationKeyAsync("collision-a"));
+        Assert.Equal(secondKey, await ReadReservationKeyAsync("collision-b"));
+        Assert.False(Directory.Exists(Path.Combine(_directory, "Backup")));
+    }
+
+    [Fact]
+    public async Task ReservationRekeyPreflightsQuarantineAndCompletedUniqueOccupants()
+    {
+        var target = Path.Combine(_directory, "reserved-target");
+        using (var first = CreateStore())
+        {
+            Assert.True((await first.AddAsync(CreatePausedTask("occupied-quarantine", target),
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await first.AddAsync(CreatePausedTask("moving", Path.Combine(_directory, "old")),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+        await InsertPreexistingQuarantineAsync("occupied-quarantine");
+        await SetPathAndReservationKeyAsync("moving", target,
+            DownloadOutputPathKey.Create(Path.Combine(_directory, "old"),
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+        using (var reopened = CreateStore())
+        {
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                reopened.InitializeAsync(TestContext.Current.CancellationToken));
+        }
+
+        // A completed row is not an active reservation, but a non-NULL key
+        // still occupies the actual SQLite UNIQUE index.
+        await SetPathAndReservationKeyAsync("moving", Path.Combine(_directory, "old"),
+            DownloadOutputPathKey.Create(Path.Combine(_directory, "old"),
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+        var safeQuarantinePath = Path.Combine(_directory, "quarantine-safe");
+        await SetPathAndReservationKeyAsync("occupied-quarantine", safeQuarantinePath,
+            DownloadOutputPathKey.Create(safeQuarantinePath,
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+        using (var store = CreateStore())
+        {
+            Assert.True((await store.AddAsync(CreateCompletedTask("occupied-history", 123),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+        await SetReservationKeyAsync("occupied-history",
+            DownloadOutputPathKey.Create(target,
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+        await SetPathAndReservationKeyAsync("moving", target,
+            DownloadOutputPathKey.Create(Path.Combine(_directory, "old"),
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+        using var completedCollision = CreateStore();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            completedCollision.InitializeAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task QuarantinedRowsRetainNullOrForeignKeysWithoutBlockingUnrelatedRecovery()
+    {
+        var foreignPath = OperatingSystem.IsWindows() ? "/foreign/quarantined" : @"C:\foreign\quarantined";
+        var quarantinedPath = Path.Combine(_directory, "quarantined-foreign-key");
+        using (var first = CreateStore())
+        {
+            Assert.True((await first.AddAsync(CreatePausedTask("quarantined-null"),
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await first.AddAsync(CreatePausedTask("quarantined-foreign",
+                quarantinedPath), TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await first.AddAsync(CreatePausedTask("safe-unfinished"),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+        await InsertPreexistingQuarantineAsync("quarantined-null");
+        await InsertPreexistingQuarantineAsync("quarantined-foreign");
+        await SetPathAndReservationKeyAsync("quarantined-null", foreignPath, null);
+        var foreignKey = DownloadOutputPathKey.Create(quarantinedPath,
+            !DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+        await SetReservationKeyAsync("quarantined-foreign", foreignKey);
+
+        using var reopened = CreateStore();
+        await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("safe-unfinished", Assert.Single(await reopened.GetUnfinishedAsync(
+            TestContext.Current.CancellationToken)).Id.Value);
+        Assert.Equal(2, (await reopened.GetQuarantinedRecordsAsync(
+            TestContext.Current.CancellationToken)).Count);
+        Assert.Null(await ReadReservationKeyAsync("quarantined-null"));
+        Assert.Equal(foreignKey, await ReadReservationKeyAsync("quarantined-foreign"));
+        Assert.Equal(foreignPath, (await ReadStoredStateAsync("quarantined-null")).Path);
+        Assert.True((await reopened.AddAsync(CreateQueuedTask("safe-new",
+            Path.Combine(_directory, "safe-new")), TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.False(Directory.Exists(Path.Combine(_directory, "Backup")));
+    }
+
+    [Fact]
+    public async Task ReservationRekeySqlFailureRollsBackAllKeysAndKeepsPrechangeBackup()
+    {
+        var firstPath = Path.Combine(_directory, "rollback-a");
+        var secondPath = Path.Combine(_directory, "rollback-b");
+        using (var first = CreateStore())
+        {
+            Assert.True((await first.AddAsync(CreatePausedTask("rollback-a", firstPath),
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await first.AddAsync(CreatePausedTask("rollback-b", secondPath),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+        var firstForeign = DownloadOutputPathKey.Create(firstPath,
+            !DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+        var secondForeign = DownloadOutputPathKey.Create(secondPath,
+            !DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+        await SetReservationKeyAsync("rollback-a", firstForeign);
+        await SetReservationKeyAsync("rollback-b", secondForeign);
+        using (var connection = await OpenConnectionAsync(readOnly: false))
+        using (var trigger = connection.CreateCommand())
+        {
+            trigger.CommandText = """
+                CREATE TRIGGER reject_second_rekey BEFORE UPDATE OF output_reservation_key
+                ON download_base WHEN NEW.id = 'rollback-b' AND NEW.output_reservation_key IS NOT NULL
+                BEGIN SELECT RAISE(ABORT, 'synthetic rekey failure'); END;
+                """;
+            await trigger.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+        using var reopened = CreateStore();
+        await Assert.ThrowsAsync<SqliteException>(() =>
+            reopened.InitializeAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(firstForeign, await ReadReservationKeyAsync("rollback-a"));
+        Assert.Equal(secondForeign, await ReadReservationKeyAsync("rollback-b"));
+        Assert.Single(Directory.GetFiles(Path.Combine(_directory, "Backup"),
+            "download.db.reservation-keys-*.bak"));
+    }
+
+    [Fact]
+    public async Task ReservationRekeyHandlesKeySwapWithoutDroppingUniqueIndex()
+    {
+        var firstPath = Path.Combine(_directory, "swap-a");
+        var secondPath = Path.Combine(_directory, "swap-b");
+        using (var store = CreateStore())
+        {
+            Assert.True((await store.AddAsync(CreateQueuedTask("swap-a", firstPath),
+                TestContext.Current.CancellationToken)).IsSuccess);
+            Assert.True((await store.AddAsync(CreateQueuedTask("swap-b", secondPath),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+        var firstKey = DownloadOutputPathKey.Create(firstPath,
+            DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+        var secondKey = DownloadOutputPathKey.Create(secondPath,
+            DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+        await SetReservationKeyAsync("swap-a", null);
+        await SetReservationKeyAsync("swap-b", null);
+        await SetReservationKeyAsync("swap-a", secondKey);
+        await SetReservationKeyAsync("swap-b", firstKey);
+
+        using var reopened = CreateStore();
+        await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(firstKey, await ReadReservationKeyAsync("swap-a"));
+        Assert.Equal(secondKey, await ReadReservationKeyAsync("swap-b"));
+        using var connection = await OpenReadOnlyConnectionAsync();
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT COUNT(*) FROM sqlite_master
+            WHERE type = 'index' AND name = 'ux_download_base_output_reservation'
+            """;
+        Assert.Equal(1L, await command.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ReservationRekeyCancellationAndBackupFailureLeaveOriginalKeyUntouched()
+    {
+        var path = Path.Combine(_directory, "backup-failure");
+        using (var first = CreateStore())
+        {
+            Assert.True((await first.AddAsync(CreatePausedTask("backup-failure", path),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+        var foreign = DownloadOutputPathKey.Create(path,
+            !DownloadOutputPathKey.UsesCaseInsensitiveComparison);
+        await SetReservationKeyAsync("backup-failure", foreign);
+
+        using var cancellation = new CancellationTokenSource();
+        using (var canceled = CreateStore(clock: new CancelOnReadClock(_clock.UtcNow, cancellation)))
+        {
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                canceled.InitializeAsync(cancellation.Token));
+        }
+        Assert.Equal(foreign, await ReadReservationKeyAsync("backup-failure"));
+
+        var backupDirectory = Path.Combine(_directory, "Backup");
+        Directory.Delete(backupDirectory);
+        await File.WriteAllTextAsync(backupDirectory, "prevent backup directory creation",
+            TestContext.Current.CancellationToken);
+        using (var failedBackup = CreateStore())
+        {
+            await Assert.ThrowsAnyAsync<IOException>(() =>
+                failedBackup.InitializeAsync(TestContext.Current.CancellationToken));
+        }
+        Assert.Equal(foreign, await ReadReservationKeyAsync("backup-failure"));
+        File.Delete(backupDirectory);
+
+        using var reopened = CreateStore();
+        await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+        Assert.Equal(DownloadOutputPathKey.Create(path,
+            DownloadOutputPathKey.UsesCaseInsensitiveComparison),
+            await ReadReservationKeyAsync("backup-failure"));
+    }
+
+    [Fact]
+    public async Task UninterpretableForeignPathBlocksBeforeChangingExistingTask()
+    {
+        var original = Path.Combine(_directory, "native-path");
+        using (var first = CreateStore())
+        {
+            Assert.True((await first.AddAsync(CreatePausedTask("foreign-path", original),
+                TestContext.Current.CancellationToken)).IsSuccess);
+        }
+        var foreignPath = OperatingSystem.IsWindows() ? "/foreign/path" : @"C:\foreign\path";
+        var originalKey = await ReadReservationKeyAsync("foreign-path");
+        await SetPathAndReservationKeyAsync("foreign-path", foreignPath, originalKey);
+        using var reopened = CreateStore();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            reopened.InitializeAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(foreignPath, (await ReadStoredStateAsync("foreign-path")).Path);
+        Assert.Equal(originalKey, await ReadReservationKeyAsync("foreign-path"));
+    }
+
+    [Fact]
+    public async Task NewUninterpretablePathIsRejectedBeforeItCanPoisonReopen()
+    {
+        var foreignPath = OperatingSystem.IsWindows() ? "/foreign/path" : @"C:\foreign\path";
+        using var store = CreateStore();
+        await store.InitializeAsync(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            store.AddAsync(CreateQueuedTask("new-foreign-path", foreignPath),
+                TestContext.Current.CancellationToken));
+
+        Assert.Equal(0, await CountDownloadBaseRecordAsync("new-foreign-path"));
+        var existing = CreateQueuedTask("update-foreign-path",
+            Path.Combine(_directory, "safe-existing"));
+        Assert.True((await store.AddAsync(existing,
+            TestContext.Current.CancellationToken)).IsSuccess);
+        var changed = existing.UpdateOutput(new DownloadOutput(foreignPath, null),
+            _clock.UtcNow.AddSeconds(1)).RequireValue();
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            store.UpdateAsync(changed, existing.Version,
+                TestContext.Current.CancellationToken));
+        Assert.Equal(existing.Output.BasePath,
+            (await ReadStoredStateAsync(existing.Id.Value)).Path);
+    }
+
+    [Fact]
+    public async Task ForwardSlashUncPathFollowsCurrentPlatformPolicyAcrossReopen()
+    {
+        const string path = "//server/share/downkyi-output";
+        using (var first = CreateStore())
+        {
+            if (OperatingSystem.IsWindows())
+            {
+                Assert.True((await first.AddAsync(CreateQueuedTask("slash-unc", path),
+                    TestContext.Current.CancellationToken)).IsSuccess);
+            }
+            else
+            {
+                await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                    first.AddAsync(CreateQueuedTask("slash-unc", path),
+                        TestContext.Current.CancellationToken));
+                Assert.True((await first.AddAsync(CreatePausedTask("legacy-slash-unc",
+                    Path.Combine(_directory, "safe-unc")),
+                    TestContext.Current.CancellationToken)).IsSuccess);
+            }
+        }
+
+        if (OperatingSystem.IsWindows())
+        {
+            using var reopened = CreateStore();
+            await reopened.InitializeAsync(TestContext.Current.CancellationToken);
+            Assert.Equal(DownloadOutputPathKey.Create(path,
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison),
+                await ReadReservationKeyAsync("slash-unc"));
+            Assert.True(await reopened.IsOutputPathReservedAsync(path,
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                TestContext.Current.CancellationToken));
+        }
+        else
+        {
+            var originalKey = await ReadReservationKeyAsync("legacy-slash-unc");
+            await SetPathAndReservationKeyAsync("legacy-slash-unc", path, originalKey);
+            using var reopened = CreateStore();
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                reopened.InitializeAsync(TestContext.Current.CancellationToken));
+            Assert.Equal(originalKey, await ReadReservationKeyAsync("legacy-slash-unc"));
+            Assert.Equal(0, await CountDownloadBaseRecordAsync("slash-unc"));
+        }
+    }
+
+    [Fact]
+    public async Task ActiveUpdateRecomputesKeyAndUniqueRejectsEquivalentNewAdmission()
+    {
+        var original = Path.Combine(_directory, "update-original");
+        var next = Path.Combine(_directory, "update-cafe\u0301");
+        var equivalent = Path.Combine(_directory, "update-caf\u00e9");
+        using var store = CreateStore();
+        var task = CreateQueuedTask("update-path", original);
+        Assert.True((await store.AddAsync(task, TestContext.Current.CancellationToken)).IsSuccess);
+        await SetReservationKeyAsync(task.Id.Value, null);
+        var updated = task.UpdateOutput(new DownloadOutput(next, null),
+            _clock.UtcNow.AddSeconds(1)).RequireValue();
+        Assert.True((await store.UpdateAsync(updated, task.Version,
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.Equal(DownloadOutputPathKey.Create(next,
+            DownloadOutputPathKey.UsesCaseInsensitiveComparison),
+            await ReadReservationKeyAsync(task.Id.Value));
+        Assert.False((await store.AddAsync(CreateQueuedTask("update-duplicate", equivalent),
+            TestContext.Current.CancellationToken)).IsSuccess);
+    }
+
+    [Fact]
     public async Task CoalescedProgressWriteAdvancesVersionAndPayloadAtomically()
     {
         var original = DownloadTask.Create(
@@ -1078,12 +1549,14 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         SqliteConnection.ClearPool(connection);
     }
 
-    private SqliteDownloadTaskStore CreateStore(IPhysicalOutputPathResolver? resolver = null)
+    private SqliteDownloadTaskStore CreateStore(
+        IPhysicalOutputPathResolver? resolver = null,
+        IClock? clock = null)
     {
         Directory.CreateDirectory(_directory);
         return new SqliteDownloadTaskStore(
             new SqliteDownloadTaskStoreOptions(Path.Combine(_directory, "download.db")),
-            _clock,
+            clock ?? _clock,
             resolver ?? new StubPhysicalOutputPathResolver(static path => path));
     }
 
@@ -1267,6 +1740,62 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         command.Parameters.AddWithValue("@id", id);
         command.Parameters.AddWithValue("@now", _clock.UtcNow.ToUnixTimeMilliseconds());
         await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task SetReservationKeyAsync(string id, string? key)
+    {
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE download_base SET output_reservation_key = @key WHERE id = @id
+            """;
+        command.Parameters.AddWithValue("@key", key ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@id", id);
+        Assert.Equal(1, await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false));
+    }
+
+    private async Task SetPathAndReservationKeyAsync(string id, string path, string? key)
+    {
+        using var connection = await OpenConnectionAsync(readOnly: false).ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            UPDATE download_base SET file_path = @path, output_reservation_key = @key
+            WHERE id = @id
+            """;
+        command.Parameters.AddWithValue("@path", path);
+        command.Parameters.AddWithValue("@key", key ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("@id", id);
+        Assert.Equal(1, await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false));
+    }
+
+    private async Task<string?> ReadReservationKeyAsync(string id)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT output_reservation_key FROM download_base WHERE id = @id";
+        command.Parameters.AddWithValue("@id", id);
+        return await command.ExecuteScalarAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false) as string;
+    }
+
+    private async Task<(string StagingToken, string PublishingKey, string PublishedArtifacts,
+        double Progress)> ReadPublicationPayloadAsync(string id)
+    {
+        using var connection = await OpenReadOnlyConnectionAsync().ConfigureAwait(false);
+        using var command = connection.CreateCommand();
+        command.CommandText = """
+            SELECT db.staging_token, db.publishing_key, db.published_artifacts, dl.progress
+            FROM download_base db INNER JOIN downloading dl ON dl.id = db.id
+            WHERE db.id = @id
+            """;
+        command.Parameters.AddWithValue("@id", id);
+        using var reader = await command.ExecuteReaderAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false);
+        Assert.True(await reader.ReadAsync(TestContext.Current.CancellationToken)
+            .ConfigureAwait(false));
+        return (reader.GetString(0), reader.GetString(1), reader.GetString(2), reader.GetDouble(3));
     }
 
     private async Task CreateQuarantineFailureTriggerAsync()
@@ -1541,6 +2070,23 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
         {
             return Task.Delay(delay, cancellationToken);
         }
+    }
+
+    private sealed class CancelOnReadClock(
+        DateTimeOffset utcNow,
+        CancellationTokenSource cancellation) : IClock
+    {
+        public DateTimeOffset UtcNow
+        {
+            get
+            {
+                cancellation.Cancel();
+                return utcNow;
+            }
+        }
+
+        public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken) =>
+            Task.Delay(delay, cancellationToken);
     }
 
     private sealed class StubPhysicalOutputPathResolver(Func<string, string> resolve)

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -735,6 +735,11 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             outputPath,
             DownloadOutputPathKey.UsesCaseInsensitiveComparison,
             TestContext.Current.CancellationToken));
+        Assert.Contains(
+            DownloadOutputPathKey.Create(outputPath, DownloadOutputPathKey.UsesCaseInsensitiveComparison),
+            await store.GetActiveOutputReservationKeysAsync(
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                TestContext.Current.CancellationToken));
 
         var deleted = canceled.Delete(_clock.UtcNow.AddSeconds(2)).RequireValue();
         Assert.True((await store
@@ -743,6 +748,71 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             outputPath,
             DownloadOutputPathKey.UsesCaseInsensitiveComparison,
             TestContext.Current.CancellationToken));
+        Assert.DoesNotContain(
+            DownloadOutputPathKey.Create(outputPath, DownloadOutputPathKey.UsesCaseInsensitiveComparison),
+            await store.GetActiveOutputReservationKeysAsync(
+                DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+                TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ReservationSnapshotIncludesFailedAndPausedButExcludesCompletedAndQuarantined()
+    {
+        using var store = CreateStore();
+        var failed = CreateQueuedTask("failed-snapshot", Path.Combine(_directory, "failed-output"));
+        failed = failed.Start(_clock.UtcNow.AddSeconds(1)).RequireValue();
+        failed = failed.Fail(
+            new DownloadFailure("download.failed", "Transfer failed.", true),
+            _clock.UtcNow.AddSeconds(2)).RequireValue();
+        var paused = CreatePausedTask("paused-snapshot");
+        var completed = CreateCompletedTask("completed-snapshot", 10);
+        var quarantined = CreateQueuedTask("quarantined-snapshot", Path.Combine(_directory, "quarantined"));
+        foreach (var task in new[] { failed, paused, completed, quarantined })
+        {
+            Assert.True((await store.AddAsync(task, TestContext.Current.CancellationToken)).IsSuccess);
+        }
+
+        await InsertPreexistingQuarantineAsync(quarantined.Id.Value);
+        var keys = await store.GetActiveOutputReservationKeysAsync(
+            DownloadOutputPathKey.UsesCaseInsensitiveComparison,
+            TestContext.Current.CancellationToken);
+
+        Assert.Contains(DownloadOutputPathKey.Create(
+            failed.Output.BasePath, DownloadOutputPathKey.UsesCaseInsensitiveComparison), keys);
+        Assert.Contains(DownloadOutputPathKey.Create(
+            paused.Output.BasePath, DownloadOutputPathKey.UsesCaseInsensitiveComparison), keys);
+        Assert.DoesNotContain(DownloadOutputPathKey.Create(
+            completed.Output.BasePath, DownloadOutputPathKey.UsesCaseInsensitiveComparison), keys);
+        Assert.DoesNotContain(DownloadOutputPathKey.Create(
+            quarantined.Output.BasePath, DownloadOutputPathKey.UsesCaseInsensitiveComparison), keys);
+    }
+
+    [Fact]
+    public async Task ReservationSnapshotNormalizesLegacyNullKeyAndCaseVariants()
+    {
+        var basePath = Path.Combine(_directory, "cafe\u0301-output");
+        using var store = CreateStore();
+        Assert.True((await store.AddAsync(
+            CreateQueuedTask("legacy-null-key", basePath),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        using (var connection = await OpenConnectionAsync(readOnly: false))
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                UPDATE download_base SET output_reservation_key = NULL WHERE id = 'legacy-null-key'
+                """;
+            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var caseSensitive = await store.GetActiveOutputReservationKeysAsync(
+            ignoreCase: false, TestContext.Current.CancellationToken);
+        var caseInsensitive = await store.GetActiveOutputReservationKeysAsync(
+            ignoreCase: true, TestContext.Current.CancellationToken);
+
+        Assert.Contains(DownloadOutputPathKey.Create(basePath, false), caseSensitive);
+        Assert.Contains(DownloadOutputPathKey.Create(basePath, true), caseInsensitive);
+        Assert.DoesNotContain(DownloadOutputPathKey.Create(
+            basePath.ToUpperInvariant(), false), caseSensitive);
     }
 
     [Fact]

--- a/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
+++ b/tests/DownKyi.Infrastructure.Tests/SqliteDownloadTaskStoreTests.cs
@@ -815,6 +815,89 @@ public sealed class SqliteDownloadTaskStoreTests : IDisposable
             basePath.ToUpperInvariant(), false), caseSensitive);
     }
 
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task ReservationPointQueryAgreesWithSnapshotForLegacyNormalizedPath(bool ignoreCase)
+    {
+        var decomposed = Path.Combine(_directory, "cafe\u0301-legacy");
+        var composed = Path.Combine(_directory, "caf\u00e9-legacy");
+        using var store = CreateStore();
+        Assert.True((await store.AddAsync(
+            CreateQueuedTask("legacy-point-equivalence", decomposed),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        using (var connection = await OpenConnectionAsync(readOnly: false))
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                UPDATE download_base SET output_reservation_key = NULL
+                WHERE id = 'legacy-point-equivalence'
+                """;
+            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var key = DownloadOutputPathKey.Create(composed, ignoreCase);
+        var snapshot = await store.GetActiveOutputReservationKeysAsync(
+            ignoreCase, TestContext.Current.CancellationToken);
+        Assert.Contains(key, snapshot);
+        Assert.True(await store.IsOutputPathReservedAsync(
+            composed, ignoreCase, TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task ReservationPointQueryMatchesSnapshotOnUnchangedMixedFixture()
+    {
+        var ignoreCase = DownloadOutputPathKey.UsesCaseInsensitiveComparison;
+        var normal = Path.Combine(_directory, "normal-caf\u00e9");
+        var legacy = Path.Combine(_directory, "legacy-cafe\u0301");
+        var completed = Path.Combine(_directory, "completed-output");
+        var quarantined = Path.Combine(_directory, "quarantined-output");
+        using var store = CreateStore();
+        Assert.True((await store.AddAsync(
+            CreateQueuedTask("normal-equivalence", normal),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await store.AddAsync(
+            CreateQueuedTask("legacy-equivalence", legacy),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await store.AddAsync(
+            CreateCompletedTask("completed-equivalence", 10, completed),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        Assert.True((await store.AddAsync(
+            CreateQueuedTask("quarantined-equivalence", quarantined),
+            TestContext.Current.CancellationToken)).IsSuccess);
+        using (var connection = await OpenConnectionAsync(readOnly: false))
+        using (var command = connection.CreateCommand())
+        {
+            command.CommandText = """
+                UPDATE download_base SET output_reservation_key = NULL
+                WHERE id = 'legacy-equivalence'
+                """;
+            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+        await InsertPreexistingQuarantineAsync("quarantined-equivalence");
+
+        var snapshot = await store.GetActiveOutputReservationKeysAsync(
+            ignoreCase, TestContext.Current.CancellationToken);
+        foreach (var (candidate, expected) in new[]
+        {
+            (normal, true),
+            (normal.ToUpperInvariant(), ignoreCase),
+            (legacy.Normalize(System.Text.NormalizationForm.FormC), true),
+            (legacy.ToUpperInvariant(), ignoreCase),
+            (completed, false),
+            (quarantined, false),
+            (Path.Combine(_directory, "unrelated"), false)
+        })
+        {
+            var key = DownloadOutputPathKey.Create(candidate, ignoreCase);
+            var snapshotReserved = snapshot.Contains(key, StringComparer.Ordinal);
+            var pointReserved = await store.IsOutputPathReservedAsync(
+                candidate, ignoreCase, TestContext.Current.CancellationToken);
+            Assert.Equal(expected, snapshotReserved);
+            Assert.Equal(snapshotReserved, pointReserved);
+        }
+    }
+
     [Fact]
     public async Task CoalescedProgressWriteAdvancesVersionAndPayloadAtomically()
     {

--- a/tests/DownKyi.Tests/DownloadAddOwnerTests.cs
+++ b/tests/DownKyi.Tests/DownloadAddOwnerTests.cs
@@ -403,6 +403,11 @@ public sealed class DownloadAddOwnerTests : IDisposable
             return Task.FromResult(Current?.Id == taskId ? Current : null);
         }
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
+++ b/tests/DownKyi.Tests/DownloadArtifactStageTests.cs
@@ -959,6 +959,11 @@ public sealed class DownloadArtifactStageTests
             bool ignoreCase,
             CancellationToken cancellationToken) => Task.FromResult(false);
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -781,6 +781,11 @@ public sealed class DownloadBootstrapHostedServiceTests
             bool ignoreCase,
             CancellationToken cancellationToken) => Task.FromResult(false);
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadBootstrapHostedServiceTests.cs
@@ -15,6 +15,91 @@ namespace DownKyi.Tests;
 
 public sealed class DownloadBootstrapHostedServiceTests
 {
+    [Fact]
+    public async Task CanonicalReservationCollisionStopsRecoveryBeforePublicationOrRuntimeStarts()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "downkyi-rekey-startup",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var databasePath = Path.Combine(directory, "download.db");
+        var firstPath = Path.Combine(directory, "caf\u00e9-conflict");
+        var secondPath = Path.Combine(directory, "cafe\u0301-conflict");
+        var destination = firstPath + ".mp4";
+        var bytes = new byte[] { 4, 5, 6 };
+        try
+        {
+            using (var firstStore = new SqliteDownloadTaskStore(
+                       new SqliteDownloadTaskStoreOptions(databasePath), new SystemClock()))
+            {
+                using var firstTasks = new DownloadTaskApplicationService(firstStore,
+                    new SystemClock());
+                var firstId = new DownloadTaskId("rekey-startup-a");
+                Assert.True((await firstTasks.AddAsync(CreateTask(firstId.Value, firstPath),
+                    TestContext.Current.CancellationToken)).IsSuccess);
+                Assert.True((await firstTasks.StartAsync(firstId,
+                    TestContext.Current.CancellationToken)).IsSuccess);
+                Assert.True((await firstTasks.BeginPublishingArtifactAsync(firstId,
+                    new DownloadPublishingArtifact("media", "output.mp4", bytes.Length,
+                        Convert.ToHexString(SHA256.HashData(bytes))),
+                    TestContext.Current.CancellationToken)).IsSuccess);
+                Assert.True((await firstTasks.AddAsync(CreateTask("rekey-startup-b",
+                    Path.Combine(directory, "other")), TestContext.Current.CancellationToken)).IsSuccess);
+            }
+            await File.WriteAllBytesAsync(destination, bytes, TestContext.Current.CancellationToken);
+            using (var connection = new SqliteConnection($"Data Source={databasePath};Pooling=False"))
+            {
+                await connection.OpenAsync(TestContext.Current.CancellationToken);
+                using var command = connection.CreateCommand();
+                command.CommandText = """
+                    UPDATE download_base SET file_path = @path, output_reservation_key = @key
+                    WHERE id = 'rekey-startup-b'
+                    """;
+                command.Parameters.AddWithValue("@path", secondPath);
+                command.Parameters.AddWithValue("@key", DownloadOutputPathKey.Create(secondPath,
+                    !DownloadOutputPathKey.UsesCaseInsensitiveComparison));
+                Assert.Equal(1, await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken));
+            }
+
+            using var reopenedStore = new SqliteDownloadTaskStore(
+                new SqliteDownloadTaskStoreOptions(databasePath), new SystemClock());
+            using var tasks = new DownloadTaskApplicationService(reopenedStore, new SystemClock());
+            using var projections = new DownloadTaskProjectionStore(tasks, new SystemClock());
+            var writer = new DownloadTaskStateWriter(tasks);
+            var staging = new DownloadTaskStaging(NullLogger<DownloadTaskStaging>.Instance);
+            var fileService = new DownloadTaskFileService(new AriaRuntimeClientRegistry(),
+                NullLogger<DownloadTaskFileService>.Instance, staging, writer);
+            using var runtime = new RecordingDownloadRuntime();
+            var gateway = new DownloadTaskQueueGateway();
+            using var bootstrap = new DownloadBootstrapHostedService(
+                new DownloadListState(), projections, writer,
+                new RecordingRuntimeFactory(runtime), gateway,
+                new ImmediateUiDispatcher(), NullLogger<DownloadBootstrapHostedService>.Instance,
+                staging, fileService);
+
+            await bootstrap.StartAsync(TestContext.Current.CancellationToken);
+
+            Assert.False(runtime.Started);
+            Assert.Empty(runtime.Enqueued);
+            await Assert.ThrowsAsync<DownloadRuntimeUnavailableException>(() =>
+                gateway.EnqueueAsync(new DownloadTaskId("after-block"),
+                    TestContext.Current.CancellationToken));
+            Assert.Equal(bytes, await File.ReadAllBytesAsync(destination,
+                TestContext.Current.CancellationToken));
+            using var check = new SqliteConnection($"Data Source={databasePath};Mode=ReadOnly;Pooling=False");
+            await check.OpenAsync(TestContext.Current.CancellationToken);
+            using var query = check.CreateCommand();
+            query.CommandText = """
+                SELECT publishing_key FROM download_base WHERE id = 'rekey-startup-a'
+                """;
+            Assert.Equal("media", await query.ExecuteScalarAsync(TestContext.Current.CancellationToken));
+        }
+        finally
+        {
+            ClearOwnedSqlitePool(databasePath);
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
     [Theory]
     [InlineData(false)]
     [InlineData(true)]

--- a/tests/DownKyi.Tests/DownloadOrchestratorTests.cs
+++ b/tests/DownKyi.Tests/DownloadOrchestratorTests.cs
@@ -434,6 +434,20 @@ public sealed class DownloadOrchestratorTests
             }
         }
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            lock (_sync)
+            {
+                return Task.FromResult<IReadOnlyList<string>>(_tasks.Values
+                    .Where(task => task.Phase != DownloadPhase.Completed)
+                    .Select(task => DownloadOutputPathKey.Create(task.Output.BasePath, ignoreCase))
+                    .ToArray());
+            }
+        }
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Tests/DownloadPipelineCommitBoundaryTests.cs
+++ b/tests/DownKyi.Tests/DownloadPipelineCommitBoundaryTests.cs
@@ -413,6 +413,11 @@ public sealed class DownloadPipelineCommitBoundaryTests
             return Task.FromResult(false);
         }
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -177,7 +177,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var resolved = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
             basePath,
             autoAddNumberSuffix: true,
-            static (_, _) => Task.FromResult(false),
+            static _ => Task.FromResult<IReadOnlyList<string>>([]),
             TestContext.Current.CancellationToken);
 
         Assert.Equal(Path.GetFullPath(basePath), resolved, ignoreCase: false);
@@ -207,7 +207,8 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             TestContext.Current.CancellationToken));
         var taskId = new DownloadTaskId(item.DownloadBase.Id);
         Assert.Equal([logicalBasePath], resolver.Inputs);
-        Assert.Equal([frozenBasePath], store.ReservationPaths);
+        Assert.Equal(1, store.ReservationSnapshotCount);
+        Assert.Equal(0, store.ReservationProbeCount);
         Assert.Equal(frozenBasePath, item.DownloadBase.FilePath, ignoreCase: false);
         Assert.Equal(frozenBasePath, persisted.Output.BasePath, ignoreCase: false);
         Assert.Equal(
@@ -425,7 +426,74 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task RepeatedAdmissionsProbeCandidatesWithoutReloadingAllUnfinishedTasks()
+    public async Task ActiveReservationHoleUsesFirstFreeSuffix()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        using var admission = CreateAdmission(
+            new DownloadListState(), tasks, projections, new RecordingDownloadTaskQueue());
+        var basePath = Path.Combine(_directory, "video");
+        await AdmitThreeWithHoleAsync(admission, basePath);
+
+        var next = CreateItem("hole", basePath);
+        await admission.AdmitAsync(next, true, TestContext.Current.CancellationToken);
+
+        Assert.Equal($"{basePath}(2)", next.DownloadBase.FilePath);
+    }
+
+    [Fact]
+    public async Task DiskOccupantBlocksReservationHole()
+    {
+        Directory.CreateDirectory(_directory);
+        using var store = CreateStore();
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        using var admission = CreateAdmission(
+            new DownloadListState(), tasks, projections, new RecordingDownloadTaskQueue());
+        var basePath = Path.Combine(_directory, "video");
+        await AdmitThreeWithHoleAsync(admission, basePath);
+        await File.WriteAllTextAsync(
+            $"{basePath}(2).mp4", "foreign output", TestContext.Current.CancellationToken);
+
+        var next = CreateItem("disk-hole", basePath);
+        await admission.AdmitAsync(next, true, TestContext.Current.CancellationToken);
+
+        Assert.Equal($"{basePath}(4)", next.DownloadBase.FilePath);
+    }
+
+    [Fact]
+    public async Task ReopenedStoreStillUsesFirstFreeReservationHole()
+    {
+        Directory.CreateDirectory(_directory);
+        var basePath = Path.Combine(_directory, "video");
+        using (var firstStore = CreateStore())
+        {
+            var clock = new SystemClock();
+            using var firstTasks = new DownloadTaskApplicationService(firstStore, clock);
+            using var firstProjections = new DownloadTaskProjectionStore(firstTasks, clock);
+            using var firstAdmission = CreateAdmission(
+                new DownloadListState(), firstTasks, firstProjections, new RecordingDownloadTaskQueue());
+            await AdmitThreeWithHoleAsync(firstAdmission, basePath);
+        }
+
+        using var reopenedStore = CreateStore();
+        var reopenedClock = new SystemClock();
+        using var reopenedTasks = new DownloadTaskApplicationService(reopenedStore, reopenedClock);
+        using var reopenedProjections = new DownloadTaskProjectionStore(reopenedTasks, reopenedClock);
+        using var reopenedAdmission = CreateAdmission(
+            new DownloadListState(), reopenedTasks, reopenedProjections, new RecordingDownloadTaskQueue());
+        var next = CreateItem("after-reopen", basePath);
+        await reopenedAdmission.AdmitAsync(next, true, TestContext.Current.CancellationToken);
+
+        Assert.Equal($"{basePath}(2)", next.DownloadBase.FilePath);
+    }
+
+    [Fact]
+    public async Task RepeatedAdmissionsSnapshotReservationsWithoutCandidateProbesOrAggregateReloads()
     {
         Directory.CreateDirectory(_directory);
         using var innerStore = CreateStore();
@@ -439,15 +507,37 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             projections,
             new RecordingDownloadTaskQueue());
 
-        for (var index = 0; index < 20; index++)
+        const int admissionCount = 64;
+        var basePath = Path.Combine(_directory, "same-output");
+        for (var index = 0; index < admissionCount; index++)
         {
-            var item = CreateItem($"task-{index}", Path.Combine(_directory, $"output-{index}"));
+            var item = CreateItem($"task-{index}", basePath);
             await admission.AdmitAsync(item, true, TestContext.Current.CancellationToken)
                 .ConfigureAwait(true);
+            Assert.Equal(index == 0 ? basePath : $"{basePath}({index})", item.DownloadBase.FilePath);
         }
 
         Assert.Equal(0, store.GetUnfinishedCallCount);
-        Assert.Equal(20, store.ReservationProbeCount);
+        Assert.Equal(admissionCount, store.ReservationSnapshotCount);
+        Assert.Equal(0, store.ReservationProbeCount);
+    }
+
+    private static async Task AdmitThreeWithHoleAsync(
+        DownloadTaskAdmissionService admission,
+        string basePath)
+    {
+        foreach (var (id, path) in new[]
+        {
+            ("zero", basePath),
+            ("one", $"{basePath}(1)"),
+            ("three", $"{basePath}(3)")
+        })
+        {
+            var item = CreateItem(id, path);
+            await admission.AdmitAsync(item, true, TestContext.Current.CancellationToken)
+                .ConfigureAwait(true);
+            Assert.Equal(path, item.DownloadBase.FilePath);
+        }
     }
 
     private SqliteDownloadTaskStore CreateStore()
@@ -504,7 +594,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
         public int ReservationProbeCount { get; private set; }
 
-        public List<string> ReservationPaths { get; } = [];
+        public int ReservationSnapshotCount { get; private set; }
 
         public Task InitializeAsync(CancellationToken cancellationToken) =>
             inner.InitializeAsync(cancellationToken);
@@ -545,8 +635,15 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             CancellationToken cancellationToken)
         {
             ReservationProbeCount++;
-            ReservationPaths.Add(basePath);
             return inner.IsOutputPathReservedAsync(basePath, ignoreCase, cancellationToken);
+        }
+
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken)
+        {
+            ReservationSnapshotCount++;
+            return inner.GetActiveOutputReservationKeysAsync(ignoreCase, cancellationToken);
         }
 
         public Task<DownloadHistoryPage> GetHistoryPageAsync(

--- a/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
+++ b/tests/DownKyi.Tests/DownloadTaskAdmissionServiceTests.cs
@@ -119,7 +119,8 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
     public async Task AdmissionSkipsDiskCollisionCreatedAfterDraftConstruction()
     {
         Directory.CreateDirectory(_directory);
-        using var store = CreateStore();
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore);
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
@@ -138,13 +139,16 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         await admission.AdmitAsync(draft, true, TestContext.Current.CancellationToken).ConfigureAwait(true);
 
         Assert.Equal($"{basePath}(1)", draft.DownloadBase.FilePath);
+        Assert.Equal(0, store.ReservationProbeCount);
+        Assert.Equal(1, store.ReservationSnapshotCount);
     }
 
     [Fact]
     public async Task DisabledAutoSuffixRejectsCollisionWithoutRenamingOrPersisting()
     {
         Directory.CreateDirectory(_directory);
-        using var store = CreateStore();
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore);
         var clock = new SystemClock();
         using var tasks = new DownloadTaskApplicationService(store, clock);
         using var projections = new DownloadTaskProjectionStore(tasks, clock);
@@ -167,6 +171,36 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
         Assert.Equal(basePath, item.DownloadBase.FilePath);
         Assert.Empty(await tasks.GetUnfinishedAsync(TestContext.Current.CancellationToken));
+        Assert.Equal(0, store.ReservationProbeCount);
+        Assert.Equal(0, store.ReservationSnapshotCount);
+        Assert.Equal(0, store.AddCallCount);
+    }
+
+    [Fact]
+    public async Task DisabledAutoSuffixRejectsDatabaseCollisionWithoutSnapshotOrSideEffects()
+    {
+        Directory.CreateDirectory(_directory);
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore);
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        var list = new DownloadListState();
+        var queue = new RecordingDownloadTaskQueue();
+        using var admission = CreateAdmission(list, tasks, projections, queue);
+        var basePath = Path.Combine(_directory, "db-no-auto-suffix");
+        await admission.AdmitAsync(CreateItem("first", basePath), true, TestContext.Current.CancellationToken);
+        var rejected = CreateItem("rejected", basePath);
+
+        await Assert.ThrowsAsync<IOException>(() => admission.AdmitAsync(
+            rejected, false, TestContext.Current.CancellationToken));
+
+        Assert.Equal(basePath, rejected.DownloadBase.FilePath);
+        Assert.Single(list.Downloading);
+        Assert.Single(queue.Enqueued);
+        Assert.Equal(2, store.ReservationProbeCount);
+        Assert.Equal(0, store.ReservationSnapshotCount);
+        Assert.Equal(1, store.AddCallCount);
     }
 
     [Fact]
@@ -177,10 +211,25 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         var resolved = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
             basePath,
             autoAddNumberSuffix: true,
+            static (_, _) => Task.FromResult(false),
             static _ => Task.FromResult<IReadOnlyList<string>>([]),
             TestContext.Current.CancellationToken);
 
         Assert.Equal(Path.GetFullPath(basePath), resolved, ignoreCase: false);
+    }
+
+    [Fact]
+    public async Task FallbackRechecksOriginalBasenameFromCurrentSnapshot()
+    {
+        var basePath = Path.Combine(_directory, "released-between-observations");
+        var resolved = await DownloadOutputPathResolver.ResolveAdmissionCollisionAsync(
+            basePath,
+            autoAddNumberSuffix: true,
+            static (_, _) => Task.FromResult(true),
+            static _ => Task.FromResult<IReadOnlyList<string>>([]),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(basePath, resolved);
     }
 
     [Fact]
@@ -207,8 +256,8 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
             TestContext.Current.CancellationToken));
         var taskId = new DownloadTaskId(item.DownloadBase.Id);
         Assert.Equal([logicalBasePath], resolver.Inputs);
-        Assert.Equal(1, store.ReservationSnapshotCount);
-        Assert.Equal(0, store.ReservationProbeCount);
+        Assert.Equal(0, store.ReservationSnapshotCount);
+        Assert.Equal(1, store.ReservationProbeCount);
         Assert.Equal(frozenBasePath, item.DownloadBase.FilePath, ignoreCase: false);
         Assert.Equal(frozenBasePath, persisted.Output.BasePath, ignoreCase: false);
         Assert.Equal(
@@ -493,7 +542,7 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task RepeatedAdmissionsSnapshotReservationsWithoutCandidateProbesOrAggregateReloads()
+    public async Task RepeatedAdmissionsUseOnePointProbeAndOnlyCollisionSnapshots()
     {
         Directory.CreateDirectory(_directory);
         using var innerStore = CreateStore();
@@ -518,8 +567,75 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
         }
 
         Assert.Equal(0, store.GetUnfinishedCallCount);
-        Assert.Equal(admissionCount, store.ReservationSnapshotCount);
-        Assert.Equal(0, store.ReservationProbeCount);
+        Assert.Equal(admissionCount - 1, store.ReservationSnapshotCount);
+        Assert.Equal(admissionCount, store.ReservationProbeCount);
+        Assert.Equal(admissionCount, store.AddCallCount);
+    }
+
+    [Fact]
+    public async Task DistinctAdmissionsUseOnlyOriginalBasenamePointQueries()
+    {
+        Directory.CreateDirectory(_directory);
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore);
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        using var admission = CreateAdmission(
+            new DownloadListState(), tasks, projections, new RecordingDownloadTaskQueue());
+
+        const int admissionCount = 64;
+        for (var index = 0; index < admissionCount; index++)
+        {
+            var basePath = Path.Combine(_directory, $"distinct-{index:D3}");
+            var item = CreateItem($"distinct-task-{index}", basePath);
+            await admission.AdmitAsync(item, true, TestContext.Current.CancellationToken);
+            Assert.Equal(basePath, item.DownloadBase.FilePath);
+        }
+
+        Assert.Equal(admissionCount, store.ReservationProbeCount);
+        Assert.Equal(0, store.ReservationSnapshotCount);
+        Assert.Equal(admissionCount, store.AddCallCount);
+        Assert.Equal(0, store.GetUnfinishedCallCount);
+    }
+
+    [Fact]
+    public async Task LegacyNullKeyWithAlternateUnicodeSpellingEntersSnapshotFallback()
+    {
+        Directory.CreateDirectory(_directory);
+        using var innerStore = CreateStore();
+        var store = new CountingDownloadTaskStore(innerStore);
+        var clock = new SystemClock();
+        using var tasks = new DownloadTaskApplicationService(store, clock);
+        using var projections = new DownloadTaskProjectionStore(tasks, clock);
+        using var admission = CreateAdmission(
+            new DownloadListState(), tasks, projections, new RecordingDownloadTaskQueue());
+        var decomposed = Path.Combine(_directory, "cafe\u0301-legacy-admission");
+        var composed = Path.Combine(_directory, "caf\u00e9-legacy-admission");
+        await admission.AdmitAsync(
+            CreateItem("legacy-first", decomposed), true, TestContext.Current.CancellationToken);
+        using (var connection = new SqliteConnection(new SqliteConnectionStringBuilder
+        {
+            DataSource = Path.Combine(_directory, "download.db"),
+            Pooling = false
+        }.ToString()))
+        {
+            await connection.OpenAsync(TestContext.Current.CancellationToken);
+            using var command = connection.CreateCommand();
+            command.CommandText = """
+                UPDATE download_base SET output_reservation_key = NULL
+                WHERE id = 'legacy-first'
+                """;
+            await command.ExecuteNonQueryAsync(TestContext.Current.CancellationToken);
+        }
+
+        var next = CreateItem("legacy-next", composed);
+        await admission.AdmitAsync(next, true, TestContext.Current.CancellationToken);
+
+        Assert.Equal($"{composed}(1)", next.DownloadBase.FilePath);
+        Assert.Equal(2, store.ReservationProbeCount);
+        Assert.Equal(1, store.ReservationSnapshotCount);
+        Assert.Equal(2, store.AddCallCount);
     }
 
     private static async Task AdmitThreeWithHoleAsync(
@@ -596,16 +712,22 @@ public sealed class DownloadTaskAdmissionServiceTests : IDisposable
 
         public int ReservationSnapshotCount { get; private set; }
 
+        public int AddCallCount { get; private set; }
+
         public Task InitializeAsync(CancellationToken cancellationToken) =>
             inner.InitializeAsync(cancellationToken);
 
         public Task<OperationResult> AddAsync(
             DownloadTask task,
-            CancellationToken cancellationToken) => RejectAdds
+            CancellationToken cancellationToken)
+        {
+            AddCallCount++;
+            return RejectAdds
                 ? Task.FromResult(OperationResult.Failure(new OperationError(
                     "test.persistence_rejected",
                     "Persistence rejected the task.")))
                 : inner.AddAsync(task, cancellationToken);
+        }
 
         public Task<OperationResult> UpdateAsync(
             DownloadTask task,

--- a/tests/DownKyi.Tests/LegacyDownloadAdmissionPresenterTests.cs
+++ b/tests/DownKyi.Tests/LegacyDownloadAdmissionPresenterTests.cs
@@ -155,6 +155,11 @@ public sealed class LegacyDownloadAdmissionPresenterTests
             return Task.FromResult(ConfirmationResult);
         }
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
+++ b/tests/DownKyi.Tests/MuxFailureRecoveryTests.cs
@@ -439,6 +439,11 @@ public sealed class MuxFailureRecoveryTests
             bool ignoreCase,
             CancellationToken cancellationToken) => Task.FromResult(false);
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,

--- a/tests/DownKyi.Tests/VideoTagLoadingTests.cs
+++ b/tests/DownKyi.Tests/VideoTagLoadingTests.cs
@@ -583,6 +583,11 @@ public sealed class VideoTagLoadingTests : IDisposable
             DownloadTaskId taskId,
             CancellationToken cancellationToken) => Task.FromResult<DownloadTask?>(null);
 
+        public Task<IReadOnlyList<string>> GetActiveOutputReservationKeysAsync(
+            bool ignoreCase,
+            CancellationToken cancellationToken) =>
+            Task.FromResult<IReadOnlyList<string>>([]);
+
         public Task<DownloadHistoryPage> GetHistoryPageAsync(
             DownloadHistoryCursor? cursor,
             int pageSize,


### PR DESCRIPTION
The G admission path now probes the original basename once when it is free and loads a reservation snapshot only after a collision. A separate SQLite-store commit reconciles persisted reservation keys before that point query or any writer is allowed to run. This fixes a portable-database counterexample: an old non-NULL key made under another platform policy made the snapshot say “reserved” while the point query and transactional `AddAsync` allowed a second equivalent task.

The reviewable commits are `a08bfc61` (G hybrid admission) and `992a22e2` (persisted-key compatibility). On every store open, one IMMEDIATE transaction reads active paths and all non-NULL UNIQUE occupants, computes current-policy keys, and preflights the entire target group, including quarantined and anomalous completed occupants. Only conflict-free changes proceed, after a consistent SQLite backup; updates and commit have explicit rollback on failure. Conflicts or uninterpretable paths fail initialization before publication reconciliation, cleanup or runtime start, so direct `AddAsync` also fails. Original rows, paths, progress and files remain untouched. Active Add/Update use the same key rule. Quarantined rows are not rekeyed, but keep occupying their persisted keys. This adds no schema marker, general migration framework or per-admission scan.

The same isolated cross-policy fixture gives `snapshot=true`, `point=false`, and a second equivalent Add succeeds on both original base `083ae96a` and pre-repair hybrid `a08bfc61`. On `992a22e2`, snapshot and point both return true, Add returns `download.store.output_path_reserved`, and the stored key matches the current policy. Regressions cover legacy NULL, Unicode/case, reopen/idempotence/policy change, full-group collision rollback, quarantine and completed UNIQUE occupants, key-swap order, cancellation, backup/SQL/commit failure, startup blocking, and preservation of completed history and #261 staging/publication data. A deferred-constraint commit-failure probe retained both old keys, rolled back its trigger row and left one pre-change backup.

Native Windows x64/.NET 10.0.12 Release comparison, 1 warmup + 3 samples, same repaired SQLite owner in A/B/C research worktrees. Admission means exclude separately measured initialization:

| Workload | A: candidate points | B: always snapshot | C: hybrid |
| --- | ---: | ---: | ---: |
| 512 same basename | 11,632 ms | 1,376 ms | 1,232 ms |
| 512 distinct names | 659 ms | 1,069 ms | 849 ms |
| 5,000 unrelated active + 128 new | 1,237 ms | 2,612 ms | 1,872 ms |
| 5,000 unrelated files + 128 new | 1,371 ms | 1,519 ms | 1,293 ms |

C made 0 reservation snapshots on the no-collision workloads; A made 131,328 candidate point queries for the same-basename workload. A separate 5,000-row store-open probe averaged 13 ms for an empty DB, 43 ms for matching keys, and 275 ms for backup/rekey. These are workload-specific measurements, not a universal speed or total-complexity claim.

**Draft; G is not complete.** Exact head is `992a22e20a4f864e710e0e673a54e5435973bb09`, base `083ae96a`, synthetic merge `1d4eadbb` (parents base and head). Strict Windows Release build passed with 0 warnings/errors; Infrastructure 112, Desktop 23 and architecture OS-skip rule tests passed; format, architecture audit, actionlint, package audits, secret scan and diff check passed. The complete local runner stopped at an unchanged Architecture cancellation test (expected exit 130, actual 2); its TRX and flight recorder were preserved. The remaining Windows project slices passed separately through the formal runner. Exact-head CI first attempts had 15 successes, 11 conditional skips, and 2 separate macOS failures: FlightRecorder oversized output in build-test and process-tree descendant cleanup in x64 packaging before package launch. One selective same-SHA rerun of each affected job passed, covering all macOS tests plus the x64 DMG and mounted/copied app launch; those passes do not explain or erase the original failures. Windows/Ubuntu build-test and macOS arm64 package-and-launch passed. No runner or #261 protocol changes are included.

The exact-head independent review raised one P1 requesting quarantine of an empty `file_path` so unaffected tasks could continue. That suggestion is intentionally not applied: the agreed compatibility contract requires retaining and blocking on an uninterpretable path, allows blocking the whole download subsystem, and forbids admitting more tasks while the database cannot be reconciled. An isolated same-head fixture confirms failed initialization and direct Add retain the original rows/path/key without quarantine or rekey. The review and its rationale remain visible for maintainers. Earlier review found and drove the Unix `//` ambiguous-UNC fix in this head. The earlier suffix-snapshot P2 assumes two uncoordinated app/store writers; reachability through the formal Release startup has not been demonstrated. Release acquires the single-instance guard before Host/storage initialization, the Host registers one admission service, and its semaphore covers snapshot selection through durable Add. The formal admission, guard and lifecycle tests pass. Do not add a cross-instance retry on this hypothetical path; require a concrete reachable trigger first. Do not merge, tag, release or close #177 as part of this draft.
